### PR TITLE
CLDR-16239 replace lateral inheritance markers in trunk

### DIFF
--- a/common/main/ab.xml
+++ b/common/main/ab.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -468,9 +468,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<script type="Hani" draft="unconfirmed">акитаи</script>
 			<script type="Hano" draft="unconfirmed">ахануну</script>
 			<script type="Hans" draft="unconfirmed">имариоу акитаи</script>
-			<script type="Hans" alt="stand-alone" draft="unconfirmed">↑↑↑</script>
+			<script type="Hans" alt="stand-alone" draft="unconfirmed">имариоу акитаи</script>
 			<script type="Hant" draft="unconfirmed">китаитәи атрадициатә</script>
-			<script type="Hant" alt="stand-alone" draft="unconfirmed">↑↑↑</script>
+			<script type="Hant" alt="stand-alone" draft="unconfirmed">китаитәи атрадициатә</script>
 			<script type="Hebr" draft="unconfirmed">ауриа</script>
 			<script type="Hira" draft="unconfirmed">ахирагана</script>
 			<script type="Hluw" draft="unconfirmed">лувиатәи аиероглифқәа</script>
@@ -648,7 +648,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="CG" alt="variant" draft="unconfirmed">Ареспублика Конго</territory>
 			<territory type="CH" draft="unconfirmed">Швеицариа</territory>
 			<territory type="CI" draft="unconfirmed">Кот-д’Ивуар</territory>
-			<territory type="CI" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="CI" alt="variant" draft="unconfirmed">Кот-д’Ивуар</territory>
 			<territory type="CK" draft="unconfirmed">Кук идгьылбжьахақәа</territory>
 			<territory type="CL" draft="unconfirmed">Чили</territory>
 			<territory type="CM" draft="unconfirmed">Камерун</territory>
@@ -847,7 +847,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN" draft="unconfirmed">Тунис</territory>
 			<territory type="TO" draft="unconfirmed">Тонга</territory>
 			<territory type="TR" draft="unconfirmed">Ҭырқәтәыла</territory>
-			<territory type="TR" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="TR" alt="variant" draft="unconfirmed">Ҭырқәтәыла</territory>
 			<territory type="TT" draft="unconfirmed">Тринидади Тобагои</territory>
 			<territory type="TV" draft="unconfirmed">Тувалу</territory>
 			<territory type="TW" draft="unconfirmed">Таиван</territory>
@@ -1188,18 +1188,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">Ажь</month>
+							<month type="2" draft="unconfirmed">Жəаб</month>
+							<month type="3" draft="unconfirmed">Хəажә</month>
+							<month type="4" draft="unconfirmed">Мш</month>
+							<month type="5" draft="unconfirmed">Лаҵ</month>
+							<month type="6" draft="unconfirmed">Рашә</month>
+							<month type="7" draft="unconfirmed">Ԥхынгә</month>
+							<month type="8" draft="unconfirmed">Нанҳә</month>
+							<month type="9" draft="unconfirmed">Цəыб</month>
+							<month type="10" draft="unconfirmed">Жьҭ</month>
+							<month type="11" draft="unconfirmed">Абҵ</month>
+							<month type="12" draft="unconfirmed">Ԥхынҷ</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="unconfirmed">Жь</month>
@@ -1216,18 +1216,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12" draft="unconfirmed">Ҷ</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">Ажьырныҳəа</month>
+							<month type="2" draft="unconfirmed">Жəабран</month>
+							<month type="3" draft="unconfirmed">Хəажəкыра</month>
+							<month type="4" draft="unconfirmed">Мшаԥы</month>
+							<month type="5" draft="unconfirmed">Лаҵара</month>
+							<month type="6" draft="unconfirmed">Рашəара</month>
+							<month type="7" draft="unconfirmed">Ԥхынгəы</month>
+							<month type="8" draft="unconfirmed">Нанҳəа</month>
+							<month type="9" draft="unconfirmed">Цəыббра</month>
+							<month type="10" draft="unconfirmed">Жьҭаара</month>
+							<month type="11" draft="unconfirmed">Абҵара</month>
+							<month type="12" draft="unconfirmed">Ԥхынҷкәын</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1252,13 +1252,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat" draft="unconfirmed">С</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">Ам</day>
+							<day type="mon" draft="unconfirmed">Ашә</day>
+							<day type="tue" draft="unconfirmed">Аҩ</day>
+							<day type="wed" draft="unconfirmed">Ах</day>
+							<day type="thu" draft="unconfirmed">Аԥ</day>
+							<day type="fri" draft="unconfirmed">Ахә</day>
+							<day type="sat" draft="unconfirmed">Ас</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun" draft="unconfirmed">Амҽыша</day>
@@ -1277,8 +1277,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="tue" draft="unconfirmed">Аҩ</day>
 							<day type="wed" draft="unconfirmed">Ах</day>
 							<day type="thu" draft="unconfirmed">Аԥ</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="fri" draft="unconfirmed">Ахә</day>
+							<day type="sat" draft="unconfirmed">Ас</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun" draft="unconfirmed">М</day>
@@ -1299,13 +1299,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat" draft="unconfirmed">Ас</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">Амҽыша</day>
+							<day type="mon" draft="unconfirmed">Ашәахьа</day>
+							<day type="tue" draft="unconfirmed">Аҩаша</day>
+							<day type="wed" draft="unconfirmed">Ахаша</day>
+							<day type="thu" draft="unconfirmed">Аԥшьаша</day>
+							<day type="fri" draft="unconfirmed">Ахәаша</day>
+							<day type="sat" draft="unconfirmed">Асабша</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -1318,10 +1318,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<quarter type="4" draft="unconfirmed">4-тәи акв.</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="1" draft="unconfirmed">1</quarter>
+							<quarter type="2" draft="unconfirmed">2</quarter>
+							<quarter type="3" draft="unconfirmed">3</quarter>
+							<quarter type="4" draft="unconfirmed">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1" draft="unconfirmed">1-тәи аквартал</quarter>
@@ -1358,26 +1358,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -4010,8 +4010,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -4621,10 +4621,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="per">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 		</unitLength>
 		<unitLength type="short">
@@ -4637,10 +4637,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -4665,28 +4665,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2" draft="unconfirmed">{0} ма {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} ма {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} ма {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} ма {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} ма {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}-и {1}-и</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0}-и {1}-и</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start" draft="unconfirmed">{0} {1}</listPatternPart>

--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -355,7 +355,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="pqm">Maliseet-Passamaquoddy</language>
 			<language type="prg">Pruisies</language>
 			<language type="ps">Pasjto</language>
-			<language type="ps" alt="variant">↑↑↑</language>
+			<language type="ps" alt="variant">Pasjto</language>
 			<language type="pt">Portugees</language>
 			<language type="pt_BR">↑↑↑</language>
 			<language type="pt_PT">↑↑↑</language>
@@ -637,7 +637,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="CG" alt="variant">Kongo (Republiek die)</territory>
 			<territory type="CH">Switserland</territory>
 			<territory type="CI">Ivoorkus</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
+			<territory type="CI" alt="variant">Ivoorkus</territory>
 			<territory type="CK">Cookeilande</territory>
 			<territory type="CL">Chili</territory>
 			<territory type="CM">Kameroen</territory>
@@ -836,7 +836,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisië</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkye</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkye</territory>
 			<territory type="TT">Trinidad en Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -2180,16 +2180,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">verlede So.</relative>
+				<relative type="0">hierdie So.</relative>
+				<relative type="1">volgende So.</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">oor {0} So.</relativeTimePattern>
 					<relativeTimePattern count="other">oor {0} So.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} So. gelede</relativeTimePattern>
+					<relativeTimePattern count="other">{0} So. gelede</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2227,8 +2227,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">oor {0} Ma.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Ma. gelede</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Ma. gelede</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -2266,8 +2266,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">oor {0} Di.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Di. gelede</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Di. gelede</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -2305,8 +2305,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">oor {0} Wo.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Wo. gelede</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Wo. gelede</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -2344,8 +2344,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">oor {0} Do.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Do. gelede</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Do. gelede</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -2383,8 +2383,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">oor {0} Vr.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Vr. gelede</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Vr. gelede</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -2422,8 +2422,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">oor {0} Sa.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Sa. gelede</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Sa. gelede</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
@@ -4895,16 +4895,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000" count="one">¤0 k</pattern>
 					<pattern type="1000" count="one" alt="alphaNextToNumber">¤0 k</pattern>
 					<pattern type="1000" count="other">¤0 k</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤0 k</pattern>
 					<pattern type="10000" count="one">¤00 k</pattern>
 					<pattern type="10000" count="one" alt="alphaNextToNumber">¤00 k</pattern>
 					<pattern type="10000" count="other">¤00 k</pattern>
 					<pattern type="10000" count="other" alt="alphaNextToNumber">¤00 k</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="one">¤000 k</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤000 k</pattern>
 					<pattern type="100000" count="other">¤000 k</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤000 k</pattern>
+					<pattern type="1000000" count="one">¤0 m</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤0 m</pattern>
 					<pattern type="1000000" count="other">¤0 m</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤0 m</pattern>
@@ -5514,8 +5514,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>Lesotho loti</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Lesotho loti</displayName>
+				<displayName count="other">Lesotho loti</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -6122,28 +6122,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>yotta{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0} per {1}</compoundUnitPattern>
@@ -6268,7 +6268,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>items</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">{0} items</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -6292,9 +6292,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} per tienduisend</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>liter per kilometer</displayName>
@@ -6520,9 +6520,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} newton</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>gigahertz</displayName>
@@ -6546,8 +6546,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipografiese em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pieksels</displayName>
@@ -6675,7 +6675,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} furlongs</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>vaam</displayName>
 				<unitPattern count="one">{0} vaam</unitPattern>
 				<unitPattern count="other">{0} vaam</unitPattern>
 			</unit>
@@ -6844,9 +6844,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} duim kwik</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>millibar</displayName>
@@ -7012,9 +7012,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} acre-voet</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>skepel</displayName>
 				<unitPattern count="one">{0} skepel</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} skepel</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>gelling</displayName>
@@ -7201,12 +7201,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7319,7 +7319,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -7344,7 +7344,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mol</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7547,7 +7547,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronvolt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -7567,12 +7567,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -7597,12 +7597,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pieksels</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
@@ -7637,7 +7637,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7747,7 +7747,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>sonradiusse</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -7757,17 +7757,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>sonligsterkte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -7836,12 +7836,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>aardemassas</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>sonmassas</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -7896,7 +7896,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>bar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -7911,7 +7911,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>Pa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -7921,12 +7921,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>MPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -8028,7 +8028,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-liter">
 				<displayName>liters</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -8064,7 +8064,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>skepel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} skepel</unitPattern>
 				<unitPattern count="other">{0} skepel</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -8164,112 +8164,112 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>swaartekrag</displayName>
 				<unitPattern count="one">{0}G</unitPattern>
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s²</displayName>
 				<unitPattern count="one">{0}m/s²</unitPattern>
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
@@ -8299,13 +8299,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0}km²</unitPattern>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektaar</displayName>
 				<unitPattern count="one">{0}ha</unitPattern>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
@@ -8313,48 +8313,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>meters²</displayName>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm²</displayName>
 				<unitPattern count="one">{0}cm²</unitPattern>
 				<unitPattern count="other">{0}cm²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>myl²</displayName>
 				<unitPattern count="one">{0}myl²</unitPattern>
 				<unitPattern count="other">{0}myl²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/myl²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>acre</displayName>
 				<unitPattern count="one">{0}ac</unitPattern>
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>jaart²</displayName>
 				<unitPattern count="one">{0}jt.²</unitPattern>
 				<unitPattern count="other">{0}jt.²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>vt.²</displayName>
 				<unitPattern count="one">{0}vt.²</unitPattern>
 				<unitPattern count="other">{0}vt.²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>duim²</displayName>
 				<unitPattern count="one">{0}dm.²</unitPattern>
 				<unitPattern count="other">{0}dm.²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/dm.²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>donum</displayName>
 				<unitPattern count="one">{0}donum</unitPattern>
 				<unitPattern count="other">{0}donum</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>karaat</displayName>
 				<unitPattern count="one">{0}kar.</unitPattern>
 				<unitPattern count="other">{0}kar.</unitPattern>
 			</unit>
@@ -8369,7 +8369,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>item</displayName>
 				<unitPattern count="one">{0}item</unitPattern>
 				<unitPattern count="other">{0}item</unitPattern>
 			</unit>
@@ -8385,16 +8385,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0}mol</unitPattern>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
@@ -8419,67 +8419,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}m/Br.g.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>PB</displayName>
 				<unitPattern count="one">{0}PB</unitPattern>
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>TB</displayName>
 				<unitPattern count="one">{0}TB</unitPattern>
 				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Tb</displayName>
 				<unitPattern count="one">{0}Tb</unitPattern>
 				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>GB</displayName>
 				<unitPattern count="one">{0}GB</unitPattern>
 				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gb</displayName>
 				<unitPattern count="one">{0}Gb</unitPattern>
 				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="one">{0}MB</unitPattern>
 				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mb</displayName>
 				<unitPattern count="one">{0}Mb</unitPattern>
 				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>kB</displayName>
 				<unitPattern count="one">{0}kB</unitPattern>
 				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>kb</displayName>
 				<unitPattern count="one">{0}kb</unitPattern>
 				<unitPattern count="other">{0}kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>greep</displayName>
 				<unitPattern count="one">{0}greep</unitPattern>
 				<unitPattern count="other">{0}greep</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>bis</displayName>
 				<unitPattern count="one">{0}bis</unitPattern>
 				<unitPattern count="other">{0}bis</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>e.</displayName>
 				<unitPattern count="one">{0}e.</unitPattern>
 				<unitPattern count="other">{0}e.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>dek.</displayName>
 				<unitPattern count="one">{0}dek.</unitPattern>
 				<unitPattern count="other">{0}dek.</unitPattern>
 			</unit>
@@ -8487,7 +8487,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>j.</displayName>
 				<unitPattern count="one">{0} j.</unitPattern>
 				<unitPattern count="other">{0} j.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/j.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>kw.</displayName>
@@ -8499,37 +8499,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>maand</displayName>
 				<unitPattern count="one">{0} md.</unitPattern>
 				<unitPattern count="other">{0} md.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/md.</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>w.</displayName>
 				<unitPattern count="one">{0} w.</unitPattern>
 				<unitPattern count="other">{0} w.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/w.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>dag</displayName>
 				<unitPattern count="one">{0} d.</unitPattern>
 				<unitPattern count="other">{0} d.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d.</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>uur</displayName>
 				<unitPattern count="one">{0} u.</unitPattern>
 				<unitPattern count="other">{0} u.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min.</displayName>
 				<unitPattern count="one">{0} min.</unitPattern>
 				<unitPattern count="other">{0} min.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min.</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s.</displayName>
 				<unitPattern count="one">{0} s.</unitPattern>
 				<unitPattern count="other">{0} s.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s.</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms.</displayName>
@@ -8537,62 +8537,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms.</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>μs.</displayName>
 				<unitPattern count="one">{0}μs.</unitPattern>
 				<unitPattern count="other">{0}μs.</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ns.</displayName>
 				<unitPattern count="one">{0}ns.</unitPattern>
 				<unitPattern count="other">{0}ns.</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>A</displayName>
 				<unitPattern count="one">{0}A</unitPattern>
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>mA</displayName>
 				<unitPattern count="one">{0}mA</unitPattern>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>ohm</displayName>
 				<unitPattern count="one">{0}Ω</unitPattern>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>volt</displayName>
 				<unitPattern count="one">{0}V</unitPattern>
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kkal.</displayName>
 				<unitPattern count="one">{0}kkal.</unitPattern>
 				<unitPattern count="other">{0}kkal.</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kal.</displayName>
 				<unitPattern count="one">{0}kal.</unitPattern>
 				<unitPattern count="other">{0}kal.</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kal.</displayName>
 				<unitPattern count="one">{0}kal.</unitPattern>
 				<unitPattern count="other">{0}kal.</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kJ</displayName>
 				<unitPattern count="one">{0}kJ</unitPattern>
 				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>joule</displayName>
 				<unitPattern count="one">{0}J</unitPattern>
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh</displayName>
 				<unitPattern count="one">{0}kWh</unitPattern>
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
@@ -8602,12 +8602,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>BTE</displayName>
 				<unitPattern count="one">{0}BTE</unitPattern>
 				<unitPattern count="other">{0}BTE</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>VSA- termiese eenheid</displayName>
 				<unitPattern count="one">{0}VSA-term.</unitPattern>
 				<unitPattern count="other">{0}VSA-term.</unitPattern>
 			</unit>
@@ -8622,32 +8622,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="one">{0}GHz</unitPattern>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="one">{0}MHz</unitPattern>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="one">{0}kHz</unitPattern>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="one">{0}Hz</unitPattern>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
@@ -8657,7 +8657,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>megapieksels</displayName>
 				<unitPattern count="one">{0}Mpx</unitPattern>
 				<unitPattern count="other">{0}Mpx</unitPattern>
 			</unit>
@@ -8678,8 +8678,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>stippel</displayName>
@@ -8687,7 +8687,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}stippel</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">{0}R⊕</unitPattern>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
@@ -8695,16 +8695,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dm</displayName>
 				<unitPattern count="one">{0}dm</unitPattern>
 				<unitPattern count="other">{0}dm</unitPattern>
 			</unit>
@@ -8712,7 +8712,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -8720,44 +8720,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>μm</displayName>
 				<unitPattern count="one">{0}μm</unitPattern>
 				<unitPattern count="other">{0}μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>nm</displayName>
 				<unitPattern count="one">{0}nm</unitPattern>
 				<unitPattern count="other">{0}nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0}pm</unitPattern>
 				<unitPattern count="other">{0}pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>myl</displayName>
 				<unitPattern count="one">{0}myl</unitPattern>
 				<unitPattern count="other">{0}myl</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>jaart</displayName>
 				<unitPattern count="one">{0}jt.</unitPattern>
 				<unitPattern count="other">{0}jt.</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>voet</displayName>
 				<unitPattern count="one">{0}vt.</unitPattern>
 				<unitPattern count="other">{0}vt.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/vt.</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>duim</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/duim</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>parsek</displayName>
 				<unitPattern count="one">{0}pc</unitPattern>
 				<unitPattern count="other">{0}pc</unitPattern>
 			</unit>
@@ -8767,27 +8767,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} lj</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>AE</displayName>
 				<unitPattern count="one">{0}AE</unitPattern>
 				<unitPattern count="other">{0}AE</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>furlongs</displayName>
 				<unitPattern count="one">{0}fur</unitPattern>
 				<unitPattern count="other">{0}fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>vaam</displayName>
 				<unitPattern count="one">{0}vaam</unitPattern>
 				<unitPattern count="other">{0}vaam</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>sm.</displayName>
 				<unitPattern count="one">{0}sm.</unitPattern>
 				<unitPattern count="other">{0}sm.</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
+				<displayName>smi</displayName>
 				<unitPattern count="one">{0}smi</unitPattern>
 				<unitPattern count="other">{0}smi</unitPattern>
 			</unit>
@@ -8802,17 +8802,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lux</displayName>
 				<unitPattern count="one">{0}lx</unitPattern>
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
@@ -8822,7 +8822,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>t</displayName>
 				<unitPattern count="one">{0}t</unitPattern>
 				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
@@ -8830,31 +8830,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gram</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="one">{0}ng</unitPattern>
 				<unitPattern count="other">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>μg</displayName>
 				<unitPattern count="one">{0}μg</unitPattern>
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>VSA-ton</displayName>
 				<unitPattern count="one">{0}VSA-t.</unitPattern>
 				<unitPattern count="other">{0}VSA-t.</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>stone</displayName>
 				<unitPattern count="one">{0}st</unitPattern>
 				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
@@ -8862,7 +8862,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>lb</displayName>
 				<unitPattern count="one">{0}#</unitPattern>
 				<unitPattern count="other">{0}#</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb.</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>ons.</displayName>
@@ -8876,7 +8876,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ons.t.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>karaat</displayName>
 				<unitPattern count="one">{0}kar.</unitPattern>
 				<unitPattern count="other">{0}kar.</unitPattern>
 			</unit>
@@ -8896,37 +8896,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>korrelgewig</displayName>
 				<unitPattern count="one">{0}korrelg.</unitPattern>
 				<unitPattern count="other">{0}korrelg.</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="one">{0}GW</unitPattern>
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="one">{0}MW</unitPattern>
 				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>watt</displayName>
 				<unitPattern count="one">{0}W</unitPattern>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">{0}mW</unitPattern>
 				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>pk.</displayName>
 				<unitPattern count="one">{0}pk.</unitPattern>
 				<unitPattern count="other">{0}pk.</unitPattern>
 			</unit>
@@ -8936,7 +8936,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb./vk. duim</displayName>
 				<unitPattern count="one">{0}lb./vk.dm</unitPattern>
 				<unitPattern count="other">{0}lb./vk.dm</unitPattern>
 			</unit>
@@ -8946,37 +8946,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="one">{0}bar</unitPattern>
 				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0}mb</unitPattern>
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm.</displayName>
 				<unitPattern count="one">{0}atm.</unitPattern>
 				<unitPattern count="other">{0}atm.</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="one">{0}Pa</unitPattern>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0}hPa</unitPattern>
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="one">{0}kPa</unitPattern>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="one">{0}MPa</unitPattern>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
@@ -8996,14 +8996,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kn.</displayName>
 				<unitPattern count="one">{0}kn.</unitPattern>
 				<unitPattern count="other">{0}kn.</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9011,12 +9011,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="one">{0}K</unitPattern>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
@@ -9026,26 +9026,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}lb.vt.-kr</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Nm</displayName>
 				<unitPattern count="one">{0}Nm</unitPattern>
 				<unitPattern count="other">{0}Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0}cm³</unitPattern>
 				<unitPattern count="other">{0}cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>myl³</displayName>
@@ -9053,7 +9053,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}myl³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>jaart³</displayName>
 				<unitPattern count="one">{0}jt.³</unitPattern>
 				<unitPattern count="other">{0}jt.³</unitPattern>
 			</unit>
@@ -9081,7 +9081,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>liter</displayName>
 				<unitPattern count="one">{0}l</unitPattern>
 				<unitPattern count="other">{0}l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>dl</displayName>
@@ -9104,28 +9104,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mpt.</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>m. kop</displayName>
 				<unitPattern count="one">{0}m.kop</unitPattern>
 				<unitPattern count="other">{0}m.kop</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>acre-voet</displayName>
 				<unitPattern count="one">{0}ac.-vt.</unitPattern>
 				<unitPattern count="other">{0}ac.-vt.</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>skepel</displayName>
 				<unitPattern count="one">{0}sk.</unitPattern>
 				<unitPattern count="other">{0}sk.</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gell.</displayName>
 				<unitPattern count="one">{0}gell.</unitPattern>
 				<unitPattern count="other">{0}gell.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gell.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Br. gell.</displayName>
 				<unitPattern count="one">{0}Br.gell.</unitPattern>
 				<unitPattern count="other">{0}Br.gell.</unitPattern>
 				<perUnitPattern>{0}/Br.gell.</perUnitPattern>
@@ -9141,12 +9141,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pt.</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>koppie</displayName>
 				<unitPattern count="one">{0}kp</unitPattern>
 				<unitPattern count="other">{0}kp.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>vl.oz.</displayName>
 				<unitPattern count="one">{0}vl.oz.</unitPattern>
 				<unitPattern count="other">{0}vl.oz.</unitPattern>
 			</unit>
@@ -9156,7 +9156,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Im.vl.oz.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>e.</displayName>
 				<unitPattern count="one">{0}e.</unitPattern>
 				<unitPattern count="other">{0}e.</unitPattern>
 			</unit>
@@ -9166,32 +9166,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}tl.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
+				<displayName>vat</displayName>
 				<unitPattern count="one">{0}vat</unitPattern>
 				<unitPattern count="other">{0}vate</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstlpl.</displayName>
 				<unitPattern count="one">{0}dstlpl.</unitPattern>
 				<unitPattern count="other">{0}dstlpl.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstlpl. Eng.</displayName>
 				<unitPattern count="one">{0}dlpl.Eng</unitPattern>
 				<unitPattern count="other">{0}dlpl.Eng</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>druppel</displayName>
 				<unitPattern count="one">{0}dr</unitPattern>
 				<unitPattern count="other">{0}dr</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>dragme vloeistof</displayName>
 				<unitPattern count="one">{0}dr.vl.</unitPattern>
 				<unitPattern count="other">{0}dr.vl.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>sopie</displayName>
 				<unitPattern count="one">{0}sopie</unitPattern>
 				<unitPattern count="other">{0}sopies</unitPattern>
 			</unit>
@@ -9201,7 +9201,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kn.</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>kwart Eng.</displayName>
 				<unitPattern count="one">{0}kw.Eng.</unitPattern>
 				<unitPattern count="other">{0}kw.Eng</unitPattern>
 			</unit>
@@ -9237,22 +9237,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} of {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} of {1}</listPatternPart>
+			<listPatternPart type="2">{0} of {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} of {1}</listPatternPart>
+			<listPatternPart type="2">{0} of {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} en {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -115,8 +115,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">ቼሮኬኛ</language>
 			<language type="chy">ችዬኔ</language>
 			<language type="ckb">የሶራኒ ኩርድኛ</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">የሶራኒ ኩርድኛ</language>
+			<language type="ckb" alt="variant">የሶራኒ ኩርድኛ</language>
 			<language type="clc">ቺልኮቲን</language>
 			<language type="co">ኮርሲካኛ</language>
 			<language type="cop">ኮፕቲክ</language>
@@ -740,7 +740,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="FR">ፈረንሳይ</territory>
 			<territory type="GA">ጋቦን</territory>
 			<territory type="GB">ዩናይትድ ኪንግደም</territory>
-			<territory type="GB" alt="short">↑↑↑</territory>
+			<territory type="GB" alt="short">ዩናይትድ ኪንግደም</territory>
 			<territory type="GD">ግሬናዳ</territory>
 			<territory type="GE">ጆርጂያ</territory>
 			<territory type="GF">የፈረንሳይ ጉዊአና</territory>
@@ -838,7 +838,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">ናኡሩ</territory>
 			<territory type="NU">ኒኡይ</territory>
 			<territory type="NZ">ኒው ዚላንድ</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">ኒው ዚላንድ</territory>
 			<territory type="OM">ኦማን</territory>
 			<territory type="PA">ፓናማ</territory>
 			<territory type="PE">ፔሩ</territory>
@@ -898,7 +898,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ቱኒዚያ</territory>
 			<territory type="TO">ቶንጋ</territory>
 			<territory type="TR">ቱርክ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ቱርክ</territory>
 			<territory type="TT">ትሪናዳድ እና ቶቤጎ</territory>
 			<territory type="TV">ቱቫሉ</territory>
 			<territory type="TW">ታይዋን</territory>
@@ -909,7 +909,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="UN">የተባበሩት መንግስታት</territory>
 			<territory type="UN" alt="short">የተመ</territory>
 			<territory type="US">ዩናይትድ ስቴትስ</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">ዩናይትድ ስቴትስ</territory>
 			<territory type="UY">ኡራጓይ</territory>
 			<territory type="UZ">ኡዝቤኪስታን</territory>
 			<territory type="VA">ቫቲካን ከተማ</territory>
@@ -1327,19 +1327,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -1369,31 +1369,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE፣ d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MEd">E፣ M/d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E፣ MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E፣ MMMM d</dateFormatItem>
+						<dateFormatItem id="yMEd">E፣ d/M/y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E፣ MMM d y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E፣ d/M/y – E፣ d/M/y</greatestDifference>
+							<greatestDifference id="y">E፣ d/M/y – E፣ d/M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d፣ y</greatestDifference>
+							<greatestDifference id="y">MMM d፣ y – MMM d፣ y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">E፣ MMM d፣ y – E፣ MMM d፣ y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1401,7 +1401,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="dangi">
 				<dateTimeFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -1742,7 +1742,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1750,7 +1750,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1758,7 +1758,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1766,7 +1766,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2253,7 +2253,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraNames>
 					<eraAbbr>
 						<era type="0">ዓ/ዓ</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">ዓ/ዓ</era>
 						<era type="1">ዓ/ም</era>
 						<era type="1" alt="variant">መዓ</era>
 					</eraAbbr>
@@ -2321,7 +2321,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2329,7 +2329,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2337,7 +2337,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2345,7 +2345,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2551,20 +2551,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="7" yeartype="leap">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -2588,45 +2588,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AM</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AM</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE፣ d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMEd">E፣ MMM d</dateFormatItem>
+						<dateFormatItem id="yMEd">E፣ d/M/y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">E፣ d/M – E፣ d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d፣ MMM</greatestDifference>
+							<greatestDifference id="M">E፣ MMM d – E፣ MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E፣ d/M/y – E፣ d/M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d፣ y</greatestDifference>
+							<greatestDifference id="y">MMM d፣ y – MMM d፣ y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">E፣ MMM d፣ y – E፣ MMM d፣ y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2635,18 +2635,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -2669,33 +2669,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE፣ d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MEd">E፣ M/d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E፣ MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E፣ MMMM d</dateFormatItem>
+						<dateFormatItem id="yMEd">E፣ d/M/y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E፣ MMM d y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">E፣ d/M – E፣ d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">E፣ MMM d – E፣ MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E፣ d/M/y – E፣ d/M/y</greatestDifference>
+							<greatestDifference id="M">E d/M/ – E d/M፣ y</greatestDifference>
+							<greatestDifference id="y">E፣ d/M/y – E፣ d/M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM፣ y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2704,18 +2704,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">ሙሀረም</month>
@@ -2748,57 +2748,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">ሙሀረም</month>
+							<month type="2">ሳፈር</month>
+							<month type="3">ረቢዑል አወል</month>
+							<month type="4">ረቢዑል አኺር</month>
+							<month type="5">ጀማደል አወል</month>
+							<month type="6">ጀማደል አኺር</month>
+							<month type="7">ረጀብ</month>
+							<month type="8">ሻእባን</month>
+							<month type="9">ረመዳን</month>
+							<month type="10">ሸዋል</month>
+							<month type="11">ዙልቂዳህ</month>
+							<month type="12">ዙልሂጃህ</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE፣ d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d፣ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E MMM d፣ y G</dateFormatItem>
+						<dateFormatItem id="MEd">E፣ M/d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E፣ MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E፣ MMMM d</dateFormatItem>
+						<dateFormatItem id="yMEd">E፣ d/M/y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E፣ MMM d y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">E፣ d/M – E፣ d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">E፣ MMM d – E፣ MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E፣ d/M/y – E፣ d/M/y</greatestDifference>
+							<greatestDifference id="M">E d/M/ – E d/M፣ y</greatestDifference>
+							<greatestDifference id="y">E፣ d/M/y – E፣ d/M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM፣ y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d፣ y</greatestDifference>
+							<greatestDifference id="y">MMM d፣ y – MMM d፣ y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2806,25 +2806,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="japanese">
 				<dateTimeFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">E፣ d/M – E፣ d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d፣ MMM</greatestDifference>
+							<greatestDifference id="M">E፣ MMM d – E፣ MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E፣ d/M/y – E፣ d/M/y</greatestDifference>
+							<greatestDifference id="M">E d/M/ – E d/M፣ y</greatestDifference>
+							<greatestDifference id="y">E፣ d/M/y – E፣ d/M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM፣ y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d፣ y</greatestDifference>
+							<greatestDifference id="y">MMM d፣ y – MMM d፣ y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2833,18 +2833,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -2867,20 +2867,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE፣ d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d፣ y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E MMM d – E MMM d፣ y</greatestDifference>
+							<greatestDifference id="M">E MMM d – E MMM d፣ y</greatestDifference>
+							<greatestDifference id="y">E፣ MMM d፣ y – E፣ MMM d፣ y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2888,7 +2888,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="roc">
 				<dateTimeFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -3454,7 +3454,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>ሰዓት</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ይህ ሰዓት</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">በ{0} ሰዓት ውስጥ</relativeTimePattern>
 					<relativeTimePattern count="other">በ{0} ሰዓቶች ውስጥ</relativeTimePattern>
@@ -3466,7 +3466,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>ሰዓት</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ይህ ሰዓት</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">በ{0} ሰዓት ውስጥ</relativeTimePattern>
 					<relativeTimePattern count="other">በ{0} ሰዓቶች ውስጥ</relativeTimePattern>
@@ -3490,7 +3490,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>ደቂቃ</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ይህ ደቂቃ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">በ{0} ደቂቃ ውስጥ</relativeTimePattern>
 					<relativeTimePattern count="other">በ{0} ደቂቃዎች ውስጥ</relativeTimePattern>
@@ -3502,7 +3502,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>ደቂቃ</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ይህ ደቂቃ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">በ{0} ደቂቃ ውስጥ</relativeTimePattern>
 					<relativeTimePattern count="other">በ{0} ደቂቃዎች ውስጥ</relativeTimePattern>
@@ -5784,7 +5784,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
@@ -5793,34 +5793,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -6545,8 +6545,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>የሌሶቶ ሎቲ</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">የሌሶቶ ሎቲ</displayName>
+				<displayName count="other">የሌሶቶ ሎቲ</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -7140,19 +7140,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>ጊጋ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>{0} ኪቢ</unitPrefixPattern>
@@ -7170,13 +7170,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>{0} ፔቢ</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
 				<unitPrefixPattern>{0} ዜቢ</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0} በ{1}</compoundUnitPattern>
@@ -7190,21 +7190,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">ኪዩቢክ {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ጂ-ኃይል</displayName>
 				<unitPattern count="one">{0} ጂ-ኃይል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ጂ-ኃይል</unitPattern>
 				<unitPattern count="other">{0} ጂ-ኃይል</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ጂ-ኃይል</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>ሜ/ሰ²</displayName>
 				<unitPattern count="one">{0} ሜ/ሰ²</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሜ/ሰ²</unitPattern>
 				<unitPattern count="other">{0} ሜ/ሰ²</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሜ/ሰ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>rev</displayName>
@@ -7223,53 +7223,53 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="angle-degree">
 				<displayName>ዲግሪ</displayName>
 				<unitPattern count="one">{0} ዲግሪ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ዲግሪ</unitPattern>
 				<unitPattern count="other">{0} ዲግሪ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ዲግሪ</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>ደቂቃ</displayName>
 				<unitPattern count="one">{0} ደቂቃ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ደቂቃ</unitPattern>
 				<unitPattern count="other">{0} ደቂቃ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ደቂቃ</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>ሰከንድ</displayName>
 				<unitPattern count="one">{0} ሰከንድ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሰከንድ</unitPattern>
 				<unitPattern count="other">{0} ሰከንድ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሰከንድ</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>ካሬ ኪሎሜትር</displayName>
 				<unitPattern count="one">{0} ካሬ ኪሎሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ካሬ ኪሎሜትር</unitPattern>
 				<unitPattern count="other">{0} ካሬ ኪሎሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ካሬ ኪሎሜትር</unitPattern>
 				<perUnitPattern>{0}/ኪሜ²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ሄክታር</displayName>
 				<unitPattern count="one">{0} ሄክታር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሄክታር</unitPattern>
 				<unitPattern count="other">{0} ሄክታር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሄክታር</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>ካሬ ሜትር</displayName>
 				<unitPattern count="one">{0} ካሬ ሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ካሬ ሜትር</unitPattern>
 				<unitPattern count="other">{0} ካሬ ሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ካሬ ሜትር</unitPattern>
 				<perUnitPattern>{0}/ሜ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>ሴሜ²</displayName>
 				<unitPattern count="one">{0} ሴሜ²</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሴሜ²</unitPattern>
 				<unitPattern count="other">{0} ሴሜ²</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሴሜ²</unitPattern>
 				<perUnitPattern>{0}/ሴሜ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -7307,9 +7307,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="concentr-karat">
 				<displayName>ካራት</displayName>
 				<unitPattern count="one">{0} ካራት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ካራት</unitPattern>
 				<unitPattern count="other">{0} ካራት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ካራት</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>ሚሊ ግራም በ ዴሲ ሊትር</displayName>
@@ -7319,16 +7319,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/L</displayName>
 				<unitPattern count="one">{0} mmol/L</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mmol/L</unitPattern>
 				<unitPattern count="other">{0} mmol/L</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>ንጥሎች</displayName>
 				<unitPattern count="one">{0} ንጥል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ንጥል</unitPattern>
 				<unitPattern count="other">{0} ንጥሎች</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ንጥሎች</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
@@ -7340,44 +7340,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="concentr-percent">
 				<displayName>ፐርሰንት</displayName>
 				<unitPattern count="one">{0} ፐርሰንት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ፐርሰንት</unitPattern>
 				<unitPattern count="other">{0} ፐርሰንት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ፐርሰንት</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>በማይል</displayName>
 				<unitPattern count="one">{0} በማይል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} በማይል</unitPattern>
 				<unitPattern count="other">{0}‰</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="one" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
+				<unitPattern count="other" case="accusative">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="one" case="accusative">{0} mole</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 				<unitPattern count="other" case="accusative">{0} moles</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>ሊ/ኪሜ</displayName>
 				<unitPattern count="one">{0} ሊ/ኪሜ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሊ/ኪሜ</unitPattern>
 				<unitPattern count="other">{0} ሊ/ኪሜ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሊ/ኪሜ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ሊትሮች በ100 ኪሎሜትሮች</displayName>
 				<unitPattern count="one">{0} ሊትር በ100 ኪሎሜትሮች</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሊትር በ100 ኪሎሜትሮች</unitPattern>
 				<unitPattern count="other">{0} ሊትሮች በ100 ኪሎሜትሮች</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሊትሮች በ100 ኪሎሜትሮች</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg</displayName>
@@ -7392,184 +7392,184 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="digital-petabyte">
 				<displayName>ፔታ ባይት</displayName>
 				<unitPattern count="one">{0} ፔታ ባይት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ፔታ ባይት</unitPattern>
 				<unitPattern count="other">{0} ፔታ ባይቶች</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ፔታ ባይቶች</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>ቴራባይት</displayName>
 				<unitPattern count="one">{0} ቴራባይት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ቴራባይት</unitPattern>
 				<unitPattern count="other">{0} ቴራባይት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ቴራባይት</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>ቴራባይትስ</displayName>
 				<unitPattern count="one">{0} ቴባ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ቴባ</unitPattern>
 				<unitPattern count="other">{0} ቴባ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ቴባ</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>ጊባ</displayName>
 				<unitPattern count="one">{0} ጊባ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ጊባ</unitPattern>
 				<unitPattern count="other">{0} ጊባ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ጊባ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>ጊጋባይት</displayName>
 				<unitPattern count="one">{0} ጊጋባይት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ጊጋባይት</unitPattern>
 				<unitPattern count="other">{0} ጊጋባይት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ጊጋባይት</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>ሜጋባይት</displayName>
 				<unitPattern count="one">{0} ሜጋባይት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሜጋባይት</unitPattern>
 				<unitPattern count="other">{0} ሜጋባይት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሜጋባይት</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>ሜባ</displayName>
 				<unitPattern count="one">{0} ሜባ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሜባ</unitPattern>
 				<unitPattern count="other">{0} ሜባ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሜባ</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>ኪባ</displayName>
 				<unitPattern count="one">{0} ኪባ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኪባ</unitPattern>
 				<unitPattern count="other">{0} ኪባ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኪባ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>ኪሎባይት</displayName>
 				<unitPattern count="one">{0} ኪሎባይት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኪሎባይት</unitPattern>
 				<unitPattern count="other">{0} ኪሎባይት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኪሎባይት</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>ባይት</displayName>
 				<unitPattern count="one">{0} ባይት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ባይት</unitPattern>
 				<unitPattern count="other">{0} ባይት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ባይት</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>ቢት</displayName>
 				<unitPattern count="one">{0} ቢት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ቢት</unitPattern>
 				<unitPattern count="other">{0} ቢት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ቢት</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>ምዕተ ዓመት</displayName>
 				<unitPattern count="one">{0} ምዕተ ዓመት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ምዕተ ዓመት</unitPattern>
 				<unitPattern count="other">{0} ምዕተ ዓመት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ምዕተ ዓመት</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<displayName>ዓሠርተ-ዓመት</displayName>
 				<unitPattern count="one">{0} ዓሠርተ-ዓመት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ዓሠርተ-ዓመት</unitPattern>
 				<unitPattern count="other">{0} ዓሠርተ-ዓመታት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ዓሠርተ-ዓመታት</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ዓመታት</displayName>
 				<unitPattern count="one">{0} ዓመት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ዓመት</unitPattern>
 				<unitPattern count="other">{0} ዓመታት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ዓመታት</unitPattern>
 				<perUnitPattern>{0}/ዓ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>ሩቦች</displayName>
 				<unitPattern count="one">{0} ሩ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሩ</unitPattern>
 				<unitPattern count="other">{0} ሩ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሩ</unitPattern>
 				<perUnitPattern>{0}/ሩ</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>ወራት</displayName>
 				<unitPattern count="one">{0} ወር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ወር</unitPattern>
 				<unitPattern count="other">{0} ወራት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ወራት</unitPattern>
 				<perUnitPattern>{0}/ወ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ሳምንታት</displayName>
 				<unitPattern count="one">{0} ሳምንት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሳምንት</unitPattern>
 				<unitPattern count="other">{0} ሳምንታት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሳምንታት</unitPattern>
 				<perUnitPattern>{0}/ሳ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ቀናት</displayName>
 				<unitPattern count="one">{0} ቀናት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ቀናት</unitPattern>
 				<unitPattern count="other">{0} ቀናት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ቀናት</unitPattern>
 				<perUnitPattern>{0}/ቀ</perUnitPattern>
 			</unit>
 			<unit type="duration-day-person">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ቀናት</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ቀናት</unitPattern>
+				<unitPattern count="other">{0} ቀናት</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ቀናት</unitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ሰዓቶች</displayName>
 				<unitPattern count="one">{0} ሰዓት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሰዓት</unitPattern>
 				<unitPattern count="other">{0} ሰዓቶች</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሰዓቶች</unitPattern>
 				<perUnitPattern>{0}/ሰ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>ደቂቃዎች</displayName>
 				<unitPattern count="one">{0} ደቂቃ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ደቂቃ</unitPattern>
 				<unitPattern count="other">{0} ደቂቃዎች</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ደቂቃዎች</unitPattern>
 				<perUnitPattern>{0}/ደ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ሰከንዶች</displayName>
 				<unitPattern count="one">{0} ሰከንድ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሰከንድ</unitPattern>
 				<unitPattern count="other">{0} ሰከንዶች</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሰከንዶች</unitPattern>
 				<perUnitPattern>{0}/ሰከ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ሚሊሰከንድ</displayName>
 				<unitPattern count="one">{0} ሚሊሰከንድ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሚሊሰከንድ</unitPattern>
 				<unitPattern count="other">{0} ሚሊሰከንድ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሚሊሰከንድ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>ማይክሮሰከንድ</displayName>
 				<unitPattern count="one">{0} ማይክሮሰከንድ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ማይክሮሰከንድ</unitPattern>
 				<unitPattern count="other">{0} ማይክሮሰከንድ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ማይክሮሰከንድ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>ናኖሰከንድ</displayName>
 				<unitPattern count="one">{0} ናኖሰከንድ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ናኖሰከንድ</unitPattern>
 				<unitPattern count="other">{0} ናኖሰከንድ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ናኖሰከንድ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amp</displayName>
@@ -7581,9 +7581,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="electric-milliampere">
 				<displayName>mA</displayName>
 				<unitPattern count="one">{0} mA</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mA</unitPattern>
 				<unitPattern count="other">{0} mA</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>ohm</displayName>
@@ -7607,7 +7607,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="energy-calorie">
 				<displayName>cal</displayName>
 				<unitPattern count="one">{0} ካሎሪ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ካሎሪ</unitPattern>
 				<unitPattern count="other">{0} ካሎሪ</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ካሎሪ</unitPattern>
 			</unit>
@@ -7619,23 +7619,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="energy-kilojoule">
 				<displayName>kJ</displayName>
 				<unitPattern count="one">{0} kJ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kJ</unitPattern>
 				<unitPattern count="other">{0} kJ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>joule</displayName>
 				<unitPattern count="one">{0} J</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} J</unitPattern>
 				<unitPattern count="other">{0} J</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kWh</displayName>
 				<unitPattern count="one">{0} kWh</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kWh</unitPattern>
 				<unitPattern count="other">{0} kWh</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>ኤቮ</displayName>
@@ -7643,19 +7643,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ኤቮ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>ኒ</displayName>
@@ -7667,30 +7667,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>ኪሎዋት-ሰዓት በየ 100 ኪሎሜትሮች</displayName>
 				<unitPattern count="one">{0} ኪሎዋት-ሰዓት በየ 100 ኪሎሜትሮች</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኪሎዋት-ሰዓት በየ 100 ኪሎሜትሮች</unitPattern>
 				<unitPattern count="other">{0} ኪሎዋት-ሰዓታት በየ 100 ኪሎሜትሮች</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኪሎዋት-ሰዓታት በየ 100 ኪሎሜትሮች</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>GHz</displayName>
 				<unitPattern count="one">{0} GHz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} GHz</unitPattern>
 				<unitPattern count="other">{0} GHz</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>MHz</displayName>
 				<unitPattern count="one">{0} MHz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} MHz</unitPattern>
 				<unitPattern count="other">{0} MHz</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>kHz</displayName>
 				<unitPattern count="one">{0} kHz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kHz</unitPattern>
 				<unitPattern count="other">{0} kHz</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>Hz</displayName>
@@ -7701,31 +7701,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>ታይፖግራፊክ em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="one" case="accusative">{0} em</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 				<unitPattern count="other" case="accusative">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>ፒክስል</displayName>
 				<unitPattern count="one">{0} ፒክስል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ፒክስል</unitPattern>
 				<unitPattern count="other">{0} ፒክስል</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ፒክስል</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>ሜጋ ፒክስል</displayName>
 				<unitPattern count="one">{0} ሜጋ ፒክስል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሜጋ ፒክስል</unitPattern>
 				<unitPattern count="other">{0} ሜጋ ፒክስል</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሜጋ ፒክስል</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ፒበሴሜ</displayName>
 				<unitPattern count="one">{0} ፒበሴሜ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ፒበሴሜ</unitPattern>
 				<unitPattern count="other">{0} ፒበሴሜ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ፒበሴሜ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ፒበኢ</displayName>
@@ -7748,68 +7748,68 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ነቁጥ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ኪሎሜትር</displayName>
 				<unitPattern count="one">{0} ኪሎሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኪሎሜትር</unitPattern>
 				<unitPattern count="other">{0} ኪሎሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኪሎሜትር</unitPattern>
 				<perUnitPattern>{0}/ኪሜ</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>ሜትር</displayName>
 				<unitPattern count="one">{0} ሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሜትር</unitPattern>
 				<unitPattern count="other">{0} ሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሜትር</unitPattern>
 				<perUnitPattern>{0}/ሜ</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>ዴሲ ሜትር</displayName>
 				<unitPattern count="one">{0} ዴሲ ሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ዴሲ ሜትር</unitPattern>
 				<unitPattern count="other">{0} ዴሲ ሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ዴሲ ሜትር</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>ሴንቲሜትር</displayName>
 				<unitPattern count="one">{0} ሴንቲሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሴንቲሜትር</unitPattern>
 				<unitPattern count="other">{0} ሴንቲሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሴንቲሜትር</unitPattern>
 				<perUnitPattern>{0}/ሴሜ</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>ሚሊሜትር</displayName>
 				<unitPattern count="one">{0} ሚሊሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሚሊሜትር</unitPattern>
 				<unitPattern count="other">{0} ሚሊሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሚሊሜትር</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>ማይክሮ ሜትር</displayName>
 				<unitPattern count="one">{0} ማይክሮ ሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ማይክሮ ሜትር</unitPattern>
 				<unitPattern count="other">{0} ማይክሮ ሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ማይክሮ ሜትር</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>ናኖ ሜትር</displayName>
 				<unitPattern count="one">{0} ናኖ ሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ናኖ ሜትር</unitPattern>
 				<unitPattern count="other">{0} ናኖ ሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ናኖ ሜትር</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>ፒኮሜትር</displayName>
 				<unitPattern count="one">{0} ፒኮሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ፒኮሜትር</unitPattern>
 				<unitPattern count="other">{0} ፒኮሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ፒኮሜትር</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>ማይል</displayName>
@@ -7866,9 +7866,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-mile-scandinavian">
 				<displayName>ስማይል</displayName>
 				<unitPattern count="one">{0} ስማይል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ስማይል</unitPattern>
 				<unitPattern count="other">{0} ስማይል</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ስማይል</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>ነጥብ</displayName>
@@ -7890,21 +7890,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="light-candela">
 				<displayName>ካንዴላ</displayName>
 				<unitPattern count="one">{0} ካንዴላ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ካንዴላ</unitPattern>
 				<unitPattern count="other">{0} ካንዴላ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ካንዴላ</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>ቱቦ ቀዳዳ</displayName>
 				<unitPattern count="one">{0} ቱቦ ቀዳዳ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ቱቦ ቀዳዳ</unitPattern>
 				<unitPattern count="other">{0} ቱቦ ቀዳዳ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ቱቦ ቀዳዳ</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -7916,25 +7916,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="mass-kilogram">
 				<displayName>ኪሎግራም</displayName>
 				<unitPattern count="one">{0} ኪሎግራም</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኪሎግራም</unitPattern>
 				<unitPattern count="other">{0} ኪሎግራም</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኪሎግራም</unitPattern>
 				<perUnitPattern>{0}/ኪሎግራም</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>ግራም</displayName>
 				<unitPattern count="one">{0} ግራም</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ግራም</unitPattern>
 				<unitPattern count="other">{0} ግራም</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ግራም</unitPattern>
 				<perUnitPattern>{0}/ግራም</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>mg</displayName>
 				<unitPattern count="one">{0} mg</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mg</unitPattern>
 				<unitPattern count="other">{0} mg</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>μg</displayName>
@@ -8000,37 +8000,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-gigawatt">
 				<displayName>GW</displayName>
 				<unitPattern count="one">{0} GW</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} GW</unitPattern>
 				<unitPattern count="other">{0} GW</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>MW</displayName>
 				<unitPattern count="one">{0} MW</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} MW</unitPattern>
 				<unitPattern count="other">{0} MW</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>ኪሎዋት</displayName>
 				<unitPattern count="one">{0} ኪሎዋት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኪሎዋት</unitPattern>
 				<unitPattern count="other">{0} ኪሎዋት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኪሎዋት</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>ዋት</displayName>
 				<unitPattern count="one">{0} ዋት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ዋት</unitPattern>
 				<unitPattern count="other">{0} ዋት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ዋት</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>mW</displayName>
 				<unitPattern count="one">{0} mW</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mW</unitPattern>
 				<unitPattern count="other">{0} mW</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>የፈረስ ጉልበት</displayName>
@@ -8055,65 +8055,65 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-bar">
 				<displayName>አሞሌ</displayName>
 				<unitPattern count="one">{0} አሞሌ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} አሞሌ</unitPattern>
 				<unitPattern count="other">{0} አሞሌዎች</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} አሞሌዎች</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>ሚሊባር</displayName>
 				<unitPattern count="one">{0} ሚሊባር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሚሊባር</unitPattern>
 				<unitPattern count="other">{0} ሚሊባር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሚሊባር</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>ከባቢ አየር</displayName>
 				<unitPattern count="one">{0} ከባቢ አየር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ከባቢ አየር</unitPattern>
 				<unitPattern count="other">{0} ከባቢ አየር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ከባቢ አየር</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>ፓስካል</displayName>
 				<unitPattern count="one">{0} ፓስካል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ፓስካል</unitPattern>
 				<unitPattern count="other">{0} ፓስካል</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ፓስካል</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>ሄክቶፓስካል</displayName>
 				<unitPattern count="one">{0} ሄክቶፓስካል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሄክቶፓስካል</unitPattern>
 				<unitPattern count="other">{0} ሄክቶፓስካል</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሄክቶፓስካል</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ኪሎፓስካል</displayName>
 				<unitPattern count="one">{0} ኪሎፓስካል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኪሎፓስካል</unitPattern>
 				<unitPattern count="other">{0} ኪሎፓስካል</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኪሎፓስካል</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>ሜጋፓስካል</displayName>
 				<unitPattern count="one">{0} ሜጋፓስካል</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሜጋፓስካል</unitPattern>
 				<unitPattern count="other">{0} ሜጋፓስካሎች</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሜጋፓስካሎች</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ኪሎሜትር በሰዓት</displayName>
 				<unitPattern count="one">{0} ኪሎሜትር በሰዓት</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኪሎሜትር በሰዓት</unitPattern>
 				<unitPattern count="other">{0} ኪሎሜትር በሰዓት</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኪሎሜትር በሰዓት</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>ሜትር በሰከንድ</displayName>
 				<unitPattern count="one">{0} ሜትር በሰከንድ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሜትር በሰከንድ</unitPattern>
 				<unitPattern count="other">{0} ሜትር በሰከንድ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሜትር በሰከንድ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>ማይል በሰዓት</displayName>
@@ -8128,16 +8128,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>ዲግሪ ሴልሺየስ</displayName>
 				<unitPattern count="one">{0} ዲግሪ ሴልሺየስ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ዲግሪ ሴልሺየስ</unitPattern>
 				<unitPattern count="other">{0} ዲግሪ ሴልሺየስ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ዲግሪ ሴልሺየስ</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>ዲግሪ ፋራንሃይት</displayName>
@@ -8152,38 +8152,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="accusative">{0} ኬልቪኖች</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>ኒ.ሜ</displayName>
 				<unitPattern count="one">{0} ኒ.ሜ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኒ.ሜ</unitPattern>
 				<unitPattern count="other">{0} ኒ.ሜ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኒ.ሜ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>ኩቢክ ኪሎሜትር</displayName>
 				<unitPattern count="one">{0} ኩቢክ ኪሎሜትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ኩቢክ ኪሎሜትር</unitPattern>
 				<unitPattern count="other">{0} ኩቢክ ኪሎሜትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ኩቢክ ኪሎሜትር</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>ሜ³</displayName>
 				<unitPattern count="one">{0} ሜ³</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሜ³</unitPattern>
 				<unitPattern count="other">{0} ሜ³</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሜ³</unitPattern>
 				<perUnitPattern>{0}/ሜ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>ሴሜ³</displayName>
 				<unitPattern count="one">{0} ሴሜ³</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሴሜ³</unitPattern>
 				<unitPattern count="other">{0} ሴሜ³</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሴሜ³</unitPattern>
 				<perUnitPattern>{0}/ሴሜ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -8223,31 +8223,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-liter">
 				<displayName>ሊትር</displayName>
 				<unitPattern count="one">{0} ሊትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሊትር</unitPattern>
 				<unitPattern count="other">{0} ሊትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሊትር</unitPattern>
 				<perUnitPattern>{0}/ሊትር</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>ዴሲ ሊትር</displayName>
 				<unitPattern count="one">{0} ዴሲ ሊትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ዴሲ ሊትር</unitPattern>
 				<unitPattern count="other">{0} ዴሲ ሊትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ዴሲ ሊትር</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>ሴንቲ ሊትር</displayName>
 				<unitPattern count="one">{0} ሴንቲ ሊትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሴንቲ ሊትር</unitPattern>
 				<unitPattern count="other">{0} ሴንቲ ሊትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሴንቲ ሊትር</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>ሚሊ ሊትር</displayName>
 				<unitPattern count="one">{0} ሚሊ ሊትር</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ሚሊ ሊትር</unitPattern>
 				<unitPattern count="other">{0} ሚሊ ሊትር</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ሚሊ ሊትር</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>mpt</displayName>
@@ -8458,12 +8458,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8596,12 +8596,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -8809,17 +8809,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
@@ -8829,7 +8829,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -8854,7 +8854,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -8894,7 +8894,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9004,7 +9004,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>ሶላር ራዲ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9024,7 +9024,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9088,17 +9088,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ዳተንስ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>ኤርዝማስስ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>ሶላር ማስስ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -9228,7 +9228,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -9358,7 +9358,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -9463,22 +9463,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>ሜ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>{0} ኪቢ</unitPrefixPattern>
@@ -9496,39 +9496,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>{0} ፔቢ</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
 				<unitPrefixPattern>{0} ዜቢ</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>ጂ-ኃይል</displayName>
 				<unitPattern count="one">{0} ጂ</unitPattern>
 				<unitPattern count="other">{0} ጂ</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ሜ/ሰ²</displayName>
+				<unitPattern count="one">{0} ሜ/ሰ²</unitPattern>
+				<unitPattern count="other">{0} ሜ/ሰ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>ኡደ</displayName>
@@ -9541,99 +9541,99 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ራዲ</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>ዲግሪ</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>ደቂቃ</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሰከንድ</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ካሬ ኪሎሜትር</displayName>
 				<unitPattern count="one">{0} ኪሜ²</unitPattern>
 				<unitPattern count="other">{0} ኪሜ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ኪሜ²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሄክታር</displayName>
 				<unitPattern count="one">{0} ሄክታር</unitPattern>
 				<unitPattern count="other">{0} ሄክታር</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ካሬ ሜትር</displayName>
 				<unitPattern count="one">{0} ሜ²</unitPattern>
 				<unitPattern count="other">{0} ሜ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ሜ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ሴሜ²</displayName>
+				<unitPattern count="one">{0} ሴሜ²</unitPattern>
+				<unitPattern count="other">{0} ሴሜ²</unitPattern>
+				<perUnitPattern>{0}/ሴሜ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ካሬ ማይል</displayName>
 				<unitPattern count="one">{0} ማይል²</unitPattern>
 				<unitPattern count="other">{0} ማይል²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ማይል²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ኤክር</displayName>
 				<unitPattern count="one">{0} ኤክር</unitPattern>
 				<unitPattern count="other">{0} ኤክር</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ካሬ ጫማ</displayName>
 				<unitPattern count="one">{0} ጫማ²</unitPattern>
 				<unitPattern count="other">{0} ጫማ²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ኢንች²</displayName>
+				<unitPattern count="one">{0} ኢንች²</unitPattern>
+				<unitPattern count="other">{0} ኢንች²</unitPattern>
+				<perUnitPattern>{0}/ኢንች²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ጋሻዎች</displayName>
+				<unitPattern count="one">{0} ጋሻ</unitPattern>
+				<unitPattern count="other">{0} ጋሻ</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ካራት</displayName>
+				<unitPattern count="one">{0} ካራት</unitPattern>
+				<unitPattern count="other">{0} ካራት</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>ንጥል</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ንጥል</unitPattern>
+				<unitPattern count="other">{0} ንጥል</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9641,24 +9641,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>በማይል</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ሊ/ኪሜ</displayName>
+				<unitPattern count="one">{0} ሊ/ኪሜ</unitPattern>
+				<unitPattern count="other">{0} ሊ/ኪሜ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ሊትር በ100 ኪሎሜትሮች</displayName>
@@ -9666,127 +9666,127 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ሊበ100ኪሜ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="one">{0} mpg Imp.</unitPattern>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>ፔባ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ፔባ</unitPattern>
+				<unitPattern count="other">{0} ፔባ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>ቴባይት</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ቴራባይት</unitPattern>
+				<unitPattern count="other">{0} ቴራባይት</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ቴባ</displayName>
+				<unitPattern count="one">{0} ቴባ</unitPattern>
+				<unitPattern count="other">{0} ቴባ</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ጊባ</displayName>
+				<unitPattern count="one">{0} ጊባ</unitPattern>
+				<unitPattern count="other">{0} ጊባ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ጊጋባይት</displayName>
+				<unitPattern count="one">{0} ጊጋባይት</unitPattern>
+				<unitPattern count="other">{0} ጊጋባይት</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ሜጋባይት</displayName>
+				<unitPattern count="one">{0} ሜጋባይት</unitPattern>
+				<unitPattern count="other">{0} ሜጋባይት</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ሜባ</displayName>
+				<unitPattern count="one">{0} ሜባ</unitPattern>
+				<unitPattern count="other">{0} ሜባ</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ኪባ</displayName>
+				<unitPattern count="one">{0} ኪባ</unitPattern>
+				<unitPattern count="other">{0} ኪባ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ኪሎባይት</displayName>
+				<unitPattern count="one">{0} ኪሎባይት</unitPattern>
+				<unitPattern count="other">{0} ኪሎባይት</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ባይት</displayName>
+				<unitPattern count="one">{0} ባይት</unitPattern>
+				<unitPattern count="other">{0} ባይት</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ቢት</displayName>
+				<unitPattern count="one">{0} ቢት</unitPattern>
+				<unitPattern count="other">{0} ቢት</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>ምዕተ ዓመት</displayName>
 				<unitPattern count="one">{0}ም.ዓ</unitPattern>
 				<unitPattern count="other">{0}ም.ዓ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ዓሠርተ-ዓመት</displayName>
+				<unitPattern count="one">{0} ዓሠ.ዓ</unitPattern>
+				<unitPattern count="other">{0} ዓሠ.ዓ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ዓመታት</displayName>
 				<unitPattern count="one">{0} ዓመት</unitPattern>
 				<unitPattern count="other">{0} ዓ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ዓ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሩብ</displayName>
 				<unitPattern count="one">{0} ሩብ</unitPattern>
 				<unitPattern count="other">{0} ሩ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ሩ</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>ወራት</displayName>
 				<unitPattern count="one">{0} ወር</unitPattern>
 				<unitPattern count="other">{0} ወር</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ወ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ሳምንታት</displayName>
 				<unitPattern count="one">{0} ሳምንት</unitPattern>
 				<unitPattern count="other">{0} ሳምንት</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ሳ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ቀናት</displayName>
 				<unitPattern count="one">{0} ቀ</unitPattern>
 				<unitPattern count="other">{0} ቀ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ቀ</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ሰዓቶች</displayName>
 				<unitPattern count="one">{0} ሰ</unitPattern>
 				<unitPattern count="other">{0} ሰ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ሰ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>ደቂቃዎች</displayName>
 				<unitPattern count="one">{0} ደ</unitPattern>
 				<unitPattern count="other">{0} ደ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ደ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ሰከንድ</displayName>
 				<unitPattern count="one">{0} ሰ</unitPattern>
 				<unitPattern count="other">{0} ሰ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ሰከ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ሚሊሰከንድ</displayName>
@@ -9794,39 +9794,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ሚሴ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ማይክሮሰከንድ</displayName>
+				<unitPattern count="one">{0} ማሰ</unitPattern>
+				<unitPattern count="other">{0} ማሰ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ናኖሰከንድ</displayName>
+				<unitPattern count="one">{0} ናኖሰከንድ</unitPattern>
+				<unitPattern count="other">{0} ናኖሰከንድ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>ካሎሪ</displayName>
@@ -9839,69 +9839,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ካሎሪ</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joule</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ኤቮ</displayName>
+				<unitPattern count="one">{0} ኤቮ</unitPattern>
+				<unitPattern count="other">{0} ኤቮ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ኒ</displayName>
+				<unitPattern count="one">{0} ኒ</unitPattern>
+				<unitPattern count="other">{0} ኒ</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
@@ -9909,67 +9909,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ፒክስል</displayName>
+				<unitPattern count="one">{0} ፒክስል</unitPattern>
+				<unitPattern count="other">{0} ፒክስል</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሜጋ ፒክስል</displayName>
 				<unitPattern count="one">{0} ሜፒ</unitPattern>
 				<unitPattern count="other">{0} ሜፒ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ፒበሴሜ</displayName>
+				<unitPattern count="one">{0} ፒበሴሜ</unitPattern>
+				<unitPattern count="other">{0} ፒበሴሜ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ፒበኢ</displayName>
+				<unitPattern count="one">{0} ፒበኢ</unitPattern>
+				<unitPattern count="other">{0} ፒበኢ</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ነበሴሜ</displayName>
+				<unitPattern count="one">{0} ነበሴሜ</unitPattern>
+				<unitPattern count="other">{0} ነበሴሜ</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ነበኢ</displayName>
+				<unitPattern count="one">{0} ነበኢ</unitPattern>
+				<unitPattern count="other">{0} ነበኢ</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ነቁጥ</displayName>
+				<unitPattern count="one">{0} ነቁጥ</unitPattern>
+				<unitPattern count="other">{0} ነቁጥ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ኪሎሜትር</displayName>
 				<unitPattern count="one">{0} ኪሜ</unitPattern>
 				<unitPattern count="other">{0} ኪሜ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ኪሜ</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>ሜትር</displayName>
 				<unitPattern count="one">{0} ሜ</unitPattern>
 				<unitPattern count="other">{0} ሜ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ሜ</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ዴሜ</displayName>
+				<unitPattern count="one">{0} ዴሜ</unitPattern>
+				<unitPattern count="other">{0} ዴሜ</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>ሴንቲሜትር</displayName>
 				<unitPattern count="one">{0} ሴሜ</unitPattern>
 				<unitPattern count="other">{0} ሴሜ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ሴሜ</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>ሚሊሜትር</displayName>
@@ -9977,66 +9977,66 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ሚሜ</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ማሜ</displayName>
+				<unitPattern count="one">{0} ማሜ</unitPattern>
+				<unitPattern count="other">{0} ማሜ</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ናሜ</displayName>
+				<unitPattern count="one">{0} ናሜ</unitPattern>
+				<unitPattern count="other">{0} ናሜ</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ፒኮሜትር</displayName>
 				<unitPattern count="one">{0} ፒሜ</unitPattern>
 				<unitPattern count="other">{0} ፒሜ</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ማይል</displayName>
 				<unitPattern count="one">{0} ማይል</unitPattern>
 				<unitPattern count="other">{0} ማይል</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>ያርድ</displayName>
 				<unitPattern count="one">{0} ያርድ</unitPattern>
 				<unitPattern count="other">{0} ያርድ</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ጫማ</displayName>
 				<unitPattern count="one">{0} ጫማ</unitPattern>
 				<unitPattern count="other">{0} ጫማ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ጫማ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ኢንች</displayName>
 				<unitPattern count="one">{0} ኢንች</unitPattern>
 				<unitPattern count="other">{0} ኢንች</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ኢንች</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>የብርሃን ዓመት</displayName>
+				<unitPattern count="one">{0} ብዓ</unitPattern>
+				<unitPattern count="other">{0} ብዓ</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ፈሎን</displayName>
+				<unitPattern count="one">{0} ፈሎን</unitPattern>
+				<unitPattern count="other">{0} ፈሎን</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ተዳክሞዎች</displayName>
+				<unitPattern count="one">{0} ተዳክሞ</unitPattern>
+				<unitPattern count="other">{0} ተዳክሞ</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>ማይለባህር</displayName>
@@ -10044,19 +10044,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ማይለባህር</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ስማይል</displayName>
+				<unitPattern count="one">{0} ስማይል</unitPattern>
+				<unitPattern count="other">{0} ስማይል</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ነጥብ</displayName>
+				<unitPattern count="one">{0} ነጥብ</unitPattern>
+				<unitPattern count="other">{0} ነጥብ</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ሶላር ራዲ</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lux</displayName>
@@ -10064,19 +10064,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ካንዴላ</displayName>
+				<unitPattern count="one">{0} ካንዴላ</unitPattern>
+				<unitPattern count="other">{0} ካንዴላ</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ቱቦ ቀዳዳ</displayName>
+				<unitPattern count="one">{0} ቱቦ ቀዳዳ</unitPattern>
+				<unitPattern count="other">{0} ቱቦ ቀዳዳ</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>ቶ</displayName>
@@ -10087,13 +10087,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ኪሎግራም</displayName>
 				<unitPattern count="one">{0} ኪግ</unitPattern>
 				<unitPattern count="other">{0} ኪግ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ኪሎግራም</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>ግራም</displayName>
 				<unitPattern count="one">{0} ግ</unitPattern>
 				<unitPattern count="other">{0} ግ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ግራም</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>ሚሊግራም</displayName>
@@ -10101,139 +10101,139 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ሚሊግራም</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ቶን</displayName>
+				<unitPattern count="one">{0} ቶን</unitPattern>
+				<unitPattern count="other">{0} ቶን</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ድንጋይ</displayName>
+				<unitPattern count="one">{0} ድንጋይ</unitPattern>
+				<unitPattern count="other">{0} ድንጋይ</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>ፓውንድ</displayName>
 				<unitPattern count="one">{0} ፓውንድ</unitPattern>
 				<unitPattern count="other">{0} ፓውንድ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ፓውንድ</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>አውንስ</displayName>
 				<unitPattern count="one">{0} አውንስ</unitPattern>
 				<unitPattern count="other">{0} አውንስ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/አውንስ</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>ካራት</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ዳተንስ</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ኤርዝማስስ</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ሶላር ማስስ</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ጥራ ጥሬ</displayName>
+				<unitPattern count="one">{0} ጥራ ጥሬ</unitPattern>
+				<unitPattern count="other">{0} ጥራ ጥሬ</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ኪሎዋት</displayName>
 				<unitPattern count="one">{0} ኪዋ</unitPattern>
 				<unitPattern count="other">{0} ኪዋ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ዋት</displayName>
 				<unitPattern count="one">{0} ዋ</unitPattern>
 				<unitPattern count="other">{0} ዋ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>የፈረስ ጉልበት</displayName>
 				<unitPattern count="one">{0} የፈረስ ኃይል</unitPattern>
 				<unitPattern count="other">{0} የፈረስ ኃይል</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="one">{0} mm Hg</unitPattern>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>ኢንች ሜርኩሪ</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>አሞሌ</displayName>
+				<unitPattern count="one">{0} አሞሌ</unitPattern>
+				<unitPattern count="other">{0} አሞሌዎች</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሚሊባር</displayName>
 				<unitPattern count="one">{0} ሚባ</unitPattern>
 				<unitPattern count="other">{0} ሚባ</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>ከባቢ አየር</displayName>
 				<unitPattern count="one">{0} ከአ</unitPattern>
 				<unitPattern count="other">{0} ከአ</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ፓስካል</displayName>
+				<unitPattern count="one">{0} ፓስካል</unitPattern>
+				<unitPattern count="other">{0} ፓስካል</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሄክቶፓስካል</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>ኪሎፓስካል</displayName>
 				<unitPattern count="one">{0} ኪፓ</unitPattern>
 				<unitPattern count="other">{0} ኪፓ</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሜጋፓስካል</displayName>
 				<unitPattern count="one">{0} ሜፓ</unitPattern>
 				<unitPattern count="other">{0} ሜፓ</unitPattern>
 			</unit>
@@ -10243,24 +10243,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ኪሜ/ሰ</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሜትር በሰከንድ</displayName>
 				<unitPattern count="one">{0} ሜ/ሴ</unitPattern>
 				<unitPattern count="other">{0} ሜ/ሴ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>ማይል በሰዓት</displayName>
 				<unitPattern count="one">{0} ማይል/ሰ</unitPattern>
 				<unitPattern count="other">{0} ማይል/ሰ</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>ዲግሪ ሴልሺየስ</displayName>
@@ -10268,7 +10268,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ዲግሪ ፋራንሃይት</displayName>
 				<unitPattern count="one">{0}°ፋ</unitPattern>
 				<unitPattern count="other">{0}°ፋ</unitPattern>
 			</unit>
@@ -10278,51 +10278,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ኬ</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ኒ.ሜ</displayName>
+				<unitPattern count="one">{0} ኒ.ሜ</unitPattern>
+				<unitPattern count="other">{0} ኒ.ሜ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ኩቢክ ኪሎሜትር</displayName>
 				<unitPattern count="one">{0} ኪሜ³</unitPattern>
 				<unitPattern count="other">{0} ኪሜ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ሜ³</displayName>
+				<unitPattern count="one">{0} ሜ³</unitPattern>
+				<unitPattern count="other">{0} ሜ³</unitPattern>
+				<perUnitPattern>{0}/ሜ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ሴሜ³</displayName>
+				<unitPattern count="one">{0} ሴሜ³</unitPattern>
+				<unitPattern count="other">{0} ሴሜ³</unitPattern>
+				<perUnitPattern>{0}/ሴሜ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ኩቢክ ማይል</displayName>
 				<unitPattern count="one">{0} ማይል³</unitPattern>
 				<unitPattern count="other">{0} ማይል³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ጫማ³</displayName>
+				<unitPattern count="one">{0} ጫማ³</unitPattern>
+				<unitPattern count="other">{0} ጫማ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ኢንች³</displayName>
+				<unitPattern count="one">{0} ኢንች³</unitPattern>
+				<unitPattern count="other">{0} ኢንች³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>ሜጋሊትር</displayName>
@@ -10330,28 +10330,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ሜጋሊትር</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ሊትር</displayName>
 				<unitPattern count="one">{0} ሊ</unitPattern>
 				<unitPattern count="other">{0} ሊ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ሊትር</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ዴሊ</displayName>
+				<unitPattern count="one">{0} ዴሊ</unitPattern>
+				<unitPattern count="other">{0} ዴሊ</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ሴሊ</displayName>
+				<unitPattern count="one">{0} ሴሊ</unitPattern>
+				<unitPattern count="other">{0} ሴሊ</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሚሊ ሊትር</displayName>
 				<unitPattern count="one">{0} ሚሊ</unitPattern>
 				<unitPattern count="other">{0} ሚሊ</unitPattern>
 			</unit>
@@ -10361,41 +10361,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ኤከር ጫማ</displayName>
 				<unitPattern count="one">{0} ኤጫ</unitPattern>
 				<unitPattern count="other">{0} ኤጫ</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ዳውላ</displayName>
+				<unitPattern count="one">{0} ዳውላ</unitPattern>
+				<unitPattern count="other">{0} ዳውላ</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="one">{0} gal Imp.</unitPattern>
+				<unitPattern count="other">{0} gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>ኩባያ</displayName>
@@ -10403,62 +10403,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ኩባያ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>በርሜል</displayName>
+				<unitPattern count="one">{0} በርሜል</unitPattern>
+				<unitPattern count="other">{0} በርሜል</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>የመምድረ በዳ ማንኪያ</displayName>
+				<unitPattern count="one">{0} የመምድረ በዳ ማንኪያ</unitPattern>
+				<unitPattern count="other">{0} የመምድረ በዳ ማንኪያ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>የምድረ በዳ ማንኪያ</displayName>
+				<unitPattern count="one">{0} የምድረ በዳ ማንኪያ</unitPattern>
+				<unitPattern count="other">{0} የምድረ በዳ ማንኪያ</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ጠብታ</displayName>
+				<unitPattern count="one">{0} ጠብታ</unitPattern>
+				<unitPattern count="other">{0} ጠብታ</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>የክብደት መለኪያ</displayName>
 				<unitPattern count="one">{0} ክመ</unitPattern>
 				<unitPattern count="other">{0} ክመ</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ሙጃሌ</displayName>
+				<unitPattern count="one">{0} ሙጃሌ</unitPattern>
+				<unitPattern count="other">{0} ሙጃሌ</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ቁንጥ</displayName>
+				<unitPattern count="one">{0} ቁንጥ</unitPattern>
+				<unitPattern count="other">{0} ቁንጥ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>የፈሳሽ መለኪያ</displayName>
 				<unitPattern count="one">{0} ፈመ</unitPattern>
 				<unitPattern count="other">{0} ፈመ</unitPattern>
 			</unit>
@@ -10494,22 +10494,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ወይም {1}﻿</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="middle">{0}፣ {1}</listPatternPart>
 			<listPatternPart type="end">{0}፣ ወይም {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} ወይም {1}﻿</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="middle">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="end">{0}፣ ወይም {1}</listPatternPart>
+			<listPatternPart type="2">{0} ወይም {1}﻿</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="middle">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="end">{0}, እና {1}</listPatternPart>
+			<listPatternPart type="2">{0} እና {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}፣ {1}</listPatternPart>
@@ -10723,127 +10723,127 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">ዜንዳያ</nameField>

--- a/common/main/an.xml
+++ b/common/main/an.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -682,7 +682,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
 							<month type="1" draft="unconfirmed">chi.</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
+							<month type="2" draft="unconfirmed">feb.</month>
 							<month type="3" draft="unconfirmed">mar.</month>
 							<month type="4" draft="unconfirmed">abr.</month>
 							<month type="5" draft="unconfirmed">may.</month>
@@ -745,13 +745,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat" draft="unconfirmed">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">dom</day>
+							<day type="mon" draft="unconfirmed">lun</day>
+							<day type="tue" draft="unconfirmed">mar</day>
+							<day type="wed" draft="unconfirmed">mie</day>
+							<day type="thu" draft="unconfirmed">chu</day>
+							<day type="fri" draft="unconfirmed">vie</day>
+							<day type="sat" draft="unconfirmed">sab</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun" draft="unconfirmed">dominche</day>
@@ -783,13 +783,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat" draft="unconfirmed">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">dom</day>
+							<day type="mon" draft="unconfirmed">lun</day>
+							<day type="tue" draft="unconfirmed">mar</day>
+							<day type="wed" draft="unconfirmed">mie</day>
+							<day type="thu" draft="unconfirmed">chu</day>
+							<day type="fri" draft="unconfirmed">vie</day>
+							<day type="sat" draft="unconfirmed">sab</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun" draft="unconfirmed">dominche</day>
@@ -876,10 +876,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</dayPeriods>
 				<eras>
 					<eraNames>
-						<era type="0" draft="unconfirmed">↑↑↑</era>
-						<era type="0" alt="variant" draft="unconfirmed">↑↑↑</era>
-						<era type="1" draft="unconfirmed">↑↑↑</era>
-						<era type="1" alt="variant" draft="unconfirmed">↑↑↑</era>
+						<era type="0" draft="unconfirmed">a.C.</era>
+						<era type="0" alt="variant" draft="unconfirmed">AEC</era>
+						<era type="1" draft="unconfirmed">d.C.</era>
+						<era type="1" alt="variant" draft="unconfirmed">EC</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="unconfirmed">a.C.</era>
@@ -1453,8 +1453,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MYR">
 				<displayName draft="unconfirmed">ringgit de Malasia</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
-				<displayName count="other" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">ringgit de Malasia</displayName>
+				<displayName count="other" draft="unconfirmed">ringgit de Malasia</displayName>
 			</currency>
 			<currency type="PHP">
 				<displayName draft="unconfirmed">piso filipino</displayName>
@@ -1476,7 +1476,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="THB">
 				<displayName draft="unconfirmed">baht tailandés</displayName>
 				<displayName count="one" draft="unconfirmed">baht tailandés</displayName>
-				<displayName count="other" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="other" draft="unconfirmed">baht tailandés</displayName>
 			</currency>
 			<currency type="USD">
 				<displayName draft="unconfirmed">dolar d’os Estaus Unius</displayName>
@@ -1509,7 +1509,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern draft="unconfirmed">{0} per {1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="angle-revolution">
 				<displayName draft="unconfirmed">revolución</displayName>
@@ -1641,17 +1641,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<unit type="angle-revolution">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} rev</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} rad</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName draft="unconfirmed">º</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}°</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
@@ -1666,27 +1666,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-karat">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kt</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}%</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}‰</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}‱</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName draft="unconfirmed">J</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} J</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
@@ -1702,44 +1702,44 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kg</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName draft="unconfirmed">g</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} g</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} tn</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} M⊕</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} M☉</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName draft="unconfirmed">W</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} W</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} hp</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}°C</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -1752,15 +1752,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="concentr-percent">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">%</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}%</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}%</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName draft="unconfirmed">cm</displayName>
@@ -1768,24 +1768,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} cm</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">kg</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} kg</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} kg</unitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName draft="unconfirmed">g</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} g</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} g</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">°C</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}°C</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}°C</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName draft="unconfirmed">punto</displayName>
-				<coordinateUnitPattern type="north" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="north" draft="unconfirmed">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south" draft="unconfirmed">{0}S</coordinateUnitPattern>
 				<coordinateUnitPattern type="west" draft="unconfirmed">{0}U</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
@@ -1813,34 +1813,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0} u {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} u {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} u {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} u {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} u {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} y {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} y {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} y {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} y {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} y {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} y {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
 			<listPatternPart type="start" draft="unconfirmed">{0} {1}</listPatternPart>
@@ -1849,10 +1849,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0} {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} y {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} y {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -109,7 +109,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">الشايان</language>
 			<language type="ckb">السورانية الكردية</language>
 			<language type="ckb" alt="menu">الكردية، السورانية</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">السورانية الكردية</language>
 			<language type="clc">تسيلكوتين</language>
 			<language type="co">الكورسيكية</language>
 			<language type="cop">القبطية</language>
@@ -592,9 +592,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="zh">الصينية</language>
 			<language type="zh" alt="menu">الصينية</language>
 			<language type="zh_Hans">الصينية المبسطة</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">الصينية المبسطة</language>
 			<language type="zh_Hant">الصينية التقليدية</language>
-			<language type="zh_Hant" alt="long">↑↑↑</language>
+			<language type="zh_Hant" alt="long">الصينية التقليدية</language>
 			<language type="zu">الزولو</language>
 			<language type="zun">الزونية</language>
 			<language type="zxx">بدون محتوى لغوي</language>
@@ -949,7 +949,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">ناورو</territory>
 			<territory type="NU">نيوي</territory>
 			<territory type="NZ">نيوزيلندا</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">نيوزيلندا</territory>
 			<territory type="OM">عُمان</territory>
 			<territory type="PA">بنما</territory>
 			<territory type="PE">بيرو</territory>
@@ -1009,7 +1009,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">تونس</territory>
 			<territory type="TO">تونغا</territory>
 			<territory type="TR">تركيا</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">تركيا</territory>
 			<territory type="TT">ترينيداد وتوباغو</territory>
 			<territory type="TV">توفالو</territory>
 			<territory type="TW">تايوان</territory>
@@ -1445,7 +1445,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}، {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}، {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1453,7 +1453,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2823,9 +2823,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>السنة</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">السنة الماضية</relative>
+				<relative type="0">السنة الحالية</relative>
+				<relative type="1">السنة القادمة</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">خلال {0} سنة</relativeTimePattern>
 					<relativeTimePattern count="one">خلال سنة واحدة</relativeTimePattern>
@@ -2845,9 +2845,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>السنة</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">السنة الماضية</relative>
+				<relative type="0">السنة الحالية</relative>
+				<relative type="1">السنة القادمة</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">خلال {0} سنة</relativeTimePattern>
 					<relativeTimePattern count="one">خلال سنة واحدة</relativeTimePattern>
@@ -2955,9 +2955,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>الشهر</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">الشهر الماضي</relative>
+				<relative type="0">هذا الشهر</relative>
+				<relative type="1">الشهر القادم</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">خلال {0} شهر</relativeTimePattern>
 					<relativeTimePattern count="one">خلال شهر واحد</relativeTimePattern>
@@ -2977,9 +2977,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>الشهر</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">الشهر الماضي</relative>
+				<relative type="0">هذا الشهر</relative>
+				<relative type="1">الشهر القادم</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">خلال {0} شهر</relativeTimePattern>
 					<relativeTimePattern count="one">خلال شهر واحد</relativeTimePattern>
@@ -3022,9 +3022,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>الأسبوع</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">الأسبوع الماضي</relative>
+				<relative type="0">هذا الأسبوع</relative>
+				<relative type="1">الأسبوع القادم</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">خلال {0} أسبوع</relativeTimePattern>
 					<relativeTimePattern count="one">خلال أسبوع واحد</relativeTimePattern>
@@ -3045,9 +3045,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>الأسبوع</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">الأسبوع الماضي</relative>
+				<relative type="0">هذا الأسبوع</relative>
+				<relative type="1">الأسبوع القادم</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">خلال {0} أسبوع</relativeTimePattern>
 					<relativeTimePattern count="one">خلال أسبوع واحد</relativeTimePattern>
@@ -6309,7 +6309,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="10000" count="few">00 ألف ¤</pattern>
 					<pattern type="10000" count="many">00 ألف ¤</pattern>
 					<pattern type="10000" count="other">00 ألف ¤</pattern>
-					<pattern type="100000" count="zero">↑↑↑</pattern>
+					<pattern type="100000" count="zero">000 ألف ¤</pattern>
 					<pattern type="100000" count="one">000 ألف ¤</pattern>
 					<pattern type="100000" count="two">000 ألف ¤</pattern>
 					<pattern type="100000" count="few">000 ألف ¤</pattern>
@@ -8779,7 +8779,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="two">{0} مربّعان</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="feminine">{0} مربّعتان</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">{0} مربّعة</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">{0} مربّعة</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">{0} مربّعًا</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine">{0} مربّعة</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0} مربّع</compoundUnitPattern1>
@@ -8793,14 +8793,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="two">{0} مكعّبان</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="feminine">{0} مكعّبتان</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">{0} مكعّبة</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">{0} مكعّبة</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">{0} مكعبًا</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine">{0} مكعّبة</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0} مكعّب</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine">{0} مكعّبة</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>feminine</gender>
@@ -8857,7 +8857,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>دقيقة قوسية</displayName>
 				<unitPattern count="zero">{0} دقيقة قوسية</unitPattern>
 				<unitPattern count="one">دقيقة قوسية</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">دقيقتان قوسيتان</unitPattern>
 				<unitPattern count="few">{0} دقائق قوسية</unitPattern>
 				<unitPattern count="many">{0} دقيقة قوسية</unitPattern>
 				<unitPattern count="other">{0} دقيقة قوسية</unitPattern>
@@ -9042,13 +9042,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>feminine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="zero">{0}‱</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>masculine</gender>
@@ -9722,7 +9722,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-yard">
 				<displayName>ياردة</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ياردة</unitPattern>
 				<unitPattern count="one">ياردة</unitPattern>
 				<unitPattern count="two">{0} ياردة</unitPattern>
 				<unitPattern count="few">{0} ياردة</unitPattern>
@@ -9945,7 +9945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="zero">{0} رطل</unitPattern>
 				<unitPattern count="one">{0} رطل</unitPattern>
 				<unitPattern count="two">رطلان</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} رطل</unitPattern>
 				<unitPattern count="many">{0} رطلًا</unitPattern>
 				<unitPattern count="other">{0} رطل</unitPattern>
 				<perUnitPattern>{0}/رطل</perUnitPattern>
@@ -10687,20 +10687,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10929,11 +10929,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0}‱</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -11308,7 +11308,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>وحدة حرارية بريطانية</displayName>
 				<unitPattern count="zero">{0} وحدة حرارية بريطانية</unitPattern>
 				<unitPattern count="one">{0} وحدة حرارية بريطانية</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} وحدة حرارية بريطانية</unitPattern>
 				<unitPattern count="few">{0} وحدات حرارية بريطانية</unitPattern>
 				<unitPattern count="many">{0} وحدة حرارية بريطانية</unitPattern>
 				<unitPattern count="other">{0} وحدة حرارية بريطانية</unitPattern>
@@ -11317,7 +11317,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>وحدة حرارية أمريكية</displayName>
 				<unitPattern count="zero">{0} وحدة حرارية أمريكية</unitPattern>
 				<unitPattern count="one">{0} وحدة حرارية أمريكية</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} وحدة حرارية أمريكية</unitPattern>
 				<unitPattern count="few">{0} وحدات حرارية أمريكية</unitPattern>
 				<unitPattern count="many">{0} وحدة حرارية أمريكية</unitPattern>
 				<unitPattern count="other">{0} وحدة حرارية أمريكية</unitPattern>
@@ -11434,7 +11434,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>نقطة/سم</displayName>
 				<unitPattern count="zero">{0} نقطة/سم</unitPattern>
 				<unitPattern count="one">{0} نقطة/سم</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} بكسل/سم</unitPattern>
 				<unitPattern count="few">{0} نقاط/سم</unitPattern>
 				<unitPattern count="many">{0} نقطة/سم</unitPattern>
 				<unitPattern count="other">{0} نقطة/سم</unitPattern>
@@ -11443,7 +11443,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>نقطة لكل بوصة</displayName>
 				<unitPattern count="zero">{0} نقطة/بوصة</unitPattern>
 				<unitPattern count="one">{0} نقطة/بوصة</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} بكسل/بوصة</unitPattern>
 				<unitPattern count="few">{0} نقاط/بوصة</unitPattern>
 				<unitPattern count="many">{0} نقطة/بوصة</unitPattern>
 				<unitPattern count="other">{0} نقطة/بوصة</unitPattern>
@@ -12339,7 +12339,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>قطرة</displayName>
 				<unitPattern count="zero">{0} قطرة</unitPattern>
 				<unitPattern count="one">{0} قطرة</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} قطرة</unitPattern>
 				<unitPattern count="few">{0} قطرة</unitPattern>
 				<unitPattern count="many">{0} قطرة</unitPattern>
 				<unitPattern count="other">{0} قطرة</unitPattern>
@@ -12477,28 +12477,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">قوة تسارع</displayName>
 				<unitPattern count="zero" draft="contributed">{0} قوة تسارع</unitPattern>
 				<unitPattern count="one" draft="contributed">{0} قوة تسارع</unitPattern>
 				<unitPattern count="two" draft="contributed">{0} قوة تسارع</unitPattern>
@@ -12507,37 +12507,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} قوة تسارع</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">م/ث²</displayName>
+				<unitPattern count="zero" draft="contributed">{0} م/ث²</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} م/ث²</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} م/ث²</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} م/ث²</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} م/ث²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} م/ث²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">دورة</displayName>
+				<unitPattern count="zero" draft="contributed">{0} دورة</unitPattern>
+				<unitPattern count="one" draft="contributed">دورة</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} دورة</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} دورة</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} دورة</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} دورة</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">راديان</displayName>
+				<unitPattern count="zero" draft="contributed">{0} راديان</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} راديان</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} راديان</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} راديان</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} راديان</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} راديان</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">درجة</displayName>
 				<unitPattern count="zero">{0} درجة</unitPattern>
 				<unitPattern count="one">{0} درجة</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">درجتان</unitPattern>
 				<unitPattern count="few">{0} درجات</unitPattern>
 				<unitPattern count="many">{0} درجة</unitPattern>
 				<unitPattern count="other">{0} درجة</unitPattern>
@@ -12561,108 +12561,108 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ث قوسية</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>كم²</displayName>
 				<unitPattern count="zero">{0} كم²</unitPattern>
 				<unitPattern count="one">{0} كم²</unitPattern>
 				<unitPattern count="two">{0} كم²</unitPattern>
 				<unitPattern count="few">{0} كم²</unitPattern>
 				<unitPattern count="many">{0} كم²</unitPattern>
 				<unitPattern count="other">{0} كم²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/كم²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>هكتار</displayName>
+				<unitPattern count="zero">{0} هكتار</unitPattern>
+				<unitPattern count="one">{0} هكتار</unitPattern>
+				<unitPattern count="two">{0} هكتار</unitPattern>
+				<unitPattern count="few">{0} هكتار</unitPattern>
+				<unitPattern count="many">{0} هكتار</unitPattern>
+				<unitPattern count="other">{0} هكتار</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>م²</displayName>
 				<unitPattern count="zero">{0} م²</unitPattern>
 				<unitPattern count="one">{0} م²</unitPattern>
 				<unitPattern count="two">{0} م²</unitPattern>
 				<unitPattern count="few">{0} م²</unitPattern>
 				<unitPattern count="many">{0} م²</unitPattern>
 				<unitPattern count="other">{0} م²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/م²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>سم ²</displayName>
+				<unitPattern count="zero">{0} سم²</unitPattern>
+				<unitPattern count="one">{0} سم²</unitPattern>
+				<unitPattern count="two">{0} سم²</unitPattern>
+				<unitPattern count="few">{0} سم²</unitPattern>
+				<unitPattern count="many">{0} سم²</unitPattern>
+				<unitPattern count="other">{0} سم²</unitPattern>
+				<perUnitPattern>{0}/سم²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ميل²</displayName>
+				<unitPattern count="zero">{0} ميل²</unitPattern>
+				<unitPattern count="one">{0} ميل²</unitPattern>
+				<unitPattern count="two">{0} ميل²</unitPattern>
+				<unitPattern count="few">{0} ميل²</unitPattern>
+				<unitPattern count="many">{0} ميل²</unitPattern>
+				<unitPattern count="other">{0} ميل²</unitPattern>
+				<perUnitPattern>{0}/ميل²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>فدان</displayName>
+				<unitPattern count="zero">{0} فدان</unitPattern>
+				<unitPattern count="one">فدان</unitPattern>
+				<unitPattern count="two">{0} فدان</unitPattern>
+				<unitPattern count="few">{0} فدان</unitPattern>
+				<unitPattern count="many">{0} فدان</unitPattern>
+				<unitPattern count="other">{0} فدان</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ياردة²</displayName>
+				<unitPattern count="zero">{0} ياردة²</unitPattern>
+				<unitPattern count="one">{0} ياردة²</unitPattern>
+				<unitPattern count="two">{0} ياردة²</unitPattern>
+				<unitPattern count="few">{0} ياردة²</unitPattern>
+				<unitPattern count="many">{0} ياردة²</unitPattern>
+				<unitPattern count="other">{0} ياردة²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قدم²</displayName>
+				<unitPattern count="zero">{0} قدم²</unitPattern>
+				<unitPattern count="one">{0} قدم²</unitPattern>
+				<unitPattern count="two">{0} قدم²</unitPattern>
+				<unitPattern count="few">{0} قدم²</unitPattern>
+				<unitPattern count="many">{0} قدم²</unitPattern>
+				<unitPattern count="other">{0} قدم²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>بوصة²</displayName>
+				<unitPattern count="zero">{0} بوصة²</unitPattern>
+				<unitPattern count="one">{0} بوصة²</unitPattern>
+				<unitPattern count="two">{0} بوصة²</unitPattern>
+				<unitPattern count="few">{0} بوصة²</unitPattern>
+				<unitPattern count="many">{0} بوصة²</unitPattern>
+				<unitPattern count="other">{0} بوصة²</unitPattern>
+				<perUnitPattern>{0}/بوصة²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>دونم</displayName>
+				<unitPattern count="zero">{0} دونم</unitPattern>
+				<unitPattern count="one">{0} دونم</unitPattern>
+				<unitPattern count="two">{0} دونم</unitPattern>
+				<unitPattern count="few">{0} دونم</unitPattern>
+				<unitPattern count="many">{0} دونم</unitPattern>
+				<unitPattern count="other">{0} دونم</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">قيراط</displayName>
+				<unitPattern count="zero" draft="contributed">{0} قيراط</unitPattern>
+				<unitPattern count="one" draft="contributed">قيراط</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} قيراط</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} قيراط</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} قيراط</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} قيراط</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName draft="contributed">مغ/ديسبل</displayName>
@@ -12674,13 +12674,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} مغ/ديسبل</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">م.مول/ل</displayName>
+				<unitPattern count="zero" draft="contributed">{0} م.مول/ل</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} م.مول/ل</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} م.مول/ل</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} م.مول/ل</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} م.مول/ل</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} م.مول/ل</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>عنصر</displayName>
@@ -12692,13 +12692,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} عنصر</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">جزء/مليون</displayName>
+				<unitPattern count="zero" draft="contributed">{0} جزء/مليون</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} جزء/مليون</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} جزء/مليون</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} جزء/مليون</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} جزء/مليون</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} جزء/مليون</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>٪</displayName>
@@ -12711,12 +12711,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName draft="contributed">؉</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="zero" draft="contributed">{0}؉</unitPattern>
+				<unitPattern count="one" draft="contributed">{0}؉</unitPattern>
+				<unitPattern count="two" draft="contributed">{0}؉</unitPattern>
+				<unitPattern count="few" draft="contributed">{0}؉</unitPattern>
+				<unitPattern count="many" draft="contributed">{0}؉</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}؉</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName draft="contributed">؊</displayName>
@@ -12728,13 +12728,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} ؊</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">مول</displayName>
+				<unitPattern count="zero" draft="contributed">{0} مول</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} مول</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} مول</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} مول</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} مول</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} مول</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName draft="contributed">ل/كم</displayName>
@@ -12755,31 +12755,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ل/١٠٠كم</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ميل/غالون</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ميل/غالون</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ميل/غالون</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ميل/غالون</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ميل/غالون</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ميل/غالون</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ميل/غالون</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ميل/غ. إمبراطوري</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ميل/غ. إمبراطوري</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ميل/غ. إمبراطوري</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ميل/غ. إمبراطوري</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ميل/غ. إمبراطوري</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ميل/غ. إمبراطوري</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ميل/غ. إمبراطوري</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">بيتابايت</displayName>
+				<unitPattern count="zero" draft="contributed">{0} بيتابايت</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} بيتابايت</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} بيتابايت</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} بيتابايت</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} بيتابايت</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} بيتابايت</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName draft="contributed">ت.ب</displayName>
@@ -12863,31 +12863,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} ب</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">بت</displayName>
+				<unitPattern count="zero" draft="contributed">{0} بت</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} بت</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} بت</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} بت</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} بت</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} بت</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قرن</displayName>
+				<unitPattern count="zero">{0} قرن</unitPattern>
+				<unitPattern count="one">قرن</unitPattern>
+				<unitPattern count="two">قرنان</unitPattern>
+				<unitPattern count="few">{0} قرون</unitPattern>
+				<unitPattern count="many">{0} قرنًا</unitPattern>
+				<unitPattern count="other">{0} قرن</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>عقد</displayName>
+				<unitPattern count="zero">{0} عقد</unitPattern>
+				<unitPattern count="one">عقد</unitPattern>
+				<unitPattern count="two">عقدان</unitPattern>
+				<unitPattern count="few">{0} عقود</unitPattern>
+				<unitPattern count="many">{0} عقدًا</unitPattern>
+				<unitPattern count="other">{0} عقد</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>سنة</displayName>
@@ -12912,10 +12912,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-month">
 				<displayName>شهر</displayName>
 				<unitPattern count="zero">{0} شهر</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">شهر</unitPattern>
 				<unitPattern count="two">شهران</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} أشهر</unitPattern>
+				<unitPattern count="many">{0} شهرًا</unitPattern>
 				<unitPattern count="other">{0} شهر</unitPattern>
 				<perUnitPattern>{0}/ش</perUnitPattern>
 			</unit>
@@ -12927,7 +12927,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} أ</unitPattern>
 				<unitPattern count="many">{0} أ</unitPattern>
 				<unitPattern count="other">{0} أ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/أ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>يوم</displayName>
@@ -12937,7 +12937,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} ي</unitPattern>
 				<unitPattern count="many">{0} ي</unitPattern>
 				<unitPattern count="other">{0} ي</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ي</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ساعة</displayName>
@@ -12947,7 +12947,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} س</unitPattern>
 				<unitPattern count="many">{0} س</unitPattern>
 				<unitPattern count="other">{0} س</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/س</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>د</displayName>
@@ -12957,7 +12957,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} د</unitPattern>
 				<unitPattern count="many">{0} د</unitPattern>
 				<unitPattern count="other">{0} د</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/د</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ث</displayName>
@@ -12967,7 +12967,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} ث</unitPattern>
 				<unitPattern count="many">{0} ث</unitPattern>
 				<unitPattern count="other">{0} ث</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ث</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ملي ث.</displayName>
@@ -12979,58 +12979,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ملي ث</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>م.ث.</displayName>
+				<unitPattern count="zero">{0} م.ث.</unitPattern>
+				<unitPattern count="one">{0} م.ث.</unitPattern>
+				<unitPattern count="two">{0} م.ث.</unitPattern>
+				<unitPattern count="few">{0} م.ث.</unitPattern>
+				<unitPattern count="many">{0} م.ث.</unitPattern>
+				<unitPattern count="other">{0} م.ث.</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ن.ث.</displayName>
+				<unitPattern count="zero">{0} ن.ث.</unitPattern>
+				<unitPattern count="one">{0} ن.ث.</unitPattern>
+				<unitPattern count="two">{0} ن.ث.</unitPattern>
+				<unitPattern count="few">{0} ن.ث.</unitPattern>
+				<unitPattern count="many">{0} ن.ث.</unitPattern>
+				<unitPattern count="other">{0} ن.ث.</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">أمبير</displayName>
+				<unitPattern count="zero" draft="contributed">{0} أمبير</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} أمبير</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} أمبير</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} أمبير</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} أمبير</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} أمبير</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">م أمبير</displayName>
+				<unitPattern count="zero" draft="contributed">{0} م أمبير</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} م أمبير</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} م أمبير</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} م أمبير</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} م أمبير</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} م أمبير</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">أوم</displayName>
+				<unitPattern count="zero" draft="contributed">{0} أوم</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} أوم</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} أوم</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} أوم</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} أوم</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} أوم</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">فولت</displayName>
+				<unitPattern count="zero" draft="contributed">{0} فولت</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} فولت</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} فولت</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} فولت</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} فولت</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} فولت</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName draft="contributed">ك سع</displayName>
@@ -13042,94 +13042,94 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} ك سع</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">سع</displayName>
+				<unitPattern count="zero" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} سع</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">سع</displayName>
+				<unitPattern count="zero" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} سع</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} سع</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ك جول</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ك جول</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ك جول</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ك جول</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ك جول</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ك جول</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ك جول</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">جول</displayName>
+				<unitPattern count="zero" draft="contributed">{0} جول</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} جول</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} جول</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} جول</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} جول</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} جول</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ك.و.س</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ك.و.س</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ك.و.س</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ك.و.س</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ك.و.س</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ك.و.س</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ك.و.س</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">إلكترون فولت</displayName>
+				<unitPattern count="zero" draft="contributed">{0} إلكترون فولت</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} إلكترون فولت</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} إلكترون فولت</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} إلكترون فولت</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} إلكترون فولت</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} إلكترون فولت</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">وحدة حرارية بريطانية</displayName>
+				<unitPattern count="zero" draft="contributed">{0} وحدة حرارية بريطانية</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} وحدة حرارية بريطانية</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} وحدة حرارية بريطانية</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} وحدات حرارية بريطانية</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} وحدة حرارية بريطانية</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} وحدة حرارية بريطانية</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">وحدة حرارية أمريكية</displayName>
+				<unitPattern count="zero" draft="contributed">{0} وحدة حرارية أمريكية</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} وحدة حرارية أمريكية</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} وحدة حرارية أمريكية</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} وحدات حرارية أمريكية</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} وحدة حرارية أمريكية</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} وحدة حرارية أمريكية</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">باوند قوة</displayName>
+				<unitPattern count="zero" draft="contributed">{0} باوند قوة</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} باوند قوة</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} باوند قوة</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} باوند قوة</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} باوند قوة</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} باوند قوة</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">نيوتن</displayName>
+				<unitPattern count="zero" draft="contributed">{0} نيوتن</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} نيوتن</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} نيوتن</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} نيوتن</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} نيوتن</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} نيوتن</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>ك.و.س/100 كم</displayName>
@@ -13141,61 +13141,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} ك.و.س/100 كم</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">غ هرتز</displayName>
+				<unitPattern count="zero" draft="contributed">{0} غ هرتز</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} غ هرتز</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} غ هرتز</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} غ هرتز</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} غ هرتز</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} غ هرتز</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">م هرتز</displayName>
+				<unitPattern count="zero" draft="contributed">{0} م هرتز</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} م هرتز</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} م هرتز</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} م هرتز</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} م هرتز</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} م هرتز</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ك هرتز</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ك هرتز</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ك هرتز</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ك هرتز</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ك هرتز</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ك هرتز</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ك هرتز</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">هرتز</displayName>
+				<unitPattern count="zero" draft="contributed">{0} هرتز</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} هرتز</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} هرتز</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} هرتز</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} هرتز</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} هرتز</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>إم</displayName>
+				<unitPattern count="zero">{0} إم</unitPattern>
+				<unitPattern count="one">{0} إم</unitPattern>
+				<unitPattern count="two">{0} إم</unitPattern>
+				<unitPattern count="few">{0} إم</unitPattern>
+				<unitPattern count="many">{0} إم</unitPattern>
+				<unitPattern count="other">{0} إم</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بكسل</displayName>
+				<unitPattern count="zero">{0} بكسل</unitPattern>
+				<unitPattern count="one">{0} بكسل</unitPattern>
+				<unitPattern count="two">{0} بكسل</unitPattern>
+				<unitPattern count="few">{0} بكسل</unitPattern>
+				<unitPattern count="many">{0} بكسل</unitPattern>
+				<unitPattern count="other">{0} بكسل</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>م.بكسل</displayName>
 				<unitPattern count="zero">{0} م.بك</unitPattern>
 				<unitPattern count="one">{0} م.بك</unitPattern>
 				<unitPattern count="two">{0} م.بك</unitPattern>
@@ -13240,22 +13240,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ن/بوصة</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بكسل</displayName>
+				<unitPattern count="zero">{0} بكسل</unitPattern>
+				<unitPattern count="one">{0} بكسل</unitPattern>
+				<unitPattern count="two">{0} بكسل</unitPattern>
+				<unitPattern count="few">{0} بكسل</unitPattern>
+				<unitPattern count="many">{0} بكسل</unitPattern>
+				<unitPattern count="other">{0} بكسل</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نق أرضي</displayName>
+				<unitPattern count="zero">{0} نق أرضي</unitPattern>
+				<unitPattern count="one">{0} نق أرضي</unitPattern>
+				<unitPattern count="two">{0} نق أرضي</unitPattern>
+				<unitPattern count="few">{0} نق أرضي</unitPattern>
+				<unitPattern count="many">{0} نق أرضي</unitPattern>
+				<unitPattern count="other">{0} نق أرضي</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>كم</displayName>
@@ -13265,7 +13265,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} كم</unitPattern>
 				<unitPattern count="many">{0} كم</unitPattern>
 				<unitPattern count="other">{0} كم</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/كم</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>متر</displayName>
@@ -13275,16 +13275,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} م</unitPattern>
 				<unitPattern count="many">{0} م</unitPattern>
 				<unitPattern count="other">{0} م</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/م</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>دسم</displayName>
+				<unitPattern count="zero">{0} دسم</unitPattern>
+				<unitPattern count="one">{0} دسم</unitPattern>
+				<unitPattern count="two">{0} دسم</unitPattern>
+				<unitPattern count="few">{0} دسم</unitPattern>
+				<unitPattern count="many">{0} دسم</unitPattern>
+				<unitPattern count="other">{0} دسم</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>سم</displayName>
@@ -13294,7 +13294,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} سم</unitPattern>
 				<unitPattern count="many">{0} سم</unitPattern>
 				<unitPattern count="other">{0} سم</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/سم</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>مم</displayName>
@@ -13306,25 +13306,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} مم</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميكرومتر</displayName>
+				<unitPattern count="zero">{0} ميكرومتر</unitPattern>
+				<unitPattern count="one">{0} ميكرومتر</unitPattern>
+				<unitPattern count="two">{0} ميكرومتر</unitPattern>
+				<unitPattern count="few">{0} ميكرومتر</unitPattern>
+				<unitPattern count="many">{0} ميكرومتر</unitPattern>
+				<unitPattern count="other">{0} ميكرومتر</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نانو متر</displayName>
+				<unitPattern count="zero">{0} نانو متر</unitPattern>
+				<unitPattern count="one">{0} نانو متر</unitPattern>
+				<unitPattern count="two">{0} نانو متر</unitPattern>
+				<unitPattern count="few">{0} نانو متر</unitPattern>
+				<unitPattern count="many">{0} نانو متر</unitPattern>
+				<unitPattern count="other">{0} نانو متر</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>بيكومتر</displayName>
 				<unitPattern count="zero">{0} بيكومتر</unitPattern>
 				<unitPattern count="one">{0} بيكومتر</unitPattern>
 				<unitPattern count="two">{0} بيكومتر</unitPattern>
@@ -13333,7 +13333,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} بيكومتر</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ميل</displayName>
 				<unitPattern count="zero">{0} ميل</unitPattern>
 				<unitPattern count="one">{0} ميل</unitPattern>
 				<unitPattern count="two">{0} ميل</unitPattern>
@@ -13342,45 +13342,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ميل</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>ياردة</displayName>
+				<unitPattern count="zero">{0} ياردة</unitPattern>
 				<unitPattern count="one">{0} ياردة</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} ياردة</unitPattern>
 				<unitPattern count="few">{0} ياردة</unitPattern>
 				<unitPattern count="many">{0} ياردة</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ياردة</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<displayName>قدم</displayName>
+				<unitPattern count="zero">{0} قدم</unitPattern>
+				<unitPattern count="one">قدم</unitPattern>
+				<unitPattern count="two">{0} قدم</unitPattern>
+				<unitPattern count="few">{0} قدم</unitPattern>
 				<unitPattern count="many">{0} قدمًا</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} قدم</unitPattern>
+				<perUnitPattern>{0}/قدم</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>بوصة</displayName>
 				<unitPattern count="zero">{0} بوصة</unitPattern>
 				<unitPattern count="one">{0} بوصة</unitPattern>
 				<unitPattern count="two">{0} بوصة</unitPattern>
 				<unitPattern count="few">{0} بوصة</unitPattern>
 				<unitPattern count="many">{0} بوصة</unitPattern>
 				<unitPattern count="other">{0} بوصة</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/بوصة</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>فرسخ فلكي</displayName>
+				<unitPattern count="zero">{0} فرسخ فلكي</unitPattern>
+				<unitPattern count="one">فرسخ فلكي</unitPattern>
+				<unitPattern count="two">{0} فرسخ فلكي</unitPattern>
+				<unitPattern count="few">{0} فرسخ فلكي</unitPattern>
+				<unitPattern count="many">{0} فرسخ فلكي</unitPattern>
+				<unitPattern count="other">{0} فرسخ فلكي</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>سنة ضوئية</displayName>
 				<unitPattern count="zero">{0}س ض</unitPattern>
 				<unitPattern count="one">{0} س ض</unitPattern>
 				<unitPattern count="two">{0} س ض</unitPattern>
@@ -13389,112 +13389,112 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} س ض</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>و.ف.</displayName>
+				<unitPattern count="zero">{0} و.ف.</unitPattern>
+				<unitPattern count="one">{0} و.ف.</unitPattern>
+				<unitPattern count="two">{0} و.ف.</unitPattern>
+				<unitPattern count="few">{0} و.ف.</unitPattern>
+				<unitPattern count="many">{0} و.ف.</unitPattern>
+				<unitPattern count="other">{0} و.ف.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>فرلنغ</displayName>
+				<unitPattern count="zero">{0} فرلنغ</unitPattern>
+				<unitPattern count="one">{0} فرلنغ</unitPattern>
+				<unitPattern count="two">{0} فرلنغ</unitPattern>
+				<unitPattern count="few">{0} فرلنغ</unitPattern>
+				<unitPattern count="many">{0} فرلنغ</unitPattern>
+				<unitPattern count="other">{0} فرلنغ</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قامة</displayName>
+				<unitPattern count="zero">{0} قامة</unitPattern>
+				<unitPattern count="one">{0} قامة</unitPattern>
+				<unitPattern count="two">{0} قامة</unitPattern>
+				<unitPattern count="few">{0} قامة</unitPattern>
+				<unitPattern count="many">{0} قامة</unitPattern>
+				<unitPattern count="other">{0} قامة</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميل بحري</displayName>
+				<unitPattern count="zero">{0} ميل بحري</unitPattern>
+				<unitPattern count="one">ميل بحري</unitPattern>
+				<unitPattern count="two">{0} ميل بحري</unitPattern>
+				<unitPattern count="few">{0} ميل بحري</unitPattern>
+				<unitPattern count="many">{0} ميل بحري</unitPattern>
+				<unitPattern count="other">{0} ميل بحري</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميل اسكندنافي</displayName>
+				<unitPattern count="zero">{0} ميل اسكندنافي</unitPattern>
+				<unitPattern count="one">{0} ميل اسكندنافي</unitPattern>
+				<unitPattern count="two">{0} ميل اسكندنافي</unitPattern>
+				<unitPattern count="few">{0} ميل اسكندنافي</unitPattern>
+				<unitPattern count="many">{0} ميل اسكندنافي</unitPattern>
+				<unitPattern count="other">{0} ميل اسكندنافي</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نقطة</displayName>
+				<unitPattern count="zero">{0} نقطة</unitPattern>
+				<unitPattern count="one">نقطة</unitPattern>
+				<unitPattern count="two">نقطتان</unitPattern>
+				<unitPattern count="few">{0} نقاط</unitPattern>
+				<unitPattern count="many">{0} نقطة</unitPattern>
+				<unitPattern count="other">{0} نقطة</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نق شمسي</displayName>
+				<unitPattern count="zero">{0} نق شمسي</unitPattern>
+				<unitPattern count="one">{0} نق شمسي</unitPattern>
+				<unitPattern count="two">{0} نق شمسي</unitPattern>
+				<unitPattern count="few">{0} نق شمسي</unitPattern>
+				<unitPattern count="many">{0} نق شمسي</unitPattern>
+				<unitPattern count="other">{0} نق شمسي</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">لكس</displayName>
+				<unitPattern count="zero" draft="contributed">{0} لكس</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} لكس</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} لكس</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} لكس</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} لكس</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} لكس</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">شمعة</displayName>
+				<unitPattern count="zero" draft="contributed">{0} شمعة</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} شمعة</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} شمعة</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} شمعة</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} شمعة</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} شمعة</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">لومن</displayName>
+				<unitPattern count="zero" draft="contributed">{0} لومن</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} لومن</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} لومن</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} لومن</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} لومن</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} لومن</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ضياء شمسي</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ضياء شمسي</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ضياء شمسي</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ضياء شمسي</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ضياء شمسي</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ضياء شمسي</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ضياء شمسي</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ط.م</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ط.م</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ط.م</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ط.م</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ط.م</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ط.م</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ط.م</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>كغ</displayName>
@@ -13517,135 +13517,135 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0} غ</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">مغم</displayName>
+				<unitPattern count="zero" draft="contributed">{0} مغم</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} مغم</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} مغم</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} مغم</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} مغم</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} مغم</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">مكغم</displayName>
+				<unitPattern count="zero" draft="contributed">{0} مكغم</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} مكغم</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} مكغم</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} مكغم</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} مكغم</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} مكغم</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">طن</displayName>
+				<unitPattern count="zero" draft="contributed">{0} طن</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} طن</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} طن</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} طن</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} طن</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} طن</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ستون</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ستون</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ستون</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ستون</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ستون</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ستون</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ستون</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">رطل</displayName>
+				<unitPattern count="zero">{0} رطل</unitPattern>
+				<unitPattern count="one">{0} رطل</unitPattern>
+				<unitPattern count="two">{0} رطل</unitPattern>
+				<unitPattern count="few">{0} رطل</unitPattern>
+				<unitPattern count="many">{0} رطل</unitPattern>
+				<unitPattern count="other">{0} رطل</unitPattern>
+				<perUnitPattern draft="contributed">{0}/رطل</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>أونصة</displayName>
+				<unitPattern count="zero">{0} أونصة</unitPattern>
+				<unitPattern count="one">أونصة</unitPattern>
+				<unitPattern count="two">{0} أونصة</unitPattern>
+				<unitPattern count="few">{0} أونصة</unitPattern>
+				<unitPattern count="many">{0} أونصة</unitPattern>
+				<unitPattern count="other">{0} أونصة</unitPattern>
+				<perUnitPattern>{0}/أونصة</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">أونصة ترويسية</displayName>
+				<unitPattern count="zero" draft="contributed">{0} أونصة ترويسية</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} أونصة ترويسية</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} أونصة ترويسية</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} أونصة ترويسية</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} أونصة ترويسية</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} أونصة ترويسية</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">قيراط</displayName>
+				<unitPattern count="zero" draft="contributed">{0} قيراط</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} قيراط</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} قيراط</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} قيراط</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} قيراط</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} قيراط</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">دالتون</displayName>
+				<unitPattern count="zero" draft="contributed">{0} دالتون</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} دالتون</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} دالتون</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} دالتون</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} دالتون</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} دالتون</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">كتلة أرضية</displayName>
+				<unitPattern count="zero" draft="contributed">{0} كتلة أرضية</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} كتلة أرضية</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} كتلة أرضية</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} كتلة أرضية</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} كتلة أرضية</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} كتلة أرضية</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">كتلة شمسية</displayName>
+				<unitPattern count="zero" draft="contributed">{0} كتلة شمسية</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} كتلة شمسية</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} كتلة شمسية</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} كتلة شمسية</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} كتلة شمسية</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} كتلة شمسية</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">قمحة</displayName>
+				<unitPattern count="zero" draft="contributed">{0} قمحة</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} قمحة</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} قمحة</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} قمحة</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} قمحة</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} قمحة</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">غ واط</displayName>
+				<unitPattern count="zero" draft="contributed">{0} غ واط</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} غ واط</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} غ واط</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} غ واط</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} غ واط</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} غ واط</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">م واط</displayName>
+				<unitPattern count="zero" draft="contributed">{0} م واط</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} م واط</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} م واط</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} م واط</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} م واط</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} م واط</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ك واط</displayName>
 				<unitPattern count="zero">{0} ك واط</unitPattern>
 				<unitPattern count="one">{0} ك واط</unitPattern>
 				<unitPattern count="two">{0} ك واط</unitPattern>
@@ -13654,7 +13654,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ك واط</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">واط</displayName>
 				<unitPattern count="zero" draft="contributed">{0} واط</unitPattern>
 				<unitPattern count="one" draft="contributed">{0} واط</unitPattern>
 				<unitPattern count="two" draft="contributed">{0} واط</unitPattern>
@@ -13663,40 +13663,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} واط</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ملي واط</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ملي واط</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ملي واط</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ملي واط</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ملي واط</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ملي واط</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ملي واط</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">حصان</displayName>
+				<unitPattern count="zero">{0} حصان</unitPattern>
+				<unitPattern count="one">{0} حصان</unitPattern>
+				<unitPattern count="two">{0} حصان</unitPattern>
+				<unitPattern count="few">{0} حصان</unitPattern>
+				<unitPattern count="many">{0} حصان</unitPattern>
+				<unitPattern count="other">{0} حصان</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ملم زئبقي</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ملم زئبقي</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ملم زئبقي</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ملم زئبقي</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ملم زئبقي</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ملم زئبقي</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ملم زئبقي</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName draft="contributed">رطل/بوصة²</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="zero" draft="contributed">{0} رطل/بوصة²</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} رطل/بوصة²</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} رطل/بوصة²</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} رطل/بوصة²</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} رطل/بوصة²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} رطل/بوصة²</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName draft="contributed">ب ز</displayName>
@@ -13708,67 +13708,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ب ز</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">بار</displayName>
+				<unitPattern count="zero" draft="contributed">{0} بار</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} بار</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} بار</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} بار</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} بار</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} بار</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">م. بار</displayName>
+				<unitPattern count="zero">{0} م. بار</unitPattern>
+				<unitPattern count="one">{0} م. بار</unitPattern>
+				<unitPattern count="two">{0} م. بار</unitPattern>
+				<unitPattern count="few">{0} م. بار</unitPattern>
+				<unitPattern count="many">{0} م. بار</unitPattern>
+				<unitPattern count="other">{0} م. بار</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ض.ج</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ض.ج</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ض.ج</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ض.ج</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ض.ج</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ض.ج</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ض.ج</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">باسكال</displayName>
+				<unitPattern count="zero" draft="contributed">{0} باسكال</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} باسكال</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} باسكال</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} باسكال</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} باسكال</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} باسكال</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>هكتوباسكال</displayName>
+				<unitPattern count="zero">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="one">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="two">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="few">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="many">{0} هكتوباسكال</unitPattern>
+				<unitPattern count="other">{0} هكتوباسكال</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ك.باسكال</displayName>
+				<unitPattern count="zero" draft="contributed">{0} ك.باسكال</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ك.باسكال</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ك.باسكال</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ك.باسكال</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ك.باسكال</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ك.باسكال</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">م.باسكال</displayName>
+				<unitPattern count="zero" draft="contributed">{0} م.باسكال</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} م.باسكال</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} م.باسكال</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} م.باسكال</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} م.باسكال</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} م.باسكال</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>كم/س</displayName>
@@ -13780,7 +13780,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} كم/س</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">م/ث</displayName>
 				<unitPattern count="zero" draft="contributed">{0} م/ث</unitPattern>
 				<unitPattern count="one" draft="contributed">{0} م/ث</unitPattern>
 				<unitPattern count="two" draft="contributed">{0} م/ث</unitPattern>
@@ -13789,7 +13789,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} م/ث</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ميل/س</displayName>
 				<unitPattern count="zero" draft="contributed">{0} ميل/س</unitPattern>
 				<unitPattern count="one" draft="contributed">{0} ميل/س</unitPattern>
 				<unitPattern count="two" draft="contributed">{0} ميل/س</unitPattern>
@@ -13798,22 +13798,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} ميل/س</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">عقدة</displayName>
+				<unitPattern count="zero" draft="contributed">{0} عقدة</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} عقدة</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} عقدة</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} عقدة</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} عقدة</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} عقدة</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">°</displayName>
+				<unitPattern count="zero" draft="contributed">{0}°</unitPattern>
+				<unitPattern count="one" draft="contributed">{0}°</unitPattern>
+				<unitPattern count="two" draft="contributed">{0}°</unitPattern>
+				<unitPattern count="few" draft="contributed">{0}°</unitPattern>
+				<unitPattern count="many" draft="contributed">{0}°</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°م</displayName>
@@ -13826,30 +13826,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName draft="contributed">°ف</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0}°ف</unitPattern>
+				<unitPattern count="one">{0}°ف</unitPattern>
+				<unitPattern count="two">{0}°ف</unitPattern>
+				<unitPattern count="few">{0}°ف</unitPattern>
+				<unitPattern count="many">{0}°ف</unitPattern>
+				<unitPattern count="other">{0}°ف</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">د كلفن</displayName>
+				<unitPattern count="zero" draft="contributed">{0} د كلفن</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} د كلفن</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} د كلفن</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} د كلفن</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} د كلفن</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} د كلفن</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="zero" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">باوند قدم</displayName>
+				<unitPattern count="zero" draft="contributed">{0} باوند قدم</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} باوند قدم</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} باوند قدم</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} باوند قدم</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} باوند قدم</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} باوند قدم</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName draft="contributed">نيوتن م</displayName>
@@ -13861,7 +13861,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} نيوتن م</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>كم³</displayName>
 				<unitPattern count="zero">{0} كم³</unitPattern>
 				<unitPattern count="one">{0} كم³</unitPattern>
 				<unitPattern count="two">{0} كم³</unitPattern>
@@ -13870,51 +13870,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} كم³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>م³</displayName>
+				<unitPattern count="zero">{0} م³</unitPattern>
+				<unitPattern count="one">{0} م³</unitPattern>
+				<unitPattern count="two">{0} م³</unitPattern>
+				<unitPattern count="few">{0} م³</unitPattern>
+				<unitPattern count="many">{0} م³</unitPattern>
+				<unitPattern count="other">{0} م³</unitPattern>
+				<perUnitPattern>{0}/م³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>سم³</displayName>
+				<unitPattern count="zero">{0} سم³</unitPattern>
+				<unitPattern count="one">{0} سم³</unitPattern>
+				<unitPattern count="two">{0} سم³</unitPattern>
+				<unitPattern count="few">{0} سم³</unitPattern>
+				<unitPattern count="many">{0} سم³</unitPattern>
+				<unitPattern count="other">{0} سم³</unitPattern>
+				<perUnitPattern>{0}/سم³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميل³</displayName>
+				<unitPattern count="zero">{0} ميل³</unitPattern>
+				<unitPattern count="one">{0} ميل³</unitPattern>
+				<unitPattern count="two">{0} ميل³</unitPattern>
+				<unitPattern count="few">{0} ميل³</unitPattern>
+				<unitPattern count="many">{0} ميل³</unitPattern>
+				<unitPattern count="other">{0} ميل³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ياردة³</displayName>
+				<unitPattern count="zero">{0} ياردة³</unitPattern>
+				<unitPattern count="one">{0} ياردة³</unitPattern>
+				<unitPattern count="two">{0} ياردة³</unitPattern>
+				<unitPattern count="few">{0} ياردة³</unitPattern>
+				<unitPattern count="many">{0} ياردة³</unitPattern>
+				<unitPattern count="other">{0} ياردة³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قدم³</displayName>
+				<unitPattern count="zero">{0} قدم³</unitPattern>
+				<unitPattern count="one">{0} قدم³</unitPattern>
+				<unitPattern count="two">{0} قدم³</unitPattern>
+				<unitPattern count="few">{0} قدم³</unitPattern>
+				<unitPattern count="many">{0} قدم³</unitPattern>
+				<unitPattern count="other">{0} قدم³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>بوصة³</displayName>
@@ -13926,22 +13926,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} بوصة³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميغالتر</displayName>
+				<unitPattern count="zero">{0} ميغالتر</unitPattern>
+				<unitPattern count="one">{0} ميغالتر</unitPattern>
+				<unitPattern count="two">{0} ميغالتر</unitPattern>
+				<unitPattern count="few">{0} ميغالتر</unitPattern>
+				<unitPattern count="many">{0} ميغالتر</unitPattern>
+				<unitPattern count="other">{0} ميغالتر</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>هكتولتر</displayName>
+				<unitPattern count="zero">{0} هكتولتر</unitPattern>
+				<unitPattern count="one">{0} هكتولتر</unitPattern>
+				<unitPattern count="two">{0} هكتولتر</unitPattern>
+				<unitPattern count="few">{0} هكتولتر</unitPattern>
+				<unitPattern count="many">{0} هكتولتر</unitPattern>
+				<unitPattern count="other">{0} هكتولتر</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>لتر</displayName>
@@ -13951,125 +13951,125 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} ل</unitPattern>
 				<unitPattern count="many">{0} ل</unitPattern>
 				<unitPattern count="other">{0} ل</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ل</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ديسيلتر</displayName>
+				<unitPattern count="zero">{0} ديسيلتر</unitPattern>
+				<unitPattern count="one">{0} ديسيلتر</unitPattern>
+				<unitPattern count="two">{0} ديسيلتر</unitPattern>
+				<unitPattern count="few">{0} ديسيلتر</unitPattern>
+				<unitPattern count="many">{0} ديسيلتر</unitPattern>
+				<unitPattern count="other">{0} ديسيلتر</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>سنتيلتر</displayName>
+				<unitPattern count="zero">{0} سنتيلتر</unitPattern>
+				<unitPattern count="one">{0} سنتيلتر</unitPattern>
+				<unitPattern count="two">{0} سنتيلتر</unitPattern>
+				<unitPattern count="few">{0} سنتيلتر</unitPattern>
+				<unitPattern count="many">{0} سنتيلتر</unitPattern>
+				<unitPattern count="other">{0} سنتيلتر</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملتر</displayName>
+				<unitPattern count="zero">{0} ملتر</unitPattern>
+				<unitPattern count="one">{0} ملتر</unitPattern>
+				<unitPattern count="two">{0} ملتر</unitPattern>
+				<unitPattern count="few">{0} ملتر</unitPattern>
+				<unitPattern count="many">{0} ملتر</unitPattern>
+				<unitPattern count="other">{0} ملتر</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مكيال متري</displayName>
+				<unitPattern count="zero">{0} مكيال متري</unitPattern>
+				<unitPattern count="one">{0} مكيال متري</unitPattern>
+				<unitPattern count="two">{0} مكيال متري</unitPattern>
+				<unitPattern count="few">{0} مكيال متري</unitPattern>
+				<unitPattern count="many">{0} مكيال متري</unitPattern>
+				<unitPattern count="other">{0} مكيال متري</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>كوب متري</displayName>
+				<unitPattern count="zero">{0} كوب متري</unitPattern>
+				<unitPattern count="one">{0} كوب متري</unitPattern>
+				<unitPattern count="two">{0} كوب متري</unitPattern>
+				<unitPattern count="few">{0} كوب متري</unitPattern>
+				<unitPattern count="many">{0} كوب متري</unitPattern>
+				<unitPattern count="other">{0} كوب متري</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>فدان قدم</displayName>
+				<unitPattern count="zero">{0} فدان قدم</unitPattern>
+				<unitPattern count="one">{0} فدان قدم</unitPattern>
+				<unitPattern count="two">{0} فدان قدم</unitPattern>
+				<unitPattern count="few">{0} فدان قدم</unitPattern>
+				<unitPattern count="many">{0} فدان قدم</unitPattern>
+				<unitPattern count="other">{0} فدان قدم</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بوشل</displayName>
+				<unitPattern count="zero">{0} بوشل</unitPattern>
+				<unitPattern count="one">{0} بوشل</unitPattern>
+				<unitPattern count="two">{0} بوشل</unitPattern>
+				<unitPattern count="few">{0} بوشل</unitPattern>
+				<unitPattern count="many">{0} بوشل</unitPattern>
+				<unitPattern count="other">{0} بوشل</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>غالون</displayName>
+				<unitPattern count="zero">{0} غالون</unitPattern>
+				<unitPattern count="one">غالون</unitPattern>
+				<unitPattern count="two">{0} غالون</unitPattern>
+				<unitPattern count="few">{0} غالون</unitPattern>
+				<unitPattern count="many">{0} غالون</unitPattern>
+				<unitPattern count="other">{0} غالون</unitPattern>
+				<perUnitPattern>{0}/غالون</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>غالون إمبراطوري</displayName>
+				<unitPattern count="zero">{0} غالون إمبراطوري</unitPattern>
+				<unitPattern count="one">{0} غالون إمبراطوري</unitPattern>
+				<unitPattern count="two">{0} غالون إمبراطوري</unitPattern>
+				<unitPattern count="few">{0} غالون إمبراطوري</unitPattern>
+				<unitPattern count="many">{0} غالون إمبراطوري</unitPattern>
+				<unitPattern count="other">{0} غالون إمبراطوري</unitPattern>
+				<perUnitPattern>{0}/غالون إمبراطوري</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ربع غالون</displayName>
+				<unitPattern count="zero">{0} ربع غالون</unitPattern>
+				<unitPattern count="one">ربع غالون</unitPattern>
+				<unitPattern count="two">{0} ربع غالون</unitPattern>
+				<unitPattern count="few">{0} ربع غالون</unitPattern>
+				<unitPattern count="many">{0} ربع غالون</unitPattern>
+				<unitPattern count="other">{0} ربع غالون</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>باينت</displayName>
+				<unitPattern count="zero">{0} باينت</unitPattern>
+				<unitPattern count="one">{0} باينت</unitPattern>
+				<unitPattern count="two">{0} باينت</unitPattern>
+				<unitPattern count="few">{0} باينت</unitPattern>
+				<unitPattern count="many">{0} باينت</unitPattern>
+				<unitPattern count="other">{0} باينت</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>كوب</displayName>
+				<unitPattern count="zero">{0} كوب</unitPattern>
+				<unitPattern count="one">كوب</unitPattern>
+				<unitPattern count="two">{0} كوب</unitPattern>
+				<unitPattern count="few">{0} كوب</unitPattern>
+				<unitPattern count="many">{0} كوب</unitPattern>
+				<unitPattern count="other">{0} كوب</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<displayName>أونصة س</displayName>
 				<unitPattern count="zero">{0} أونصة س</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="one">أونصة س</unitPattern>
+				<unitPattern count="two">{0} أونصة س</unitPattern>
 				<unitPattern count="few">{0} أونصة س</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="many">{0} أونصة س</unitPattern>
 				<unitPattern count="other">{0} أونصة س</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
@@ -14091,85 +14091,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ملعقة ك</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملعقة ص</displayName>
+				<unitPattern count="zero">{0} ملعقة ص</unitPattern>
+				<unitPattern count="one">ملعقة ص</unitPattern>
+				<unitPattern count="two">{0} ملعقة ص</unitPattern>
+				<unitPattern count="few">{0} ملعقة ص</unitPattern>
+				<unitPattern count="many">{0} ملعقة ص</unitPattern>
+				<unitPattern count="other">{0} ملعقة ص</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>برميل</displayName>
+				<unitPattern count="zero">{0} برميل</unitPattern>
+				<unitPattern count="one">برميل</unitPattern>
 				<unitPattern count="two">{0} برميل</unitPattern>
 				<unitPattern count="few">{0} برميل</unitPattern>
 				<unitPattern count="many">{0} برميل</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} برميل</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملعقة ح.</displayName>
+				<unitPattern count="zero">{0} ملعقة ح.</unitPattern>
+				<unitPattern count="one">{0} ملعقة ح.</unitPattern>
+				<unitPattern count="two">{0} ملعقة ح.</unitPattern>
+				<unitPattern count="few">{0} ملعقة ح.</unitPattern>
+				<unitPattern count="many">{0} ملعقة ح.</unitPattern>
+				<unitPattern count="other">{0} ملعقة ح.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملعقة حلو إمبراطوري</displayName>
+				<unitPattern count="zero">{0} ملعقة ح. إمبراطوري</unitPattern>
+				<unitPattern count="one">{0} ملعقة ح. إمبراطوري</unitPattern>
+				<unitPattern count="two">{0} ملعقة ح. إمبراطوري</unitPattern>
+				<unitPattern count="few">{0} ملعقة ح. إمبراطوري</unitPattern>
+				<unitPattern count="many">{0} ملعقة ح. إمبراطوري</unitPattern>
+				<unitPattern count="other">{0} ملعقة ح. إمبراطوري</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قطرة</displayName>
+				<unitPattern count="zero">{0} قطرة</unitPattern>
+				<unitPattern count="one">{0} قطرة</unitPattern>
+				<unitPattern count="two">{0} قطرة</unitPattern>
+				<unitPattern count="few">{0} قطرة</unitPattern>
+				<unitPattern count="many">{0} قطرة</unitPattern>
+				<unitPattern count="other">{0} قطرة</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>درهم سائل</displayName>
+				<unitPattern count="zero">{0} درهم سائل</unitPattern>
+				<unitPattern count="one">{0} درهم سائل</unitPattern>
+				<unitPattern count="two">{0} درهم سائل</unitPattern>
+				<unitPattern count="few">{0} درهم سائل</unitPattern>
+				<unitPattern count="many">{0} درهم سائل</unitPattern>
+				<unitPattern count="other">{0} درهم سائل</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>قدح</displayName>
+				<unitPattern count="zero">{0} قدح</unitPattern>
 				<unitPattern count="one">قدح</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} قدح</unitPattern>
 				<unitPattern count="few">{0} قدح</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="many">{0} قدح</unitPattern>
+				<unitPattern count="other">{0} قدح</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>رشّة</displayName>
+				<unitPattern count="zero">{0} رشّة</unitPattern>
+				<unitPattern count="one">{0} رشّة</unitPattern>
+				<unitPattern count="two">{0} رشّة</unitPattern>
+				<unitPattern count="few">{0} رشّة</unitPattern>
+				<unitPattern count="many">{0} رشّة</unitPattern>
+				<unitPattern count="other">{0} رشّة</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ربع غالون إمبراطوري</displayName>
+				<unitPattern count="zero">{0} ربع غالون إمبراطوري</unitPattern>
+				<unitPattern count="one">{0} ربع غالون إمبراطوري</unitPattern>
+				<unitPattern count="two">{0} ربع غالون إمبراطوري</unitPattern>
+				<unitPattern count="few">{0} ربع غالون إمبراطوري</unitPattern>
+				<unitPattern count="many">{0} ربع غالون إمبراطوري</unitPattern>
+				<unitPattern count="other">{0} ربع غالون إمبراطوري</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>اتجاه</displayName>
@@ -14204,21 +14204,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</listPattern>
 		<listPattern type="or-narrow">
 			<listPatternPart type="start">{0} أو {1}</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="middle">{0} أو {1}</listPatternPart>
+			<listPatternPart type="end">{0} أو {1}</listPatternPart>
+			<listPatternPart type="2">{0} أو {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0} أو {1}</listPatternPart>
 			<listPatternPart type="middle">{0} أو {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} أو {1}</listPatternPart>
+			<listPatternPart type="2">{0} أو {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0} و{1}</listPatternPart>
 			<listPatternPart type="middle">{0} و{1}</listPatternPart>
 			<listPatternPart type="end">{0} و{1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} و{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0} و{1}</listPatternPart>
@@ -14236,7 +14236,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="start">{0} و{1}</listPatternPart>
 			<listPatternPart type="middle">{0} و{1}</listPatternPart>
 			<listPatternPart type="end">{0} و{1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} و{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
 			<listPatternPart type="start">{0}، و{1}</listPatternPart>
@@ -14448,8 +14448,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
-			<namePattern alt="1">{given-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 			<namePattern>{given-monogram-allCaps}.{given2-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
+			<namePattern alt="1">{given-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
 			<namePattern>{given-informal-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -81,8 +81,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">চেৰোকি</language>
 			<language type="chy">চাইয়েন</language>
 			<language type="ckb">চেণ্ট্ৰেল কুৰ্ডিচ</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">চেণ্ট্ৰেল কুৰ্ডিচ</language>
+			<language type="ckb" alt="variant">চেণ্ট্ৰেল কুৰ্ডিচ</language>
 			<language type="clc">চিলক’টিন</language>
 			<language type="co">কোৰ্ছিকান</language>
 			<language type="crg">মিচিফ</language>
@@ -809,7 +809,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">টুনিচিয়া</territory>
 			<territory type="TO">টংগা</territory>
 			<territory type="TR">তুৰ্কিয়ে</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">তুৰ্কিয়ে</territory>
 			<territory type="TT">ট্ৰিনিডাড আৰু টোবাগো</territory>
 			<territory type="TV">টুভালু</territory>
 			<territory type="TW">টাইৱান</territory>
@@ -1458,7 +1458,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraNames>
 					<eraAbbr>
 						<era type="0">খ্ৰীঃ পূঃ</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">খ্ৰীঃ পূঃ</era>
 						<era type="1">খ্ৰীঃ</era>
 						<era type="1" alt="variant">চি. ই.</era>
 					</eraAbbr>
@@ -1750,32 +1750,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
+							<month type="1">চৈত্ৰ</month>
+							<month type="2">বৈশাখ</month>
+							<month type="3">জ্যেষ্ঠ</month>
+							<month type="4">আষাঢ়</month>
+							<month type="5">শ্ৰাৱণ</month>
+							<month type="6">ভাদ্ৰ</month>
+							<month type="7">অশ্বিন</month>
+							<month type="8">কাৰ্তিক</month>
 							<month type="9">অগ্ৰহায়ণ</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
+							<month type="10">পৌষ</month>
+							<month type="11">মাঘ</month>
 							<month type="12">ফাল্গুন</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">চৈত্ৰ</month>
@@ -1794,18 +1794,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">চৈত্ৰ</month>
+							<month type="2">বৈশাখ</month>
+							<month type="3">জ্যেষ্ঠ</month>
+							<month type="4">আষাঢ়</month>
+							<month type="5">শ্ৰাৱণ</month>
+							<month type="6">ভাদ্ৰ</month>
+							<month type="7">অশ্বিন</month>
+							<month type="8">কাৰ্তিক</month>
+							<month type="9">অগ্ৰহায়ণ</month>
+							<month type="10">পৌষ</month>
+							<month type="11">মাঘ</month>
+							<month type="12">ফাল্গুন</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -1871,8 +1871,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="year-short">
 				<displayName>বছৰ</displayName>
 				<relative type="-1">যোৱা বছৰ</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="0">এই বছৰ</relative>
+				<relative type="1">অহা বছৰ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} বছৰত</relativeTimePattern>
 					<relativeTimePattern count="other">{0} বছৰত</relativeTimePattern>
@@ -1884,9 +1884,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>বছৰ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">যোৱা বছৰ</relative>
+				<relative type="0">এই বছৰ</relative>
+				<relative type="1">অহা বছৰ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} বছৰত</relativeTimePattern>
 					<relativeTimePattern count="other">{0} বছৰত</relativeTimePattern>
@@ -1948,9 +1948,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>মাহ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">যোৱা মাহ</relative>
+				<relative type="0">এই মাহ</relative>
+				<relative type="1">অহা মাহ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} মাহত</relativeTimePattern>
 					<relativeTimePattern count="other">{0} মাহত</relativeTimePattern>
@@ -1964,7 +1964,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>মাহ</displayName>
 				<relative type="-1">যোৱা মা.</relative>
 				<relative type="0">এই মা.</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">অহা মাহ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} মাহত</relativeTimePattern>
 					<relativeTimePattern count="other">{0} মাহত</relativeTimePattern>
@@ -1991,9 +1991,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>সপ্তাহ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">যোৱা সপ্তাহ</relative>
+				<relative type="0">এই সপ্তাহ</relative>
+				<relative type="1">অহা সপ্তাহ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} সপ্তাহত</relativeTimePattern>
 					<relativeTimePattern count="other">{0} সপ্তাহত</relativeTimePattern>
@@ -2006,9 +2006,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>সপ্তাহ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">যোৱা সপ্তাহ</relative>
+				<relative type="0">এই সপ্তাহ</relative>
+				<relative type="1">অহা সপ্তাহ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} সপ্তাহত</relativeTimePattern>
 					<relativeTimePattern count="other">{0} সপ্তাহত</relativeTimePattern>
@@ -2046,9 +2046,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>দিন</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">কালি</relative>
+				<relative type="0">আজি</relative>
+				<relative type="1">কাইলৈ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} দিনত</relativeTimePattern>
 					<relativeTimePattern count="other">{0} দিনত</relativeTimePattern>
@@ -2060,9 +2060,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>দিন</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">কালি</relative>
+				<relative type="0">আজি</relative>
+				<relative type="1">কাইলৈ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} দিনত</relativeTimePattern>
 					<relativeTimePattern count="other">{0} দিনত</relativeTimePattern>
@@ -2204,16 +2204,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">যোৱা মঙ্গল</relative>
+				<relative type="0">এই মঙ্গল</relative>
+				<relative type="1">অহা মঙ্গল</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} মঙ্গলে</relativeTimePattern>
+					<relativeTimePattern count="other">{0} মঙ্গলে</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} মঙ্গলৰ পূৰ্বে</relativeTimePattern>
+					<relativeTimePattern count="other">{0} মঙ্গলৰ পূৰ্বে</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -4702,7 +4702,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -6048,7 +6048,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">ঘন {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>জি-বল</displayName>
@@ -6280,7 +6280,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>কোৱাৰ্টাৰ্ছ</displayName>
 				<unitPattern count="one">{0} কোৱাৰ্টাৰ</unitPattern>
 				<unitPattern count="other">{0} কোৱাৰ্টাৰ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>মাহ</displayName>
@@ -6434,44 +6434,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} হাৰ্টজ</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>পৃথিৱীৰ ব্যাসাৰ্ধ</displayName>
@@ -6733,9 +6733,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ইঞ্চি মাৰ্কিউৰী</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>মিলিবাৰ</displayName>
@@ -6748,9 +6748,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>হেক্টোপাছকল</displayName>
@@ -7090,12 +7090,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7486,47 +7486,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7646,12 +7646,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -7785,7 +7785,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -7800,7 +7800,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -7953,7 +7953,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>বুশ্বেল</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -8010,12 +8010,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -8040,7 +8040,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -8140,112 +8140,112 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>জি-বল</displayName>
+				<unitPattern count="one">{0} জি</unitPattern>
+				<unitPattern count="other">{0} জি</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মিটাৰ/বৰ্গ ছেকেণ্ড</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ঘূৰ্ণন</displayName>
+				<unitPattern count="one">{0} ঘূৰ্ণন</unitPattern>
+				<unitPattern count="other">{0} ঘূৰ্ণন</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ৰেডিয়েন</displayName>
+				<unitPattern count="one">{0} ৰেডিয়েন</unitPattern>
+				<unitPattern count="other">{0} ৰেডিয়েন</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>আৰ্কছেকেণ্ড</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>বৰ্গ কিলোমিটাৰ</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>হেক্টৰ</displayName>
+				<unitPattern count="one">{0} হেক্টৰ</unitPattern>
+				<unitPattern count="other">{0} হেক্টৰ</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>বৰ্গ মিটাৰ</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>বৰ্গ মাইল</displayName>
+				<unitPattern count="one">{0} বৰ্গ মাইল</unitPattern>
+				<unitPattern count="other">{0} বৰ্গ মাইল</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>একৰ</displayName>
+				<unitPattern count="one">{0} একৰ</unitPattern>
+				<unitPattern count="other">{0} একৰ</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>বৰ্গ গজ</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>বৰ্গ ফুট</displayName>
+				<unitPattern count="one">{0} বৰ্গ ফুট</unitPattern>
+				<unitPattern count="other">{0} বৰ্গ ফুট</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>বৰ্গ ইঞ্চি</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ডুনাম</displayName>
+				<unitPattern count="one">{0} ডুনাম</unitPattern>
+				<unitPattern count="other">{0} ডুনাম</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কেৰেট</displayName>
+				<unitPattern count="one">{0} কেৰেট</unitPattern>
+				<unitPattern count="other">{0} কেৰেট</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মিঃ গ্ৰাঃ/ডেঃ লিঃ</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মিলিমোল/লিটাৰ</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>আইটেম</displayName>
@@ -8263,24 +8263,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>প্ৰতিমাইল</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পাৰমিৰেইড</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ম’ল</displayName>
+				<unitPattern count="one">{0} ম’ল</unitPattern>
+				<unitPattern count="other">{0} ম’ল</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>লিটাৰ/কিঃ মিঃ</displayName>
+				<unitPattern count="one">{0} লিঃ/কিঃ মিঃ</unitPattern>
+				<unitPattern count="other">{0} লিঃ/কিঃ মিঃ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ল/১০০ ক.ম.</displayName>
@@ -8288,91 +8288,91 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ল/১০০ ক.ম.</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মাইল/গেলন</displayName>
+				<unitPattern count="one">{0} mpg US</unitPattern>
+				<unitPattern count="other">{0} mpg US</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="one">{0} mpg Imp.</unitPattern>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>টেৰাবিট</displayName>
 			</unit>
 			<unit type="digital-gigabit">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} গিঃ বিঃ</unitPattern>
+				<unitPattern count="other">{0} গিঃ বিঃ</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} মেঃ বাঃ</unitPattern>
+				<unitPattern count="other">{0} মেঃ বাঃ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>মেঃ বাঃ</displayName>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>বিট</displayName>
+				<unitPattern count="one">{0} বিট</unitPattern>
+				<unitPattern count="other">{0} বিট</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>শতিকা</displayName>
+				<unitPattern count="one">{0} শতিকা</unitPattern>
+				<unitPattern count="other">{0} শতিকা</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>দশ.</displayName>
+				<unitPattern count="one">{0} দশ.</unitPattern>
+				<unitPattern count="other">{0} দশ.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>বছৰ</displayName>
 				<unitPattern count="one">{0} বছৰ</unitPattern>
 				<unitPattern count="other">{0} বছৰ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/বছৰ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>কোৱাৰ্টাৰ</displayName>
 				<unitPattern count="one">{0}q</unitPattern>
 				<unitPattern count="other">{0}q</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>মাহ</displayName>
 				<unitPattern count="one">{0} মাহ</unitPattern>
 				<unitPattern count="other">{0} মাহ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/মাহ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>সপ্তাহ</displayName>
 				<unitPattern count="one">{0} সপ্তাহ</unitPattern>
 				<unitPattern count="other">{0} সপ্তাহ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/সপ্তাহ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>দিন</displayName>
 				<unitPattern count="one">{0} দিন</unitPattern>
 				<unitPattern count="other">{0} দিন</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/দিন</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ঘণ্টা</displayName>
 				<unitPattern count="one">{0} ঘণ্টা</unitPattern>
 				<unitPattern count="other">{0} ঘণ্টা</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ঘণ্টা</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>মিনিট</displayName>
 				<unitPattern count="one">{0} মিনিট</unitPattern>
 				<unitPattern count="other">{0} মিনিট</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/মিনিট</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ছেকেণ্ড</displayName>
 				<unitPattern count="one">{0} ছেকেণ্ড</unitPattern>
 				<unitPattern count="other">{0} ছেকেণ্ড</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ছেকেণ্ড</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>মিলিছেকেণ্ড</displayName>
@@ -8380,182 +8380,182 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} মিঃ ছেঃ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মাইক্ৰছেকেণ্ড</displayName>
+				<unitPattern count="one">{0} মাঃ ছেঃ</unitPattern>
+				<unitPattern count="other">{0} মাঃ ছেঃ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>নেনোছেকেণ্ড</displayName>
+				<unitPattern count="one">{0} নেঃ ছেঃ</unitPattern>
+				<unitPattern count="other">{0} নেঃ ছেঃ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>এম্পিয়াৰ</displayName>
+				<unitPattern count="one">{0} এঃ</unitPattern>
+				<unitPattern count="other">{0} এঃ</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মিলিএম্পিয়াৰ</displayName>
+				<unitPattern count="one">{0} মিঃ এঃ</unitPattern>
+				<unitPattern count="other">{0} মিঃ এঃ</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ওম</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ভল্ট</displayName>
+				<unitPattern count="one">{0} ভঃ</unitPattern>
+				<unitPattern count="other">{0} ভঃ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কিলোকেলৰি</displayName>
+				<unitPattern count="one">{0} কিঃ কেলঃ</unitPattern>
+				<unitPattern count="other">{0} কিঃ কেলঃ</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কেলৰি</displayName>
+				<unitPattern count="one">{0} কেলৰি</unitPattern>
+				<unitPattern count="other">{0} কেলৰি</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কেলৰি</displayName>
+				<unitPattern count="one">{0} কেলৰি</unitPattern>
+				<unitPattern count="other">{0} কেলৰি</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কিলোজুল</displayName>
+				<unitPattern count="one">{0} কিঃ জুঃ</unitPattern>
+				<unitPattern count="other">{0} কিঃ জুঃ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>জুল</displayName>
+				<unitPattern count="one">{0} জুল</unitPattern>
+				<unitPattern count="other">{0} জুল</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কিঃ ৱাঃ-ঘঃ</displayName>
+				<unitPattern count="one">{0} কিঃ ৱাঃ-ঘঃ</unitPattern>
+				<unitPattern count="other">{0} কিঃ ৱাঃ-ঘঃ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ইলেক্ট্ৰ’নভ’ল্ট</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ইউ এচ থাৰ্ণ</displayName>
+				<unitPattern count="one">{0} ইউ এচ থাৰ্ণ</unitPattern>
+				<unitPattern count="other">{0} ইউ এচ থাৰ্ণ</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পাউণ্ড-বল</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>নিউটন</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>গিগাহাৰ্টজ</displayName>
+				<unitPattern count="one">{0} গিগাহাৰ্টজ</unitPattern>
+				<unitPattern count="other">{0} গিগাহাৰ্টজ</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মেগাহাৰ্টজ</displayName>
+				<unitPattern count="one">{0} মেঃ হাঃ</unitPattern>
+				<unitPattern count="other">{0} মেঃ হাঃ</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কিলোহাৰ্টজ</displayName>
+				<unitPattern count="one">{0} কিঃ হাঃ</unitPattern>
+				<unitPattern count="other">{0} কিঃ হাঃ</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>হাৰ্টজ</displayName>
+				<unitPattern count="one">{0} হাৰ্টজ</unitPattern>
+				<unitPattern count="other">{0} হাৰ্টজ</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>কিঃ মিঃ</displayName>
 				<unitPattern count="one">{0} কিঃ মিঃ</unitPattern>
 				<unitPattern count="other">{0} কিঃ মিঃ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/কিঃ মিঃ</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>মিঃ</displayName>
 				<unitPattern count="one">{0} মিঃ</unitPattern>
 				<unitPattern count="other">{0} মিঃ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/মিঃ</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ডেঃ মিঃ</displayName>
+				<unitPattern count="one">{0} ডেঃ মিঃ</unitPattern>
+				<unitPattern count="other">{0} ডেঃ মিঃ</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>ছেঃ মিঃ</displayName>
 				<unitPattern count="one">{0} ছেঃ মিঃ</unitPattern>
 				<unitPattern count="other">{0} ছেঃ মিঃ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ছেঃ মিঃ</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>মিঃ মিঃ</displayName>
@@ -8563,259 +8563,259 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} মিঃ মিঃ</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মাইক্ৰ’মিটাৰ</displayName>
+				<unitPattern count="one">{0} মাঃ মিঃ</unitPattern>
+				<unitPattern count="other">{0} মাঃ মিঃ</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>নেঃ মিঃ</displayName>
+				<unitPattern count="one">{0} নেঃ মিঃ</unitPattern>
+				<unitPattern count="other">{0} নেঃ মিঃ</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পিঃ মিঃ</displayName>
+				<unitPattern count="one">{0} পিঃ মিঃ</unitPattern>
+				<unitPattern count="other">{0} পিঃ মিঃ</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মাইল</displayName>
+				<unitPattern count="one">{0} মাঃ</unitPattern>
+				<unitPattern count="other">{0} মাঃ</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>গজ</displayName>
+				<unitPattern count="one">{0} গজ</unitPattern>
+				<unitPattern count="other">{0} গজ</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ফুট</displayName>
+				<unitPattern count="one">{0} ফুঃ</unitPattern>
+				<unitPattern count="other">{0} ফুঃ</unitPattern>
+				<perUnitPattern>{0}/ফুঃ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ইঞ্চি</displayName>
+				<unitPattern count="one">{0} ইঃ</unitPattern>
+				<unitPattern count="other">{0} ইঃ</unitPattern>
+				<perUnitPattern>{0}/ইঃ</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পাৰ্ছেক</displayName>
+				<unitPattern count="one">{0} পাৰ্ছেক</unitPattern>
+				<unitPattern count="other">{0} পাৰ্ছেক</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>আলোকবৰ্ষ</displayName>
+				<unitPattern count="one">{0} আঃ বঃ</unitPattern>
+				<unitPattern count="other">{0} আঃ বঃ</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>জ্যোঃ এঃ</displayName>
+				<unitPattern count="one">{0} জ্যোঃ এঃ</unitPattern>
+				<unitPattern count="other">{0} জ্যোঃ এঃ</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ফাৰ্লং</displayName>
+				<unitPattern count="one">{0} ফাৰ্লং</unitPattern>
+				<unitPattern count="other">{0} ফাৰ্লং</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ফাথম</displayName>
+				<unitPattern count="one">{0} ফাথম</unitPattern>
+				<unitPattern count="other">{0} ফাথম</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ন’টিঃ মাঃ</displayName>
+				<unitPattern count="one">{0} ন’টিঃ মাঃ</unitPattern>
+				<unitPattern count="other">{0} ন’টিঃ মাঃ</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মাঃ-স্কেঃ</displayName>
+				<unitPattern count="one">{0} মাঃ-স্কেঃ</unitPattern>
+				<unitPattern count="other">{0} মাঃ-স্কেঃ</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পইণ্ট</displayName>
+				<unitPattern count="one">{0} পইণ্ট</unitPattern>
+				<unitPattern count="other">{0} পইণ্ট</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>সৌৰ ৰেডিয়াছ</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>লাক্স</displayName>
+				<unitPattern count="one">{0} লাক্স</unitPattern>
+				<unitPattern count="other">{0} লাক্স</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ছ’লাৰ লুমিন’ছিটী</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ট</displayName>
+				<unitPattern count="one">{0} ট</unitPattern>
+				<unitPattern count="other">{0} ট</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>কিঃ গ্ৰাঃ</displayName>
 				<unitPattern count="one">{0} কিঃ গ্ৰাঃ</unitPattern>
 				<unitPattern count="other">{0} কিঃ গ্ৰাঃ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/কিঃ গ্ৰাঃ</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>গ্ৰাম</displayName>
 				<unitPattern count="one">{0} গ্ৰাঃ</unitPattern>
 				<unitPattern count="other">{0} গ্ৰাঃ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/গ্ৰাঃ</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মিঃ গ্ৰাঃ</displayName>
+				<unitPattern count="one">{0} মিঃ গ্ৰাঃ</unitPattern>
+				<unitPattern count="other">{0} মিঃ গ্ৰাঃ</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মাঃ গ্ৰাঃ</displayName>
+				<unitPattern count="one">{0} মাঃ গ্ৰাঃ</unitPattern>
+				<unitPattern count="other">{0} মাঃ গ্ৰাঃ</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>টন</displayName>
+				<unitPattern count="one">{0} টন</unitPattern>
+				<unitPattern count="other">{0} টন</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ষ্ট’ন</displayName>
+				<unitPattern count="one">{0} ষ্ট'ন</unitPattern>
+				<unitPattern count="other">{0} ষ্ট'ন</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>পাউণ্ড</displayName>
+				<unitPattern count="one">{0} পাউণ্ড</unitPattern>
+				<unitPattern count="other">{0} পাউণ্ড</unitPattern>
+				<perUnitPattern>{0}/পাউণ্ড</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>আউন্স</displayName>
+				<unitPattern count="one">{0} আউন্স</unitPattern>
+				<unitPattern count="other">{0} আউন্স</unitPattern>
+				<perUnitPattern>{0}/আউন্স</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ট্ৰয় আউন্স</displayName>
+				<unitPattern count="one">{0} ট্ৰঃ আঃ</unitPattern>
+				<unitPattern count="other">{0} ট্ৰঃ আঃ</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কেৰেট</displayName>
+				<unitPattern count="one">{0} কেৰেট</unitPattern>
+				<unitPattern count="other">{0} কেৰেট</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ডলট’ন</displayName>
+				<unitPattern count="one">{0} ডলট’ন</unitPattern>
+				<unitPattern count="other">{0} ডলট’ন</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>আৰ্থ মাছ</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>সৌৰ ভৰ</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>গ্ৰেইন</displayName>
+				<unitPattern count="one">{0} গ্ৰেইন</unitPattern>
+				<unitPattern count="other">{0} গ্ৰেইন</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>গিঃ ৱাঃ</displayName>
+				<unitPattern count="one">{0} গিঃ ৱাঃ</unitPattern>
+				<unitPattern count="other">{0} গিঃ ৱাঃ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মেঃ ৱাঃ</displayName>
+				<unitPattern count="one">{0} মেঃ ৱাঃ</unitPattern>
+				<unitPattern count="other">{0} মেঃ ৱাঃ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} কিঃ ৱাঃ</unitPattern>
+				<unitPattern count="other">{0} কিঃ ৱাঃ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ৱাট</displayName>
+				<unitPattern count="one">{0} ৱাট</unitPattern>
+				<unitPattern count="other">{0} ৱাট</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মিঃ ৱাঃ</displayName>
+				<unitPattern count="one">{0} মিঃ ৱাঃ</unitPattern>
+				<unitPattern count="other">{0} মিঃ ৱাঃ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>অশ্বক্ষমতা</displayName>
+				<unitPattern count="one">{0} অশ্বক্ষমতা</unitPattern>
+				<unitPattern count="other">{0} অশ্বক্ষমতা</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কি. পা.</displayName>
+				<unitPattern count="one">{0} কি. পা.</unitPattern>
+				<unitPattern count="other">{0} কি. পা.</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মেগাপাস্কেল</displayName>
+				<unitPattern count="one">{0} মে. পা.</unitPattern>
+				<unitPattern count="other">{0} মে. পা.</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>কিঃ মিঃ/ঘঃ</displayName>
@@ -8823,24 +8823,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মিটাৰ/ছেকেণ্ড</displayName>
+				<unitPattern count="one">{0} মিঃ/ছেঃ</unitPattern>
+				<unitPattern count="other">{0} মিঃ/ছেঃ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মাইল/ঘণ্টা</displayName>
+				<unitPattern count="one">{0} মাঃ/ঘঃ</unitPattern>
+				<unitPattern count="other">{0} মাঃ/ঘঃ</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>নট</displayName>
+				<unitPattern count="one">{0} নট</unitPattern>
+				<unitPattern count="other">{0} নট</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°চেঃ</displayName>
@@ -8848,199 +8848,199 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°চেঃ</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ডিঃ ফাঃ</displayName>
+				<unitPattern count="one">{0}°ফাঃ</unitPattern>
+				<unitPattern count="other">{0}°ফাঃ</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কেলভিন</displayName>
+				<unitPattern count="one">{0} কেলভিন</unitPattern>
+				<unitPattern count="other">{0} কেলভিন</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>নি. মি.</displayName>
+				<unitPattern count="one">{0} নি. মি.</unitPattern>
+				<unitPattern count="other">{0} নি. মি.</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ঘন কিলোমিটাৰ</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ঘন মিটাৰ</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ঘন ছেণ্টিমিটাৰ</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ঘন মাইল</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ঘন গজ</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ঘন ফুট</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ঘন ইঞ্চি</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মেঃ লিঃ</displayName>
+				<unitPattern count="one">{0} মেঃ লিঃ</unitPattern>
+				<unitPattern count="other">{0} মেঃ লিঃ</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>হেঃ লিঃ</displayName>
+				<unitPattern count="one">{0} হেঃ লিঃ</unitPattern>
+				<unitPattern count="other">{0} হেঃ লিঃ</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>লিটাৰ</displayName>
 				<unitPattern count="one">{0} লিঃ</unitPattern>
 				<unitPattern count="other">{0} লিঃ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/লিঃ</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ডেঃ লিঃ</displayName>
+				<unitPattern count="one">{0} ডেঃ লিঃ</unitPattern>
+				<unitPattern count="other">{0} ডেঃ লিঃ</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ছেঃ লিঃ</displayName>
+				<unitPattern count="one">{0} ছেঃ লিঃ</unitPattern>
+				<unitPattern count="other">{0} ছেঃ লিঃ</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মিঃ লিঃ</displayName>
+				<unitPattern count="one">{0} মিঃ লিঃ</unitPattern>
+				<unitPattern count="other">{0} মিঃ লিঃ</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মেঃ পিঃ</displayName>
+				<unitPattern count="one">{0} মেঃ পিঃ</unitPattern>
+				<unitPattern count="other">{0} মেঃ পিঃ</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মেঃ কাঃ</displayName>
+				<unitPattern count="one">{0} মেঃ কাঃ</unitPattern>
+				<unitPattern count="other">{0} মেঃ কাঃ</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>একৰ-ফুট</displayName>
+				<unitPattern count="one">{0} এঃ-ফুঃ</unitPattern>
+				<unitPattern count="other">{0} এঃ-ফুঃ</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>বুশ্বেল</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>গেলন</displayName>
+				<unitPattern count="one">{0} গেলন</unitPattern>
+				<unitPattern count="other">{0} গেলন</unitPattern>
+				<perUnitPattern>{0}/গেলন</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ইম্পেঃ গেঃ</displayName>
+				<unitPattern count="one">{0} ইম্পেঃ গেঃ</unitPattern>
+				<unitPattern count="other">{0} ইম্পেঃ গেঃ</unitPattern>
+				<perUnitPattern>{0}/ইম্পেঃ গেঃ</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কোৱাৰ্ট</displayName>
+				<unitPattern count="one">{0} কোৱাৰ্ট</unitPattern>
+				<unitPattern count="other">{0} কোৱাৰ্ট</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পিণ্ট</displayName>
+				<unitPattern count="one">{0} পিণ্ট</unitPattern>
+				<unitPattern count="other">{0} পিণ্ট</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>কাপ</displayName>
+				<unitPattern count="one">{0} কাপ</unitPattern>
+				<unitPattern count="other">{0} কাপ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ফ্লুঃ আঃ</displayName>
+				<unitPattern count="one">{0} ফ্লুঃ আঃ</unitPattern>
+				<unitPattern count="other">{0} ফ্লুঃ আঃ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ইম্পে. ফ্লু. আ.</displayName>
+				<unitPattern count="one">{0} ইম্পে. ফ্লু. আ.</unitPattern>
+				<unitPattern count="other">{0} ইম্পে. ফ্লু. আ.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>টেব’লস্পুন</displayName>
+				<unitPattern count="one">{0} টেব’লস্পুন</unitPattern>
+				<unitPattern count="other">{0} টেব’লস্পুন</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>চাহঃ চাঃ</displayName>
+				<unitPattern count="one">{0} চাহঃ চাঃ</unitPattern>
+				<unitPattern count="other">{0} চাহঃ চাঃ</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>বেৰেল</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ড্ৰপ</displayName>
+				<unitPattern count="one">{0} ড্ৰপ</unitPattern>
+				<unitPattern count="other">{0} ড্ৰপ</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ড্ৰাম তৰল পদাৰ্থ</displayName>
+				<unitPattern count="one">{0} ড্ৰাম তৰল পদাৰ্থ</unitPattern>
+				<unitPattern count="other">{0} ড্ৰাম তৰল পদাৰ্থ</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>জিগাৰ</displayName>
+				<unitPattern count="one">{0} জিগাৰ</unitPattern>
+				<unitPattern count="other">{0} জিগাৰ</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পিঞ্চ</displayName>
+				<unitPattern count="one">{0} পিঞ্চ</unitPattern>
+				<unitPattern count="other">{0} পিঞ্চ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>দিক্-নিৰ্দেশনা</displayName>
@@ -9074,28 +9074,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} বা {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} বা {1}</listPatternPart>
+			<listPatternPart type="2">{0} বা {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} বা {1}</listPatternPart>
+			<listPatternPart type="2">{0} বা {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} আৰু {1}</listPatternPart>
+			<listPatternPart type="2">{0} আৰু {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -215,7 +215,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="he">ivrit</language>
 			<language type="hi">hind</language>
 			<language type="hi_Latn">Hindi (latın)</language>
-			<language type="hi_Latn" alt="variant">↑↑↑</language>
+			<language type="hi_Latn" alt="variant">Hindi (latın)</language>
 			<language type="hil">hiliqaynon</language>
 			<language type="hit">hittit</language>
 			<language type="hmn">monq</language>
@@ -996,7 +996,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunis</territory>
 			<territory type="TO">Tonqa</territory>
 			<territory type="TR">Türkiyə</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Türkiyə</territory>
 			<territory type="TT">Trinidad və Tobaqo</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tayvan</territory>
@@ -1501,17 +1501,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">yanvar</month>
-							<month type="2">↑↑↑</month>
+							<month type="2">fevral</month>
 							<month type="3">mart</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="4">aprel</month>
+							<month type="5">may</month>
+							<month type="6">iyun</month>
+							<month type="7">iyul</month>
+							<month type="8">avqust</month>
+							<month type="9">sentyabr</month>
+							<month type="10">oktyabr</month>
+							<month type="11">noyabr</month>
+							<month type="12">dekabr</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -2028,18 +2028,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">Zilh.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Məhərrəm</month>
@@ -2109,57 +2109,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>G d MMMM y, EEEE</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>G d MMMM, y</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>G d MMM y</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>GGGGG dd.MM.y</pattern>
+							<datetimeSkeleton>GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">G y</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG d M y</dateFormatItem>
+						<dateFormatItem id="GyMMM">G MMM y</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G d MMM y</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G d MMM y, E</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">dd.MM, E</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">d MMM, E</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="y">G y</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">GGGGG MM y</dateFormatItem>
+						<dateFormatItem id="yyyyMd">GGGGG dd.MM.y</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">GGGGG dd.MM.y, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G MMM y</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G d MMM y</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G d MMM y, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G MMMM y</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -2167,18 +2167,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">fərvərdin</month>
+							<month type="2">ordibeheşt</month>
+							<month type="3">xordəd</month>
+							<month type="4">tir</month>
+							<month type="5">mordəd</month>
+							<month type="6">şəhrivar</month>
+							<month type="7">mehr</month>
+							<month type="8">abən</month>
+							<month type="9">azər</month>
+							<month type="10">dey</month>
+							<month type="11">bəhmən</month>
+							<month type="12">isfənd</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">fərvərdin</month>
+							<month type="2">ordibeheşt</month>
+							<month type="3">xordəd</month>
+							<month type="4">tir</month>
+							<month type="5">mordəd</month>
+							<month type="6">şəhrivar</month>
+							<month type="7">mehr</month>
+							<month type="8">abən</month>
+							<month type="9">azər</month>
+							<month type="10">dey</month>
+							<month type="11">bəhmən</month>
+							<month type="12">isfənd</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">fərvərdin</month>
+							<month type="2">ordibeheşt</month>
+							<month type="3">xordəd</month>
+							<month type="4">tir</month>
+							<month type="5">mordəd</month>
+							<month type="6">şəhrivar</month>
+							<month type="7">mehr</month>
+							<month type="8">abən</month>
+							<month type="9">azər</month>
+							<month type="10">dey</month>
+							<month type="11">bəhmən</month>
+							<month type="12">isfənd</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -2209,50 +2253,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">isfənd</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraAbbr>
@@ -2277,40 +2277,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">bu il</relative>
 				<relative type="1">gələn il</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} il ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} il ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} il öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} il öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-short">
 				<displayName>il</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">keçən il</relative>
+				<relative type="0">bu il</relative>
+				<relative type="1">gələn il</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} il ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} il ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} il öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} il öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
 				<displayName>il</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">keçən il</relative>
+				<relative type="0">bu il</relative>
+				<relative type="1">gələn il</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} il ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} il ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} il öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} il öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -2319,11 +2319,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">bu rüb</relative>
 				<relative type="1">gələn rüb</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} rüb ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} rüb ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} rüb öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} rüb öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2333,12 +2333,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">bu rüb</relative>
 				<relative type="1">gələn rüb</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} rüb ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} rüb ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} rüb öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} rüb öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
@@ -2347,12 +2347,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">bu rüb</relative>
 				<relative type="1">gələn rüb</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} rüb ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} rüb ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} rüb öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} rüb öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -2365,36 +2365,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">{0} ay ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ay öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ay öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-short">
 				<displayName>ay</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">keçən ay</relative>
+				<relative type="0">bu ay</relative>
+				<relative type="1">gələn ay</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ay ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} ay ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ay öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} ay öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
 				<displayName>ay</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">keçən ay</relative>
+				<relative type="0">bu ay</relative>
+				<relative type="1">gələn ay</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ay ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} ay ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} ay öncə</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} ay öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -2403,44 +2403,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">bu həftə</relative>
 				<relative type="1">gələn həftə</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} həftə ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} həftə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} həftə öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} həftə öncə</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>{0} həftəsi</relativePeriod>
 			</field>
 			<field type="week-short">
 				<displayName>həftə</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">keçən həftə</relative>
+				<relative type="0">bu həftə</relative>
+				<relative type="1">gələn həftə</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} həftə ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} həftə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} həftə öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} həftə öncə</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>{0} həftəsi</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>həftə</displayName>
+				<relative type="-1">keçən həftə</relative>
+				<relative type="0">bu həftə</relative>
+				<relative type="1">gələn həftə</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} həftə ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} həftə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} həftə öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} həftə öncə</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>{0} həftəsi</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName>Ayın həftəsi</displayName>
@@ -2449,7 +2449,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ay hft.</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ay hft.</displayName>
 			</field>
 			<field type="day">
 				<displayName>Gün</displayName>
@@ -2457,50 +2457,50 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">bu gün</relative>
 				<relative type="1">sabah</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} gün ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} gün ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} gün öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} gün öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Gün</displayName>
+				<relative type="-1">dünən</relative>
+				<relative type="0">bu gün</relative>
+				<relative type="1">sabah</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} gün ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} gün ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} gün öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} gün öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Gün</displayName>
+				<relative type="-1">dünən</relative>
+				<relative type="0">bu gün</relative>
+				<relative type="1">sabah</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} gün ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} gün ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} gün öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} gün öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
 				<displayName>ilin günü</displayName>
 			</field>
 			<field type="dayOfYear-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ilin günü</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ilin günü</displayName>
 			</field>
 			<field type="weekday">
 				<displayName>Həftənin Günü</displayName>
@@ -2509,7 +2509,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>hft. günü</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>hft. günü</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>ayın həftə günü</displayName>
@@ -2525,38 +2525,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">bu bazar</relative>
 				<relative type="1">gələn bazar</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bazar ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} bazar ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bazar öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} bazar öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">keçən bazar</relative>
+				<relative type="0">bu bazar</relative>
+				<relative type="1">gələn bazar</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bazar ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} bazar ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bazar öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} bazar öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">keçən bazar</relative>
+				<relative type="0">bu bazar</relative>
+				<relative type="1">gələn bazar</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bazar ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} bazar ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bazar öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} bazar öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2568,21 +2568,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">{0} bazar ertəsi əzrində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bazar ertəsi öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} bazar ertəsi öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">keçən bazar ertəsi</relative>
+				<relative type="0">bu bazar ertəsi</relative>
+				<relative type="1">gələn bazar ertəsi</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bazar ertəsi ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} bazar ertəsi ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bazar ertəsi öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} bazar ertəsi öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
@@ -2651,16 +2651,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="wed-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">keçən çərşənbə</relative>
+				<relative type="0">bu çərşənbə</relative>
+				<relative type="1">gələn çərşənbə</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} çərşənbə ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} çərşənbə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} çərşənbə öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} çərşənbə öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
@@ -2672,8 +2672,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">{0} çərşənbə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} çərşənbə öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} çərşənbə öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -2685,7 +2685,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">{0} cümə axşamı ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} cümə axşamı öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} cümə axşamı öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2794,114 +2794,114 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>AM/PM</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>AM/PM</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>AM/PM</displayName>
 			</field>
 			<field type="hour">
 				<displayName>Saat</displayName>
 				<relative type="0">bu saat</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saat ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} saat ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saat öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} saat öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-short">
 				<displayName>saat</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saat ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} saat ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saat öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} saat öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>saat</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saat ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} saat ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saat öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} saat öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
 				<displayName>Dəqiqə</displayName>
 				<relative type="0">bu dəqiqə</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dəqiqə ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} dəqiqə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dəqiqə öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} dəqiqə öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-short">
 				<displayName>dəq.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dəqiqə ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dəqiqə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dəqiqə öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dəqiqə öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>dəq.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dəqiqə ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dəqiqə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dəqiqə öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dəqiqə öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
 				<displayName>Saniyə</displayName>
 				<relative type="0">indi</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saniyə ərzində</relativeTimePattern>
 					<relativeTimePattern count="other">{0} saniyə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saniyə öncə</relativeTimePattern>
 					<relativeTimePattern count="other">{0} saniyə öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-short">
 				<displayName>san.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saniyə ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} saniyə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saniyə öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} saniyə öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>san.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saniyə ərzində</relativeTimePattern>
+					<relativeTimePattern count="other">{0} saniyə ərzində</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} saniyə öncə</relativeTimePattern>
+					<relativeTimePattern count="other">{0} saniyə öncə</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
@@ -2911,7 +2911,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>qurşaq</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>qurşaq</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -6969,7 +6969,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>yobe{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>kvadrat{0}</compoundUnitPattern1>
@@ -6982,7 +6982,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">kub {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g qüvvəsi</displayName>
@@ -7015,7 +7015,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dəqiqə</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>saniyə</displayName>
 				<unitPattern count="one">{0} saniyə</unitPattern>
 				<unitPattern count="other">{0} saniyə</unitPattern>
 			</unit>
@@ -7082,15 +7082,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>milliqram/desilitr</displayName>
 				<unitPattern count="one">{0} milliqram/desilitr</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>millimol/litr</displayName>
 				<unitPattern count="one">{0} millimol/litr</unitPattern>
 				<unitPattern count="other">{0} millimol/litr</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>element</displayName>
 				<unitPattern count="one">{0} element</unitPattern>
 				<unitPattern count="other">{0} element</unitPattern>
 			</unit>
@@ -7100,24 +7100,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} milyonda hissəcik</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
+				<displayName>faiz</displayName>
 				<unitPattern count="one">{0} faiz</unitPattern>
 				<unitPattern count="other">{0} faiz</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>promil</displayName>
 				<unitPattern count="one">{0} promil</unitPattern>
 				<unitPattern count="other">{0} promil</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>permiriada</displayName>
 				<unitPattern count="one">{0} permiriada</unitPattern>
 				<unitPattern count="other">{0} permiriada</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litr/kilometr</displayName>
@@ -7333,12 +7333,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ABŞ termal vahidi</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>güc funtu</displayName>
 				<unitPattern count="one">{0} güc funtu</unitPattern>
 				<unitPattern count="other">{0} güc funtu</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>nyuton</displayName>
 				<unitPattern count="one">{0} nyuton</unitPattern>
 				<unitPattern count="other">{0} nyuton</unitPattern>
 			</unit>
@@ -7369,8 +7369,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipoqraf emi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piksel</displayName>
@@ -7404,8 +7404,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>dot nöqtə</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>yer radiusu</displayName>
@@ -7538,7 +7538,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} lümen</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>gün işığı</displayName>
 				<unitPattern count="one">{0} gün işığı</unitPattern>
 				<unitPattern count="other">{0} gün işığı</unitPattern>
 			</unit>
@@ -7667,9 +7667,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} civə düymü</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>millibar</displayName>
@@ -7888,8 +7888,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>barrel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dessert qaşığı</displayName>
@@ -7912,9 +7912,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>çimdik</displayName>
@@ -8024,12 +8024,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8047,12 +8047,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>döv</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} döv</unitPattern>
 				<unitPattern count="other">{0} döv</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
@@ -8067,7 +8067,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>saniyə</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}san</unitPattern>
 				<unitPattern count="other">{0}san</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
@@ -8132,12 +8132,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>millimol/litr</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
 				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
@@ -8147,27 +8147,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>hissəcik/milyon</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hs/mln</unitPattern>
 				<unitPattern count="other">{0} hs/mln</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>faiz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>promil</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>permiriada</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -8177,17 +8177,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l/100km</unitPattern>
 				<unitPattern count="other">{0} l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mil/qal</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mil/qal</unitPattern>
 				<unitPattern count="other">{0} mil/qal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mil/imp. qal</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/q imp</unitPattern>
 				<unitPattern count="other">{0} m/q imp</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
@@ -8370,7 +8370,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronvolt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -8385,12 +8385,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>güc funtu</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>nyuton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -8420,7 +8420,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -8454,9 +8454,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>piksel</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>yer radiusu</displayName>
@@ -8570,7 +8570,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>günəş radiusu</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -8580,17 +8580,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>kd</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kd</unitPattern>
 				<unitPattern count="other">{0} kd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>gün işığı</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8654,17 +8654,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>yer kütləsi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>günəş kütləsi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8719,7 +8719,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -8744,12 +8744,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -8794,12 +8794,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -8939,7 +8939,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -8959,12 +8959,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>dram</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram</unitPattern>
 				<unitPattern count="other">{0} dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -8996,55 +8996,55 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>ki{0}</unitPrefixPattern>
@@ -9062,73 +9062,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>g qüvvəsi</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>m/s²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>döv</displayName>
+				<unitPattern count="one">{0} döv</unitPattern>
+				<unitPattern count="other">{0} döv</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dərəcə</displayName>
+				<unitPattern count="one">{0} dər</unitPattern>
+				<unitPattern count="other">{0} dər</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>dəqiqə</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}dəq</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>saniyə</displayName>
+				<unitPattern count="one">{0}san</unitPattern>
+				<unitPattern count="other">{0}san</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektar</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
@@ -9136,13 +9136,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>metr²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sm²</displayName>
+				<unitPattern count="one">{0} sm²</unitPattern>
+				<unitPattern count="other">{0} sm²</unitPattern>
+				<perUnitPattern>{0}/sm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mil²</displayName>
@@ -9151,14 +9151,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/mil²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>akr</displayName>
 				<unitPattern count="one">{0} ak</unitPattern>
 				<unitPattern count="other">{0} ak</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ft²</displayName>
@@ -9166,30 +9166,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dönüm</displayName>
+				<unitPattern count="one">{0} dönüm</unitPattern>
+				<unitPattern count="other">{0} dönüm</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millimol/litr</displayName>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>element</displayName>
@@ -9197,120 +9197,120 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} element</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>hissəcik/milyon</displayName>
+				<unitPattern count="one">{0} hs/mln</unitPattern>
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/100km</displayName>
+				<unitPattern count="one">{0} l/100km</unitPattern>
+				<unitPattern count="other">{0} l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil/qal</displayName>
+				<unitPattern count="one">{0} mil/qal</unitPattern>
+				<unitPattern count="other">{0} mil/qal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil/imp. qal</displayName>
 				<unitPattern count="one">{0} mil/imq</unitPattern>
 				<unitPattern count="other">{0} mil/imq</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PBayt</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bayt</displayName>
+				<unitPattern count="one">{0} bayt</unitPattern>
+				<unitPattern count="other">{0} bayt</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>əsr</displayName>
+				<unitPattern count="one">{0} əsr</unitPattern>
+				<unitPattern count="other">{0} əsr</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dek</displayName>
+				<unitPattern count="one">{0} dek</unitPattern>
+				<unitPattern count="other">{0} dek</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>il</displayName>
 				<unitPattern count="one">{0} il</unitPattern>
 				<unitPattern count="other">{0} il</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/il</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>rüb</displayName>
@@ -9322,37 +9322,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ay</displayName>
 				<unitPattern count="one">{0} ay</unitPattern>
 				<unitPattern count="other">{0} ay</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ay</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>hft</displayName>
 				<unitPattern count="one">{0} hft</unitPattern>
 				<unitPattern count="other">{0} hft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/hft</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>gün</displayName>
 				<unitPattern count="one">{0} gün</unitPattern>
 				<unitPattern count="other">{0} gün</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gün</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>saat</displayName>
 				<unitPattern count="one">{0} saat</unitPattern>
 				<unitPattern count="other">{0} saat</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/saat</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>dəq</displayName>
 				<unitPattern count="one">{0} dəq</unitPattern>
 				<unitPattern count="other">{0} dəq</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/dəq</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>san</displayName>
 				<unitPattern count="one">{0} san</unitPattern>
 				<unitPattern count="other">{0} san</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/san</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>msan</displayName>
@@ -9360,59 +9360,59 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} msan</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μsan</displayName>
+				<unitPattern count="one">{0} μsan</unitPattern>
+				<unitPattern count="other">{0} μsan</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nsan</displayName>
+				<unitPattern count="one">{0} nsan</unitPattern>
+				<unitPattern count="other">{0} nsan</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>om</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kkal</displayName>
+				<unitPattern count="one">{0} kkal</unitPattern>
+				<unitPattern count="other">{0} kkal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kal</displayName>
+				<unitPattern count="one">{0} kal</unitPattern>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kal</displayName>
+				<unitPattern count="one">{0} Kal</unitPattern>
+				<unitPattern count="other">{0} Kal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kc</displayName>
+				<unitPattern count="one">{0} kc</unitPattern>
+				<unitPattern count="other">{0} kc</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>coul</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kVt/saat</displayName>
@@ -9421,28 +9421,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTV</displayName>
+				<unitPattern count="one">{0} Btv</unitPattern>
+				<unitPattern count="other">{0} Btv</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ABŞ tv</displayName>
+				<unitPattern count="one">{0} ABŞ tv</unitPattern>
+				<unitPattern count="other">{0} ABŞ tv</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>güc funtu</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kVtst/100km</displayName>
@@ -9450,39 +9450,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kVts/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>piksel</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>meqapiksel</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>p/sm</displayName>
@@ -9511,31 +9511,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>R⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>kilometr</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>metr</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>sm</displayName>
 				<unitPattern count="one">{0} sm</unitPattern>
 				<unitPattern count="other">{0} sm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>millimetr</displayName>
@@ -9543,14 +9543,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>pm</displayName>
@@ -9558,7 +9558,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil</displayName>
 				<unitPattern count="one">{0} mil</unitPattern>
 				<unitPattern count="other">{0} mil</unitPattern>
 			</unit>
@@ -9571,13 +9571,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ft</displayName>
 				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="other">{0} ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>düym</displayName>
 				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="other">{0} in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>ps</displayName>
@@ -9590,91 +9590,91 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ii</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>av</displayName>
+				<unitPattern count="one">{0} av</unitPattern>
+				<unitPattern count="other">{0} av</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>farlonq</displayName>
 				<unitPattern count="one">{0} far</unitPattern>
 				<unitPattern count="other">{0} far</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fatom</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>xal</displayName>
+				<unitPattern count="one">{0} xal</unitPattern>
+				<unitPattern count="other">{0} xal</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kd</displayName>
+				<unitPattern count="one">{0} kd</unitPattern>
+				<unitPattern count="other">{0} kd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gün işığı</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kiloqram</displayName>
 				<unitPattern count="one">{0} kq</unitPattern>
 				<unitPattern count="other">{0} kq</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kq</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>qram</displayName>
 				<unitPattern count="one">{0} q</unitPattern>
 				<unitPattern count="other">{0} q</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mq</displayName>
+				<unitPattern count="one">{0} mq</unitPattern>
+				<unitPattern count="other">{0} mq</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μq</displayName>
+				<unitPattern count="one">{0} μq</unitPattern>
+				<unitPattern count="other">{0} μq</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>stoun</displayName>
@@ -9682,46 +9682,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} stoun</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>funt</displayName>
 				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>unsiya</displayName>
 				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">{0} oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>karat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Da</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qranul</displayName>
+				<unitPattern count="one">{0} qranul</unitPattern>
+				<unitPattern count="other">{0} qranul</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>GVt</displayName>
@@ -9754,54 +9754,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ag</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="one">{0} mm Hg</unitPattern>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>civə düymü</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>millibar</displayName>
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektopaskal</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>kilometr/saat</displayName>
@@ -9814,19 +9814,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil/saat</displayName>
 				<unitPattern count="one">{0} mil/saat</unitPattern>
 				<unitPattern count="other">{0} mil/saat</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9839,36 +9839,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sm³</displayName>
+				<unitPattern count="one">{0} sm³</unitPattern>
+				<unitPattern count="other">{0} sm³</unitPattern>
+				<perUnitPattern>{0}/sm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>mil³</displayName>
@@ -9876,19 +9876,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mil³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>Ml</displayName>
@@ -9904,7 +9904,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>litr</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>dl</displayName>
@@ -9923,8 +9923,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>mfincan</displayName>
@@ -9937,61 +9937,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ak-ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>buşel</displayName>
+				<unitPattern count="one">{0} buşel</unitPattern>
+				<unitPattern count="other">{0} buşel</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>qal</displayName>
+				<unitPattern count="one">{0} qal</unitPattern>
+				<unitPattern count="other">{0} qal</unitPattern>
+				<perUnitPattern>{0}/qal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>İmp. qal</displayName>
 				<unitPattern count="one">{0} imp.qal</unitPattern>
 				<unitPattern count="other">{0} imp.qal</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/imp. qal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>İmp. fl oz</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>xrqş</displayName>
+				<unitPattern count="one">{0} xrqş</unitPattern>
+				<unitPattern count="other">{0} xrqş</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>çyqş</displayName>
+				<unitPattern count="one">{0} çyqş</unitPattern>
+				<unitPattern count="other">{0} çyqş</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dsp</displayName>
@@ -9999,7 +9999,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dsp</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>des.qaş. İmp.</displayName>
 				<unitPattern count="one">{0}dsp-Imp</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
@@ -10009,22 +10009,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dc</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram</displayName>
+				<unitPattern count="one">{0} dram</unitPattern>
+				<unitPattern count="other">{0} dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>çimdik</displayName>
+				<unitPattern count="one">{0} çimdik</unitPattern>
+				<unitPattern count="other">{0} çimdik</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>kvarta İmp.</displayName>
 				<unitPattern count="one">{0}qt-Imp.</unitPattern>
 				<unitPattern count="other">{0}qt-Imp.</unitPattern>
 			</unit>
@@ -10060,20 +10060,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} yaxud {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, yaxud {1}</listPatternPart>
 			<listPatternPart type="2">{0}, yaxud {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, yaxud {1}</listPatternPart>
 			<listPatternPart type="2">{0}, yaxud {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -10118,7 +10118,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<characterLabelPattern type="miscellaneous">{0} — Qarışıq</characterLabelPattern>
 		<characterLabelPattern type="other">{0} — Digər</characterLabelPattern>
 		<characterLabelPattern type="scripts">Yazılar — {0}</characterLabelPattern>
-		<characterLabelPattern type="strokes" count="one">↑↑↑</characterLabelPattern>
+		<characterLabelPattern type="strokes" count="one">{0} Vurğu</characterLabelPattern>
 		<characterLabelPattern type="strokes" count="other">{0} Vurğu</characterLabelPattern>
 		<characterLabelPattern type="subscript">indeks {0}</characterLabelPattern>
 		<characterLabelPattern type="superscript">üst indeks {0}</characterLabelPattern>
@@ -10370,46 +10370,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">Sinbad</nameField>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -835,7 +835,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Туніс</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Турцыя</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Турцыя</territory>
 			<territory type="TT">Трынідад і Табага</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тайвань</territory>
@@ -1014,13 +1014,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="buddhist">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">б.э.</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">б.э.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">б.э.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -1092,18 +1092,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -1142,19 +1142,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -1180,62 +1180,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1289,7 +1289,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1297,7 +1297,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1743,10 +1743,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<era type="1" alt="variant">н.э.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="0">да н.э.</era>
+						<era type="0" alt="variant">да н.э.</era>
+						<era type="1">н.э.</era>
+						<era type="1" alt="variant">н.э.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -1831,7 +1831,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2069,7 +2069,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="year-short">
 				<displayName>г.</displayName>
 				<relative type="-1">у мін. годзе</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">у гэтым годзе</relative>
 				<relative type="1">у наст. годзе</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} г.</relativeTimePattern>
@@ -2087,7 +2087,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="year-narrow">
 				<displayName>г.</displayName>
 				<relative type="-1">у мін. годзе</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">у гэтым годзе</relative>
 				<relative type="1">у наст. годзе</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} г.</relativeTimePattern>
@@ -2122,9 +2122,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-short">
 				<displayName>кв.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">у мінулым квартале</relative>
+				<relative type="0">у гэтым квартале</relative>
+				<relative type="1">у наступным квартале</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} кв.</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} кв.</relativeTimePattern>
@@ -2140,9 +2140,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-narrow">
 				<displayName>кв.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">у мінулым квартале</relative>
+				<relative type="0">у гэтым квартале</relative>
+				<relative type="1">у наступным квартале</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} кв.</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} кв.</relativeTimePattern>
@@ -2298,11 +2298,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>дзень</displayName>
-				<relative type="-2">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="-2">пазаўчора</relative>
+				<relative type="-1">учора</relative>
+				<relative type="0">сёння</relative>
+				<relative type="1">заўтра</relative>
+				<relative type="2">паслязаўтра</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} дзень</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} дні</relativeTimePattern>
@@ -2318,11 +2318,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>д.</displayName>
-				<relative type="-2">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="-2">пазаўчора</relative>
+				<relative type="-1">учора</relative>
+				<relative type="0">сёння</relative>
+				<relative type="1">заўтра</relative>
+				<relative type="2">паслязаўтра</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} дзень</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} дні</relativeTimePattern>
@@ -2747,7 +2747,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>гадз</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">у гэту гадзіну</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} гадз</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} гадз</relativeTimePattern>
@@ -2763,7 +2763,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>гадз</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">у гэту гадзіну</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} гадз</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} гадз</relativeTimePattern>
@@ -2795,7 +2795,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>хв</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">у гэту хвіліну</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} хв</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} хв</relativeTimePattern>
@@ -2811,7 +2811,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>хв</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">у гэту хвіліну</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} хв</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} хв</relativeTimePattern>
@@ -2843,7 +2843,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>с</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">цяпер</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} с</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} с</relativeTimePattern>
@@ -2859,7 +2859,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>с</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">цяпер</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">праз {0} с</relativeTimePattern>
 					<relativeTimePattern count="few">праз {0} с</relativeTimePattern>
@@ -6799,7 +6799,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">куб. {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>паскарэнне свабоднага падзення</displayName>
@@ -7391,8 +7391,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-earth-radius">
 				<displayName>радыус Зямлі</displayName>
 				<unitPattern count="one">{0} радыус Зямлі</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">{0} радыуса Зямлі</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -8708,7 +8708,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>фунт-сілы</displayName>
 				<unitPattern count="one">{0} фунт-сіла</unitPattern>
 				<unitPattern count="few">{0} фунт-сілы</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
 				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
@@ -8811,9 +8811,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -8963,9 +8963,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
 				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -8991,9 +8991,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
 				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9086,16 +9086,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
 				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
 				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -9641,166 +9641,166 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>g</displayName>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="few">{0} g</unitPattern>
+				<unitPattern count="many">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>м/с²</displayName>
+				<unitPattern count="one">{0} м/с²</unitPattern>
+				<unitPattern count="few">{0} м/с²</unitPattern>
+				<unitPattern count="many">{0} м/с²</unitPattern>
+				<unitPattern count="other">{0} м/с²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>аб</displayName>
+				<unitPattern count="one">{0} аб</unitPattern>
+				<unitPattern count="few">{0} аб</unitPattern>
+				<unitPattern count="many">{0} аб</unitPattern>
+				<unitPattern count="other">{0} аб</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>рад</displayName>
+				<unitPattern count="one">{0} рад</unitPattern>
+				<unitPattern count="few">{0} рад</unitPattern>
+				<unitPattern count="many">{0} рад</unitPattern>
+				<unitPattern count="other">{0} рад</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="many">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>′</displayName>
+				<unitPattern count="one">{0}′</unitPattern>
+				<unitPattern count="few">{0}′</unitPattern>
+				<unitPattern count="many">{0}′</unitPattern>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>′′</displayName>
+				<unitPattern count="one">{0}″</unitPattern>
+				<unitPattern count="few">{0}″</unitPattern>
+				<unitPattern count="many">{0}″</unitPattern>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>км²</displayName>
+				<unitPattern count="one">{0} км²</unitPattern>
+				<unitPattern count="few">{0} км²</unitPattern>
+				<unitPattern count="many">{0} км²</unitPattern>
+				<unitPattern count="other">{0} км²</unitPattern>
+				<perUnitPattern>{0}/км²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>га</displayName>
+				<unitPattern count="one">{0} га</unitPattern>
+				<unitPattern count="few">{0} га</unitPattern>
+				<unitPattern count="many">{0} га</unitPattern>
+				<unitPattern count="other">{0} га</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>м²</displayName>
+				<unitPattern count="one">{0} м²</unitPattern>
+				<unitPattern count="few">{0} м²</unitPattern>
+				<unitPattern count="many">{0} м²</unitPattern>
+				<unitPattern count="other">{0} м²</unitPattern>
+				<perUnitPattern>{0}/м²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>см²</displayName>
+				<unitPattern count="one">{0} см²</unitPattern>
+				<unitPattern count="few">{0} см²</unitPattern>
+				<unitPattern count="many">{0} см²</unitPattern>
+				<unitPattern count="other">{0} см²</unitPattern>
+				<perUnitPattern>{0}/см²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>кв. мілі</displayName>
+				<unitPattern count="one">{0} кв. міля</unitPattern>
+				<unitPattern count="few">{0} кв. мілі</unitPattern>
+				<unitPattern count="many">{0} кв. міль</unitPattern>
+				<unitPattern count="other">{0} кв. мілі</unitPattern>
+				<perUnitPattern>{0}/кв. мілю</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>акры</displayName>
+				<unitPattern count="one">{0} акр</unitPattern>
+				<unitPattern count="few">{0} акры</unitPattern>
+				<unitPattern count="many">{0} акраў</unitPattern>
+				<unitPattern count="other">{0} акра</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кв. ярды</displayName>
+				<unitPattern count="one">{0} кв. ярд</unitPattern>
+				<unitPattern count="few">{0} кв. ярды</unitPattern>
+				<unitPattern count="many">{0} кв. ярдаў</unitPattern>
+				<unitPattern count="other">{0} кв. ярда</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кв. футы</displayName>
+				<unitPattern count="one">{0} кв. фут</unitPattern>
+				<unitPattern count="few">{0} кв. футы</unitPattern>
+				<unitPattern count="many">{0} кв. футаў</unitPattern>
+				<unitPattern count="other">{0} кв. фута</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>кв. цалі</displayName>
+				<unitPattern count="one">{0} кв. цаля</unitPattern>
+				<unitPattern count="few">{0} кв. цалі</unitPattern>
+				<unitPattern count="many">{0} кв. цаляў</unitPattern>
+				<unitPattern count="other">{0} кв. цалі</unitPattern>
+				<perUnitPattern>{0}/кв. цалю</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дунамы</displayName>
+				<unitPattern count="one">{0} дунам</unitPattern>
+				<unitPattern count="few">{0} дунамы</unitPattern>
+				<unitPattern count="many">{0} дунамаў</unitPattern>
+				<unitPattern count="other">{0} дунама</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кар золата</displayName>
+				<unitPattern count="one">{0} кар</unitPattern>
+				<unitPattern count="few">{0} кар</unitPattern>
+				<unitPattern count="many">{0} кар</unitPattern>
+				<unitPattern count="other">{0} кар</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мг/дл</displayName>
+				<unitPattern count="one">{0} мг/дл</unitPattern>
+				<unitPattern count="few">{0} мг/дл</unitPattern>
+				<unitPattern count="many">{0} мг/дл</unitPattern>
+				<unitPattern count="other">{0} мг/дл</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ммоль/л</displayName>
+				<unitPattern count="one">{0} ммоль/л</unitPattern>
+				<unitPattern count="few">{0} ммоль/л</unitPattern>
+				<unitPattern count="many">{0} ммоль/л</unitPattern>
+				<unitPattern count="other">{0} ммоль/л</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>элем.</displayName>
 				<unitPattern count="one">{0} элем.</unitPattern>
 				<unitPattern count="few">{0} элем.</unitPattern>
 				<unitPattern count="many">{0} элем.</unitPattern>
 				<unitPattern count="other">{0} элем.</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="many">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9810,32 +9810,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>праміле</displayName>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="few">{0} ‰</unitPattern>
+				<unitPattern count="many">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="few">{0} ‱</unitPattern>
+				<unitPattern count="many">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>моль</displayName>
+				<unitPattern count="one">{0} моль</unitPattern>
+				<unitPattern count="few">{0} молі</unitPattern>
+				<unitPattern count="many">{0} моляў</unitPattern>
+				<unitPattern count="other">{0} моля</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>л/км</displayName>
+				<unitPattern count="one">{0} л/км</unitPattern>
+				<unitPattern count="few">{0} л/км</unitPattern>
+				<unitPattern count="many">{0} л/км</unitPattern>
+				<unitPattern count="other">{0} л/км</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>л/100 км</displayName>
@@ -9845,109 +9845,109 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} л/100 км</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мілі/гал.</displayName>
+				<unitPattern count="one">{0} міля/гал.</unitPattern>
+				<unitPattern count="few">{0} мілі/гал.</unitPattern>
+				<unitPattern count="many">{0} міль/гал.</unitPattern>
+				<unitPattern count="other">{0} мілі/гал.</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>міль/імп. гал.</displayName>
+				<unitPattern count="one">{0} міля/імп. гал.</unitPattern>
+				<unitPattern count="few">{0} мілі/імп. гал.</unitPattern>
+				<unitPattern count="many">{0} міль/імп. галон</unitPattern>
+				<unitPattern count="other">{0} мілі/імп. галон</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ПБ</displayName>
+				<unitPattern count="one">{0} ПБ</unitPattern>
+				<unitPattern count="few">{0} ПБ</unitPattern>
+				<unitPattern count="many">{0} ПБ</unitPattern>
+				<unitPattern count="other">{0} ПБ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ТБ</displayName>
+				<unitPattern count="one">{0} ТБ</unitPattern>
+				<unitPattern count="few">{0} ТБ</unitPattern>
+				<unitPattern count="many">{0} ТБ</unitPattern>
+				<unitPattern count="other">{0} ТБ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Тбіт</displayName>
+				<unitPattern count="one">{0} Тбіт</unitPattern>
+				<unitPattern count="few">{0} Тбіт</unitPattern>
+				<unitPattern count="many">{0} Тбіт</unitPattern>
+				<unitPattern count="other">{0} Тбіт</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ГБ</displayName>
+				<unitPattern count="one">{0} ГБ</unitPattern>
+				<unitPattern count="few">{0} ГБ</unitPattern>
+				<unitPattern count="many">{0} ГБ</unitPattern>
+				<unitPattern count="other">{0} ГБ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гбіт</displayName>
+				<unitPattern count="one">{0} Гбіт</unitPattern>
+				<unitPattern count="few">{0} Гбіт</unitPattern>
+				<unitPattern count="many">{0} Гбіт</unitPattern>
+				<unitPattern count="other">{0} Гбіт</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МБ</displayName>
+				<unitPattern count="one">{0} МБ</unitPattern>
+				<unitPattern count="few">{0} МБ</unitPattern>
+				<unitPattern count="many">{0} МБ</unitPattern>
+				<unitPattern count="other">{0} МБ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мбіт</displayName>
+				<unitPattern count="one">{0} Мбіт</unitPattern>
+				<unitPattern count="few">{0} Мбіт</unitPattern>
+				<unitPattern count="many">{0} Мбіт</unitPattern>
+				<unitPattern count="other">{0} Мбіт</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>КБ</displayName>
+				<unitPattern count="one">{0} КБ</unitPattern>
+				<unitPattern count="few">{0} КБ</unitPattern>
+				<unitPattern count="many">{0} КБ</unitPattern>
+				<unitPattern count="other">{0} КБ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кбіт</displayName>
+				<unitPattern count="one">{0} кбіт</unitPattern>
+				<unitPattern count="few">{0} кбіт</unitPattern>
+				<unitPattern count="many">{0} кбіт</unitPattern>
+				<unitPattern count="other">{0} кбіт</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>байт</displayName>
+				<unitPattern count="one">{0} байт</unitPattern>
+				<unitPattern count="few">{0} байты</unitPattern>
+				<unitPattern count="many">{0} байт</unitPattern>
+				<unitPattern count="other">{0} байта</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>біт</displayName>
+				<unitPattern count="one">{0} біт</unitPattern>
+				<unitPattern count="few">{0} біты</unitPattern>
+				<unitPattern count="many">{0} біт</unitPattern>
+				<unitPattern count="other">{0} біта</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ст.</displayName>
+				<unitPattern count="one">{0} ст.</unitPattern>
+				<unitPattern count="few">{0} ст.</unitPattern>
+				<unitPattern count="many">{0} ст.</unitPattern>
+				<unitPattern count="other">{0} ст.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дзесяцігоддзе</displayName>
+				<unitPattern count="one">{0} дз.</unitPattern>
+				<unitPattern count="few">{0} дз.</unitPattern>
+				<unitPattern count="many">{0} дз.</unitPattern>
+				<unitPattern count="other">{0} дз.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>г.</displayName>
@@ -9955,7 +9955,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} г.</unitPattern>
 				<unitPattern count="many">{0} г.</unitPattern>
 				<unitPattern count="other">{0} г.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} у г.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>кв.</displayName>
@@ -9971,7 +9971,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} мес.</unitPattern>
 				<unitPattern count="many">{0} мес.</unitPattern>
 				<unitPattern count="other">{0} мес.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} у мес.</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>тыдз.</displayName>
@@ -9979,7 +9979,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} тыдз.</unitPattern>
 				<unitPattern count="many">{0} тыдз.</unitPattern>
 				<unitPattern count="other">{0} тыдз.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} у тыдз.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>сут</displayName>
@@ -9987,7 +9987,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} сут</unitPattern>
 				<unitPattern count="many">{0} сут</unitPattern>
 				<unitPattern count="other">{0} сут</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} сут</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>гадз</displayName>
@@ -9995,7 +9995,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} гадз</unitPattern>
 				<unitPattern count="many">{0} гадз</unitPattern>
 				<unitPattern count="other">{0} гадз</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/гадз</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>хв</displayName>
@@ -10003,7 +10003,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} хв</unitPattern>
 				<unitPattern count="many">{0} хв</unitPattern>
 				<unitPattern count="other">{0} хв</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ хв</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>с</displayName>
@@ -10011,7 +10011,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} с</unitPattern>
 				<unitPattern count="many">{0} с</unitPattern>
 				<unitPattern count="other">{0} с</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/с</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>мс</displayName>
@@ -10021,116 +10021,116 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мс</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мкс</displayName>
+				<unitPattern count="one">{0} мкс</unitPattern>
+				<unitPattern count="few">{0} мкс</unitPattern>
+				<unitPattern count="many">{0} мкс</unitPattern>
+				<unitPattern count="other">{0} мкс</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>нс</displayName>
+				<unitPattern count="one">{0} нс</unitPattern>
+				<unitPattern count="few">{0} нс</unitPattern>
+				<unitPattern count="many">{0} нс</unitPattern>
+				<unitPattern count="other">{0} нс</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>А</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="many">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мА</displayName>
+				<unitPattern count="one">{0} мА</unitPattern>
+				<unitPattern count="few">{0} мА</unitPattern>
+				<unitPattern count="many">{0} мА</unitPattern>
+				<unitPattern count="other">{0} мА</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ом</displayName>
+				<unitPattern count="one">{0} Ом</unitPattern>
+				<unitPattern count="few">{0} Ом</unitPattern>
+				<unitPattern count="many">{0} Ом</unitPattern>
+				<unitPattern count="other">{0} Ом</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>В</displayName>
+				<unitPattern count="one">{0} В</unitPattern>
+				<unitPattern count="few">{0} В</unitPattern>
+				<unitPattern count="many">{0} В</unitPattern>
+				<unitPattern count="other">{0} В</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ккал</displayName>
+				<unitPattern count="one">{0} ккал</unitPattern>
+				<unitPattern count="few">{0} ккал</unitPattern>
+				<unitPattern count="many">{0} ккал</unitPattern>
+				<unitPattern count="other">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кал</displayName>
+				<unitPattern count="one">{0} кал</unitPattern>
+				<unitPattern count="few">{0} кал</unitPattern>
+				<unitPattern count="many">{0} кал</unitPattern>
+				<unitPattern count="other">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кал</displayName>
+				<unitPattern count="one">{0} кал</unitPattern>
+				<unitPattern count="few">{0} кал</unitPattern>
+				<unitPattern count="many">{0} кал</unitPattern>
+				<unitPattern count="other">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кДж</displayName>
+				<unitPattern count="one">{0} кДж</unitPattern>
+				<unitPattern count="few">{0} кДж</unitPattern>
+				<unitPattern count="many">{0} кДж</unitPattern>
+				<unitPattern count="other">{0} кДж</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Дж</displayName>
+				<unitPattern count="one">{0} Дж</unitPattern>
+				<unitPattern count="few">{0} Дж</unitPattern>
+				<unitPattern count="many">{0} Дж</unitPattern>
+				<unitPattern count="other">{0} Дж</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кВт·г</displayName>
+				<unitPattern count="one">{0} кВт·г</unitPattern>
+				<unitPattern count="few">{0} кВт·г</unitPattern>
+				<unitPattern count="many">{0} кВт·г</unitPattern>
+				<unitPattern count="other">{0} кВт·г</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>эВ</displayName>
+				<unitPattern count="one">{0} эВ</unitPattern>
+				<unitPattern count="few">{0} эВ</unitPattern>
+				<unitPattern count="many">{0} эВ</unitPattern>
+				<unitPattern count="other">{0} эВ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} BTU</unitPattern>
+				<unitPattern count="few">{0} BTU</unitPattern>
+				<unitPattern count="many">{0} BTU</unitPattern>
+				<unitPattern count="other">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>амер. тэрмы</displayName>
+				<unitPattern count="one">{0} амер. тэрм</unitPattern>
+				<unitPattern count="few">{0} амер. тэрмы</unitPattern>
+				<unitPattern count="many">{0} амер. тэрмаў</unitPattern>
+				<unitPattern count="other">{0} амер. тэрма</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фунт-сілы</displayName>
+				<unitPattern count="one">{0} фунт-сіла</unitPattern>
+				<unitPattern count="few">{0} фунт-сілы</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>Н</displayName>
@@ -10147,95 +10147,95 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} кВт·г/100 км</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ГГц</displayName>
+				<unitPattern count="one">{0} ГГц</unitPattern>
+				<unitPattern count="few">{0} ГГц</unitPattern>
+				<unitPattern count="many">{0} ГГц</unitPattern>
+				<unitPattern count="other">{0} ГГц</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МГц</displayName>
+				<unitPattern count="one">{0} МГц</unitPattern>
+				<unitPattern count="few">{0} МГц</unitPattern>
+				<unitPattern count="many">{0} МГц</unitPattern>
+				<unitPattern count="other">{0} МГц</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кГц</displayName>
+				<unitPattern count="one">{0} кГц</unitPattern>
+				<unitPattern count="few">{0} кГц</unitPattern>
+				<unitPattern count="many">{0} кГц</unitPattern>
+				<unitPattern count="other">{0} кГц</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гц</displayName>
+				<unitPattern count="one">{0} Гц</unitPattern>
+				<unitPattern count="few">{0} Гц</unitPattern>
+				<unitPattern count="many">{0} Гц</unitPattern>
+				<unitPattern count="other">{0} Гц</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>эм</displayName>
+				<unitPattern count="one">{0} эм</unitPattern>
+				<unitPattern count="few">{0} эм</unitPattern>
+				<unitPattern count="many">{0} эм</unitPattern>
+				<unitPattern count="other">{0} эм</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пікселі</displayName>
+				<unitPattern count="one">{0} піксель</unitPattern>
+				<unitPattern count="few">{0} пікселі</unitPattern>
+				<unitPattern count="many">{0} пікселяў</unitPattern>
+				<unitPattern count="other">{0} пікселя</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мпікс</displayName>
+				<unitPattern count="one">{0} Мпікс</unitPattern>
+				<unitPattern count="few">{0} Мпікс</unitPattern>
+				<unitPattern count="many">{0} Мпікс</unitPattern>
+				<unitPattern count="other">{0} Мпікс</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>піксель/см</displayName>
+				<unitPattern count="one">{0} піксель/см</unitPattern>
+				<unitPattern count="few">{0} пікселі/см</unitPattern>
+				<unitPattern count="many">{0} пікселяў/см</unitPattern>
+				<unitPattern count="other">{0} пікселя/см</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>піксель/цалю</displayName>
+				<unitPattern count="one">{0} піксель/цалю</unitPattern>
+				<unitPattern count="few">{0} пікселі/цалю</unitPattern>
+				<unitPattern count="many">{0} пікселяў/цалю</unitPattern>
+				<unitPattern count="other">{0} пікселя/цалю</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кр/см</displayName>
+				<unitPattern count="one">{0} кр/см</unitPattern>
+				<unitPattern count="few">{0} кр/см</unitPattern>
+				<unitPattern count="many">{0} кр/см</unitPattern>
+				<unitPattern count="other">{0} кр/см</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="few">{0} dpi</unitPattern>
+				<unitPattern count="many">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кр</displayName>
+				<unitPattern count="one">{0} кр</unitPattern>
+				<unitPattern count="few">{0} кр</unitPattern>
+				<unitPattern count="many">{0} кр</unitPattern>
+				<unitPattern count="other">{0} кр</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>км</displayName>
@@ -10243,7 +10243,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} км</unitPattern>
 				<unitPattern count="many">{0} км</unitPattern>
 				<unitPattern count="other">{0} км</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/км</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>м</displayName>
@@ -10251,14 +10251,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} м</unitPattern>
 				<unitPattern count="many">{0} м</unitPattern>
 				<unitPattern count="other">{0} м</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/м</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дм</displayName>
+				<unitPattern count="one">{0} дм</unitPattern>
+				<unitPattern count="few">{0} дм</unitPattern>
+				<unitPattern count="many">{0} дм</unitPattern>
+				<unitPattern count="other">{0} дм</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>см</displayName>
@@ -10266,7 +10266,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} см</unitPattern>
 				<unitPattern count="many">{0} см</unitPattern>
 				<unitPattern count="other">{0} см</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/см</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>мм</displayName>
@@ -10276,153 +10276,153 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мм</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мкм</displayName>
+				<unitPattern count="one">{0} мкм</unitPattern>
+				<unitPattern count="few">{0} мкм</unitPattern>
+				<unitPattern count="many">{0} мкм</unitPattern>
+				<unitPattern count="other">{0} мкм</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>нм</displayName>
+				<unitPattern count="one">{0} нм</unitPattern>
+				<unitPattern count="few">{0} нм</unitPattern>
+				<unitPattern count="many">{0} нм</unitPattern>
+				<unitPattern count="other">{0} нм</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пм</displayName>
+				<unitPattern count="one">{0} пм</unitPattern>
+				<unitPattern count="few">{0} пм</unitPattern>
+				<unitPattern count="many">{0} пм</unitPattern>
+				<unitPattern count="other">{0} пм</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мілі</displayName>
+				<unitPattern count="one">{0} міля</unitPattern>
+				<unitPattern count="few">{0} мілі</unitPattern>
+				<unitPattern count="many">{0} міль</unitPattern>
+				<unitPattern count="other">{0} мілі</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ярды</displayName>
+				<unitPattern count="one">{0} ярд</unitPattern>
+				<unitPattern count="few">{0} ярды</unitPattern>
+				<unitPattern count="many">{0} ярдаў</unitPattern>
+				<unitPattern count="other">{0} ярда</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>футы</displayName>
+				<unitPattern count="one">{0} фут</unitPattern>
+				<unitPattern count="few">{0} футы</unitPattern>
+				<unitPattern count="many">{0} футаў</unitPattern>
+				<unitPattern count="other">{0} фута</unitPattern>
+				<perUnitPattern>{0}/фут</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>цалі</displayName>
+				<unitPattern count="one">{0} цаля</unitPattern>
+				<unitPattern count="few">{0} цалі</unitPattern>
+				<unitPattern count="many">{0} цаляў</unitPattern>
+				<unitPattern count="other">{0} цалі</unitPattern>
+				<perUnitPattern>{0}/цалю</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пс</displayName>
+				<unitPattern count="one">{0} пс</unitPattern>
+				<unitPattern count="few">{0} пс</unitPattern>
+				<unitPattern count="many">{0} пс</unitPattern>
+				<unitPattern count="other">{0} пс</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>св. г.</displayName>
+				<unitPattern count="one">{0} св. г.</unitPattern>
+				<unitPattern count="few">{0} св. г.</unitPattern>
+				<unitPattern count="many">{0} св. г.</unitPattern>
+				<unitPattern count="other">{0} св. г.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>а. а.</displayName>
+				<unitPattern count="one">{0} а. а.</unitPattern>
+				<unitPattern count="few">{0} а. а.</unitPattern>
+				<unitPattern count="many">{0} а. а.</unitPattern>
+				<unitPattern count="other">{0} а. а.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фурлонгі</displayName>
+				<unitPattern count="one">{0} фур.</unitPattern>
+				<unitPattern count="few">{0} фур.</unitPattern>
+				<unitPattern count="many">{0} фур.</unitPattern>
+				<unitPattern count="other">{0} фур.</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фатамы</displayName>
+				<unitPattern count="one">{0} фат.</unitPattern>
+				<unitPattern count="few">{0} фат.</unitPattern>
+				<unitPattern count="many">{0} фат.</unitPattern>
+				<unitPattern count="other">{0} фат.</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мар. мілі</displayName>
+				<unitPattern count="one">{0} мар. міля</unitPattern>
+				<unitPattern count="few">{0} мар. мілі</unitPattern>
+				<unitPattern count="many">{0} мар. міль</unitPattern>
+				<unitPattern count="other">{0} мар. міль</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>сканд. мілі</displayName>
+				<unitPattern count="one">{0} скан. мілі</unitPattern>
+				<unitPattern count="few">{0} скан. мілі</unitPattern>
+				<unitPattern count="many">{0} скан. міль</unitPattern>
+				<unitPattern count="other">{0} скан. мілі</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пт</displayName>
+				<unitPattern count="one">{0} пт</unitPattern>
+				<unitPattern count="few">{0} пт</unitPattern>
+				<unitPattern count="many">{0} пт</unitPattern>
+				<unitPattern count="other">{0} пт</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>лк</displayName>
+				<unitPattern count="one">{0} лк</unitPattern>
+				<unitPattern count="few">{0} лк</unitPattern>
+				<unitPattern count="many">{0} лк</unitPattern>
+				<unitPattern count="other">{0} лк</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кд</displayName>
+				<unitPattern count="one">{0} кд</unitPattern>
+				<unitPattern count="few">{0} кд</unitPattern>
+				<unitPattern count="many">{0} кд</unitPattern>
+				<unitPattern count="other">{0} кд</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>лм</displayName>
+				<unitPattern count="one">{0} лм</unitPattern>
+				<unitPattern count="few">{0} лм</unitPattern>
+				<unitPattern count="many">{0} лм</unitPattern>
+				<unitPattern count="other">{0} лм</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>т</displayName>
+				<unitPattern count="one">{0} т</unitPattern>
+				<unitPattern count="few">{0} т</unitPattern>
+				<unitPattern count="many">{0} т</unitPattern>
+				<unitPattern count="other">{0} т</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>кг</displayName>
@@ -10430,7 +10430,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} кг</unitPattern>
 				<unitPattern count="many">{0} кг</unitPattern>
 				<unitPattern count="other">{0} кг</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/кг</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>г</displayName>
@@ -10438,205 +10438,205 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} г</unitPattern>
 				<unitPattern count="many">{0} г</unitPattern>
 				<unitPattern count="other">{0} г</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/г</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мг</displayName>
+				<unitPattern count="one">{0} мг</unitPattern>
+				<unitPattern count="few">{0} мг</unitPattern>
+				<unitPattern count="many">{0} мг</unitPattern>
+				<unitPattern count="other">{0} мг</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мкг</displayName>
+				<unitPattern count="one">{0} мкг</unitPattern>
+				<unitPattern count="few">{0} мкг</unitPattern>
+				<unitPattern count="many">{0} мкг</unitPattern>
+				<unitPattern count="other">{0} мкг</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>амер. т</displayName>
+				<unitPattern count="one">{0} амер. т</unitPattern>
+				<unitPattern count="few">{0} амер. т</unitPattern>
+				<unitPattern count="many">{0} амер. т</unitPattern>
+				<unitPattern count="other">{0} амер. т</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>стоны</displayName>
+				<unitPattern count="one">{0} стон</unitPattern>
+				<unitPattern count="few">{0} стоны</unitPattern>
+				<unitPattern count="many">{0} стонаў</unitPattern>
+				<unitPattern count="other">{0} стона</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>фунты</displayName>
+				<unitPattern count="one">{0} фунт</unitPattern>
+				<unitPattern count="few">{0} фунты</unitPattern>
+				<unitPattern count="many">{0} фунтаў</unitPattern>
+				<unitPattern count="other">{0} фунта</unitPattern>
+				<perUnitPattern>{0}/фунт</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>унц.</displayName>
+				<unitPattern count="one">{0} унц.</unitPattern>
+				<unitPattern count="few">{0} унц.</unitPattern>
+				<unitPattern count="many">{0} унц.</unitPattern>
+				<unitPattern count="other">{0} унц.</unitPattern>
+				<perUnitPattern>{0}/унц.</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>тр. унц.</displayName>
+				<unitPattern count="one">{0} тр. унц.</unitPattern>
+				<unitPattern count="few">{0} тр. унц.</unitPattern>
+				<unitPattern count="many">{0} тр. унц.</unitPattern>
+				<unitPattern count="other">{0} тр. унц.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кар</displayName>
+				<unitPattern count="one">{0} кар</unitPattern>
+				<unitPattern count="few">{0} кар</unitPattern>
+				<unitPattern count="many">{0} кар</unitPattern>
+				<unitPattern count="other">{0} кар</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Да</displayName>
+				<unitPattern count="one">{0} Да</unitPattern>
+				<unitPattern count="few">{0} Да</unitPattern>
+				<unitPattern count="many">{0} Да</unitPattern>
+				<unitPattern count="other">{0} Да</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>гран</displayName>
+				<unitPattern count="one">{0} гран</unitPattern>
+				<unitPattern count="few">{0} граны</unitPattern>
+				<unitPattern count="many">{0} гранаў</unitPattern>
+				<unitPattern count="other">{0} грана</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ГВт</displayName>
+				<unitPattern count="one">{0} ГВт</unitPattern>
+				<unitPattern count="few">{0} ГВт</unitPattern>
+				<unitPattern count="many">{0} ГВт</unitPattern>
+				<unitPattern count="other">{0} ГВт</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МВт</displayName>
+				<unitPattern count="one">{0} МВт</unitPattern>
+				<unitPattern count="few">{0} МВт</unitPattern>
+				<unitPattern count="many">{0} МВт</unitPattern>
+				<unitPattern count="other">{0} МВт</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кВт</displayName>
+				<unitPattern count="one">{0} кВт</unitPattern>
+				<unitPattern count="few">{0} кВт</unitPattern>
+				<unitPattern count="many">{0} кВт</unitPattern>
+				<unitPattern count="other">{0} кВт</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Вт</displayName>
+				<unitPattern count="one">{0} Вт</unitPattern>
+				<unitPattern count="few">{0} Вт</unitPattern>
+				<unitPattern count="many">{0} Вт</unitPattern>
+				<unitPattern count="other">{0} Вт</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мВт</displayName>
+				<unitPattern count="one">{0} мВт</unitPattern>
+				<unitPattern count="few">{0} мВт</unitPattern>
+				<unitPattern count="many">{0} мВт</unitPattern>
+				<unitPattern count="other">{0} мВт</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>к. с.</displayName>
+				<unitPattern count="one">{0} к. с.</unitPattern>
+				<unitPattern count="few">{0} к. с.</unitPattern>
+				<unitPattern count="many">{0} к. с.</unitPattern>
+				<unitPattern count="other">{0} к. с.</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мм рт. сл.</displayName>
+				<unitPattern count="one">{0} мм рт. сл.</unitPattern>
+				<unitPattern count="few">{0} мм рт. сл.</unitPattern>
+				<unitPattern count="many">{0} мм рт. сл.</unitPattern>
+				<unitPattern count="other">{0} мм рт. сл.</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фунты на кв. цалю</displayName>
+				<unitPattern count="one">{0} фунт на кв. цалю</unitPattern>
+				<unitPattern count="few">{0} фунты на кв. цалю</unitPattern>
+				<unitPattern count="many">{0} фунтаў на кв. цалю</unitPattern>
+				<unitPattern count="other">{0} фунта на кв. цалю</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>цалі рт. сл.</displayName>
+				<unitPattern count="one">{0} цаля рт. сл.</unitPattern>
+				<unitPattern count="few">{0} цалі рт. сл.</unitPattern>
+				<unitPattern count="many">{0} цаляў рт. сл.</unitPattern>
+				<unitPattern count="other">{0} цалі рт. сл.</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бар</displayName>
+				<unitPattern count="one">{0} бар</unitPattern>
+				<unitPattern count="few">{0} бары</unitPattern>
+				<unitPattern count="many">{0} бар</unitPattern>
+				<unitPattern count="other">{0} бара</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мбар</displayName>
+				<unitPattern count="one">{0} мбар</unitPattern>
+				<unitPattern count="few">{0} мбар</unitPattern>
+				<unitPattern count="many">{0} мбар</unitPattern>
+				<unitPattern count="other">{0} мбар</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>атм</displayName>
+				<unitPattern count="one">{0} атм</unitPattern>
+				<unitPattern count="few">{0} атм</unitPattern>
+				<unitPattern count="many">{0} атм</unitPattern>
+				<unitPattern count="other">{0} атм</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Па</displayName>
+				<unitPattern count="one">{0} Па</unitPattern>
+				<unitPattern count="few">{0} Па</unitPattern>
+				<unitPattern count="many">{0} Па</unitPattern>
+				<unitPattern count="other">{0} Па</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>гПа</displayName>
+				<unitPattern count="one">{0} гПа</unitPattern>
+				<unitPattern count="few">{0} гПа</unitPattern>
+				<unitPattern count="many">{0} гПа</unitPattern>
+				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кПа</displayName>
+				<unitPattern count="one">{0} кПа</unitPattern>
+				<unitPattern count="few">{0} кПа</unitPattern>
+				<unitPattern count="many">{0} кПа</unitPattern>
+				<unitPattern count="other">{0} кПа</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МПа</displayName>
+				<unitPattern count="one">{0} МПа</unitPattern>
+				<unitPattern count="few">{0} МПа</unitPattern>
+				<unitPattern count="many">{0} МПа</unitPattern>
+				<unitPattern count="other">{0} МПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/гадз</displayName>
@@ -10646,132 +10646,132 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} км/гадз</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>м/с</displayName>
+				<unitPattern count="one">{0} м/с</unitPattern>
+				<unitPattern count="few">{0} м/с</unitPattern>
+				<unitPattern count="many">{0} м/с</unitPattern>
+				<unitPattern count="other">{0} м/с</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мілі/гадз</displayName>
+				<unitPattern count="one">{0} міля/гадз</unitPattern>
+				<unitPattern count="few">{0} мілі/гадз</unitPattern>
+				<unitPattern count="many">{0} міль/гадз</unitPattern>
+				<unitPattern count="other">{0} мілі/гадз</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>вуз.</displayName>
+				<unitPattern count="one">{0} вуз.</unitPattern>
+				<unitPattern count="few">{0} вуз.</unitPattern>
+				<unitPattern count="many">{0} вуз.</unitPattern>
+				<unitPattern count="other">{0} вуз.</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0} °</unitPattern>
+				<unitPattern count="few">{0} °</unitPattern>
+				<unitPattern count="many">{0} °</unitPattern>
+				<unitPattern count="other">{0} °</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} °C</unitPattern>
+				<unitPattern count="few">{0} °C</unitPattern>
+				<unitPattern count="many">{0} °C</unitPattern>
+				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="one">{0} °F</unitPattern>
+				<unitPattern count="few">{0} °F</unitPattern>
+				<unitPattern count="many">{0} °F</unitPattern>
+				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>К</displayName>
+				<unitPattern count="one">{0} К</unitPattern>
+				<unitPattern count="few">{0} К</unitPattern>
+				<unitPattern count="many">{0} К</unitPattern>
+				<unitPattern count="other">{0} К</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фунт-футы</displayName>
+				<unitPattern count="one">{0} фунт-фут</unitPattern>
+				<unitPattern count="few">{0} фунт-футы</unitPattern>
+				<unitPattern count="many">{0} фунт-футаў</unitPattern>
+				<unitPattern count="other">{0} фунт-фута</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Н⋅м</displayName>
+				<unitPattern count="one">{0} Н⋅м</unitPattern>
+				<unitPattern count="few">{0} Н⋅м</unitPattern>
+				<unitPattern count="many">{0} Н⋅м</unitPattern>
+				<unitPattern count="other">{0} Н⋅м</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>км³</displayName>
+				<unitPattern count="one">{0} км³</unitPattern>
+				<unitPattern count="few">{0} км³</unitPattern>
+				<unitPattern count="many">{0} км³</unitPattern>
+				<unitPattern count="other">{0} км³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>м³</displayName>
+				<unitPattern count="one">{0} м³</unitPattern>
+				<unitPattern count="few">{0} м³</unitPattern>
+				<unitPattern count="many">{0} м³</unitPattern>
+				<unitPattern count="other">{0} м³</unitPattern>
+				<perUnitPattern>{0}/м³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>см³</displayName>
+				<unitPattern count="one">{0} см³</unitPattern>
+				<unitPattern count="few">{0} см³</unitPattern>
+				<unitPattern count="many">{0} см³</unitPattern>
+				<unitPattern count="other">{0} см³</unitPattern>
+				<perUnitPattern>{0}/см³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>куб. мілі</displayName>
+				<unitPattern count="one">{0} куб. міля</unitPattern>
+				<unitPattern count="few">{0} куб. мілі</unitPattern>
+				<unitPattern count="many">{0} куб. міль</unitPattern>
+				<unitPattern count="other">{0} куб. мілі</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>куб. ярды</displayName>
+				<unitPattern count="one">{0} куб. ярд</unitPattern>
+				<unitPattern count="few">{0} куб. ярды</unitPattern>
+				<unitPattern count="many">{0} куб. ярдаў</unitPattern>
+				<unitPattern count="other">{0} куб. ярда</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>куб. футы</displayName>
+				<unitPattern count="one">{0} куб. фут</unitPattern>
+				<unitPattern count="few">{0} куб. футы</unitPattern>
+				<unitPattern count="many">{0} куб. футаў</unitPattern>
+				<unitPattern count="other">{0} куб. фута</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>куб. цалі</displayName>
+				<unitPattern count="one">{0} куб. цаля</unitPattern>
+				<unitPattern count="few">{0} куб. цалі</unitPattern>
+				<unitPattern count="many">{0} куб. цаляў</unitPattern>
+				<unitPattern count="other">{0} куб. цалі</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мл</displayName>
+				<unitPattern count="one">{0} Мл</unitPattern>
+				<unitPattern count="few">{0} Мл</unitPattern>
+				<unitPattern count="many">{0} Мл</unitPattern>
+				<unitPattern count="other">{0} Мл</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>гл</displayName>
+				<unitPattern count="one">{0} гл</unitPattern>
+				<unitPattern count="few">{0} гл</unitPattern>
+				<unitPattern count="many">{0} гл</unitPattern>
+				<unitPattern count="other">{0} гл</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>л</displayName>
@@ -10779,177 +10779,177 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} л</unitPattern>
 				<unitPattern count="many">{0} л</unitPattern>
 				<unitPattern count="other">{0} л</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/л</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дл</displayName>
+				<unitPattern count="one">{0} дл</unitPattern>
+				<unitPattern count="few">{0} дл</unitPattern>
+				<unitPattern count="many">{0} дл</unitPattern>
+				<unitPattern count="other">{0} дл</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>сл</displayName>
+				<unitPattern count="one">{0} сл</unitPattern>
+				<unitPattern count="few">{0} сл</unitPattern>
+				<unitPattern count="many">{0} сл</unitPattern>
+				<unitPattern count="other">{0} сл</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мл</displayName>
+				<unitPattern count="one">{0} мл</unitPattern>
+				<unitPattern count="few">{0} мл</unitPattern>
+				<unitPattern count="many">{0} мл</unitPattern>
+				<unitPattern count="other">{0} мл</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мет. пінты</displayName>
+				<unitPattern count="one">{0} мет. пінта</unitPattern>
+				<unitPattern count="few">{0} мет. пінты</unitPattern>
+				<unitPattern count="many">{0} мет. пінтаў</unitPattern>
+				<unitPattern count="other">{0} мет. пінты</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мет. кубак</displayName>
+				<unitPattern count="one">{0} мет. кубак</unitPattern>
+				<unitPattern count="few">{0} мет. кубкі</unitPattern>
+				<unitPattern count="many">{0} мет. кубкаў</unitPattern>
+				<unitPattern count="other">{0} мет. кубка</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>акр-футы</displayName>
+				<unitPattern count="one">{0} акр-фут</unitPattern>
+				<unitPattern count="few">{0} акр-футы</unitPattern>
+				<unitPattern count="many">{0} акр-футаў</unitPattern>
+				<unitPattern count="other">{0} акр-фута</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бушалі</displayName>
+				<unitPattern count="one">{0} буш.</unitPattern>
+				<unitPattern count="few">{0} буш.</unitPattern>
+				<unitPattern count="many">{0} буш.</unitPattern>
+				<unitPattern count="other">{0} буш.</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>гал</displayName>
+				<unitPattern count="one">{0} гал</unitPattern>
+				<unitPattern count="few">{0} гал</unitPattern>
+				<unitPattern count="many">{0} гал</unitPattern>
+				<unitPattern count="other">{0} гал</unitPattern>
+				<perUnitPattern>{0}/гал</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>імп. гал</displayName>
+				<unitPattern count="one">{0} імп. гал.</unitPattern>
+				<unitPattern count="few">{0} імп. гал.</unitPattern>
+				<unitPattern count="many">{0} імп. гал.</unitPattern>
+				<unitPattern count="other">{0} імп. гал.</unitPattern>
+				<perUnitPattern>{0}/імп. гал.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кварты</displayName>
+				<unitPattern count="one">{0} кварта</unitPattern>
+				<unitPattern count="few">{0} кварты</unitPattern>
+				<unitPattern count="many">{0} кварт</unitPattern>
+				<unitPattern count="other">{0} кварты</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пінты</displayName>
+				<unitPattern count="one">{0} пінта</unitPattern>
+				<unitPattern count="few">{0} пінты</unitPattern>
+				<unitPattern count="many">{0} пінтаў</unitPattern>
+				<unitPattern count="other">{0} пінты</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кубкі</displayName>
+				<unitPattern count="one">{0} кубак</unitPattern>
+				<unitPattern count="few">{0} кубкі</unitPattern>
+				<unitPattern count="many">{0} кубкаў</unitPattern>
+				<unitPattern count="other">{0} кубка</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>вадк. унц.</displayName>
+				<unitPattern count="one">{0} вадк. унц.</unitPattern>
+				<unitPattern count="few">{0} вадк. унц.</unitPattern>
+				<unitPattern count="many">{0} вадк. унц.</unitPattern>
+				<unitPattern count="other">{0} вадк. унц.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>імп. вадкая унцыя</displayName>
+				<unitPattern count="one">{0} імп. вадкая унцыя</unitPattern>
+				<unitPattern count="few">{0} імп. вадкія унцыі</unitPattern>
+				<unitPattern count="many">{0} імп. вадкіх унцый</unitPattern>
+				<unitPattern count="other">{0} імп. вадкай унцыі</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ст. лыжкі</displayName>
+				<unitPattern count="one">{0} ст. лыжка</unitPattern>
+				<unitPattern count="few">{0} ст. лыжкі</unitPattern>
+				<unitPattern count="many">{0} ст. лыжак</unitPattern>
+				<unitPattern count="other">{0} ст. лыжкі</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ч. лыжкі</displayName>
+				<unitPattern count="one">{0} ч. лыжка</unitPattern>
+				<unitPattern count="few">{0} ч. лыжкі</unitPattern>
+				<unitPattern count="many">{0} ч. лыжак</unitPattern>
+				<unitPattern count="other">{0} ч. лыжкі</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>барэль</displayName>
+				<unitPattern count="one">{0} барэль</unitPattern>
+				<unitPattern count="few">{0} барэлі</unitPattern>
+				<unitPattern count="many">{0} барэляў</unitPattern>
+				<unitPattern count="other">{0} барэля</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дэс. л.</displayName>
+				<unitPattern count="one">{0} дэс. л.</unitPattern>
+				<unitPattern count="few">{0} дэс. л.</unitPattern>
+				<unitPattern count="many">{0} дэс. л.</unitPattern>
+				<unitPattern count="other">{0} дэс. л.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>брыт. дэс. л.</displayName>
+				<unitPattern count="one">{0} брыт. дэс. л.</unitPattern>
+				<unitPattern count="few">{0} брыт. дэс. л.</unitPattern>
+				<unitPattern count="many">{0} брыт. дэс. л.</unitPattern>
+				<unitPattern count="other">{0} брыт. дэс. л.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кропля</displayName>
+				<unitPattern count="one">{0} кропля</unitPattern>
+				<unitPattern count="few">{0} кроплі</unitPattern>
+				<unitPattern count="many">{0} кропель</unitPattern>
+				<unitPattern count="other">{0} кроплі</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>вад. драхма</displayName>
+				<unitPattern count="one">{0} вад. драхма</unitPattern>
+				<unitPattern count="few">{0} вад. драхмы</unitPattern>
+				<unitPattern count="many">{0} вад. драхмаў</unitPattern>
+				<unitPattern count="other">{0} вад. драхмы</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>джыгер</displayName>
+				<unitPattern count="one">{0} джыгер</unitPattern>
+				<unitPattern count="few">{0} джыгеры</unitPattern>
+				<unitPattern count="many">{0} джыгераў</unitPattern>
+				<unitPattern count="other">{0} джыгера</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дробка</displayName>
+				<unitPattern count="one">{0} дробка</unitPattern>
+				<unitPattern count="few">{0} дробкі</unitPattern>
+				<unitPattern count="many">{0} дробак</unitPattern>
+				<unitPattern count="other">{0} дробкі</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>брыт. кварта</displayName>
+				<unitPattern count="one">{0} брыт. кварта</unitPattern>
+				<unitPattern count="few">{0} брыт. кварты</unitPattern>
+				<unitPattern count="many">{0} брыт. кварт</unitPattern>
+				<unitPattern count="other">{0} брыт. кварты</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>кірунак</displayName>
@@ -10983,22 +10983,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ці {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ці {1}</listPatternPart>
+			<listPatternPart type="2">{0} ці {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ці {1}</listPatternPart>
+			<listPatternPart type="2">{0} ці {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} і {1}</listPatternPart>
+			<listPatternPart type="2">{0} і {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -11226,10 +11226,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -11283,7 +11283,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {given-informal}</namePattern>
@@ -11325,13 +11325,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -100,7 +100,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">черокски</language>
 			<language type="chy">шайенски</language>
 			<language type="ckb">кюрдски (централен)</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">кюрдски (централен)</language>
 			<language type="ckb" alt="variant">кюрдски (Сорани)</language>
 			<language type="clc">чилкотин</language>
 			<language type="co">корсикански</language>
@@ -993,7 +993,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Тунис</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Турция</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Турция</territory>
 			<territory type="TT">Тринидад и Тобаго</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тайван</territory>
@@ -1302,7 +1302,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1310,7 +1310,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2834,7 +2834,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>сек</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">сл. {0} сек</relativeTimePattern>
 					<relativeTimePattern count="other">сл. {0} сек</relativeTimePattern>
@@ -6873,7 +6873,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">кубични {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -7260,8 +7260,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>типографски ем</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>пиксели</displayName>
@@ -7789,8 +7789,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>брит. дес. лъжици</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} брит. дес. лъжица</unitPattern>
+				<unitPattern count="other">{0} брит. дес. лъжици</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>капки</displayName>
@@ -7920,7 +7920,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8311,38 +8311,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>ем</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>точка</displayName>
@@ -8610,7 +8610,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -8625,7 +8625,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8966,44 +8966,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">G</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">m/s²</displayName>
+				<unitPattern count="one" draft="contributed">{0} m/s²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">об.</displayName>
+				<unitPattern count="one" draft="contributed">{0} об.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} об.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">rad</displayName>
+				<unitPattern count="one" draft="contributed">{0} rad</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">дъгови мин.</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
@@ -9013,84 +9013,84 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ha</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">cm²</displayName>
+				<unitPattern count="one" draft="contributed">{0} cm²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cm²</unitPattern>
+				<perUnitPattern draft="contributed">{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mi²</displayName>
 				<unitPattern count="one">{0} кв. миля</unitPattern>
 				<unitPattern count="other">{0} кв. мили</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">акри</displayName>
 				<unitPattern count="one">{0} акър</unitPattern>
 				<unitPattern count="other">{0} акра</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">yd²</displayName>
+				<unitPattern count="one" draft="contributed">{0} yd²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ft²</displayName>
 				<unitPattern count="one">{0} кв. фут</unitPattern>
 				<unitPattern count="other">{0} кв. фута</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">in²</displayName>
+				<unitPattern count="one" draft="contributed">{0} in²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} in²</unitPattern>
+				<perUnitPattern draft="contributed">{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дюнюми</displayName>
+				<unitPattern count="one" draft="contributed">{0} дюнюм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дюнюма</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kt</displayName>
+				<unitPattern count="one" draft="contributed">{0} kt</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mg/dL</displayName>
+				<unitPattern count="one" draft="contributed">{0} mg/dl</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mmol/L</displayName>
+				<unitPattern count="one" draft="contributed">{0} mmol/L</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">единица</displayName>
+				<unitPattern count="one" draft="contributed">{0} ед.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ед.</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppm</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9098,24 +9098,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">‰</displayName>
+				<unitPattern count="one" draft="contributed">{0}‰</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">базисен пункт</displayName>
+				<unitPattern count="one" draft="contributed">{0}‱</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мол</displayName>
+				<unitPattern count="one" draft="contributed">{0} мол</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мол</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">l/km</displayName>
+				<unitPattern count="one" draft="contributed">{0} l/km</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -9123,85 +9123,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mpg</displayName>
+				<unitPattern count="one" draft="contributed">{0} mpg</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мили/имп. гал.</displayName>
+				<unitPattern count="one" draft="contributed">{0} mpg Imp.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">PByte</displayName>
+				<unitPattern count="one" draft="contributed">{0} PB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">TB</displayName>
+				<unitPattern count="one" draft="contributed">{0} TB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Tb</displayName>
+				<unitPattern count="one" draft="contributed">{0} Tb</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">GB</displayName>
+				<unitPattern count="one" draft="contributed">{0} GB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Gb</displayName>
+				<unitPattern count="one" draft="contributed">{0} Gb</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">MB</displayName>
+				<unitPattern count="one" draft="contributed">{0} MB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Mb</displayName>
+				<unitPattern count="one" draft="contributed">{0} Mb</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kB</displayName>
+				<unitPattern count="one" draft="contributed">{0} kB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kb</displayName>
+				<unitPattern count="one" draft="contributed">{0} kb</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">B</displayName>
+				<unitPattern count="one" draft="contributed">{0} B</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">b</displayName>
+				<unitPattern count="one" draft="contributed">{0} b</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">в.</displayName>
+				<unitPattern count="one" draft="contributed">{0} в.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} в.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">декада</displayName>
+				<unitPattern count="one" draft="contributed">{0} декада</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} декади</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>г.</displayName>
 				<unitPattern count="one">{0} г.</unitPattern>
 				<unitPattern count="other">{0} г.</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/год.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>тримес.</displayName>
@@ -9225,25 +9225,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>д</displayName>
 				<unitPattern count="one">{0} д</unitPattern>
 				<unitPattern count="other">{0} д</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/д</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ч</displayName>
 				<unitPattern count="one">{0} ч</unitPattern>
 				<unitPattern count="other">{0} ч</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/ч</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>мин</displayName>
 				<unitPattern count="one">{0} мин</unitPattern>
 				<unitPattern count="other">{0} мин</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/мин</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>сек</displayName>
 				<unitPattern count="one">{0} с</unitPattern>
 				<unitPattern count="other">{0} с</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/сек</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>мсек</displayName>
@@ -9251,182 +9251,182 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мсек</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">μs</displayName>
+				<unitPattern count="one" draft="contributed">{0} μs</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ns</displayName>
+				<unitPattern count="one" draft="contributed">{0} ns</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">A</displayName>
+				<unitPattern count="one" draft="contributed">{0} A</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mA</displayName>
+				<unitPattern count="one" draft="contributed">{0} mA</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Ω</displayName>
+				<unitPattern count="one" draft="contributed">{0} Ω</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">V</displayName>
+				<unitPattern count="one" draft="contributed">{0} V</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kcal</displayName>
+				<unitPattern count="one" draft="contributed">{0} kcal</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">cal</displayName>
+				<unitPattern count="one" draft="contributed">{0} cal</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">cal</displayName>
+				<unitPattern count="one" draft="contributed">{0} cal</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kJ</displayName>
+				<unitPattern count="one" draft="contributed">{0} kJ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">J</displayName>
+				<unitPattern count="one" draft="contributed">{0} J</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kWh</displayName>
+				<unitPattern count="one" draft="contributed">{0} kWh</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">eV</displayName>
+				<unitPattern count="one" draft="contributed">{0} eV</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">BTU</displayName>
+				<unitPattern count="one" draft="contributed">{0} BTU</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">амер. термални ед.</displayName>
+				<unitPattern count="one" draft="contributed">{0} амер. терм. ед.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} амер. терм. ед.</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">lbf</displayName>
+				<unitPattern count="one" draft="contributed">{0} lbf</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">N</displayName>
+				<unitPattern count="one" draft="contributed">{0} N</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100 km</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} kWh/100 km</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kWh/100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">GHz</displayName>
+				<unitPattern count="one" draft="contributed">{0} GHz</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">MHz</displayName>
+				<unitPattern count="one" draft="contributed">{0} MHz</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kHz</displayName>
+				<unitPattern count="one" draft="contributed">{0} kHz</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Hz</displayName>
+				<unitPattern count="one" draft="contributed">{0} Hz</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ем</displayName>
+				<unitPattern count="one" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">px</displayName>
+				<unitPattern count="one" draft="contributed">{0} px</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">MP</displayName>
+				<unitPattern count="one" draft="contributed">{0} MP</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppcm</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppcm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppi</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppi</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppcm</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppcm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppi</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppi</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">точка</displayName>
+				<unitPattern count="one" draft="contributed">{0} точка</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} точки</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">R⊕</displayName>
+				<unitPattern count="one" draft="contributed">{0} R⊕</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">dm</displayName>
+				<unitPattern count="one" draft="contributed">{0} dm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -9434,265 +9434,265 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">μm</displayName>
+				<unitPattern count="one" draft="contributed">{0} μm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">nm</displayName>
+				<unitPattern count="one" draft="contributed">{0} nm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mi</displayName>
 				<unitPattern count="one">{0} миля</unitPattern>
 				<unitPattern count="other">{0} мили</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">yd</displayName>
 				<unitPattern count="one">{0} ярд</unitPattern>
 				<unitPattern count="other">{0} ярда</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ft</displayName>
 				<unitPattern count="one">{0} фут</unitPattern>
 				<unitPattern count="other">{0} фута</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">in</displayName>
 				<unitPattern count="one">{0}&quot;</unitPattern>
 				<unitPattern count="other">{0}&quot;</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">pc</displayName>
+				<unitPattern count="one" draft="contributed">{0} pc</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">св. г.</displayName>
 				<unitPattern count="one">{0} св.г.</unitPattern>
 				<unitPattern count="other">{0} св.г.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">AU</displayName>
+				<unitPattern count="one" draft="contributed">{0} AU</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} AU</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">fur</displayName>
+				<unitPattern count="one" draft="contributed">{0} fur</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">fth</displayName>
+				<unitPattern count="one" draft="contributed">{0} fth</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">nmi</displayName>
+				<unitPattern count="one" draft="contributed">{0} nmi</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">smi</displayName>
+				<unitPattern count="one" draft="contributed">{0} smi</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">pt</displayName>
+				<unitPattern count="one" draft="contributed">{0} pt</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">R☉</displayName>
+				<unitPattern count="one" draft="contributed">{0} R☉</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">lx</displayName>
+				<unitPattern count="one" draft="contributed">{0} lx</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">cd</displayName>
+				<unitPattern count="one" draft="contributed">{0} cd</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">lm</displayName>
+				<unitPattern count="one" draft="contributed">{0} lm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">L☉</displayName>
+				<unitPattern count="one" draft="contributed">{0} L☉</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">t</displayName>
+				<unitPattern count="one" draft="contributed">{0} t</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mg</displayName>
+				<unitPattern count="one" draft="contributed">{0} mg</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">tn</displayName>
+				<unitPattern count="one" draft="contributed">{0} tn</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>стоун.</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">lb</displayName>
 				<unitPattern count="one">{0} фунт</unitPattern>
 				<unitPattern count="other">{0} фунта</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">oz</displayName>
 				<unitPattern count="one">{0} унц.</unitPattern>
 				<unitPattern count="other">{0} унц.</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">тр. унц.</displayName>
+				<unitPattern count="one" draft="contributed">{0} тр. унц.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} тр. унц.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">CD</displayName>
+				<unitPattern count="one" draft="contributed">{0} CD</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName draft="contributed">Da</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Da</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">M⊕</displayName>
+				<unitPattern count="one" draft="contributed">{0} M⊕</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">M☉</displayName>
+				<unitPattern count="one" draft="contributed">{0} M☉</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">гран</displayName>
+				<unitPattern count="one" draft="contributed">{0} гран</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} грана</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">GW</displayName>
+				<unitPattern count="one" draft="contributed">{0} GW</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">MW</displayName>
+				<unitPattern count="one" draft="contributed">{0} MW</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">W</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mW</displayName>
+				<unitPattern count="one" draft="contributed">{0} mW</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">к. с.</displayName>
 				<unitPattern count="one">{0} к.с.</unitPattern>
 				<unitPattern count="other">{0} к.с.</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mmHg</displayName>
+				<unitPattern count="one" draft="contributed">{0} mmHg</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">psi</displayName>
+				<unitPattern count="one" draft="contributed">{0} psi</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">bar</displayName>
+				<unitPattern count="one" draft="contributed">{0} bar</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">atm</displayName>
+				<unitPattern count="one" draft="contributed">{0} atm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Pa</displayName>
+				<unitPattern count="one" draft="contributed">{0} Pa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kPa</displayName>
+				<unitPattern count="one" draft="contributed">{0} kPa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">MPa</displayName>
+				<unitPattern count="one" draft="contributed">{0} MPa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -9700,24 +9700,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">m/s</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mph</displayName>
 				<unitPattern count="one">{0} миля/ч</unitPattern>
 				<unitPattern count="other">{0} мили/ч</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kn</displayName>
+				<unitPattern count="one" draft="contributed">{0} kn</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">°</displayName>
+				<unitPattern count="one" draft="contributed">{0}°</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9725,199 +9725,199 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">°F</displayName>
 				<unitPattern count="one">{0} °F</unitPattern>
 				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">K</displayName>
+				<unitPattern count="one" draft="contributed">{0} K</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">lbf⋅ft</displayName>
+				<unitPattern count="one" draft="contributed">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">N⋅m</displayName>
+				<unitPattern count="one" draft="contributed">{0} N⋅m</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">m³</displayName>
+				<unitPattern count="one" draft="contributed">{0} m³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} m³</unitPattern>
+				<perUnitPattern draft="contributed">{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">cm³</displayName>
+				<unitPattern count="one" draft="contributed">{0} cm³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cm³</unitPattern>
+				<perUnitPattern draft="contributed">{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mi³</displayName>
 				<unitPattern count="one">{0} куб. миля</unitPattern>
 				<unitPattern count="other">{0} куб. мили</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">yd³</displayName>
+				<unitPattern count="one" draft="contributed">{0} yd³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ft³</displayName>
+				<unitPattern count="one" draft="contributed">{0} ft³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">in³</displayName>
+				<unitPattern count="one" draft="contributed">{0} in³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Ml</displayName>
+				<unitPattern count="one" draft="contributed">{0} Ml</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">hl</displayName>
+				<unitPattern count="one" draft="contributed">{0} hl</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">dl</displayName>
+				<unitPattern count="one" draft="contributed">{0} dl</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">cl</displayName>
+				<unitPattern count="one" draft="contributed">{0} cl</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ml</displayName>
+				<unitPattern count="one" draft="contributed">{0} ml</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mpt</displayName>
+				<unitPattern count="one" draft="contributed">{0} mpt</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mcup</displayName>
+				<unitPattern count="one" draft="contributed">{0} mc</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ac ft</displayName>
+				<unitPattern count="one" draft="contributed">{0} ac ft</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">бушели</displayName>
+				<unitPattern count="one" draft="contributed">{0} bu</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">US gal</displayName>
+				<unitPattern count="one" draft="contributed">{0} gal US</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} gal US</unitPattern>
+				<perUnitPattern draft="contributed">{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">имп. галон</displayName>
+				<unitPattern count="one" draft="contributed">{0} имп. галон</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} имп. галона</unitPattern>
+				<perUnitPattern draft="contributed">{0}/имп. галон</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">qt</displayName>
+				<unitPattern count="one" draft="contributed">{0} qt</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">pt</displayName>
+				<unitPattern count="one" draft="contributed">{0} pt</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ч.</displayName>
+				<unitPattern count="one" draft="contributed">{0} ч.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ч.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">US fl oz</displayName>
+				<unitPattern count="one" draft="contributed">{0} fl oz US</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} fl oz US</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Imp. fl oz</displayName>
+				<unitPattern count="one" draft="contributed">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">с. л.</displayName>
+				<unitPattern count="one" draft="contributed">{0} с. л.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} с. л.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ч. л.</displayName>
+				<unitPattern count="one" draft="contributed">{0} ч. л.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ч. л.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName draft="contributed">bbl</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} bbl</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">дес. лъжица</displayName>
 				<unitPattern count="one">{0} дес. лъж.</unitPattern>
 				<unitPattern count="other">{0} дес. лъж.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">брит. дес. лъжица</displayName>
 				<unitPattern count="one">{0} брит. дес. лъж.</unitPattern>
 				<unitPattern count="other">{0} брит. дес. лъж.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">капка</displayName>
+				<unitPattern count="one" draft="contributed">{0} капка</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} капки</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">течен драм</displayName>
+				<unitPattern count="one" draft="contributed">{0} теч. драм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} теч. драма</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">джигър</displayName>
+				<unitPattern count="one" draft="contributed">{0} джигър</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} джигъра</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">щипка</displayName>
+				<unitPattern count="one" draft="contributed">{0} щипка</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} щипки</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">имп. кварта</displayName>
+				<unitPattern count="one" draft="contributed">{0} имп. кварта</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} имп. кварти</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>посока</displayName>
@@ -9951,28 +9951,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} или {1}</listPatternPart>
+			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} или {1}</listPatternPart>
+			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} и {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} и {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} и {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -10192,10 +10192,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-core-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-core-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname-core}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given} {surname-core}</namePattern>
@@ -10207,7 +10207,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-core-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
 			<namePattern>{given-monogram-allCaps}</namePattern>
@@ -10225,7 +10225,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-core-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
 			<namePattern>{given-monogram-allCaps}</namePattern>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -1004,7 +1004,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">তিউনিসিয়া</territory>
 			<territory type="TO">টোঙ্গা</territory>
 			<territory type="TR">তুরস্ক</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">তুরস্ক</territory>
 			<territory type="TT">ত্রিনিনাদ ও টোব্যাগো</territory>
 			<territory type="TV">টুভালু</territory>
 			<territory type="TW">তাইওয়ান</territory>
@@ -1013,7 +1013,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="UG">উগান্ডা</territory>
 			<territory type="UM">যুক্তরাষ্ট্রের পার্শ্ববর্তী দ্বীপপুঞ্জ</territory>
 			<territory type="UN">জাতিসংঘ</territory>
-			<territory type="UN" alt="short">↑↑↑</territory>
+			<territory type="UN" alt="short">জাতিসংঘ</territory>
 			<territory type="US">মার্কিন যুক্তরাষ্ট্র</territory>
 			<territory type="US" alt="short">ইউ এস</territory>
 			<territory type="UY">উরুগুয়ে</territory>
@@ -1559,7 +1559,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1567,7 +1567,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1809,8 +1809,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">জানু</month>
+							<month type="2">ফেব</month>
 							<month type="3">মার্চ</month>
 							<month type="4">এপ্রিল</month>
 							<month type="5">মে</month>
@@ -2834,221 +2834,221 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, d MMMM, y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern>d MMMM, y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern>d MMM, y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern>d/M/y GGGGG</pattern>
+							<datetimeSkeleton draft="contributed">GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMdd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d MMM, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E, d-M</dateFormatItem>
+						<dateFormatItem id="MMdd" draft="contributed">dd-MM</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMM" draft="contributed">MM-y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d MMM, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d/M/y GGGGG – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M – d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M – d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M – E, d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M – E, d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M/y – d/M/y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M/y – d/M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d/M/y – d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM, y – d MMM, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM, y – E, d MMM, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3480,7 +3480,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">{0} সোমবারে</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} সোমবার আগে</relativeTimePattern>
 					<relativeTimePattern count="other">{0} সোমবার আগে</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -6116,7 +6116,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -7027,8 +7027,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>লেসুটু লোটি</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">লেসুটু লোটি</displayName>
+				<displayName count="other">লেসুটু লোটি</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -7814,25 +7814,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>{0}কিবি</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{1} প্রতি {0}</compoundUnitPattern>
@@ -7848,7 +7848,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">ঘন {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>জি-বল</displayName>
@@ -7976,7 +7976,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}প্রতিমাইল</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>পারমিরিয়াড</displayName>
 				<unitPattern count="one">{0} পারমিরিয়াড</unitPattern>
 				<unitPattern count="other">{0} পারমিরিয়াড</unitPattern>
 			</unit>
@@ -8203,9 +8203,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} US থার্ম</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>নিউটন্স</displayName>
@@ -8239,7 +8239,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>টাইপোগ্রাফিক em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} ems</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -8483,13 +8483,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>সৌর ভর</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">{0} সৌর ভর</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>গিগাওয়াট</displayName>
@@ -8742,7 +8742,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ফ্লুইড আউন্স</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="one">{0} Imp. fl oz</unitPattern>
 				<unitPattern count="other">{0} Imp. fluid ounces</unitPattern>
 			</unit>
@@ -8772,7 +8772,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ইম্পেরিয়েল ডেসার্ট চামচ</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>ফোঁটা</displayName>
 				<unitPattern count="one">{0} ফোঁটা</unitPattern>
 				<unitPattern count="other">{0} ফোঁটা</unitPattern>
 			</unit>
@@ -8782,8 +8782,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ড্র্য়াম</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>জিগার</displayName>
+				<unitPattern count="one">{0} জিগার</unitPattern>
 				<unitPattern count="other">{0} জিগার</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -9032,7 +9032,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>পারমিরিয়াড</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -9240,12 +9240,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>ইলেকট্রন ভোল্ট</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -9255,17 +9255,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>নিউটন</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -9290,27 +9290,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>পিক্সেল</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>মেগাপিক্সেল</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -9324,13 +9324,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পিক্সেল</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9440,7 +9440,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>সৌর রেডি</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9450,17 +9450,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>সৌর ঔজ্জ্বল্য</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9524,22 +9524,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ড্যালটন্স</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>পৃথিবীর ভর</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>সৌর ভর</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -9604,7 +9604,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -9614,12 +9614,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -9664,12 +9664,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -9757,7 +9757,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -9794,7 +9794,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>Imp. fl oz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -9809,17 +9809,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>ব্যারেল</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -9829,7 +9829,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>ড্র্যাম ফ্লুইড</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
@@ -9844,7 +9844,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -9920,25 +9920,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>{0}কি</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
 				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
@@ -9954,7 +9954,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>জি-বল</displayName>
@@ -9968,98 +9968,98 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>ঘুর্ণন</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ঘুর্ণন</unitPattern>
+				<unitPattern count="other">{0} ঘুর্ণন</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>রেডিয়্যান্স</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>ডিগ্রী</displayName>
 				<unitPattern count="one">{0}ডিগ্রী</unitPattern>
 				<unitPattern count="other">{0}ডিগ্রী</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>আর্কমিন</displayName>
 				<unitPattern count="one">{0}মিনিট</unitPattern>
 				<unitPattern count="other">{0}মিনিট</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>আর্কসেকেন্ড</displayName>
 				<unitPattern count="one">{0}সেকেন্ড</unitPattern>
 				<unitPattern count="other">{0}সেকেন্ড</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>বর্গ কিমি</displayName>
 				<unitPattern count="one">{0} বর্গ কিমি</unitPattern>
 				<unitPattern count="other">{0} বর্গ কিমি</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/বর্গ কিমি</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>হেক্টর</displayName>
 				<unitPattern count="one">{0} হেক্টর</unitPattern>
 				<unitPattern count="other">{0} হেক্টর</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>বর্গ মিটার</displayName>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>বর্গ সেমি</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>বর্গ মাইল</displayName>
 				<unitPattern count="one">{0} বর্গ মাইল</unitPattern>
 				<unitPattern count="other">{0} বর্গ মাইল</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>একর</displayName>
 				<unitPattern count="one">{0} একর</unitPattern>
 				<unitPattern count="other">{0} একর</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>বর্গ গজ</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>বর্গ ফুট</displayName>
 				<unitPattern count="one">{0} বর্গ ফুট</unitPattern>
 				<unitPattern count="other">{0} বর্গ ফুট</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>দুনাম</displayName>
 				<unitPattern count="one">{0} দুনাম</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} দুনাম</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ক্যারেট</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>আইটেম</displayName>
@@ -10067,9 +10067,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} আইটেম</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>শতাংশ</displayName>
@@ -10078,23 +10078,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পারমিরিয়াড</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>মোল</displayName>
 				<unitPattern count="one">{0} মোল</unitPattern>
 				<unitPattern count="other">{0} মোল</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>লিটার/কিমি</displayName>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>লি/100কিমি</displayName>
@@ -10102,9 +10102,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} লি/100কিমি</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মাইল/গ্যালন</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg UK</displayName>
@@ -10112,59 +10112,59 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PByte</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TByte</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tbit</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>বাইট</displayName>
+				<unitPattern count="one">{0} বাইট</unitPattern>
+				<unitPattern count="other">{0} বাইট</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>বিট</displayName>
+				<unitPattern count="one">{0} বিট</unitPattern>
+				<unitPattern count="other">{0} বিট</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>শতক</displayName>
@@ -10172,9 +10172,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} শতক</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>দশক</displayName>
+				<unitPattern count="one">{0} দশক</unitPattern>
+				<unitPattern count="other">{0} দশক</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>বছর</displayName>
@@ -10240,129 +10240,129 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ওহম</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ভোল্ট</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>জুল</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ইলেকট্রন ভোল্ট</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US থার্ম</displayName>
+				<unitPattern count="one">{0} US থার্ম</unitPattern>
+				<unitPattern count="other">{0} US থার্ম</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>নিউটন</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>পিক্সেল</displayName>
 				<unitPattern count="one">{0} পিক্সেল</unitPattern>
 				<unitPattern count="other">{0} পিক্সেল</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>মেগাপিক্সেল</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
@@ -10380,9 +10380,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ডট</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>কিলোমিটার</displayName>
@@ -10491,28 +10491,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>সৌর ঔজ্জ্বল্য</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>টন</displayName>
@@ -10574,52 +10574,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ড্যালটন্স</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পৃথিবীর ভর</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>সৌর ভর</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ওয়াট</displayName>
 				<unitPattern count="one">{0} ওয়াট</unitPattern>
 				<unitPattern count="other">{0} ওয়াট</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
@@ -10639,9 +10639,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>বার</displayName>
+				<unitPattern count="one">{0} বার</unitPattern>
+				<unitPattern count="other">{0} বার</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -10649,14 +10649,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -10664,14 +10664,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>
@@ -10714,154 +10714,154 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>কিউবিক কিলোমিটার</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0}mi³</unitPattern>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>লিটার</displayName>
 				<unitPattern count="one">{0} লিটার</unitPattern>
 				<unitPattern count="other">{0} লিটার</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>acre ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
 				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. gal</displayName>
 				<unitPattern count="one">{0}galIm</unitPattern>
 				<unitPattern count="other">{0}galIm</unitPattern>
 				<perUnitPattern>{0}/galIm</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>পিন্ট</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cup</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>bbl</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dsp</displayName>
@@ -10889,14 +10889,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} জিগার</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>চিমটে</displayName>
+				<unitPattern count="one">{0} চিমটে</unitPattern>
+				<unitPattern count="other">{0} চিমটে</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>দিকনির্দেশ</displayName>
@@ -10930,20 +10930,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} বা {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, বা {1}</listPatternPart>
+			<listPatternPart type="2">{0} বা {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, বা {1}</listPatternPart>
+			<listPatternPart type="2">{0} বা {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -11162,7 +11162,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
@@ -11171,43 +11171,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
@@ -11216,7 +11216,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname} {surname2} {given} {given2}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
 			<namePattern>{surname} {surname2} {given} {given2}</namePattern>
@@ -11225,43 +11225,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {surname2} {given} {given2}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
 			<namePattern>{surname} {surname2} {given} {given2}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
 			<namePattern>{surname} {surname2} {given} {given2}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
 			<namePattern>{surname} {surname2} {given} {given2}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
@@ -11270,13 +11270,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname} {surname2}, {given} {given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {surname2}, {given} {given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname} {surname2}, {given} {given2}</namePattern>

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -108,7 +108,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chy">cheyenne</language>
 			<language type="ckb">kurdeg sorani</language>
 			<language type="ckb" alt="menu">kurdeg kreiz</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">kurdeg sorani</language>
 			<language type="clc">chilkotineg</language>
 			<language type="co">korseg</language>
 			<language type="cop">kopteg</language>
@@ -1369,18 +1369,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
 						<dateFormatItem id="Md">dd/MM</dateFormatItem>
 						<dateFormatItem id="MEd">E dd/MM</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
@@ -1402,16 +1402,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<intervalFormats>
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">y G – y G</greatestDifference>
@@ -2515,7 +2515,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a">h a – h a</greatestDifference>
 							<greatestDifference id="h">h–h a</greatestDifference>
@@ -2549,7 +2549,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
 							<greatestDifference id="d">dd/MM–dd/MM</greatestDifference>
@@ -2560,7 +2560,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">d–d MMM</greatestDifference>
@@ -3474,7 +3474,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">E d MMM – E d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">U–U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M">MM/y – MM/y</greatestDifference>
@@ -3997,8 +3997,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Kzu.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">01</month>
+							<month type="2">02</month>
 							<month type="3">03</month>
 							<month type="4">04</month>
 							<month type="5">05</month>
@@ -4314,7 +4314,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4322,7 +4322,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -6998,7 +6998,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-narrow">
 				<displayName>e</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">dʼan eur-mañ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">+{0} h</relativeTimePattern>
 					<relativeTimePattern count="two">+{0} h</relativeTimePattern>
@@ -9320,18 +9320,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</otherNumberingSystems>
 		<minimumGroupingDigits draft="contributed">1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group> </group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal>٫</decimal>
@@ -9384,7 +9384,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
 			<timeSeparator draft="contributed">:</timeSeparator>
@@ -9468,7 +9468,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
 			<timeSeparator draft="contributed">:</timeSeparator>
@@ -9506,14 +9506,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arab">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -9655,14 +9655,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arab">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -9676,7 +9676,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -9697,10 +9697,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -12756,11 +12756,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>moloù</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="two">{0} vol</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
 				<unitPattern count="many">{0} a voloù</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litroù dre gilometr</displayName>
@@ -13381,7 +13381,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} skin heol</unitPattern>
 				<unitPattern count="few">{0} skin heol</unitPattern>
 				<unitPattern count="many">{0} skin heol</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>luksoù</displayName>
@@ -13524,7 +13524,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} tolzad heol</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>gr</displayName>
 				<unitPattern count="one">{0} greunad</unitPattern>
 				<unitPattern count="two">{0} c'hreunad</unitPattern>
 				<unitPattern count="few">{0} greunad</unitPattern>
@@ -14105,17 +14105,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -14123,10 +14123,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="two">{0} G</unitPattern>
+				<unitPattern count="few">{0} G</unitPattern>
+				<unitPattern count="many">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
@@ -14231,10 +14231,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="two">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="many">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
@@ -14288,10 +14288,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="two">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="many">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
@@ -14320,10 +14320,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="two">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="many">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -14640,18 +14640,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="two">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="two">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -14664,18 +14664,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -14712,18 +14712,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="two">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="many">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
@@ -14776,10 +14776,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -14859,10 +14859,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="two">{0} yd</unitPattern>
+				<unitPattern count="few">{0} yd</unitPattern>
+				<unitPattern count="many">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
@@ -14910,17 +14910,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} fur</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="many">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fth</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="two">{0} fth</unitPattern>
+				<unitPattern count="few">{0} fth</unitPattern>
+				<unitPattern count="many">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -14949,10 +14949,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="two">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -14965,26 +14965,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -15039,10 +15039,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="two">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
+				<unitPattern count="many">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -15081,26 +15081,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -15138,7 +15138,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="power-watt">
 				<displayName>W</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} W</unitPattern>
 				<unitPattern count="few">{0} W</unitPattern>
 				<unitPattern count="many">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
@@ -15185,10 +15185,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="two">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="many">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -15201,18 +15201,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="two">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -15225,18 +15225,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="two">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="two">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -15305,18 +15305,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="two">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
+				<unitPattern count="many">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -15355,10 +15355,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="two">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="many">{0} yd³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
@@ -15444,18 +15444,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="two">{0} ac ft</unitPattern>
+				<unitPattern count="few">{0} ac ft</unitPattern>
+				<unitPattern count="many">{0} ac ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="two">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="many">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -15534,10 +15534,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="two">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="many">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -15606,108 +15606,108 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -15818,7 +15818,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd²</displayName>
 				<unitPattern count="one">{0}yd²</unitPattern>
 				<unitPattern count="two">{0}yd²</unitPattern>
 				<unitPattern count="few">{0}yd²</unitPattern>
@@ -15875,7 +15875,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppm</displayName>
 				<unitPattern count="one">{0}ppm</unitPattern>
 				<unitPattern count="two">{0}ppm</unitPattern>
 				<unitPattern count="few">{0}ppm</unitPattern>
@@ -15883,7 +15883,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
+				<displayName>%</displayName>
 				<unitPattern count="one">{0}%</unitPattern>
 				<unitPattern count="two">{0}%</unitPattern>
 				<unitPattern count="few">{0}%</unitPattern>
@@ -15891,7 +15891,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>‰</displayName>
 				<unitPattern count="one">{0}‰</unitPattern>
 				<unitPattern count="two">{0}‰</unitPattern>
 				<unitPattern count="few">{0}‰</unitPattern>
@@ -15899,7 +15899,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="two">{0}‱</unitPattern>
 				<unitPattern count="few">{0}‱</unitPattern>
@@ -15907,7 +15907,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0}mol</unitPattern>
 				<unitPattern count="two">{0}mol</unitPattern>
 				<unitPattern count="few">{0}mol</unitPattern>
@@ -16035,7 +16035,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>kved</displayName>
 				<unitPattern count="one">{0}kved</unitPattern>
 				<unitPattern count="two">{0}kved</unitPattern>
 				<unitPattern count="few">{0}kved</unitPattern>
@@ -16087,7 +16087,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/sizh.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
+				<displayName>d</displayName>
 				<unitPattern count="one">{0}d</unitPattern>
 				<unitPattern count="two">{0}d</unitPattern>
 				<unitPattern count="few">{0}d</unitPattern>
@@ -16105,7 +16105,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>min</displayName>
 				<unitPattern count="one">{0}min</unitPattern>
 				<unitPattern count="two">{0}min</unitPattern>
 				<unitPattern count="few">{0}min</unitPattern>
@@ -16114,16 +16114,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>s</displayName>
 				<unitPattern count="one">{0}s</unitPattern>
 				<unitPattern count="two">{0}s</unitPattern>
 				<unitPattern count="few">{0}s</unitPattern>
 				<unitPattern count="many">{0}s</unitPattern>
 				<unitPattern count="other">{0}s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ms</displayName>
 				<unitPattern count="one">{0}ms</unitPattern>
 				<unitPattern count="two">{0}ms</unitPattern>
 				<unitPattern count="few">{0}ms</unitPattern>
@@ -16131,7 +16131,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>μs</displayName>
 				<unitPattern count="one">{0}μs</unitPattern>
 				<unitPattern count="two">{0}μs</unitPattern>
 				<unitPattern count="few">{0}μs</unitPattern>
@@ -16139,7 +16139,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ns</displayName>
 				<unitPattern count="one">{0}ns</unitPattern>
 				<unitPattern count="two">{0}ns</unitPattern>
 				<unitPattern count="few">{0}ns</unitPattern>
@@ -16147,7 +16147,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>A</displayName>
 				<unitPattern count="one">{0}A</unitPattern>
 				<unitPattern count="two">{0}A</unitPattern>
 				<unitPattern count="few">{0}A</unitPattern>
@@ -16155,9 +16155,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>mA</displayName>
 				<unitPattern count="one">{0}mA</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mA</unitPattern>
 				<unitPattern count="few">{0}mA</unitPattern>
 				<unitPattern count="many">{0}mA</unitPattern>
 				<unitPattern count="other">{0}mA</unitPattern>
@@ -16171,7 +16171,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>V</displayName>
 				<unitPattern count="one">{0}V</unitPattern>
 				<unitPattern count="two">{0}V</unitPattern>
 				<unitPattern count="few">{0}V</unitPattern>
@@ -16179,7 +16179,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0}kcal</unitPattern>
 				<unitPattern count="two">{0}kcal</unitPattern>
 				<unitPattern count="few">{0}kcal</unitPattern>
@@ -16187,7 +16187,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="one">{0}cal</unitPattern>
 				<unitPattern count="two">{0}cal</unitPattern>
 				<unitPattern count="few">{0}cal</unitPattern>
@@ -16195,7 +16195,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>Cal</displayName>
 				<unitPattern count="one">{0}Cal</unitPattern>
 				<unitPattern count="two">{0}Cal</unitPattern>
 				<unitPattern count="few">{0}Cal</unitPattern>
@@ -16203,7 +16203,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kJ</displayName>
 				<unitPattern count="one">{0}kJ</unitPattern>
 				<unitPattern count="two">{0}kJ</unitPattern>
 				<unitPattern count="few">{0}kJ</unitPattern>
@@ -16211,7 +16211,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>J</displayName>
 				<unitPattern count="one">{0}J</unitPattern>
 				<unitPattern count="two">{0}J</unitPattern>
 				<unitPattern count="few">{0}J</unitPattern>
@@ -16219,7 +16219,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh</displayName>
 				<unitPattern count="one">{0}kWh</unitPattern>
 				<unitPattern count="two">{0}kWh</unitPattern>
 				<unitPattern count="few">{0}kWh</unitPattern>
@@ -16227,7 +16227,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>eV</displayName>
 				<unitPattern count="one">{0}eV</unitPattern>
 				<unitPattern count="two">{0}eV</unitPattern>
 				<unitPattern count="few">{0}eV</unitPattern>
@@ -16251,7 +16251,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}thm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf</displayName>
 				<unitPattern count="one">{0}lbf</unitPattern>
 				<unitPattern count="two">{0}lbf</unitPattern>
 				<unitPattern count="few">{0}lbf</unitPattern>
@@ -16259,7 +16259,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>N</displayName>
 				<unitPattern count="one">{0}N</unitPattern>
 				<unitPattern count="two">{0}N</unitPattern>
 				<unitPattern count="few">{0}N</unitPattern>
@@ -16267,7 +16267,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="one">{0}GHz</unitPattern>
 				<unitPattern count="two">{0}GHz</unitPattern>
 				<unitPattern count="few">{0}GHz</unitPattern>
@@ -16275,7 +16275,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="one">{0}MHz</unitPattern>
 				<unitPattern count="two">{0}MHz</unitPattern>
 				<unitPattern count="few">{0}MHz</unitPattern>
@@ -16283,7 +16283,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="one">{0}kHz</unitPattern>
 				<unitPattern count="two">{0}kHz</unitPattern>
 				<unitPattern count="few">{0}kHz</unitPattern>
@@ -16291,7 +16291,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="one">{0}Hz</unitPattern>
 				<unitPattern count="two">{0}Hz</unitPattern>
 				<unitPattern count="few">{0}Hz</unitPattern>
@@ -16299,7 +16299,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="two">{0}em</unitPattern>
 				<unitPattern count="few">{0}em</unitPattern>
@@ -16307,7 +16307,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="one">{0}px</unitPattern>
 				<unitPattern count="two">{0}px</unitPattern>
 				<unitPattern count="few">{0}px</unitPattern>
@@ -16363,7 +16363,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}pik</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">{0}R⊕</unitPattern>
 				<unitPattern count="two">{0}R⊕</unitPattern>
 				<unitPattern count="few">{0}R⊕</unitPattern>
@@ -16446,7 +16446,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd</displayName>
 				<unitPattern count="one">{0}yd</unitPattern>
 				<unitPattern count="two">{0}yd</unitPattern>
 				<unitPattern count="few">{0}yd</unitPattern>
@@ -16496,7 +16496,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>fur</displayName>
 				<unitPattern count="one">{0}fur</unitPattern>
 				<unitPattern count="two">{0}fur</unitPattern>
 				<unitPattern count="few">{0}fur</unitPattern>
@@ -16536,7 +16536,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R☉</displayName>
 				<unitPattern count="one">{0}R☉</unitPattern>
 				<unitPattern count="two">{0}R☉</unitPattern>
 				<unitPattern count="few">{0}R☉</unitPattern>
@@ -16552,7 +16552,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">{0}cd</unitPattern>
 				<unitPattern count="two">{0}cd</unitPattern>
 				<unitPattern count="few">{0}cd</unitPattern>
@@ -16560,7 +16560,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="two">{0}lm</unitPattern>
 				<unitPattern count="few">{0}lm</unitPattern>
@@ -16568,7 +16568,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>L☉</displayName>
 				<unitPattern count="one">{0}L☉</unitPattern>
 				<unitPattern count="two">{0}L☉</unitPattern>
 				<unitPattern count="few">{0}L☉</unitPattern>
@@ -16626,7 +16626,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>st</displayName>
 				<unitPattern count="one">{0}st</unitPattern>
 				<unitPattern count="two">{0}st</unitPattern>
 				<unitPattern count="few">{0}st</unitPattern>
@@ -16643,7 +16643,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0}oz</unitPattern>
 				<unitPattern count="two">{0}oz</unitPattern>
 				<unitPattern count="few">{0}oz</unitPattern>
@@ -16668,7 +16668,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>Da</displayName>
 				<unitPattern count="one">{0}Da</unitPattern>
 				<unitPattern count="two">{0}Da</unitPattern>
 				<unitPattern count="few">{0}Da</unitPattern>
@@ -16676,7 +16676,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M⊕</displayName>
 				<unitPattern count="one">{0}M⊕</unitPattern>
 				<unitPattern count="two">{0}M⊕</unitPattern>
 				<unitPattern count="few">{0}M⊕</unitPattern>
@@ -16684,7 +16684,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M☉</displayName>
 				<unitPattern count="one">{0}M☉</unitPattern>
 				<unitPattern count="two">{0}M☉</unitPattern>
 				<unitPattern count="few">{0}M☉</unitPattern>
@@ -16700,7 +16700,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="one">{0}GW</unitPattern>
 				<unitPattern count="two">{0}GW</unitPattern>
 				<unitPattern count="few">{0}GW</unitPattern>
@@ -16708,7 +16708,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="one">{0}MW</unitPattern>
 				<unitPattern count="two">{0}MW</unitPattern>
 				<unitPattern count="few">{0}MW</unitPattern>
@@ -16716,7 +16716,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="two">{0}kW</unitPattern>
 				<unitPattern count="few">{0}kW</unitPattern>
@@ -16724,7 +16724,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0}W</unitPattern>
 				<unitPattern count="two">{0}W</unitPattern>
 				<unitPattern count="few">{0}W</unitPattern>
@@ -16732,7 +16732,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">{0}mW</unitPattern>
 				<unitPattern count="two">{0}mW</unitPattern>
 				<unitPattern count="few">{0}mW</unitPattern>
@@ -16772,7 +16772,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}″Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="one">{0}bar</unitPattern>
 				<unitPattern count="two">{0}bar</unitPattern>
 				<unitPattern count="few">{0}bar</unitPattern>
@@ -16788,7 +16788,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm</displayName>
 				<unitPattern count="one">{0}atm</unitPattern>
 				<unitPattern count="two">{0}atm</unitPattern>
 				<unitPattern count="few">{0}atm</unitPattern>
@@ -16796,7 +16796,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="one">{0}Pa</unitPattern>
 				<unitPattern count="two">{0}Pa</unitPattern>
 				<unitPattern count="few">{0}Pa</unitPattern>
@@ -16812,7 +16812,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="one">{0}kPa</unitPattern>
 				<unitPattern count="two">{0}kPa</unitPattern>
 				<unitPattern count="few">{0}kPa</unitPattern>
@@ -16820,7 +16820,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="one">{0}MPa</unitPattern>
 				<unitPattern count="two">{0}MPa</unitPattern>
 				<unitPattern count="few">{0}MPa</unitPattern>
@@ -16892,7 +16892,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="one">{0}lbf⋅ft</unitPattern>
 				<unitPattern count="two">{0}lbf⋅ft</unitPattern>
 				<unitPattern count="few">{0}lbf⋅ft</unitPattern>
@@ -16900,7 +16900,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>N⋅m</displayName>
 				<unitPattern count="one">{0}N⋅m</unitPattern>
 				<unitPattern count="two">{0}N⋅m</unitPattern>
 				<unitPattern count="few">{0}N⋅m</unitPattern>
@@ -16942,7 +16942,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd³</displayName>
 				<unitPattern count="one">{0}yd³</unitPattern>
 				<unitPattern count="two">{0}yd³</unitPattern>
 				<unitPattern count="few">{0}yd³</unitPattern>
@@ -17039,7 +17039,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}acft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bu</displayName>
 				<unitPattern count="one">{0}bu</unitPattern>
 				<unitPattern count="two">{0}bu</unitPattern>
 				<unitPattern count="few">{0}bu</unitPattern>
@@ -17047,7 +17047,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">{0}gal</unitPattern>
 				<unitPattern count="two">{0}gal</unitPattern>
 				<unitPattern count="few">{0}gal</unitPattern>
@@ -17121,7 +17121,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}l.-g.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bbl</displayName>
 				<unitPattern count="one">{0}bbl</unitPattern>
 				<unitPattern count="two">{0}bbl</unitPattern>
 				<unitPattern count="few">{0}bbl</unitPattern>
@@ -17216,26 +17216,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} pe {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} pe {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} pe {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} pe {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} pe {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} &amp; {1}</listPatternPart>
+			<listPatternPart type="2">{0} &amp; {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} &amp; {1}</listPatternPart>
 			<listPatternPart type="2">{0} &amp; {1}</listPatternPart>
 		</listPattern>
@@ -17381,13 +17381,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern draft="provisional">↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given" draft="provisional">Yann</nameField>

--- a/common/main/brx.xml
+++ b/common/main/brx.xml
@@ -6461,31 +6461,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -5099,15 +5099,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<era type="1" alt="variant">Nove ere</era>
 					</eraNames>
 					<eraAbbr>
-						<era type="0">p. n. e.</era>
-						<era type="0" alt="variant">p. n. e.</era>
-						<era type="1">n. e.</era>
+						<era type="0">p.n.e.</era>
+						<era type="0" alt="variant">p.n.e.</era>
+						<era type="1">n.e.</era>
 						<era type="1" alt="variant">n.e.</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">p.n.e.</era>
-						<era type="0" alt="variant">p. n. e.</era>
-						<era type="1">n. e.</era>
+						<era type="0" alt="variant">p.n.e.</era>
+						<era type="1">n.e.</era>
 						<era type="1" alt="variant">n.e.</era>
 					</eraNarrow>
 				</eras>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -107,8 +107,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">čeroki</language>
 			<language type="chy">čejenski</language>
 			<language type="ckb">centralnokurdski</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">centralnokurdski</language>
+			<language type="ckb" alt="variant">centralnokurdski</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">korzikanski</language>
 			<language type="cop">koptski</language>
@@ -885,7 +885,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="CG" alt="variant">Republika Kongo</territory>
 			<territory type="CH">Švicarska</territory>
 			<territory type="CI">Obala Slonovače</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
+			<territory type="CI" alt="variant">Obala Slonovače</territory>
 			<territory type="CK">Kukova ostrva</territory>
 			<territory type="CL">Čile</territory>
 			<territory type="CM">Kamerun</territory>
@@ -1079,12 +1079,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TJ">Tadžikistan</territory>
 			<territory type="TK">Tokelau</territory>
 			<territory type="TL">Istočni Timor</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">Istočni Timor</territory>
 			<territory type="TM">Turkmenistan</territory>
 			<territory type="TN">Tunis</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turska</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turska</territory>
 			<territory type="TT">Trinidad i Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tajvan</territory>
@@ -1493,239 +1493,239 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="buddhist">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">BE</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">BE</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">BE</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d.</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d.M.</dateFormatItem>
+						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
+						<dateFormatItem id="y">y. G</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h'h' a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH'h'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h – h 'h' a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1748,18 +1748,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">12. mjesec</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Prvi mjesec</month>
@@ -1781,7 +1781,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="1">1. mjesec</month>
 							<month type="2">2. mjesec</month>
 							<month type="3">3. mjesec</month>
-							<month type="4">↑↑↑</month>
+							<month type="4">4. mjesec</month>
 							<month type="5">5. mjesec</month>
 							<month type="6">6. mjesec</month>
 							<month type="7">7. mjesec</month>
@@ -1824,10 +1824,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
 							<monthPattern type="leap">↑↑↑</monthPattern>
@@ -1840,13 +1840,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthPatternContext>
 					<monthPatternContext type="stand-alone">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
 							<monthPattern type="leap">↑↑↑</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 				</monthPatterns>
@@ -1868,412 +1868,412 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="12">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="months">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2307,10 +2307,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
 								<cyclicName type="1">kreće proljeće</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
+								<cyclicName type="2">kišnica</cyclicName>
+								<cyclicName type="3">bude se insekti</cyclicName>
+								<cyclicName type="4">proljetna ravnodnevica</cyclicName>
+								<cyclicName type="5">vedro</cyclicName>
 								<cyclicName type="6">kiša zrna</cyclicName>
 								<cyclicName type="7">kreće ljeto</cyclicName>
 								<cyclicName type="8">puno zrno</cyclicName>
@@ -2332,13 +2332,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="24">jaka hladnoća</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
+								<cyclicName type="1">kreće proljeće</cyclicName>
+								<cyclicName type="2">kišnica</cyclicName>
+								<cyclicName type="3">bude se insekti</cyclicName>
+								<cyclicName type="4">proljetna ravnodnevica</cyclicName>
+								<cyclicName type="5">vedro</cyclicName>
+								<cyclicName type="6">kiša zrna</cyclicName>
+								<cyclicName type="7">kreće ljeto</cyclicName>
 								<cyclicName type="8">puno zrno</cyclicName>
 								<cyclicName type="9">zrelo zrno</cyclicName>
 								<cyclicName type="10">ljetni solsticij</cyclicName>
@@ -2424,174 +2424,174 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="60">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="zodiacs">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2644,7 +2644,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2652,7 +2652,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2814,34 +2814,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tout</month>
+							<month type="2">Baba</month>
+							<month type="3">Hator</month>
+							<month type="4">Kiahk</month>
+							<month type="5">Toba</month>
+							<month type="6">Amshir</month>
+							<month type="7">Baramhat</month>
+							<month type="8">Baramouda</month>
+							<month type="9">Bashans</month>
+							<month type="10">Paona</month>
+							<month type="11">Epep</month>
+							<month type="12">Mesra</month>
+							<month type="13">Nasie</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -2861,19 +2861,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tout</month>
+							<month type="2">Baba</month>
+							<month type="3">Hator</month>
+							<month type="4">Kiahk</month>
+							<month type="5">Toba</month>
+							<month type="6">Amshir</month>
+							<month type="7">Baramhat</month>
+							<month type="8">Baramouda</month>
+							<month type="9">Bashans</month>
+							<month type="10">Paona</month>
+							<month type="11">Epep</month>
+							<month type="12">Mesra</month>
+							<month type="13">Nasie</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -2891,260 +2891,260 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="13">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tout</month>
+							<month type="2">Baba</month>
+							<month type="3">Hator</month>
+							<month type="4">Kiahk</month>
+							<month type="5">Toba</month>
+							<month type="6">Amshir</month>
+							<month type="7">Baramhat</month>
+							<month type="8">Baramouda</month>
+							<month type="9">Bashans</month>
+							<month type="10">Paona</month>
+							<month type="11">Epep</month>
+							<month type="12">Mesra</month>
+							<month type="13">Nasie</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 						<era type="1">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d.</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d.M.</dateFormatItem>
+						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
+						<dateFormatItem id="y">y. G</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h'h' a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH'h'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h – h 'h' a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3153,119 +3153,119 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1. mjesec</month>
+							<month type="2">2. mjesec</month>
+							<month type="3">3. mjesec</month>
+							<month type="4">4. mjesec</month>
+							<month type="5">5. mjesec</month>
+							<month type="6">6. mjesec</month>
+							<month type="7">7. mjesec</month>
+							<month type="8">8. mjesec</month>
+							<month type="9">9. mjesec</month>
+							<month type="10">10. mjesec</month>
+							<month type="11">11. mjesec</month>
+							<month type="12">12. mjesec</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Prvi mjesec</month>
+							<month type="2">Drugi mjesec</month>
+							<month type="3">Treći mjesec</month>
+							<month type="4">Četvrti mjesec</month>
+							<month type="5">Peti mjesec</month>
+							<month type="6">Šesti mjesec</month>
+							<month type="7">Sedmi mjesec</month>
+							<month type="8">Osmi mjesec</month>
+							<month type="9">Deveti mjesec</month>
+							<month type="10">Deseti mjesec</month>
+							<month type="11">Jedanaesti mjesec</month>
+							<month type="12">Dvanaesti mjesec</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1. mjesec</month>
+							<month type="2">2. mjesec</month>
+							<month type="3">3. mjesec</month>
+							<month type="4">4. mjesec</month>
+							<month type="5">5. mjesec</month>
+							<month type="6">6. mjesec</month>
+							<month type="7">7. mjesec</month>
+							<month type="8">8. mjesec</month>
+							<month type="9">9. mjesec</month>
+							<month type="10">10.. mjesec</month>
+							<month type="11">11. mjesec</month>
+							<month type="12">12. mjesec</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Prvi mjesec</month>
+							<month type="2">Drugi mjesec</month>
+							<month type="3">Treći mjesec</month>
+							<month type="4">Četvrti mjesec</month>
+							<month type="5">Peti mjesec</month>
+							<month type="6">Šesti mjesec</month>
+							<month type="7">Sedmi mjesec</month>
+							<month type="8">Osmi mjesec</month>
+							<month type="9">Deveti mjesec</month>
+							<month type="10">Deseti mjesec</month>
+							<month type="11">Jedanaesti mjesec</month>
+							<month type="12">Dvanaesti mjesec</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 					<monthPatternContext type="numeric">
 						<monthPatternWidth type="all">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 					<monthPatternContext type="stand-alone">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 				</monthPatterns>
@@ -3273,744 +3273,744 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<cyclicNameSet type="dayParts">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="months">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="solarTerms">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">kreće proljeće</cyclicName>
+								<cyclicName type="2">kišnica</cyclicName>
+								<cyclicName type="3">bude se insekti</cyclicName>
+								<cyclicName type="4">proljetna ravnodnevica</cyclicName>
+								<cyclicName type="5">vedro</cyclicName>
+								<cyclicName type="6">kiša zrna</cyclicName>
+								<cyclicName type="7">kreće ljeto</cyclicName>
+								<cyclicName type="8">puno zrno</cyclicName>
+								<cyclicName type="9">zrelo zrno</cyclicName>
+								<cyclicName type="10">ljetni solsticij</cyclicName>
+								<cyclicName type="11">blaga vrućina</cyclicName>
+								<cyclicName type="12">velika vrućina</cyclicName>
+								<cyclicName type="13">kreće jesen</cyclicName>
+								<cyclicName type="14">kraj vrućine</cyclicName>
+								<cyclicName type="15">bijela rosa</cyclicName>
+								<cyclicName type="16">jesenja ravnodnevnica</cyclicName>
+								<cyclicName type="17">hladna rosa</cyclicName>
+								<cyclicName type="18">spušta se mraz</cyclicName>
+								<cyclicName type="19">kreće zima</cyclicName>
+								<cyclicName type="20">blagi snijeg</cyclicName>
+								<cyclicName type="21">veliki snijeg</cyclicName>
+								<cyclicName type="22">zimski solsticij</cyclicName>
+								<cyclicName type="23">blaga hladnoća</cyclicName>
+								<cyclicName type="24">jaka hladnoća</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">kreće proljeće</cyclicName>
+								<cyclicName type="2">kišnica</cyclicName>
+								<cyclicName type="3">bude se insekti</cyclicName>
+								<cyclicName type="4">proljetna ravnodnevica</cyclicName>
+								<cyclicName type="5">vedro</cyclicName>
+								<cyclicName type="6">kiša zrna</cyclicName>
+								<cyclicName type="7">kreće ljeto</cyclicName>
+								<cyclicName type="8">puno zrno</cyclicName>
+								<cyclicName type="9">zrelo zrno</cyclicName>
+								<cyclicName type="10">ljetni solsticij</cyclicName>
+								<cyclicName type="11">blaga vrućina</cyclicName>
+								<cyclicName type="12">velika vrućina</cyclicName>
+								<cyclicName type="13">kreće jesen</cyclicName>
+								<cyclicName type="14">kraj vrućine</cyclicName>
+								<cyclicName type="15">bijela rosa</cyclicName>
+								<cyclicName type="16">jesenja ravnodnevnica</cyclicName>
+								<cyclicName type="17">hladna rosa</cyclicName>
+								<cyclicName type="18">spušta se mraz</cyclicName>
+								<cyclicName type="19">kreće zima</cyclicName>
+								<cyclicName type="20">blagi snijeg</cyclicName>
+								<cyclicName type="21">veliki snijeg</cyclicName>
+								<cyclicName type="22">zimski solsticij</cyclicName>
+								<cyclicName type="23">blaga hladnoća</cyclicName>
+								<cyclicName type="24">jaka hladnoća</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">kreće proljeće</cyclicName>
+								<cyclicName type="2">kišnica</cyclicName>
+								<cyclicName type="3">bude se insekti</cyclicName>
+								<cyclicName type="4">proljetna ravnodnevica</cyclicName>
+								<cyclicName type="5">vedro</cyclicName>
+								<cyclicName type="6">kiša zrna</cyclicName>
+								<cyclicName type="7">kreće ljeto</cyclicName>
+								<cyclicName type="8">puno zrno</cyclicName>
+								<cyclicName type="9">zrelo zrno</cyclicName>
+								<cyclicName type="10">ljetni solsticij</cyclicName>
+								<cyclicName type="11">blaga vrućina</cyclicName>
+								<cyclicName type="12">velika vrućina</cyclicName>
+								<cyclicName type="13">kreće jesen</cyclicName>
+								<cyclicName type="14">kraj vrućine</cyclicName>
+								<cyclicName type="15">bijela rosa</cyclicName>
+								<cyclicName type="16">jesenja ravnodnevnica</cyclicName>
+								<cyclicName type="17">hladna rosa</cyclicName>
+								<cyclicName type="18">spušta se mraz</cyclicName>
+								<cyclicName type="19">kreće zima</cyclicName>
+								<cyclicName type="20">blagi snijeg</cyclicName>
+								<cyclicName type="21">veliki snijeg</cyclicName>
+								<cyclicName type="22">zimski solsticij</cyclicName>
+								<cyclicName type="23">blaga hladnoća</cyclicName>
+								<cyclicName type="24">jaka hladnoća</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="years">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="zodiacs">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -4018,197 +4018,197 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>E, d.M.y.</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d.M.y.</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d.M.y.</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d.M.y.</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d E</dateFormatItem>
+						<dateFormatItem id="Gy">r(U)</dateFormatItem>
+						<dateFormatItem id="GyMMM">r MMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">r MMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">r MMM d, E</dateFormatItem>
+						<dateFormatItem id="GyMMMM">r(U) MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMMd">r(U) MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd">r(U) MMMM d, E</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM-dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM-dd, E</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM d, E</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="UM">U MM</dateFormatItem>
+						<dateFormatItem id="UMd">U MM-d</dateFormatItem>
+						<dateFormatItem id="UMMM">U MMM</dateFormatItem>
+						<dateFormatItem id="UMMMd">U MMM d</dateFormatItem>
+						<dateFormatItem id="y">r(U)</dateFormatItem>
+						<dateFormatItem id="yMd">r-MM-dd</dateFormatItem>
+						<dateFormatItem id="yyyy">r(U)</dateFormatItem>
+						<dateFormatItem id="yyyyM">r-MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">r-MM-dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">r-MM-dd, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">r MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">r MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">r MMM d, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">r(U) MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">r(U) MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">r(U) MMMM d, E</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">r(U) QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">r(U) QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">U–U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">U MMM–MMM</greatestDifference>
+							<greatestDifference id="y">U MMM – U MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">U MMM d–d</greatestDifference>
+							<greatestDifference id="M">U MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">U MMM d – U MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">U MMM d, E – U MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">U MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">U MMMM – U MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4217,34 +4217,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Meskerem</month>
+							<month type="2">Tekemt</month>
+							<month type="3">Hedar</month>
+							<month type="4">Tahsas</month>
+							<month type="5">Ter</month>
+							<month type="6">Yekatit</month>
+							<month type="7">Megabit</month>
+							<month type="8">Miazia</month>
+							<month type="9">Genbot</month>
+							<month type="10">Sene</month>
+							<month type="11">Hamle</month>
+							<month type="12">Nehasse</month>
+							<month type="13">Pagumen</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -4264,19 +4264,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Meskerem</month>
+							<month type="2">Tekemt</month>
+							<month type="3">Hedar</month>
+							<month type="4">Tahsas</month>
+							<month type="5">Ter</month>
+							<month type="6">Yekatit</month>
+							<month type="7">Megabit</month>
+							<month type="8">Miazia</month>
+							<month type="9">Genbot</month>
+							<month type="10">Sene</month>
+							<month type="11">Hamle</month>
+							<month type="12">Nehasse</month>
+							<month type="13">Pagumen</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -4294,260 +4294,260 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="13">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Meskerem</month>
+							<month type="2">Tekemt</month>
+							<month type="3">Hedar</month>
+							<month type="4">Tahsas</month>
+							<month type="5">Ter</month>
+							<month type="6">Yekatit</month>
+							<month type="7">Megabit</month>
+							<month type="8">Miazia</month>
+							<month type="9">Genbot</month>
+							<month type="10">Sene</month>
+							<month type="11">Hamle</month>
+							<month type="12">Nehasse</month>
+							<month type="13">Pagumen</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 						<era type="1">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d.</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d.M.</dateFormatItem>
+						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
+						<dateFormatItem id="y">y. G</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h'h' a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH'h'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h – h 'h' a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4555,13 +4555,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="ethiopic-amete-alem">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">ERA0</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">ERA0</era>
 					</eraNarrow>
 				</eras>
 			</calendar>
@@ -4614,7 +4614,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4622,7 +4622,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5100,15 +5100,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraNames>
 					<eraAbbr>
 						<era type="0">p. n. e.</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">p. n. e.</era>
 						<era type="1">n. e.</era>
 						<era type="1" alt="variant">n.e.</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">p.n.e.</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">p. n. e.</era>
+						<era type="1">n. e.</era>
+						<era type="1" alt="variant">n.e.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -5185,7 +5185,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -5193,7 +5193,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5403,36 +5403,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tishri</month>
+							<month type="2">Heshvan</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
+							<month type="5">Shevat</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
+							<month type="9">Iyar</month>
+							<month type="10">Sivan</month>
+							<month type="11">Tamuz</month>
+							<month type="12">Av</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="7" yeartype="leap">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -5453,20 +5453,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tishri</month>
+							<month type="2">Heshvan</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
+							<month type="5">Shevat</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
+							<month type="9">Iyar</month>
+							<month type="10">Sivan</month>
+							<month type="11">Tamuz</month>
+							<month type="12">Av</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -5485,258 +5485,258 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="13">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tishri</month>
+							<month type="2">Heshvan</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
+							<month type="5">Shevat</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
+							<month type="9">Iyar</month>
+							<month type="10">Sivan</month>
+							<month type="11">Tamuz</month>
+							<month type="12">Av</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AM</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">AM</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AM</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d.</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d.M.</dateFormatItem>
+						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
+						<dateFormatItem id="y">y. G</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h'h' a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH'h'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h – h 'h' a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5745,32 +5745,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Chaitra</month>
+							<month type="2">Vaisakha</month>
+							<month type="3">Jyaistha</month>
+							<month type="4">Asadha</month>
+							<month type="5">Sravana</month>
+							<month type="6">Bhadra</month>
+							<month type="7">Asvina</month>
+							<month type="8">Kartika</month>
+							<month type="9">Agrahayana</month>
+							<month type="10">Pausa</month>
+							<month type="11">Magha</month>
+							<month type="12">Phalguna</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -5789,18 +5789,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Chaitra</month>
+							<month type="2">Vaisakha</month>
+							<month type="3">Jyaistha</month>
+							<month type="4">Asadha</month>
+							<month type="5">Sravana</month>
+							<month type="6">Bhadra</month>
+							<month type="7">Asvina</month>
+							<month type="8">Kartika</month>
+							<month type="9">Agrahayana</month>
+							<month type="10">Pausa</month>
+							<month type="11">Magha</month>
+							<month type="12">Phalguna</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -5817,256 +5817,256 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Chaitra</month>
+							<month type="2">Vaisakha</month>
+							<month type="3">Jyaistha</month>
+							<month type="4">Asadha</month>
+							<month type="5">Sravana</month>
+							<month type="6">Bhadra</month>
+							<month type="7">Asvina</month>
+							<month type="8">Kartika</month>
+							<month type="9">Agrahayana</month>
+							<month type="10">Pausa</month>
+							<month type="11">Magha</month>
+							<month type="12">Phalguna</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">Saka</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">Saka</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d.</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d.M.</dateFormatItem>
+						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
+						<dateFormatItem id="y">y. G</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h'h' a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH'h'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h – h 'h' a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -6078,6 +6078,50 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="1">muh.</month>
 							<month type="2">saf.</month>
 							<month type="3">↑↑↑</month>
+							<month type="4">rab. ii</month>
+							<month type="5">džum. i</month>
+							<month type="6">džum. ii</month>
+							<month type="7">redž.</month>
+							<month type="8">ša.</month>
+							<month type="9">ram.</month>
+							<month type="10">še.</month>
+							<month type="11">zul-k.</month>
+							<month type="12">zul-h.</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">muharem</month>
+							<month type="2">safer</month>
+							<month type="3">rabiʻ i</month>
+							<month type="4">rabiʻ ii</month>
+							<month type="5">džumade i</month>
+							<month type="6">džumade ii</month>
+							<month type="7">redžeb</month>
+							<month type="8">↑↑↑</month>
+							<month type="9">ramazan</month>
+							<month type="10">ševal</month>
+							<month type="11">zul-kade</month>
+							<month type="12">zul-hidže</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">muh.</month>
+							<month type="2">saf.</month>
+							<month type="3">Rab. I</month>
 							<month type="4">rab. ii</month>
 							<month type="5">džum. i</month>
 							<month type="6">džum. ii</month>
@@ -6110,67 +6154,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="5">džumade i</month>
 							<month type="6">džumade ii</month>
 							<month type="7">redžeb</month>
-							<month type="8">↑↑↑</month>
+							<month type="8">Shaʻban</month>
 							<month type="9">ramazan</month>
 							<month type="10">ševal</month>
 							<month type="11">zul-kade</month>
 							<month type="12">zul-hidže</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AH</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">AH</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AH</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -6202,45 +6202,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
 						<dateFormatItem id="d">d</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E, dd.</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
 						<dateFormatItem id="hm">hh:mm a</dateFormatItem>
 						<dateFormatItem id="Hm">HH:mm</dateFormatItem>
 						<dateFormatItem id="hms">hh:mm:ss a</dateFormatItem>
@@ -6251,8 +6251,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">dd. MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, dd. MMM</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">y. G</dateFormatItem>
 						<dateFormatItem id="yM">MM.y. G</dateFormatItem>
@@ -6263,157 +6263,157 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yMMMEd">E, dd. MMM y. G</dateFormatItem>
 						<dateFormatItem id="yQQQ">y G QQQ</dateFormatItem>
 						<dateFormatItem id="yQQQQ">y G QQQQ</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h'h' a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH'h'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h – h 'h' a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -6421,243 +6421,243 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="japanese">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="2">↑↑↑</era>
-						<era type="3">↑↑↑</era>
-						<era type="4">↑↑↑</era>
-						<era type="5">↑↑↑</era>
-						<era type="6">↑↑↑</era>
-						<era type="7">↑↑↑</era>
-						<era type="8">↑↑↑</era>
-						<era type="9">↑↑↑</era>
-						<era type="10">↑↑↑</era>
-						<era type="11">↑↑↑</era>
-						<era type="12">↑↑↑</era>
-						<era type="13">↑↑↑</era>
-						<era type="14">↑↑↑</era>
-						<era type="15">↑↑↑</era>
-						<era type="16">↑↑↑</era>
-						<era type="17">↑↑↑</era>
-						<era type="18">↑↑↑</era>
-						<era type="19">↑↑↑</era>
-						<era type="20">↑↑↑</era>
-						<era type="21">↑↑↑</era>
-						<era type="22">↑↑↑</era>
-						<era type="23">↑↑↑</era>
-						<era type="24">↑↑↑</era>
-						<era type="25">↑↑↑</era>
-						<era type="26">↑↑↑</era>
-						<era type="27">↑↑↑</era>
-						<era type="28">↑↑↑</era>
-						<era type="29">↑↑↑</era>
-						<era type="30">↑↑↑</era>
-						<era type="31">↑↑↑</era>
-						<era type="32">↑↑↑</era>
-						<era type="33">↑↑↑</era>
-						<era type="34">↑↑↑</era>
-						<era type="35">↑↑↑</era>
-						<era type="36">↑↑↑</era>
-						<era type="37">↑↑↑</era>
-						<era type="38">↑↑↑</era>
-						<era type="39">↑↑↑</era>
-						<era type="40">↑↑↑</era>
-						<era type="41">↑↑↑</era>
-						<era type="42">↑↑↑</era>
-						<era type="43">↑↑↑</era>
-						<era type="44">↑↑↑</era>
-						<era type="45">↑↑↑</era>
-						<era type="46">↑↑↑</era>
-						<era type="47">↑↑↑</era>
-						<era type="48">↑↑↑</era>
-						<era type="49">↑↑↑</era>
-						<era type="50">↑↑↑</era>
-						<era type="51">↑↑↑</era>
-						<era type="52">↑↑↑</era>
-						<era type="53">↑↑↑</era>
-						<era type="54">↑↑↑</era>
-						<era type="55">↑↑↑</era>
-						<era type="56">↑↑↑</era>
-						<era type="57">↑↑↑</era>
-						<era type="58">↑↑↑</era>
-						<era type="59">↑↑↑</era>
-						<era type="60">↑↑↑</era>
-						<era type="61">↑↑↑</era>
-						<era type="62">↑↑↑</era>
-						<era type="63">↑↑↑</era>
-						<era type="64">↑↑↑</era>
-						<era type="65">↑↑↑</era>
-						<era type="66">↑↑↑</era>
-						<era type="67">↑↑↑</era>
-						<era type="68">↑↑↑</era>
-						<era type="69">↑↑↑</era>
-						<era type="70">↑↑↑</era>
-						<era type="71">↑↑↑</era>
-						<era type="72">↑↑↑</era>
-						<era type="73">↑↑↑</era>
-						<era type="74">↑↑↑</era>
-						<era type="75">↑↑↑</era>
-						<era type="76">↑↑↑</era>
-						<era type="77">↑↑↑</era>
-						<era type="78">↑↑↑</era>
-						<era type="79">↑↑↑</era>
-						<era type="80">↑↑↑</era>
-						<era type="81">↑↑↑</era>
-						<era type="82">↑↑↑</era>
-						<era type="83">↑↑↑</era>
-						<era type="84">↑↑↑</era>
-						<era type="85">↑↑↑</era>
-						<era type="86">↑↑↑</era>
-						<era type="87">↑↑↑</era>
-						<era type="88">↑↑↑</era>
-						<era type="89">↑↑↑</era>
-						<era type="90">↑↑↑</era>
-						<era type="91">↑↑↑</era>
-						<era type="92">↑↑↑</era>
-						<era type="93">↑↑↑</era>
-						<era type="94">↑↑↑</era>
-						<era type="95">↑↑↑</era>
-						<era type="96">↑↑↑</era>
-						<era type="97">↑↑↑</era>
-						<era type="98">↑↑↑</era>
-						<era type="99">↑↑↑</era>
-						<era type="100">↑↑↑</era>
-						<era type="101">↑↑↑</era>
-						<era type="102">↑↑↑</era>
-						<era type="103">↑↑↑</era>
-						<era type="104">↑↑↑</era>
-						<era type="105">↑↑↑</era>
-						<era type="106">↑↑↑</era>
-						<era type="107">↑↑↑</era>
-						<era type="108">↑↑↑</era>
-						<era type="109">↑↑↑</era>
-						<era type="110">↑↑↑</era>
-						<era type="111">↑↑↑</era>
-						<era type="112">↑↑↑</era>
-						<era type="113">↑↑↑</era>
-						<era type="114">↑↑↑</era>
-						<era type="115">↑↑↑</era>
-						<era type="116">↑↑↑</era>
-						<era type="117">↑↑↑</era>
-						<era type="118">↑↑↑</era>
-						<era type="119">↑↑↑</era>
-						<era type="120">↑↑↑</era>
-						<era type="121">↑↑↑</era>
-						<era type="122">↑↑↑</era>
-						<era type="123">↑↑↑</era>
-						<era type="124">↑↑↑</era>
-						<era type="125">↑↑↑</era>
-						<era type="126">↑↑↑</era>
-						<era type="127">↑↑↑</era>
-						<era type="128">↑↑↑</era>
-						<era type="129">↑↑↑</era>
-						<era type="130">↑↑↑</era>
-						<era type="131">↑↑↑</era>
-						<era type="132">↑↑↑</era>
-						<era type="133">↑↑↑</era>
-						<era type="134">↑↑↑</era>
-						<era type="135">↑↑↑</era>
-						<era type="136">↑↑↑</era>
-						<era type="137">↑↑↑</era>
-						<era type="138">↑↑↑</era>
-						<era type="139">↑↑↑</era>
-						<era type="140">↑↑↑</era>
-						<era type="141">↑↑↑</era>
-						<era type="142">↑↑↑</era>
-						<era type="143">↑↑↑</era>
-						<era type="144">↑↑↑</era>
-						<era type="145">↑↑↑</era>
-						<era type="146">↑↑↑</era>
-						<era type="147">↑↑↑</era>
-						<era type="148">↑↑↑</era>
-						<era type="149">↑↑↑</era>
-						<era type="150">↑↑↑</era>
-						<era type="151">↑↑↑</era>
-						<era type="152">↑↑↑</era>
-						<era type="153">↑↑↑</era>
-						<era type="154">↑↑↑</era>
-						<era type="155">↑↑↑</era>
-						<era type="156">↑↑↑</era>
-						<era type="157">↑↑↑</era>
-						<era type="158">↑↑↑</era>
-						<era type="159">↑↑↑</era>
-						<era type="160">↑↑↑</era>
-						<era type="161">↑↑↑</era>
-						<era type="162">↑↑↑</era>
-						<era type="163">↑↑↑</era>
-						<era type="164">↑↑↑</era>
-						<era type="165">↑↑↑</era>
-						<era type="166">↑↑↑</era>
-						<era type="167">↑↑↑</era>
-						<era type="168">↑↑↑</era>
-						<era type="169">↑↑↑</era>
-						<era type="170">↑↑↑</era>
-						<era type="171">↑↑↑</era>
-						<era type="172">↑↑↑</era>
-						<era type="173">↑↑↑</era>
-						<era type="174">↑↑↑</era>
-						<era type="175">↑↑↑</era>
-						<era type="176">↑↑↑</era>
-						<era type="177">↑↑↑</era>
-						<era type="178">↑↑↑</era>
-						<era type="179">↑↑↑</era>
-						<era type="180">↑↑↑</era>
-						<era type="181">↑↑↑</era>
-						<era type="182">↑↑↑</era>
-						<era type="183">↑↑↑</era>
-						<era type="184">↑↑↑</era>
-						<era type="185">↑↑↑</era>
-						<era type="186">↑↑↑</era>
-						<era type="187">↑↑↑</era>
-						<era type="188">↑↑↑</era>
-						<era type="189">↑↑↑</era>
-						<era type="190">↑↑↑</era>
-						<era type="191">↑↑↑</era>
-						<era type="192">↑↑↑</era>
-						<era type="193">↑↑↑</era>
-						<era type="194">↑↑↑</era>
-						<era type="195">↑↑↑</era>
-						<era type="196">↑↑↑</era>
-						<era type="197">↑↑↑</era>
-						<era type="198">↑↑↑</era>
-						<era type="199">↑↑↑</era>
-						<era type="200">↑↑↑</era>
-						<era type="201">↑↑↑</era>
-						<era type="202">↑↑↑</era>
-						<era type="203">↑↑↑</era>
-						<era type="204">↑↑↑</era>
-						<era type="205">↑↑↑</era>
-						<era type="206">↑↑↑</era>
-						<era type="207">↑↑↑</era>
-						<era type="208">↑↑↑</era>
-						<era type="209">↑↑↑</era>
-						<era type="210">↑↑↑</era>
-						<era type="211">↑↑↑</era>
-						<era type="212">↑↑↑</era>
-						<era type="213">↑↑↑</era>
-						<era type="214">↑↑↑</era>
-						<era type="215">↑↑↑</era>
-						<era type="216">↑↑↑</era>
-						<era type="217">↑↑↑</era>
-						<era type="218">↑↑↑</era>
-						<era type="219">↑↑↑</era>
-						<era type="220">↑↑↑</era>
-						<era type="221">↑↑↑</era>
-						<era type="222">↑↑↑</era>
-						<era type="223">↑↑↑</era>
-						<era type="224">↑↑↑</era>
-						<era type="225">↑↑↑</era>
-						<era type="226">↑↑↑</era>
-						<era type="227">↑↑↑</era>
-						<era type="228">↑↑↑</era>
-						<era type="229">↑↑↑</era>
-						<era type="230">↑↑↑</era>
-						<era type="231">↑↑↑</era>
-						<era type="232">↑↑↑</era>
-						<era type="233">↑↑↑</era>
-						<era type="234">↑↑↑</era>
-						<era type="235">↑↑↑</era>
-						<era type="236">↑↑↑</era>
+						<era type="0">Taika (645–650)</era>
+						<era type="1">Hakuchi (650–671)</era>
+						<era type="2">Hakuhō (672–686)</era>
+						<era type="3">Shuchō (686–701)</era>
+						<era type="4">Taihō (701–704)</era>
+						<era type="5">Keiun (704–708)</era>
+						<era type="6">Wadō (708–715)</era>
+						<era type="7">Reiki (715–717)</era>
+						<era type="8">Yōrō (717–724)</era>
+						<era type="9">Jinki (724–729)</era>
+						<era type="10">Tenpyō (729–749)</era>
+						<era type="11">Tenpyō-kampō (749–749)</era>
+						<era type="12">Tenpyō-shōhō (749–757)</era>
+						<era type="13">Tenpyō-hōji (757–765)</era>
+						<era type="14">Tenpyō-jingo (765–767)</era>
+						<era type="15">Jingo-keiun (767–770)</era>
+						<era type="16">Hōki (770–780)</era>
+						<era type="17">Ten-ō (781–782)</era>
+						<era type="18">Enryaku (782–806)</era>
+						<era type="19">Daidō (806–810)</era>
+						<era type="20">Kōnin (810–824)</era>
+						<era type="21">Tenchō (824–834)</era>
+						<era type="22">Jōwa (834–848)</era>
+						<era type="23">Kajō (848–851)</era>
+						<era type="24">Ninju (851–854)</era>
+						<era type="25">Saikō (854–857)</era>
+						<era type="26">Ten-an (857–859)</era>
+						<era type="27">Jōgan (859–877)</era>
+						<era type="28">Gangyō (877–885)</era>
+						<era type="29">Ninna (885–889)</era>
+						<era type="30">Kanpyō (889–898)</era>
+						<era type="31">Shōtai (898–901)</era>
+						<era type="32">Engi (901–923)</era>
+						<era type="33">Enchō (923–931)</era>
+						<era type="34">Jōhei (931–938)</era>
+						<era type="35">Tengyō (938–947)</era>
+						<era type="36">Tenryaku (947–957)</era>
+						<era type="37">Tentoku (957–961)</era>
+						<era type="38">Ōwa (961–964)</era>
+						<era type="39">Kōhō (964–968)</era>
+						<era type="40">Anna (968–970)</era>
+						<era type="41">Tenroku (970–973)</era>
+						<era type="42">Ten’en (973–976)</era>
+						<era type="43">Jōgen (976–978)</era>
+						<era type="44">Tengen (978–983)</era>
+						<era type="45">Eikan (983–985)</era>
+						<era type="46">Kanna (985–987)</era>
+						<era type="47">Eien (987–989)</era>
+						<era type="48">Eiso (989–990)</era>
+						<era type="49">Shōryaku (990–995)</era>
+						<era type="50">Chōtoku (995–999)</era>
+						<era type="51">Chōhō (999–1004)</era>
+						<era type="52">Kankō (1004–1012)</era>
+						<era type="53">Chōwa (1012–1017)</era>
+						<era type="54">Kannin (1017–1021)</era>
+						<era type="55">Jian (1021–1024)</era>
+						<era type="56">Manju (1024–1028)</era>
+						<era type="57">Chōgen (1028–1037)</era>
+						<era type="58">Chōryaku (1037–1040)</era>
+						<era type="59">Chōkyū (1040–1044)</era>
+						<era type="60">Kantoku (1044–1046)</era>
+						<era type="61">Eishō (1046–1053)</era>
+						<era type="62">Tengi (1053–1058)</era>
+						<era type="63">Kōhei (1058–1065)</era>
+						<era type="64">Jiryaku (1065–1069)</era>
+						<era type="65">Enkyū (1069–1074)</era>
+						<era type="66">Shōho (1074–1077)</era>
+						<era type="67">Shōryaku (1077–1081)</era>
+						<era type="68">Eihō (1081–1084)</era>
+						<era type="69">Ōtoku (1084–1087)</era>
+						<era type="70">Kanji (1087–1094)</era>
+						<era type="71">Kahō (1094–1096)</era>
+						<era type="72">Eichō (1096–1097)</era>
+						<era type="73">Jōtoku (1097–1099)</era>
+						<era type="74">Kōwa (1099–1104)</era>
+						<era type="75">Chōji (1104–1106)</era>
+						<era type="76">Kashō (1106–1108)</era>
+						<era type="77">Tennin (1108–1110)</era>
+						<era type="78">Ten-ei (1110–1113)</era>
+						<era type="79">Eikyū (1113–1118)</era>
+						<era type="80">Gen’ei (1118–1120)</era>
+						<era type="81">Hōan (1120–1124)</era>
+						<era type="82">Tenji (1124–1126)</era>
+						<era type="83">Daiji (1126–1131)</era>
+						<era type="84">Tenshō (1131–1132)</era>
+						<era type="85">Chōshō (1132–1135)</era>
+						<era type="86">Hōen (1135–1141)</era>
+						<era type="87">Eiji (1141–1142)</era>
+						<era type="88">Kōji (1142–1144)</era>
+						<era type="89">Ten’yō (1144–1145)</era>
+						<era type="90">Kyūan (1145–1151)</era>
+						<era type="91">Ninpei (1151–1154)</era>
+						<era type="92">Kyūju (1154–1156)</era>
+						<era type="93">Hōgen (1156–1159)</era>
+						<era type="94">Heiji (1159–1160)</era>
+						<era type="95">Eiryaku (1160–1161)</era>
+						<era type="96">Ōho (1161–1163)</era>
+						<era type="97">Chōkan (1163–1165)</era>
+						<era type="98">Eiman (1165–1166)</era>
+						<era type="99">Nin’an (1166–1169)</era>
+						<era type="100">Kaō (1169–1171)</era>
+						<era type="101">Shōan (1171–1175)</era>
+						<era type="102">Angen (1175–1177)</era>
+						<era type="103">Jishō (1177–1181)</era>
+						<era type="104">Yōwa (1181–1182)</era>
+						<era type="105">Juei (1182–1184)</era>
+						<era type="106">Genryaku (1184–1185)</era>
+						<era type="107">Bunji (1185–1190)</era>
+						<era type="108">Kenkyū (1190–1199)</era>
+						<era type="109">Shōji (1199–1201)</era>
+						<era type="110">Kennin (1201–1204)</era>
+						<era type="111">Genkyū (1204–1206)</era>
+						<era type="112">Ken’ei (1206–1207)</era>
+						<era type="113">Jōgen (1207–1211)</era>
+						<era type="114">Kenryaku (1211–1213)</era>
+						<era type="115">Kenpō (1213–1219)</era>
+						<era type="116">Jōkyū (1219–1222)</era>
+						<era type="117">Jōō (1222–1224)</era>
+						<era type="118">Gennin (1224–1225)</era>
+						<era type="119">Karoku (1225–1227)</era>
+						<era type="120">Antei (1227–1229)</era>
+						<era type="121">Kanki (1229–1232)</era>
+						<era type="122">Jōei (1232–1233)</era>
+						<era type="123">Tenpuku (1233–1234)</era>
+						<era type="124">Bunryaku (1234–1235)</era>
+						<era type="125">Katei (1235–1238)</era>
+						<era type="126">Ryakunin (1238–1239)</era>
+						<era type="127">En’ō (1239–1240)</era>
+						<era type="128">Ninji (1240–1243)</era>
+						<era type="129">Kangen (1243–1247)</era>
+						<era type="130">Hōji (1247–1249)</era>
+						<era type="131">Kenchō (1249–1256)</era>
+						<era type="132">Kōgen (1256–1257)</era>
+						<era type="133">Shōka (1257–1259)</era>
+						<era type="134">Shōgen (1259–1260)</era>
+						<era type="135">Bun’ō (1260–1261)</era>
+						<era type="136">Kōchō (1261–1264)</era>
+						<era type="137">Bun’ei (1264–1275)</era>
+						<era type="138">Kenji (1275–1278)</era>
+						<era type="139">Kōan (1278–1288)</era>
+						<era type="140">Shōō (1288–1293)</era>
+						<era type="141">Einin (1293–1299)</era>
+						<era type="142">Shōan (1299–1302)</era>
+						<era type="143">Kengen (1302–1303)</era>
+						<era type="144">Kagen (1303–1306)</era>
+						<era type="145">Tokuji (1306–1308)</era>
+						<era type="146">Enkyō (1308–1311)</era>
+						<era type="147">Ōchō (1311–1312)</era>
+						<era type="148">Shōwa (1312–1317)</era>
+						<era type="149">Bunpō (1317–1319)</era>
+						<era type="150">Genō (1319–1321)</era>
+						<era type="151">Genkō (1321–1324)</era>
+						<era type="152">Shōchū (1324–1326)</era>
+						<era type="153">Karyaku (1326–1329)</era>
+						<era type="154">Gentoku (1329–1331)</era>
+						<era type="155">Genkō (1331–1334)</era>
+						<era type="156">Kenmu (1334–1336)</era>
+						<era type="157">Engen (1336–1340)</era>
+						<era type="158">Kōkoku (1340–1346)</era>
+						<era type="159">Shōhei (1346–1370)</era>
+						<era type="160">Kentoku (1370–1372)</era>
+						<era type="161">Bunchū (1372–1375)</era>
+						<era type="162">Tenju (1375–1379)</era>
+						<era type="163">Kōryaku (1379–1381)</era>
+						<era type="164">Kōwa (1381–1384)</era>
+						<era type="165">Genchū (1384–1392)</era>
+						<era type="166">Meitoku (1384–1387)</era>
+						<era type="167">Kakei (1387–1389)</era>
+						<era type="168">Kōō (1389–1390)</era>
+						<era type="169">Meitoku (1390–1394)</era>
+						<era type="170">Ōei (1394–1428)</era>
+						<era type="171">Shōchō (1428–1429)</era>
+						<era type="172">Eikyō (1429–1441)</era>
+						<era type="173">Kakitsu (1441–1444)</era>
+						<era type="174">Bun’an (1444–1449)</era>
+						<era type="175">Hōtoku (1449–1452)</era>
+						<era type="176">Kyōtoku (1452–1455)</era>
+						<era type="177">Kōshō (1455–1457)</era>
+						<era type="178">Chōroku (1457–1460)</era>
+						<era type="179">Kanshō (1460–1466)</era>
+						<era type="180">Bunshō (1466–1467)</era>
+						<era type="181">Ōnin (1467–1469)</era>
+						<era type="182">Bunmei (1469–1487)</era>
+						<era type="183">Chōkyō (1487–1489)</era>
+						<era type="184">Entoku (1489–1492)</era>
+						<era type="185">Meiō (1492–1501)</era>
+						<era type="186">Bunki (1501–1504)</era>
+						<era type="187">Eishō (1504–1521)</era>
+						<era type="188">Taiei (1521–1528)</era>
+						<era type="189">Kyōroku (1528–1532)</era>
+						<era type="190">Tenbun (1532–1555)</era>
+						<era type="191">Kōji (1555–1558)</era>
+						<era type="192">Eiroku (1558–1570)</era>
+						<era type="193">Genki (1570–1573)</era>
+						<era type="194">Tenshō (1573–1592)</era>
+						<era type="195">Bunroku (1592–1596)</era>
+						<era type="196">Keichō (1596–1615)</era>
+						<era type="197">Genna (1615–1624)</era>
+						<era type="198">Kan’ei (1624–1644)</era>
+						<era type="199">Shōho (1644–1648)</era>
+						<era type="200">Keian (1648–1652)</era>
+						<era type="201">Jōō (1652–1655)</era>
+						<era type="202">Meireki (1655–1658)</era>
+						<era type="203">Manji (1658–1661)</era>
+						<era type="204">Kanbun (1661–1673)</era>
+						<era type="205">Enpō (1673–1681)</era>
+						<era type="206">Tenna (1681–1684)</era>
+						<era type="207">Jōkyō (1684–1688)</era>
+						<era type="208">Genroku (1688–1704)</era>
+						<era type="209">Hōei (1704–1711)</era>
+						<era type="210">Shōtoku (1711–1716)</era>
+						<era type="211">Kyōhō (1716–1736)</era>
+						<era type="212">Genbun (1736–1741)</era>
+						<era type="213">Kanpō (1741–1744)</era>
+						<era type="214">Enkyō (1744–1748)</era>
+						<era type="215">Kan’en (1748–1751)</era>
+						<era type="216">Hōreki (1751–1764)</era>
+						<era type="217">Meiwa (1764–1772)</era>
+						<era type="218">An’ei (1772–1781)</era>
+						<era type="219">Tenmei (1781–1789)</era>
+						<era type="220">Kansei (1789–1801)</era>
+						<era type="221">Kyōwa (1801–1804)</era>
+						<era type="222">Bunka (1804–1818)</era>
+						<era type="223">Bunsei (1818–1830)</era>
+						<era type="224">Tenpō (1830–1844)</era>
+						<era type="225">Kōka (1844–1848)</era>
+						<era type="226">Kaei (1848–1854)</era>
+						<era type="227">Ansei (1854–1860)</era>
+						<era type="228">Man’en (1860–1861)</era>
+						<era type="229">Bunkyū (1861–1864)</era>
+						<era type="230">Genji (1864–1865)</era>
+						<era type="231">Keiō (1865–1868)</era>
+						<era type="232">Meiji</era>
+						<era type="233">Taishō</era>
+						<era type="234">Shōwa</era>
+						<era type="235">Heisei</era>
+						<era type="236">Reiwa</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
@@ -7141,75 +7141,75 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E, d.</dateFormatItem>
 						<dateFormatItem id="Gy">y. GGG</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
 						<dateFormatItem id="Md">d. M.</dateFormatItem>
 						<dateFormatItem id="MEd">E, d. M.</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
 						<dateFormatItem id="y">y. GGG</dateFormatItem>
 						<dateFormatItem id="yM">M. y. GGGGG</dateFormatItem>
 						<dateFormatItem id="yMd">d. M. y. GGGGG</dateFormatItem>
@@ -7218,157 +7218,157 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yMMMd">d. MMM y. GGGGG</dateFormatItem>
 						<dateFormatItem id="yMMMEd">E, d. MMM y. GGGGG</dateFormatItem>
 						<dateFormatItem id="yQQQ">QQQ y. GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h'h' a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH'h'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h – h 'h' a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7377,32 +7377,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Farvardin</month>
+							<month type="2">Ordibehesht</month>
+							<month type="3">Khordad</month>
+							<month type="4">Tir</month>
+							<month type="5">Mordad</month>
+							<month type="6">Shahrivar</month>
+							<month type="7">Mehr</month>
+							<month type="8">Aban</month>
+							<month type="9">Azar</month>
+							<month type="10">Dey</month>
+							<month type="11">Bahman</month>
+							<month type="12">Esfand</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -7421,18 +7421,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Farvardin</month>
+							<month type="2">Ordibehesht</month>
+							<month type="3">Khordad</month>
+							<month type="4">Tir</month>
+							<month type="5">Mordad</month>
+							<month type="6">Shahrivar</month>
+							<month type="7">Mehr</month>
+							<month type="8">Aban</month>
+							<month type="9">Azar</month>
+							<month type="10">Dey</month>
+							<month type="11">Bahman</month>
+							<month type="12">Esfand</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -7449,256 +7449,256 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Farvardin</month>
+							<month type="2">Ordibehesht</month>
+							<month type="3">Khordad</month>
+							<month type="4">Tir</month>
+							<month type="5">Mordad</month>
+							<month type="6">Shahrivar</month>
+							<month type="7">Mehr</month>
+							<month type="8">Aban</month>
+							<month type="9">Azar</month>
+							<month type="10">Dey</month>
+							<month type="11">Bahman</month>
+							<month type="12">Esfand</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AP</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AP</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d.</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d.M.</dateFormatItem>
+						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
+						<dateFormatItem id="y">y. G</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h'h' a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH'h'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h – h 'h' a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7706,242 +7706,242 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="roc">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">prije R.O.C.</era>
+						<era type="1">R.O.C.</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">prije R.O.C.</era>
 						<era type="1">R.O.C.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">prije R.O.C.</era>
+						<era type="1">R.O.C.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd.MM.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'u' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
 						<dateFormatItem id="d">d.</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d.</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
 						<dateFormatItem id="M">L.</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Md">d.M.</dateFormatItem>
+						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
+						<dateFormatItem id="y">y. G</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">LLLL y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h'h' a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH'h'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h – h 'h' a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH 'h' v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M. – M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M. – d.M.</greatestDifference>
+							<greatestDifference id="M">d.M. – d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M. – E, d.M.</greatestDifference>
+							<greatestDifference id="M">E, d.M. – E, d.M.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd. – dd. MMM</greatestDifference>
+							<greatestDifference id="M">dd. MMM – dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM</greatestDifference>
+							<greatestDifference id="M">E, dd. MMM – E, dd. MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y. – y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y G</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="M">d.M.y. – d.M.y. G</greatestDifference>
+							<greatestDifference id="y">d.M.y. – d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="M">E, d.M.y. – E, d.M.y. G</greatestDifference>
+							<greatestDifference id="y">E, d.M.y. – E, d.M.y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL y. G</greatestDifference>
+							<greatestDifference id="y">LLL y. – LLL y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d. – d. MMM y. G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd. – E, dd. MMM y. G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y. G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y. – E, d. MMM y. G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLLL – LLLL y. G</greatestDifference>
+							<greatestDifference id="y">LLLL y. – LLLL y. G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7975,9 +7975,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>god.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">prošle godine</relative>
+				<relative type="0">ove godine</relative>
+				<relative type="1">sljedeće godine</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} god.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} god.</relativeTimePattern>
@@ -7991,9 +7991,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>g.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">prošle godine</relative>
+				<relative type="0">ove godine</relative>
+				<relative type="1">sljedeće godine</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} g.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} g.</relativeTimePattern>
@@ -8016,16 +8016,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">za {0} kvartala</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">prije {0} kvartala</relativeTimePattern>
 					<relativeTimePattern count="few">prije {0} kvartala</relativeTimePattern>
 					<relativeTimePattern count="other">prije {0} kvartala</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
 				<displayName>kv.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">posljednji kvartal</relative>
+				<relative type="0">ovaj kvartal</relative>
+				<relative type="1">sljedeći kvartal</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} kv.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} kv.</relativeTimePattern>
@@ -8039,9 +8039,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-narrow">
 				<displayName>kv.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">posljednji kvartal</relative>
+				<relative type="0">ovaj kvartal</relative>
+				<relative type="1">sljedeći kvartal</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} kv.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} kv.</relativeTimePattern>
@@ -8071,9 +8071,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>mj.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">prošli mjesec</relative>
+				<relative type="0">ovaj mjesec</relative>
+				<relative type="1">sljedeći mjesec</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} mj.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} mj.</relativeTimePattern>
@@ -8087,9 +8087,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>mj.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">prošli mjesec</relative>
+				<relative type="0">ovaj mjesec</relative>
+				<relative type="1">sljedeći mjesec</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} mj.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} mj.</relativeTimePattern>
@@ -8120,9 +8120,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>sed.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">prošle sedmice</relative>
+				<relative type="0">ove sedmice</relative>
+				<relative type="1">sljedeće sedmice</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} sed.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} sed.</relativeTimePattern>
@@ -8137,9 +8137,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>sed.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">prošle sedmice</relative>
+				<relative type="0">ove sedmice</relative>
+				<relative type="1">sljedeće sedmice</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} sed.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} sed.</relativeTimePattern>
@@ -8181,11 +8181,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>dan</displayName>
-				<relative type="-2">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="-2">prekjučer</relative>
+				<relative type="-1">jučer</relative>
+				<relative type="0">danas</relative>
+				<relative type="1">sutra</relative>
+				<relative type="2">prekosutra</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} d.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} d.</relativeTimePattern>
@@ -8199,11 +8199,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>dan</displayName>
-				<relative type="-2">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="-2">prekjučer</relative>
+				<relative type="-1">jučer</relative>
+				<relative type="0">danas</relative>
+				<relative type="1">sutra</relative>
+				<relative type="2">prekosutra</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} d.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} d.</relativeTimePattern>
@@ -8582,7 +8582,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>h</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ovaj sat</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} sat</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} sata</relativeTimePattern>
@@ -8596,7 +8596,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>h</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ovaj sat</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} sat</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} sata</relativeTimePattern>
@@ -8624,7 +8624,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>min</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ova minuta</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} min.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} min.</relativeTimePattern>
@@ -8638,7 +8638,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>min.</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ova minuta</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} min.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} min.</relativeTimePattern>
@@ -8666,7 +8666,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>sek.</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">sada</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} sek.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} sek.</relativeTimePattern>
@@ -8680,7 +8680,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>s</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">sada</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} sek.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} sek.</relativeTimePattern>
@@ -11005,19 +11005,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
@@ -11050,304 +11050,304 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
@@ -11365,501 +11365,501 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>≈</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arab">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="bali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="beng">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="brah">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cakm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="deva">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="fullwide">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gonm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gujr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="guru">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="hanidec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="java">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="kali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="khmr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="knda">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lana">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lanatham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="laoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -11953,315 +11953,315 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="lepc">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="limb">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mlym">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mtei">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymrshan">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="nkoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="olck">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="orya">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="osma">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="rohg">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="saur">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="shrd">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sora">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sund">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="takr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="talu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tamldec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="telu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="thai">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tibt">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="vaii">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arab">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arabext">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="bali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="beng">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="brah">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cakm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="deva">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="fullwide">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gonm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gujr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="guru">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="hanidec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="java">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="kali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="khmr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="knda">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lana">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lanatham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="laoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -12275,168 +12275,168 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scientificFormats numberSystem="lepc">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="limb">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mlym">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mtei">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymrshan">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="nkoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="olck">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="orya">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="osma">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="rohg">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="saur">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="shrd">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sora">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sund">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="takr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="talu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tamldec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="telu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="thai">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tibt">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="vaii">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -12450,140 +12450,140 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<percentFormats numberSystem="arabext">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="bali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="beng">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="brah">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cakm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="deva">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="fullwide">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gonm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gujr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="guru">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="hanidec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="java">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="kali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="khmr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="knda">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lana">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lanatham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="laoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -12597,179 +12597,179 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<percentFormats numberSystem="lepc">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="limb">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mlym">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mtei">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymrshan">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="nkoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="olck">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="orya">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="osma">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="rohg">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="saur">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="shrd">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sora">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sund">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="takr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="talu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tamldec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="telu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="thai">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tibt">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="vaii">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12778,330 +12778,330 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -13162,370 +13162,370 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">
@@ -15583,136 +15583,136 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 		</currencies>
 		<miscPatterns numberSystem="adlm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arab">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arabext">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="bali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="beng">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="brah">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cakm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="deva">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="fullwide">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gonm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gujr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="guru">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="hanidec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="java">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="kali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="khmr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="knda">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lana">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lanatham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="laoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="latn">
 			<pattern type="approximately">~{0}</pattern>
@@ -15721,142 +15721,142 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lepc">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="limb">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mlym">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mtei">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymrshan">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="nkoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="olck">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="orya">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="osma">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="rohg">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="saur">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="shrd">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sora">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sund">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="takr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="talu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tamldec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="telu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="thai">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tibt">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="vaii">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0} – {1}</pattern>
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one">{0} sat</pluralMinimalPairs>
@@ -15868,64 +15868,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>kibi{0}</unitPrefixPattern>
@@ -15965,7 +15965,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">kubnih {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -16377,10 +16377,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} britanskih termalnih jedinica</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>funte sile</displayName>
@@ -16425,46 +16425,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} herca</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pikseli</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapikseli</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>tačka</displayName>
@@ -16722,10 +16722,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Sunčevih masa</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="few">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>gigavati</displayName>
@@ -16782,8 +16782,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inča živinog stuba</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="few">{0} bara</unitPattern>
 				<unitPattern count="other">{0} bara</unitPattern>
 			</unit>
@@ -17190,14 +17190,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -17614,8 +17614,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>US therm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
 				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
@@ -17662,56 +17662,56 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -17853,14 +17853,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -17909,8 +17909,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -17959,8 +17959,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="few">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -18019,8 +18019,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>bar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -18037,8 +18037,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>Pa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
 				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -18338,123 +18338,123 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>G</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="few">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="few">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<unitPattern count="one">{0}°</unitPattern>
@@ -18472,11 +18472,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<unitPattern count="one">{0} ha</unitPattern>
@@ -18484,25 +18484,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="few">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<unitPattern count="one">{0} kj</unitPattern>
@@ -18510,33 +18510,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kj</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="few">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunum</unitPattern>
+				<unitPattern count="few">{0} dunuma</unitPattern>
+				<unitPattern count="other">{0} dunuma</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="few">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>stavka</displayName>
@@ -18545,9 +18545,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} stavki</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -18556,22 +18556,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="few">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100 km</displayName>
@@ -18580,136 +18580,136 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} L/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="few">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milje/b. gal</displayName>
+				<unitPattern count="one">{0} mi/b. gal</unitPattern>
+				<unitPattern count="few">{0} mi/b. gal</unitPattern>
+				<unitPattern count="other">{0} mi/b. gal</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>bajt</displayName>
 				<unitPattern count="one">{0} B</unitPattern>
 				<unitPattern count="few">{0} B</unitPattern>
 				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
 				<unitPattern count="few">{0} bita</unitPattern>
 				<unitPattern count="other">{0} bita</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st.</displayName>
+				<unitPattern count="one">{0} st.</unitPattern>
+				<unitPattern count="few">{0} st.</unitPattern>
+				<unitPattern count="other">{0} st.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec.</displayName>
+				<unitPattern count="one">{0} dec.</unitPattern>
+				<unitPattern count="few">{0} dec.</unitPattern>
+				<unitPattern count="other">{0} dec.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>god.</displayName>
 				<unitPattern count="one">{0} god.</unitPattern>
 				<unitPattern count="few">{0} god.</unitPattern>
 				<unitPattern count="other">{0} god.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/god.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>čet.</displayName>
+				<unitPattern count="one">{0} čet.</unitPattern>
+				<unitPattern count="few">{0} čet.</unitPattern>
+				<unitPattern count="other">{0} čet.</unitPattern>
+				<perUnitPattern>{0}/čet.</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>mjesec</displayName>
 				<unitPattern count="one">{0} mj.</unitPattern>
 				<unitPattern count="few">{0} mj.</unitPattern>
 				<unitPattern count="other">{0} mj.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} mj.</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>sedm.</displayName>
 				<unitPattern count="one">{0} sedm.</unitPattern>
 				<unitPattern count="few">{0} sedm.</unitPattern>
 				<unitPattern count="other">{0} sedm.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sedm.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>dan</displayName>
 				<unitPattern count="one">{0} d.</unitPattern>
 				<unitPattern count="few">{0} d.</unitPattern>
 				<unitPattern count="other">{0} d.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d.</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>sat</displayName>
 				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="few">{0} h</unitPattern>
 				<unitPattern count="other">{0} h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>minuta</displayName>
@@ -18723,7 +18723,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="few">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>milisekunda</displayName>
@@ -18733,87 +18733,87 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>mikrosekunda</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>ns</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="few">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} BTU</unitPattern>
+				<unitPattern count="few">{0} BTU</unitPattern>
+				<unitPattern count="other">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100 km</displayName>
@@ -18822,84 +18822,84 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kWh/100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="few">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>metar</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="few">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -18908,19 +18908,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="few">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
@@ -18936,182 +18936,182 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="few">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="few">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} sg</unitPattern>
+				<unitPattern count="few">{0} sg</unitPattern>
+				<unitPattern count="other">{0} sg</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>aj</displayName>
+				<unitPattern count="one">{0} aj</unitPattern>
+				<unitPattern count="few">{0} aj</unitPattern>
+				<unitPattern count="other">{0} aj</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>osmina milje</displayName>
+				<unitPattern count="one">{0} osmina milje</unitPattern>
+				<unitPattern count="few">{0} osmine milje</unitPattern>
+				<unitPattern count="other">{0} osmina milje</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hvat</displayName>
+				<unitPattern count="one">{0} hvat</unitPattern>
+				<unitPattern count="few">{0} hvata</unitPattern>
+				<unitPattern count="other">{0} hvata</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="few">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>luks</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="few">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gram</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="few">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="few">{0} lb</unitPattern>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="few">{0} oz</unitPattern>
 				<unitPattern count="other">{0} oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="few">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="few">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="few">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="few">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
@@ -19122,73 +19122,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="few">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ks</displayName>
+				<unitPattern count="one">{0} ks</unitPattern>
+				<unitPattern count="few">{0} ks</unitPattern>
+				<unitPattern count="other">{0} ks</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="few">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="few">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="few">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mb</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="few">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -19197,28 +19197,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="few">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/h</displayName>
 				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="few">{0} mi/h</unitPattern>
 				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>čv</displayName>
+				<unitPattern count="one">{0} čv</unitPattern>
+				<unitPattern count="few">{0} čv</unitPattern>
+				<unitPattern count="other">{0} čv</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -19227,203 +19227,203 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="few">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="few">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nm</displayName>
+				<unitPattern count="one">{0} Nm</unitPattern>
+				<unitPattern count="few">{0} Nm</unitPattern>
+				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="few">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="few">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="few">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litar</displayName>
 				<unitPattern count="one">{0}l</unitPattern>
 				<unitPattern count="few">{0}l</unitPattern>
 				<unitPattern count="other">{0}l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="few">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="few">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="few">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="few">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>B. gal</displayName>
+				<unitPattern count="one">{0} b. gal</unitPattern>
+				<unitPattern count="few">{0} b. gal</unitPattern>
+				<unitPattern count="other">{0} b. gal</unitPattern>
+				<perUnitPattern>{0}/b. gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="few">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="few">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp. fl oz</displayName>
+				<unitPattern count="one">{0} imp. fl oz</unitPattern>
+				<unitPattern count="few">{0} imp. fl oz</unitPattern>
+				<unitPattern count="other">{0} imp. fl oz</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kš. des.</displayName>
+				<unitPattern count="one">{0} kš. des.</unitPattern>
+				<unitPattern count="few">{0} kš. des.</unitPattern>
+				<unitPattern count="other">{0} kš. des.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp. kš. des.</displayName>
+				<unitPattern count="one">{0} imp. kš. des.</unitPattern>
+				<unitPattern count="few">{0} imp. kš. des.</unitPattern>
+				<unitPattern count="other">{0} imp. kš. des.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kap</displayName>
+				<unitPattern count="one">{0} kap</unitPattern>
+				<unitPattern count="few">{0} kapi</unitPattern>
+				<unitPattern count="other">{0} kapi</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>teč. dram</displayName>
+				<unitPattern count="one">{0} teč. dram</unitPattern>
+				<unitPattern count="few">{0} teč. drama</unitPattern>
+				<unitPattern count="other">{0} teč. drama</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mala čašica</displayName>
+				<unitPattern count="one">{0} mala čašica</unitPattern>
+				<unitPattern count="few">{0} male čašice</unitPattern>
+				<unitPattern count="other">{0} malih čašica</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>prstohvat</displayName>
+				<unitPattern count="one">{0} prstohvat</unitPattern>
+				<unitPattern count="few">{0} prstohvata</unitPattern>
+				<unitPattern count="other">{0} prstohvata</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>imp. kvarc</displayName>
 			</unit>
 			<coordinateUnit>
 				<displayName>pravac</displayName>
@@ -19457,22 +19457,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ili {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ili {1}</listPatternPart>
+			<listPatternPart type="2">{0} ili {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ili {1}</listPatternPart>
+			<listPatternPart type="2">{0} ili {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} i {1}</listPatternPart>
+			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -19690,7 +19690,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -19699,7 +19699,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{title} {given} {given2-initial} {surname}, {credentials}</namePattern>
@@ -19714,7 +19714,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>

--- a/common/main/bs_Cyrl.xml
+++ b/common/main/bs_Cyrl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -98,8 +98,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">чероки</language>
 			<language type="chy">чејенски</language>
 			<language type="ckb">централнокурдски</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">централнокурдски</language>
+			<language type="ckb" alt="variant">централнокурдски</language>
 			<language type="clc">Чилкотин</language>
 			<language type="co">корзикански</language>
 			<language type="cop">коптски</language>
@@ -1054,7 +1054,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Тунис</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Турска</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Турска</territory>
 			<territory type="TT">Тринидад и Тобаго</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тајван</territory>
@@ -1596,18 +1596,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">дец</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">ј</month>
+							<month type="2">ф</month>
+							<month type="3">м</month>
+							<month type="4">а</month>
+							<month type="5">м</month>
+							<month type="6">ј</month>
+							<month type="7">ј</month>
+							<month type="8">а</month>
+							<month type="9">с</month>
+							<month type="10">о</month>
+							<month type="11">н</month>
+							<month type="12">д</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">јануар</month>
@@ -1681,22 +1681,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">суб</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">н</day>
+							<day type="mon">п</day>
+							<day type="tue">у</day>
+							<day type="wed">с</day>
+							<day type="thu">ч</day>
+							<day type="fri">п</day>
+							<day type="sat">с</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">нед</day>
+							<day type="mon">пон</day>
+							<day type="tue">уто</day>
+							<day type="wed">сри</day>
+							<day type="thu">чет</day>
+							<day type="fri">пет</day>
+							<day type="sat">суб</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">недјеља</day>
@@ -1710,13 +1710,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">нед</day>
+							<day type="mon">пон</day>
+							<day type="tue">уто</day>
+							<day type="wed">сри</day>
+							<day type="thu">чет</day>
+							<day type="fri">пет</day>
+							<day type="sat">суб</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">н</day>
@@ -1728,13 +1728,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">с</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">нед</day>
+							<day type="mon">пон</day>
+							<day type="tue">уто</day>
+							<day type="wed">сри</day>
+							<day type="thu">чет</day>
+							<day type="fri">пет</day>
+							<day type="sat">суб</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">недјеља</day>
@@ -1770,10 +1770,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">К1</quarter>
+							<quarter type="2">К2</quarter>
+							<quarter type="3">К3</quarter>
+							<quarter type="4">К4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">1.</quarter>
@@ -1782,10 +1782,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">4.</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">Прво тромесечје</quarter>
+							<quarter type="2">Друго тромесечје</quarter>
+							<quarter type="3">Треће тромесечје</quarter>
+							<quarter type="4">Четврто тромесечје</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -1803,9 +1803,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">поноћ</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
+							<dayPeriod type="am">пре подне</dayPeriod>
 							<dayPeriod type="noon">подне</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">поподне</dayPeriod>
 							<dayPeriod type="morning1">ујутру</dayPeriod>
 							<dayPeriod type="afternoon1">у подне</dayPeriod>
 							<dayPeriod type="evening1">увече</dayPeriod>
@@ -1825,9 +1825,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
 							<dayPeriod type="midnight">поноћ</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
+							<dayPeriod type="am">пре подне</dayPeriod>
 							<dayPeriod type="noon">подне</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">поподне</dayPeriod>
 							<dayPeriod type="morning1">јутро</dayPeriod>
 							<dayPeriod type="afternoon1">послийеподне</dayPeriod>
 							<dayPeriod type="evening1">вече</dayPeriod>
@@ -1835,9 +1835,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">поноћ</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
+							<dayPeriod type="am">пре подне</dayPeriod>
 							<dayPeriod type="noon">подне</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">поподне</dayPeriod>
 							<dayPeriod type="morning1">јутро</dayPeriod>
 							<dayPeriod type="afternoon1">послийеподне</dayPeriod>
 							<dayPeriod type="evening1">вече</dayPeriod>
@@ -1864,9 +1864,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</eraNames>
 					<eraAbbr>
 						<era type="0">п. н. е.</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">п. н. е.</era>
 						<era type="1">н. е.</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">н. е.</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">п.н.е.</era>
@@ -2634,9 +2634,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове год.</relative>
 				<relative type="1">сљед. године</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">за {0} годину</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} године</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} година</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} годину</relativeTimePattern>
@@ -2650,9 +2650,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове год.</relative>
 				<relative type="1">сљед. године</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">за {0} годину</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} године</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} година</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} годину</relativeTimePattern>
@@ -2666,40 +2666,40 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ово тромјесечје</relative>
 				<relative type="1">сљедеће тромјесечје</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Q</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Q</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Q</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Q</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
 				<displayName>тромје.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Q</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Q</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Q</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Q</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Q</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Q</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
 				<displayName>qtr.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Q</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Q</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Q</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Q</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Q</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Q</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -2830,13 +2830,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>дан</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">јуче</relative>
+				<relative type="0">данас</relative>
+				<relative type="1">сутра</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">за {0} дан</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} дана</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} дана</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} дан</relativeTimePattern>
@@ -2846,13 +2846,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>дан</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">јуче</relative>
+				<relative type="0">данас</relative>
+				<relative type="1">сутра</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">за {0} дан</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} дана</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} дана</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} дан</relativeTimePattern>
@@ -2892,13 +2892,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове недјеље</relative>
 				<relative type="1">сљедеће недјеље</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Sundays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Sundays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2907,14 +2907,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове недјеље</relative>
 				<relative type="1">сљ. недјеље</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Sundays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Sundays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
@@ -2922,14 +2922,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове недј.</relative>
 				<relative type="1">сљ. недјеље</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Sundays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Sundays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2937,13 +2937,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог понедјељка</relative>
 				<relative type="1">сљедећег понедјељка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Mondays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Mondays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2952,14 +2952,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог понедј.</relative>
 				<relative type="1">сљ. понедјељка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Mondays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Mondays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
@@ -2967,14 +2967,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог понедј.</relative>
 				<relative type="1">сљ. понедј.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Mondays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Mondays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -2982,13 +2982,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог уторка</relative>
 				<relative type="1">сљедећег уторка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Tuesdays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Tuesdays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2997,14 +2997,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог утор.</relative>
 				<relative type="1">сљед. уторка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
@@ -3012,14 +3012,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог утор.</relative>
 				<relative type="1">сљ. уторка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -3027,13 +3027,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове сриједе</relative>
 				<relative type="1">сљедеће сриједе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Wednesdays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Wednesdays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3042,14 +3042,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове сриједе</relative>
 				<relative type="1">сљед. сриједе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
@@ -3057,14 +3057,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове сриј.</relative>
 				<relative type="1">сљ. сриједе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -3072,13 +3072,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог четвртка</relative>
 				<relative type="1">сљедећег четвртка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Thursdays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Thursdays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3087,14 +3087,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог чет.</relative>
 				<relative type="1">сљед. чет.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
@@ -3102,14 +3102,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог чет.</relative>
 				<relative type="1">сљ. чет.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -3117,13 +3117,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог петка</relative>
 				<relative type="1">сљедећег петка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Fridays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Fridays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3132,14 +3132,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог пет.</relative>
 				<relative type="1">сљед. петка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Fridays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Fridays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
@@ -3147,14 +3147,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог пет.</relative>
 				<relative type="1">сљ. петка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Fridays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Fridays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -3162,13 +3162,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове суботе</relative>
 				<relative type="1">сљедеће суботе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Saturdays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Saturdays</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3177,14 +3177,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове суб.</relative>
 				<relative type="1">сљед. суботе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
@@ -3192,14 +3192,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове суб.</relative>
 				<relative type="1">сљ. суботе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="few">+{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="few">-{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
@@ -3228,9 +3228,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="hour-short">
 				<displayName>сат</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">за {0} сат</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} сата</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} сати</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} сат</relativeTimePattern>
@@ -3241,9 +3241,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="hour-narrow">
 				<displayName>сат</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">за {0} сат</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} сата</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} сати</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} сат</relativeTimePattern>
@@ -3268,9 +3268,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="minute-short">
 				<displayName>мин.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">за {0} минут</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} минута</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} минута</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} минут</relativeTimePattern>
@@ -3281,9 +3281,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="minute-narrow">
 				<displayName>мин</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">за {0} минут</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} минута</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} минута</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} мин.</relativeTimePattern>
@@ -3309,8 +3309,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>сек.</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">за {0} сек.</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} секунде</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} секунди</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} сек.</relativeTimePattern>
@@ -3322,8 +3322,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>сек</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">за {0} сек.</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">за {0} секунде</relativeTimePattern>
+					<relativeTimePattern count="other">за {0} секунди</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} сек.</relativeTimePattern>
@@ -3335,10 +3335,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>зона</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>зона</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>зона</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -5729,7 +5729,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -6134,7 +6134,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="few">белоруске рубље</displayName>
 				<displayName count="other">белоруских рубаља</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">BYN</symbol>
 			</currency>
 			<currency type="BYR">
 				<displayName>Белоруска рубља (2000–2016)</displayName>
@@ -7864,22 +7864,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>квадратне стопе</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="few">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>квадратни инчи</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="few">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>вијекови</displayName>
@@ -7961,46 +7961,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} наносекунди</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>пиксели</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>мегапиксели</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>тачке по центиметру</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>тачке по инчу</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>километри</displayName>
@@ -8048,10 +8048,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} нанометара</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="few">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>миље</displayName>
@@ -8066,24 +8066,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} јарди</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="few">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in</displayName>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="few">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>свјетлосне године</displayName>
@@ -8104,10 +8104,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} наутичких миља</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>тачке</displayName>
@@ -8116,151 +8116,151 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} тачака</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="few">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>кубни метри</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>кубни центиметри</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="few">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="few">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="few">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>литри</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="few">{0} l</unitPattern>
+				<unitPattern count="other">{0} l</unitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="few">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="few">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 		</unitLength>
 		<unitLength type="short">
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>хектари</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="few">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="few">{0} mi²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>акре</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
+				<unitPattern count="few">{0} ac</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="few">{0} ft²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="few">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -8332,259 +8332,259 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="few">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="few">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="few">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="few">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="few">{0} mi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="few">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="few">{0} ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="few">{0} in</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ly</unitPattern>
+				<unitPattern count="few">{0} ly</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="few">{0} au</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="few">{0} nmi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="few">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="few">{0} ML</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="few">{0} hL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="few">{0} dL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="few">{0} cL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 		</unitLength>
 		<unitLength type="narrow">
 			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>година</displayName>
+				<unitPattern count="one">{0} год</unitPattern>
+				<unitPattern count="few">{0} год</unitPattern>
+				<unitPattern count="other">{0} год</unitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>мјесец</displayName>
@@ -8599,64 +8599,64 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} сед.</unitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дани</displayName>
+				<unitPattern count="one">{0} дан</unitPattern>
+				<unitPattern count="few">{0} дана</unitPattern>
+				<unitPattern count="other">{0} дан</unitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<displayName>сати</displayName>
+				<unitPattern count="one">{0} сат</unitPattern>
+				<unitPattern count="few">{0} сата</unitPattern>
 				<unitPattern count="other">{0} сати</unitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>минут</displayName>
+				<unitPattern count="one">{0} мин.</unitPattern>
+				<unitPattern count="few">{0} мин.</unitPattern>
+				<unitPattern count="other">{0} мин.</unitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>секунде</displayName>
+				<unitPattern count="one">{0} сек.</unitPattern>
+				<unitPattern count="few">{0} сек.</unitPattern>
+				<unitPattern count="other">{0} сек.</unitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мс</displayName>
+				<unitPattern count="one">{0} мс</unitPattern>
+				<unitPattern count="few">{0} мс</unitPattern>
+				<unitPattern count="other">{0} мс</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="few">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m</displayName>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="few">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="few">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="few">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>liter</displayName>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="few">{0} l</unitPattern>
+				<unitPattern count="other">{0} l</unitPattern>
 			</unit>
 		</unitLength>
 		<durationUnit type="hm">

--- a/common/main/bs_Cyrl.xml
+++ b/common/main/bs_Cyrl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2023 Unicode, Inc.
+<!-- Copyright © 1991-2022 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -98,8 +98,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">чероки</language>
 			<language type="chy">чејенски</language>
 			<language type="ckb">централнокурдски</language>
-			<language type="ckb" alt="menu">централнокурдски</language>
-			<language type="ckb" alt="variant">централнокурдски</language>
+			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="variant">↑↑↑</language>
 			<language type="clc">Чилкотин</language>
 			<language type="co">корзикански</language>
 			<language type="cop">коптски</language>
@@ -1054,7 +1054,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Тунис</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Турска</territory>
-			<territory type="TR" alt="variant">Турска</territory>
+			<territory type="TR" alt="variant">↑↑↑</territory>
 			<territory type="TT">Тринидад и Тобаго</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тајван</territory>
@@ -1596,18 +1596,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">дец</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">ј</month>
-							<month type="2">ф</month>
-							<month type="3">м</month>
-							<month type="4">а</month>
-							<month type="5">м</month>
-							<month type="6">ј</month>
-							<month type="7">ј</month>
-							<month type="8">а</month>
-							<month type="9">с</month>
-							<month type="10">о</month>
-							<month type="11">н</month>
-							<month type="12">д</month>
+							<month type="1">↑↑↑</month>
+							<month type="2">↑↑↑</month>
+							<month type="3">↑↑↑</month>
+							<month type="4">↑↑↑</month>
+							<month type="5">↑↑↑</month>
+							<month type="6">↑↑↑</month>
+							<month type="7">↑↑↑</month>
+							<month type="8">↑↑↑</month>
+							<month type="9">↑↑↑</month>
+							<month type="10">↑↑↑</month>
+							<month type="11">↑↑↑</month>
+							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">јануар</month>
@@ -1681,22 +1681,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">суб</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">н</day>
-							<day type="mon">п</day>
-							<day type="tue">у</day>
-							<day type="wed">с</day>
-							<day type="thu">ч</day>
-							<day type="fri">п</day>
-							<day type="sat">с</day>
+							<day type="sun">↑↑↑</day>
+							<day type="mon">↑↑↑</day>
+							<day type="tue">↑↑↑</day>
+							<day type="wed">↑↑↑</day>
+							<day type="thu">↑↑↑</day>
+							<day type="fri">↑↑↑</day>
+							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">нед</day>
-							<day type="mon">пон</day>
-							<day type="tue">уто</day>
-							<day type="wed">сри</day>
-							<day type="thu">чет</day>
-							<day type="fri">пет</day>
-							<day type="sat">суб</day>
+							<day type="sun">↑↑↑</day>
+							<day type="mon">↑↑↑</day>
+							<day type="tue">↑↑↑</day>
+							<day type="wed">↑↑↑</day>
+							<day type="thu">↑↑↑</day>
+							<day type="fri">↑↑↑</day>
+							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">недјеља</day>
@@ -1710,13 +1710,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">нед</day>
-							<day type="mon">пон</day>
-							<day type="tue">уто</day>
-							<day type="wed">сри</day>
-							<day type="thu">чет</day>
-							<day type="fri">пет</day>
-							<day type="sat">суб</day>
+							<day type="sun">↑↑↑</day>
+							<day type="mon">↑↑↑</day>
+							<day type="tue">↑↑↑</day>
+							<day type="wed">↑↑↑</day>
+							<day type="thu">↑↑↑</day>
+							<day type="fri">↑↑↑</day>
+							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">н</day>
@@ -1728,13 +1728,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">с</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">нед</day>
-							<day type="mon">пон</day>
-							<day type="tue">уто</day>
-							<day type="wed">сри</day>
-							<day type="thu">чет</day>
-							<day type="fri">пет</day>
-							<day type="sat">суб</day>
+							<day type="sun">↑↑↑</day>
+							<day type="mon">↑↑↑</day>
+							<day type="tue">↑↑↑</day>
+							<day type="wed">↑↑↑</day>
+							<day type="thu">↑↑↑</day>
+							<day type="fri">↑↑↑</day>
+							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">недјеља</day>
@@ -1770,10 +1770,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">К1</quarter>
-							<quarter type="2">К2</quarter>
-							<quarter type="3">К3</quarter>
-							<quarter type="4">К4</quarter>
+							<quarter type="1">↑↑↑</quarter>
+							<quarter type="2">↑↑↑</quarter>
+							<quarter type="3">↑↑↑</quarter>
+							<quarter type="4">↑↑↑</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">1.</quarter>
@@ -1782,10 +1782,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">4.</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">Прво тромесечје</quarter>
-							<quarter type="2">Друго тромесечје</quarter>
-							<quarter type="3">Треће тромесечје</quarter>
-							<quarter type="4">Четврто тромесечје</quarter>
+							<quarter type="1">↑↑↑</quarter>
+							<quarter type="2">↑↑↑</quarter>
+							<quarter type="3">↑↑↑</quarter>
+							<quarter type="4">↑↑↑</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -1803,9 +1803,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">поноћ</dayPeriod>
-							<dayPeriod type="am">пре подне</dayPeriod>
+							<dayPeriod type="am">↑↑↑</dayPeriod>
 							<dayPeriod type="noon">подне</dayPeriod>
-							<dayPeriod type="pm">поподне</dayPeriod>
+							<dayPeriod type="pm">↑↑↑</dayPeriod>
 							<dayPeriod type="morning1">ујутру</dayPeriod>
 							<dayPeriod type="afternoon1">у подне</dayPeriod>
 							<dayPeriod type="evening1">увече</dayPeriod>
@@ -1825,9 +1825,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
 							<dayPeriod type="midnight">поноћ</dayPeriod>
-							<dayPeriod type="am">пре подне</dayPeriod>
+							<dayPeriod type="am">↑↑↑</dayPeriod>
 							<dayPeriod type="noon">подне</dayPeriod>
-							<dayPeriod type="pm">поподне</dayPeriod>
+							<dayPeriod type="pm">↑↑↑</dayPeriod>
 							<dayPeriod type="morning1">јутро</dayPeriod>
 							<dayPeriod type="afternoon1">послийеподне</dayPeriod>
 							<dayPeriod type="evening1">вече</dayPeriod>
@@ -1835,9 +1835,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">поноћ</dayPeriod>
-							<dayPeriod type="am">пре подне</dayPeriod>
+							<dayPeriod type="am">↑↑↑</dayPeriod>
 							<dayPeriod type="noon">подне</dayPeriod>
-							<dayPeriod type="pm">поподне</dayPeriod>
+							<dayPeriod type="pm">↑↑↑</dayPeriod>
 							<dayPeriod type="morning1">јутро</dayPeriod>
 							<dayPeriod type="afternoon1">послийеподне</dayPeriod>
 							<dayPeriod type="evening1">вече</dayPeriod>
@@ -1864,9 +1864,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</eraNames>
 					<eraAbbr>
 						<era type="0">п. н. е.</era>
-						<era type="0" alt="variant">п. н. е.</era>
+						<era type="0" alt="variant">↑↑↑</era>
 						<era type="1">н. е.</era>
-						<era type="1" alt="variant">н. е.</era>
+						<era type="1" alt="variant">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">п.н.е.</era>
@@ -2634,9 +2634,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове год.</relative>
 				<relative type="1">сљед. године</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">за {0} годину</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} године</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} година</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} годину</relativeTimePattern>
@@ -2650,9 +2650,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове год.</relative>
 				<relative type="1">сљед. године</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">за {0} годину</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} године</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} година</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} годину</relativeTimePattern>
@@ -2666,40 +2666,40 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ово тромјесечје</relative>
 				<relative type="1">сљедеће тромјесечје</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Q</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Q</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Q</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Q</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
 				<displayName>тромје.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Q</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Q</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Q</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Q</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Q</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Q</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
 				<displayName>qtr.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Q</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Q</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Q</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Q</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Q</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Q</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -2830,13 +2830,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>дан</displayName>
-				<relative type="-1">јуче</relative>
-				<relative type="0">данас</relative>
-				<relative type="1">сутра</relative>
+				<relative type="-1">↑↑↑</relative>
+				<relative type="0">↑↑↑</relative>
+				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">за {0} дан</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} дана</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} дана</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} дан</relativeTimePattern>
@@ -2846,13 +2846,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>дан</displayName>
-				<relative type="-1">јуче</relative>
-				<relative type="0">данас</relative>
-				<relative type="1">сутра</relative>
+				<relative type="-1">↑↑↑</relative>
+				<relative type="0">↑↑↑</relative>
+				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">за {0} дан</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} дана</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} дана</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} дан</relativeTimePattern>
@@ -2892,13 +2892,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове недјеље</relative>
 				<relative type="1">сљедеће недјеље</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2907,14 +2907,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове недјеље</relative>
 				<relative type="1">сљ. недјеље</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
@@ -2922,14 +2922,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове недј.</relative>
 				<relative type="1">сљ. недјеље</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Sundays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Sundays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2937,13 +2937,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог понедјељка</relative>
 				<relative type="1">сљедећег понедјељка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2952,14 +2952,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог понедј.</relative>
 				<relative type="1">сљ. понедјељка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
@@ -2967,14 +2967,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог понедј.</relative>
 				<relative type="1">сљ. понедј.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Mondays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Mondays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -2982,13 +2982,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог уторка</relative>
 				<relative type="1">сљедећег уторка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2997,14 +2997,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог утор.</relative>
 				<relative type="1">сљед. уторка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
@@ -3012,14 +3012,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог утор.</relative>
 				<relative type="1">сљ. уторка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Tuesdays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Tuesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -3027,13 +3027,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове сриједе</relative>
 				<relative type="1">сљедеће сриједе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3042,14 +3042,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове сриједе</relative>
 				<relative type="1">сљед. сриједе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
@@ -3057,14 +3057,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове сриј.</relative>
 				<relative type="1">сљ. сриједе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Wednesdays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Wednesdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -3072,13 +3072,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог четвртка</relative>
 				<relative type="1">сљедећег четвртка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3087,14 +3087,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог чет.</relative>
 				<relative type="1">сљед. чет.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
@@ -3102,14 +3102,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог чет.</relative>
 				<relative type="1">сљ. чет.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Thursdays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Thursdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -3117,13 +3117,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог петка</relative>
 				<relative type="1">сљедећег петка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3132,14 +3132,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог пет.</relative>
 				<relative type="1">сљед. петка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
@@ -3147,14 +3147,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">овог пет.</relative>
 				<relative type="1">сљ. петка</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Fridays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Fridays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -3162,13 +3162,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове суботе</relative>
 				<relative type="1">сљедеће суботе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3177,14 +3177,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове суб.</relative>
 				<relative type="1">сљед. суботе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
@@ -3192,14 +3192,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ове суб.</relative>
 				<relative type="1">сљ. суботе</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">+{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="few">+{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="other">+{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">-{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="few">-{0} Saturdays</relativeTimePattern>
-					<relativeTimePattern count="other">-{0} Saturdays</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
@@ -3228,9 +3228,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="hour-short">
 				<displayName>сат</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">за {0} сат</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} сата</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} сати</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} сат</relativeTimePattern>
@@ -3241,9 +3241,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="hour-narrow">
 				<displayName>сат</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">за {0} сат</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} сата</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} сати</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} сат</relativeTimePattern>
@@ -3268,9 +3268,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="minute-short">
 				<displayName>мин.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">за {0} минут</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} минута</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} минута</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} минут</relativeTimePattern>
@@ -3281,9 +3281,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="minute-narrow">
 				<displayName>мин</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">за {0} минут</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} минута</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} минута</relativeTimePattern>
+					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} мин.</relativeTimePattern>
@@ -3309,8 +3309,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>сек.</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">за {0} сек.</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} секунде</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} секунди</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} сек.</relativeTimePattern>
@@ -3322,8 +3322,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>сек</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">за {0} сек.</relativeTimePattern>
-					<relativeTimePattern count="few">за {0} секунде</relativeTimePattern>
-					<relativeTimePattern count="other">за {0} секунди</relativeTimePattern>
+					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">прије {0} сек.</relativeTimePattern>
@@ -3335,10 +3335,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>зона</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>зона</displayName>
+				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>зона</displayName>
+				<displayName>↑↑↑</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -5729,7 +5729,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>#,##0.00 ¤</pattern>
+					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -6134,7 +6134,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="few">белоруске рубље</displayName>
 				<displayName count="other">белоруских рубаља</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">BYN</symbol>
+				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BYR">
 				<displayName>Белоруска рубља (2000–2016)</displayName>
@@ -7864,22 +7864,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>квадратне стопе</displayName>
-				<unitPattern count="one">{0} ft²</unitPattern>
-				<unitPattern count="few">{0} ft²</unitPattern>
-				<unitPattern count="other">{0} ft²</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>квадратни инчи</displayName>
-				<unitPattern count="one">{0} in²</unitPattern>
-				<unitPattern count="few">{0} in²</unitPattern>
-				<unitPattern count="other">{0} in²</unitPattern>
-				<perUnitPattern>{0}/in²</perUnitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
+				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>dunam</displayName>
-				<unitPattern count="one">{0} dunam</unitPattern>
-				<unitPattern count="few">{0} dunam</unitPattern>
-				<unitPattern count="other">{0} dunam</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>вијекови</displayName>
@@ -7961,46 +7961,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} наносекунди</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>em</displayName>
-				<unitPattern count="one">{0} em</unitPattern>
-				<unitPattern count="few">{0} em</unitPattern>
-				<unitPattern count="other">{0} em</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>пиксели</displayName>
-				<unitPattern count="one">{0} px</unitPattern>
-				<unitPattern count="few">{0} px</unitPattern>
-				<unitPattern count="other">{0} px</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>мегапиксели</displayName>
-				<unitPattern count="one">{0} MP</unitPattern>
-				<unitPattern count="few">{0} MP</unitPattern>
-				<unitPattern count="other">{0} MP</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>ppcm</displayName>
-				<unitPattern count="one">{0} ppcm</unitPattern>
-				<unitPattern count="few">{0} ppcm</unitPattern>
-				<unitPattern count="other">{0} ppcm</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>ppi</displayName>
-				<unitPattern count="one">{0} ppi</unitPattern>
-				<unitPattern count="few">{0} ppi</unitPattern>
-				<unitPattern count="other">{0} ppi</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>тачке по центиметру</displayName>
-				<unitPattern count="one">{0} ppcm</unitPattern>
-				<unitPattern count="few">{0} ppcm</unitPattern>
-				<unitPattern count="other">{0} ppcm</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>тачке по инчу</displayName>
-				<unitPattern count="one">{0} ppi</unitPattern>
-				<unitPattern count="few">{0} ppi</unitPattern>
-				<unitPattern count="other">{0} ppi</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>километри</displayName>
@@ -8048,10 +8048,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} нанометара</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>pm</displayName>
-				<unitPattern count="one">{0} pm</unitPattern>
-				<unitPattern count="few">{0} pm</unitPattern>
-				<unitPattern count="other">{0} pm</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>миље</displayName>
@@ -8066,24 +8066,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} јарди</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>ft</displayName>
-				<unitPattern count="one">{0} ft</unitPattern>
-				<unitPattern count="few">{0} ft</unitPattern>
-				<unitPattern count="other">{0} ft</unitPattern>
-				<perUnitPattern>{0}/ft</perUnitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
+				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>in</displayName>
-				<unitPattern count="one">{0} in</unitPattern>
-				<unitPattern count="few">{0} in</unitPattern>
-				<unitPattern count="other">{0} in</unitPattern>
-				<perUnitPattern>{0}/in</perUnitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
+				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>pc</displayName>
-				<unitPattern count="one">{0} pc</unitPattern>
-				<unitPattern count="few">{0} pc</unitPattern>
-				<unitPattern count="other">{0} pc</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>свјетлосне године</displayName>
@@ -8104,10 +8104,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} наутичких миља</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>smi</displayName>
-				<unitPattern count="one">{0} smi</unitPattern>
-				<unitPattern count="few">{0} smi</unitPattern>
-				<unitPattern count="other">{0} smi</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>тачке</displayName>
@@ -8116,151 +8116,151 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} тачака</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>R☉</displayName>
-				<unitPattern count="one">{0} R☉</unitPattern>
-				<unitPattern count="few">{0} R☉</unitPattern>
-				<unitPattern count="other">{0} R☉</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>km³</displayName>
-				<unitPattern count="one">{0} km³</unitPattern>
-				<unitPattern count="few">{0} km³</unitPattern>
-				<unitPattern count="other">{0} km³</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>кубни метри</displayName>
-				<unitPattern count="one">{0} m³</unitPattern>
-				<unitPattern count="few">{0} m³</unitPattern>
-				<unitPattern count="other">{0} m³</unitPattern>
-				<perUnitPattern>{0}/m³</perUnitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
+				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>кубни центиметри</displayName>
-				<unitPattern count="one">{0} cm³</unitPattern>
-				<unitPattern count="few">{0} cm³</unitPattern>
-				<unitPattern count="other">{0} cm³</unitPattern>
-				<perUnitPattern>{0}/cm³</perUnitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
+				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>mi³</displayName>
-				<unitPattern count="one">{0} mi³</unitPattern>
-				<unitPattern count="few">{0} mi³</unitPattern>
-				<unitPattern count="other">{0} mi³</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>yd³</displayName>
-				<unitPattern count="one">{0} yd³</unitPattern>
-				<unitPattern count="few">{0} yd³</unitPattern>
-				<unitPattern count="other">{0} yd³</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>ft³</displayName>
-				<unitPattern count="one">{0} ft³</unitPattern>
-				<unitPattern count="few">{0} ft³</unitPattern>
-				<unitPattern count="other">{0} ft³</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>in³</displayName>
-				<unitPattern count="one">{0} in³</unitPattern>
-				<unitPattern count="few">{0} in³</unitPattern>
-				<unitPattern count="other">{0} in³</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>ML</displayName>
-				<unitPattern count="one">{0} ML</unitPattern>
-				<unitPattern count="few">{0} ML</unitPattern>
-				<unitPattern count="other">{0} ML</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>hL</displayName>
-				<unitPattern count="one">{0} hL</unitPattern>
-				<unitPattern count="few">{0} hL</unitPattern>
-				<unitPattern count="other">{0} hL</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>литри</displayName>
-				<unitPattern count="one">{0} l</unitPattern>
-				<unitPattern count="few">{0} l</unitPattern>
-				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>{0}/l</perUnitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
+				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>dL</displayName>
-				<unitPattern count="one">{0} dL</unitPattern>
-				<unitPattern count="few">{0} dL</unitPattern>
-				<unitPattern count="other">{0} dL</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>cL</displayName>
-				<unitPattern count="one">{0} cL</unitPattern>
-				<unitPattern count="few">{0} cL</unitPattern>
-				<unitPattern count="other">{0} cL</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 		</unitLength>
 		<unitLength type="short">
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} km²</unitPattern>
-				<unitPattern count="few">{0} km²</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>хектари</displayName>
-				<unitPattern count="one">{0} ha</unitPattern>
-				<unitPattern count="few">{0} ha</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} m²</unitPattern>
-				<unitPattern count="few">{0} m²</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} cm²</unitPattern>
-				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} mi²</unitPattern>
-				<unitPattern count="few">{0} mi²</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>акре</displayName>
-				<unitPattern count="one">{0} ac</unitPattern>
-				<unitPattern count="few">{0} ac</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} yd²</unitPattern>
-				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} ft²</unitPattern>
-				<unitPattern count="few">{0} ft²</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} in²</unitPattern>
-				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} dunam</unitPattern>
-				<unitPattern count="few">{0} dunam</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -8332,259 +8332,259 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} μs</unitPattern>
-				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} ns</unitPattern>
-				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} em</unitPattern>
-				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} px</unitPattern>
-				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} MP</unitPattern>
-				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} ppcm</unitPattern>
-				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} ppi</unitPattern>
-				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>ppcm</displayName>
-				<unitPattern count="one">{0} ppcm</unitPattern>
-				<unitPattern count="few">{0} ppcm</unitPattern>
-				<unitPattern count="other">{0} ppcm</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>ppi</displayName>
-				<unitPattern count="one">{0} ppi</unitPattern>
-				<unitPattern count="few">{0} ppi</unitPattern>
-				<unitPattern count="other">{0} ppi</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} km</unitPattern>
-				<unitPattern count="few">{0} km</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">{0} m</unitPattern>
-				<unitPattern count="few">{0} m</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} dm</unitPattern>
-				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} cm</unitPattern>
-				<unitPattern count="few">{0} cm</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} mm</unitPattern>
-				<unitPattern count="few">{0} mm</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} μm</unitPattern>
-				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} nm</unitPattern>
-				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} pm</unitPattern>
-				<unitPattern count="few">{0} pm</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} mi</unitPattern>
-				<unitPattern count="few">{0} mi</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} yd</unitPattern>
-				<unitPattern count="few">{0} yd</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} ft</unitPattern>
-				<unitPattern count="few">{0} ft</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} in</unitPattern>
-				<unitPattern count="few">{0} in</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} pc</unitPattern>
-				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} ly</unitPattern>
-				<unitPattern count="few">{0} ly</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} au</unitPattern>
-				<unitPattern count="few">{0} au</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} nmi</unitPattern>
-				<unitPattern count="few">{0} nmi</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} smi</unitPattern>
-				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} pt</unitPattern>
-				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} R☉</unitPattern>
-				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} km³</unitPattern>
-				<unitPattern count="few">{0} km³</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} m³</unitPattern>
-				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} cm³</unitPattern>
-				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} mi³</unitPattern>
-				<unitPattern count="few">{0} mi³</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} yd³</unitPattern>
-				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} ft³</unitPattern>
-				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} in³</unitPattern>
-				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} ML</unitPattern>
-				<unitPattern count="few">{0} ML</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} hL</unitPattern>
-				<unitPattern count="few">{0} hL</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} l</unitPattern>
-				<unitPattern count="few">{0} l</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} dL</unitPattern>
-				<unitPattern count="few">{0} dL</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">{0} cL</unitPattern>
-				<unitPattern count="few">{0} cL</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 		</unitLength>
 		<unitLength type="narrow">
 			<unit type="duration-year">
-				<displayName>година</displayName>
-				<unitPattern count="one">{0} год</unitPattern>
-				<unitPattern count="few">{0} год</unitPattern>
-				<unitPattern count="other">{0} год</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>мјесец</displayName>
@@ -8599,64 +8599,64 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} сед.</unitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>дани</displayName>
-				<unitPattern count="one">{0} дан</unitPattern>
-				<unitPattern count="few">{0} дана</unitPattern>
-				<unitPattern count="other">{0} дан</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>сати</displayName>
-				<unitPattern count="one">{0} сат</unitPattern>
-				<unitPattern count="few">{0} сата</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} сати</unitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>минут</displayName>
-				<unitPattern count="one">{0} мин.</unitPattern>
-				<unitPattern count="few">{0} мин.</unitPattern>
-				<unitPattern count="other">{0} мин.</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>секунде</displayName>
-				<unitPattern count="one">{0} сек.</unitPattern>
-				<unitPattern count="few">{0} сек.</unitPattern>
-				<unitPattern count="other">{0} сек.</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>мс</displayName>
-				<unitPattern count="one">{0} мс</unitPattern>
-				<unitPattern count="few">{0} мс</unitPattern>
-				<unitPattern count="other">{0} мс</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>km</displayName>
-				<unitPattern count="one">{0} km</unitPattern>
-				<unitPattern count="few">{0} km</unitPattern>
-				<unitPattern count="other">{0} km</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>m</displayName>
-				<unitPattern count="one">{0} m</unitPattern>
-				<unitPattern count="few">{0} m</unitPattern>
-				<unitPattern count="other">{0} m</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>cm</displayName>
-				<unitPattern count="one">{0} cm</unitPattern>
-				<unitPattern count="few">{0} cm</unitPattern>
-				<unitPattern count="other">{0} cm</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>mm</displayName>
-				<unitPattern count="one">{0} mm</unitPattern>
-				<unitPattern count="few">{0} mm</unitPattern>
-				<unitPattern count="other">{0} mm</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>liter</displayName>
-				<unitPattern count="one">{0} l</unitPattern>
-				<unitPattern count="few">{0} l</unitPattern>
-				<unitPattern count="other">{0} l</unitPattern>
+				<displayName>↑↑↑</displayName>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 		</unitLength>
 		<durationUnit type="hm">

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -1097,7 +1097,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunísia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turquia</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turquia</territory>
 			<territory type="TT">Trinitat i Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1609,7 +1609,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1617,7 +1617,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2193,7 +2193,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2201,7 +2201,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2581,9 +2581,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>mes</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">el mes passat</relative>
 				<relative type="0">aquest mes</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">el mes que ve</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">d’aquí a {0} mes</relativeTimePattern>
 					<relativeTimePattern count="other">d’aquí a {0} mesos</relativeTimePattern>
@@ -2625,9 +2625,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>setm.</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">la setm. passada</relative>
 				<relative type="0">aquesta setm.</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">la setm. que ve</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">d’aquí a {0} setm.</relativeTimePattern>
 					<relativeTimePattern count="other">d’aquí a {0} setm.</relativeTimePattern>
@@ -5395,7 +5395,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -5479,7 +5479,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -7408,7 +7408,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" gender="feminine">{0} cúbiques</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>feminine</gender>
@@ -7858,8 +7858,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="graphics-em">
 				<gender>masculine</gender>
 				<displayName>em tipogràfic</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
@@ -7896,8 +7896,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>píxels</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} punt</unitPattern>
+				<unitPattern count="other">{0} punts</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>radi terrestre</displayName>
@@ -8563,12 +8563,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8706,7 +8706,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -8909,12 +8909,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -8924,12 +8924,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lliures-força</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -8959,12 +8959,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>píxels</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
@@ -8979,7 +8979,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>PPI</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PPI</unitPattern>
 				<unitPattern count="other">{0} PPI</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -8999,7 +8999,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9084,12 +9084,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fth</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -9109,7 +9109,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9119,17 +9119,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>lm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>lluminositats solars</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9193,17 +9193,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -9273,7 +9273,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>Pa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -9283,12 +9283,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>MPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -9333,12 +9333,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>lbf⋅ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>N⋅m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -9478,7 +9478,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>bbl</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -9526,64 +9526,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -9601,10 +9601,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
 				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
@@ -9613,37 +9613,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>r</displayName>
+				<unitPattern count="one">{0} r</unitPattern>
+				<unitPattern count="other">{0} r</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>rad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>°</displayName>
@@ -9651,74 +9651,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcmin</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcsec</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hectàrea</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>metres²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>acre</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunams</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>quirat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ct</unitPattern>
+				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>mg/dL</displayName>
@@ -9737,8 +9737,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9747,8 +9747,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
@@ -9756,14 +9756,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -9771,69 +9771,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/gal</displayName>
+				<unitPattern count="one">{0} mi/gal</unitPattern>
+				<unitPattern count="other">{0} mi/gal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/gal imp.</displayName>
+				<unitPattern count="one">{0} mi/gal imp.</unitPattern>
+				<unitPattern count="other">{0} mi/gal imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mbit</displayName>
+				<unitPattern count="one">{0} Mbit</unitPattern>
+				<unitPattern count="other">{0} Mbit</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bits</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>s.</displayName>
@@ -9841,9 +9841,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} s.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dèc.</displayName>
+				<unitPattern count="one">{0} dèc.</unitPattern>
+				<unitPattern count="other">{0} dèc.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>anys</displayName>
@@ -9861,7 +9861,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mes</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>setm.</displayName>
@@ -9873,25 +9873,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>dia</displayName>
 				<unitPattern count="one">{0} d</unitPattern>
 				<unitPattern count="other">{0} d</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>h</displayName>
 				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="other">{0} h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
 				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">{0} min</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -9899,129 +9899,129 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>thm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} thm</unitPattern>
+				<unitPattern count="other">{0} thm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100 km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100 km</unitPattern>
+				<unitPattern count="other">{0} kWh/100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>Mpx</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Mpx</unitPattern>
+				<unitPattern count="other">{0} Mpx</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>px/cm</displayName>
@@ -10029,52 +10029,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} px/cm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PPI</displayName>
+				<unitPattern count="one">{0} PPI</unitPattern>
+				<unitPattern count="other">{0} PPI</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppp</displayName>
+				<unitPattern count="one">{0} ppp</unitPattern>
+				<unitPattern count="other">{0} ppp</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>punt</displayName>
+				<unitPattern count="one">{0} punt</unitPattern>
+				<unitPattern count="other">{0} punts</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -10082,46 +10082,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>yd</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>in</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>parsec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>anys llum</displayName>
@@ -10134,54 +10134,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ua</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>braça</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>NM</displayName>
+				<unitPattern count="one">{0} NM</unitPattern>
+				<unitPattern count="other">{0} NM</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t mètriques</displayName>
@@ -10192,23 +10192,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>t</displayName>
@@ -10216,21 +10216,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>lb</displayName>
+				<unitPattern count="one">{0} lb</unitPattern>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>ozt</displayName>
@@ -10243,104 +10243,104 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gra</displayName>
+				<unitPattern count="one">{0} gra</unitPattern>
+				<unitPattern count="other">{0} grans</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>W</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>CV</displayName>
+				<unitPattern count="one">{0} CV</unitPattern>
+				<unitPattern count="other">{0} CV</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bars</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -10348,24 +10348,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/h</displayName>
+				<unitPattern count="one">{0} mi/h</unitPattern>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -10373,164 +10373,164 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0}mi³</unitPattern>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ptm</displayName>
+				<unitPattern count="one">{0} ptm</unitPattern>
+				<unitPattern count="other">{0} ptm</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>bu</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal imp.</displayName>
+				<unitPattern count="one">{0} gal imp.</unitPattern>
+				<unitPattern count="other">{0} gal imp.</unitPattern>
+				<perUnitPattern>{0}/gal imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tassa</displayName>
+				<unitPattern count="one">{0} tassa</unitPattern>
+				<unitPattern count="other">{0} tasses</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz imp.</displayName>
+				<unitPattern count="one">{0} fl oz imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cull.</displayName>
+				<unitPattern count="one">{0} cull.</unitPattern>
+				<unitPattern count="other">{0} cull.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cdta.</displayName>
+				<unitPattern count="one">{0} cdta.</unitPattern>
+				<unitPattern count="other">{0} cdta.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>c. postres</displayName>
@@ -10538,19 +10538,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} c. postr.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cull. postres imp.</displayName>
+				<unitPattern count="one">{0} cull. postres imp.</unitPattern>
+				<unitPattern count="other">{0} cull. postres imp.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gota</displayName>
+				<unitPattern count="one">{0} gota</unitPattern>
+				<unitPattern count="other">{0} gotes</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dracma fluid</displayName>
+				<unitPattern count="one">{0} dracma fluid</unitPattern>
+				<unitPattern count="other">{0} dracmes fluids</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>mes.</displayName>
@@ -10558,9 +10558,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mes.</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pessic</displayName>
+				<unitPattern count="one">{0} pessic</unitPattern>
+				<unitPattern count="other">{0} pessics</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>qt imp</displayName>
@@ -10599,22 +10599,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} o {1}</listPatternPart>
+			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} o {1}</listPatternPart>
+			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} i {1}</listPatternPart>
+			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -10944,7 +10944,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname-prefix-initialCap} {surname-core} {surname2}, {given} {given2-initial}</namePattern>
-			<namePattern alt="1">↑↑↑</namePattern>
+			<namePattern alt="1">{surname-prefix-initialCap} {surname-core}, {given} {given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname-prefix-initialCap} {surname-core} {surname2}, {given-informal}</namePattern>

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -532,9 +532,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="zh">𑄌𑄩𑄚</language>
 			<language type="zh" alt="menu" draft="unconfirmed">𑄌𑄨𑄚, 𑄟𑄚𑄴𑄓𑄢𑄨𑄚𑄴</language>
 			<language type="zh_Hans">𑄅𑄪𑄎𑄪𑄅𑄪𑄏𑄫 𑄌𑄩𑄚</language>
-			<language type="zh_Hans" alt="long" draft="unconfirmed">↑↑↑</language>
+			<language type="zh_Hans" alt="long" draft="unconfirmed">𑄅𑄪𑄎𑄪𑄅𑄪𑄏𑄫 𑄌𑄩𑄚</language>
 			<language type="zh_Hant">𑄢𑄨𑄘𑄨𑄥𑄪𑄘𑄮𑄟𑄴 𑄌𑄩𑄚</language>
-			<language type="zh_Hant" alt="long" draft="unconfirmed">↑↑↑</language>
+			<language type="zh_Hant" alt="long" draft="unconfirmed">𑄢𑄨𑄘𑄨𑄥𑄪𑄘𑄮𑄟𑄴 𑄌𑄩𑄚</language>
 			<language type="zu">𑄎𑄪𑄣𑄪</language>
 			<language type="zun">𑄎𑄪𑄚𑄨</language>
 			<language type="zxx">𑄞𑄏𑄧𑄢𑄴𑄘𑄮𑄇𑄳𑄠𑄬 𑄝𑄨𑄥𑄧𑄠𑄴 𑄚𑄳𑄄𑄬</language>

--- a/common/main/ceb.xml
+++ b/common/main/ceb.xml
@@ -356,7 +356,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkey</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkey</territory>
 			<territory type="TT">Trinidad &amp; Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -511,7 +511,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -519,7 +519,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -714,16 +714,16 @@ the LDML specification (http://unicode.org/reports/tr35/)
 						<monthWidth type="abbreviated">
 							<month type="1">Ene</month>
 							<month type="2">Peb</month>
-							<month type="3">↑↑↑</month>
+							<month type="3">Mar</month>
 							<month type="4">Abr</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="5">May</month>
+							<month type="6">Hun</month>
+							<month type="7">Hul</month>
+							<month type="8">Ago</month>
+							<month type="9">Set</month>
+							<month type="10">Okt</month>
+							<month type="11">Nob</month>
+							<month type="12">Dis</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">E</month>
@@ -776,9 +776,9 @@ the LDML specification (http://unicode.org/reports/tr35/)
 							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
+							<day type="sun">Dom</day>
+							<day type="mon">Lun</day>
+							<day type="tue">Mar</day>
 							<day type="wed">Miy</day>
 							<day type="thu">Huw</day>
 							<day type="fri">Biy</day>
@@ -796,9 +796,9 @@ the LDML specification (http://unicode.org/reports/tr35/)
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
+							<day type="sun">Dom</day>
+							<day type="mon">Lun</day>
+							<day type="tue">Mar</day>
 							<day type="wed">Miy</day>
 							<day type="thu">Huw</day>
 							<day type="fri">Biy</day>
@@ -814,22 +814,22 @@ the LDML specification (http://unicode.org/reports/tr35/)
 							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Dom</day>
+							<day type="mon">Lun</day>
+							<day type="tue">Mar</day>
+							<day type="wed">Miy</day>
+							<day type="thu">Huw</day>
+							<day type="fri">Biy</day>
+							<day type="sat">Sab</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Domingo</day>
+							<day type="mon">Lunes</day>
+							<day type="tue">Martes</day>
+							<day type="wed">Miyerkules</day>
+							<day type="thu">Huwebes</day>
+							<day type="fri">Biyernes</day>
+							<day type="sat">Sabado</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -842,10 +842,10 @@ the LDML specification (http://unicode.org/reports/tr35/)
 							<quarter type="4">Q4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">1</quarter>
+							<quarter type="2">2</quarter>
+							<quarter type="3">3</quarter>
+							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1">unang quarter</quarter>
@@ -857,9 +857,9 @@ the LDML specification (http://unicode.org/reports/tr35/)
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
 							<quarter type="1">Q1</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="2">Q2</quarter>
+							<quarter type="3">Q3</quarter>
+							<quarter type="4">Q4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">↑↑↑</quarter>
@@ -892,16 +892,16 @@ the LDML specification (http://unicode.org/reports/tr35/)
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -993,7 +993,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1001,7 +1001,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1205,13 +1205,13 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<relative type="1">sunod nga tuig</relative>
 			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>tuig</displayName>
 				<relative type="-1">miaging tuig</relative>
 				<relative type="0">karong tuiga</relative>
 				<relative type="1">sunod nga tuig</relative>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>tuig</displayName>
 				<relative type="-1">miaging tuig</relative>
 				<relative type="0">karong tuiga</relative>
 				<relative type="1">sunod nga tuig</relative>
@@ -1272,14 +1272,14 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</field>
 			<field type="day-short">
 				<displayName>adlaw</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">gahapon</relative>
+				<relative type="0">karong adlawa</relative>
 				<relative type="1">ugma</relative>
 			</field>
 			<field type="day-narrow">
 				<displayName>adlaw</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">gahapon</relative>
+				<relative type="0">karong adlawa</relative>
 				<relative type="1">ugma</relative>
 			</field>
 			<field type="weekday">
@@ -3725,7 +3725,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<displayName count="one">Belarusian ruble</displayName>
 				<displayName count="other">Belarusian rubles</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">BYN</symbol>
 			</currency>
 			<currency type="BZD">
 				<displayName>Belize Dollar</displayName>
@@ -4719,10 +4719,10 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<compoundUnitPattern1 count="other">cubic {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>g-force</displayName>
 				<unitPattern count="one">{0} g-force</unitPattern>
 				<unitPattern count="other">{0} g-force</unitPattern>
 			</unit>
@@ -5124,9 +5124,9 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<unitPattern count="other">{0} ka mga dot kada pulgada</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>mga pixel</displayName>
 				<unitPattern count="one">{0} dot</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>radyus sa yuta</displayName>
@@ -5323,7 +5323,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<unitPattern count="other">{0} ka mga solar mass</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>grain</displayName>
 				<unitPattern count="one">{0} ka grain</unitPattern>
 				<unitPattern count="other">{0} ka grain</unitPattern>
 			</unit>
@@ -5428,9 +5428,9 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<unitPattern count="other">{0} ka mga knot</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>mga degree Celsius</displayName>
@@ -5454,7 +5454,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>mga newton-meter</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">{0} ka mga newton-meter</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -5603,7 +5603,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<unitPattern count="other">{0} ka Imp. nga kutsarang panghinam-is</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>drop</displayName>
 				<unitPattern count="one">{0} ka drop</unitPattern>
 				<unitPattern count="other">{0} ka drop</unitPattern>
 			</unit>
@@ -5613,12 +5613,12 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<unitPattern count="other">{0} ka dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>jigger</displayName>
 				<unitPattern count="one">{0} ka jigger</unitPattern>
 				<unitPattern count="other">{0} ka jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>pinch</displayName>
 				<unitPattern count="one">{0} ka pinch</unitPattern>
 				<unitPattern count="other">{0} ka pinch</unitPattern>
 			</unit>
@@ -5725,12 +5725,12 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -5738,22 +5738,22 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>mga metro/sec²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rev</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>mga radian</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
@@ -5773,24 +5773,24 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>mga ektarya</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>mga metro²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -5802,12 +5802,12 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="area-acre">
 				<displayName>mga acre</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>mga yard²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
@@ -5817,7 +5817,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>mga inch²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -5828,7 +5828,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>mga karat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
@@ -5838,27 +5838,27 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>millimol/litro</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>mga part/million</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>porsyento</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>permille</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>permyriad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -5868,7 +5868,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>mga litro/km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L/km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
@@ -5888,47 +5888,47 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>PByte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TByte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>Tbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>GByte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MByte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kByte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-byte">
@@ -5943,12 +5943,12 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="duration-century">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} c</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dec</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -5995,22 +5995,22 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>mga millisec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>μsecs</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>mga nanosec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>mga amp</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
@@ -6025,47 +6025,47 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="electric-volt">
 				<displayName>mga boltahe</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kilojoule</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>mga joule</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kW-hour</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>electronvolt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -6075,32 +6075,32 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>pound-force</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>MHz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
@@ -6110,266 +6110,266 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>mga pixel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>mga megapixel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mga pixel</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>mga μmeter</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mga milya</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>mga yarda</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>mga piye</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>mga pulgada</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>mga parsec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>mga light yr</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ly</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} au</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nmi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>mga point</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>mga solar radius</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lux</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>mga solar luminosity</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>mga gramo</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>mga tonelada</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>mga pound</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz troy</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>mga carat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} CD</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>mga dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>mga mass sa Earth</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>mga solar mass</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>mga watt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -6379,17 +6379,17 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} psi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ka bar</unitPattern>
 				<unitPattern count="other">{0} ka bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -6399,37 +6399,37 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/oras</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>mga metro/seg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
@@ -6439,84 +6439,84 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="speed-knot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>deg. C</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°C</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>deg. F</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>mga yard³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>mga foot³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>mga inch³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ML</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-liter">
@@ -6527,32 +6527,32 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>acre ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -6563,23 +6563,23 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} gal Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qts</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>mga pint</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>mga tasa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} c</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
@@ -6594,7 +6594,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tbsp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
@@ -6604,17 +6604,17 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>barrel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -6639,7 +6639,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -6652,109 +6652,109 @@ the LDML specification (http://unicode.org/reports/tr35/)
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -6802,7 +6802,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<unitPattern count="other">{0}ms</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km</displayName>
 				<unitPattern count="one">{0}km</unitPattern>
 				<unitPattern count="other">{0}km</unitPattern>
 			</unit>
@@ -6812,24 +6812,24 @@ the LDML specification (http://unicode.org/reports/tr35/)
 				<unitPattern count="other">{0}m</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm</displayName>
 				<unitPattern count="one">{0}cm</unitPattern>
 				<unitPattern count="other">{0}cm</unitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mm</displayName>
 				<unitPattern count="one">{0}mm</unitPattern>
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
+				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gramo</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>
@@ -6838,8 +6838,8 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°C</unitPattern>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litro</displayName>
@@ -6878,32 +6878,32 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, o {1}</listPatternPart>
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, o {1}</listPatternPart>
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, ug {1}</listPatternPart>
 			<listPatternPart type="2">{0} ug {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -6914,8 +6914,8 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			<listPatternPart type="2">{0} {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -79,8 +79,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">ᏣᎳᎩ</language>
 			<language type="chy">ᏣᏰᏂ</language>
 			<language type="ckb">ᎠᏰᏟ ᎫᏗᏏ</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">ᎠᏰᏟ ᎫᏗᏏ</language>
+			<language type="ckb" alt="variant">ᎠᏰᏟ ᎫᏗᏏ</language>
 			<language type="clc">ᏥᎸᎪᏘᎾ</language>
 			<language type="co">ᎪᎵᏍᎢᎧᏂ</language>
 			<language type="crg">ᎻᏥᏩ</language>
@@ -1027,7 +1027,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1035,7 +1035,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1541,7 +1541,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1549,7 +1549,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1951,9 +1951,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>ᎢᎦ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ᏒᎯ</relative>
+				<relative type="0">ᎪᎯ ᎢᎦ</relative>
+				<relative type="1">ᏌᎾᎴᎢ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ᎾᎿ {0} ᎢᎦ</relativeTimePattern>
 					<relativeTimePattern count="other">ᎾᎿ {0} ᎯᎸᏍᎩ ᏧᏒᎯᏛ</relativeTimePattern>
@@ -1965,9 +1965,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>ᎢᎦ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ᏒᎯ</relative>
+				<relative type="0">ᎪᎯ ᎢᎦ</relative>
+				<relative type="1">ᏌᎾᎴᎢ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ᎾᎿ {0} ᎢᎦ</relativeTimePattern>
 					<relativeTimePattern count="other">ᎾᎿ {0} ᎯᎸᏍᎩ ᏧᏒᎯᏛ</relativeTimePattern>
@@ -5974,7 +5974,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">ᏣᏁᎳ ᏧᏅᏏᏱ {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ᎠᏓᎾᏌᏁᏍᎩ-ᎦᏌᏙᏯᏍᏗ</displayName>
@@ -6206,7 +6206,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ᎯᎸᏍᎩ ᎩᏄᏘᏗ</displayName>
 				<unitPattern count="one">{0} ᎩᏄᏘᏗ</unitPattern>
 				<unitPattern count="other">{0} ᎯᎸᏍᎩ ᎩᏄᏘᏗ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>ᏗᎧᎸᎢ</displayName>
@@ -6361,8 +6361,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>ᎪᏪᎸ em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>ᏗᏇᎦᏎᎵ</displayName>
@@ -7011,12 +7011,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7250,7 +7250,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} q</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -7407,27 +7407,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>ᏗᏇᎦᏎᎵ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>ᏧᏔᎾ ᏗᏇᎦᏎᎵ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -7442,7 +7442,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7527,12 +7527,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-furlong">
 				<displayName>ᎠᏰᏟ ᎩᏄᏘᏗ ᎢᏳᏟᎶᏓ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>ᏑᏓᎵ ᎢᏗᎳᏏᏗ ᎠᏯᏱ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -7869,7 +7869,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>ᎤᎧᏲᏗ ᏑᏟᎶᏓ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -7969,64 +7969,64 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -8056,20 +8056,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᎠᏓᎾᏌᏁᏍᎩ-ᎦᏌᏙᏯᏍᏗ</displayName>
 				<unitPattern count="one">{0}G</unitPattern>
 				<unitPattern count="other">{0}Gs</unitPattern>
 			</unit>
@@ -8104,27 +8104,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᎮᏔ ᎢᏳᏟᎶᏛ</displayName>
 				<unitPattern count="one">{0}ha</unitPattern>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᏗᏟᎶᏍᏗ²</displayName>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0}m²</unitPattern>
 				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
@@ -8133,7 +8133,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᎢᏧᏟᎶᏓ</displayName>
 				<unitPattern count="one">{0}ac</unitPattern>
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
@@ -8274,67 +8274,67 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᎤᏍᎦᎳ</displayName>
 				<unitPattern count="one">{0}ᎤᏍᎦᎳ</unitPattern>
 				<unitPattern count="other">{0}ᎤᏍᎦᎳ</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ᏍᏧ</displayName>
+				<unitPattern count="one">{0} ᏍᏧ</unitPattern>
+				<unitPattern count="other">{0} ᏍᏧ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ᏍᎪᎯ</displayName>
+				<unitPattern count="one">{0} ᏍᎪᎯ</unitPattern>
+				<unitPattern count="other">{0} ᏍᎪᎯ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ᎤᏕ</displayName>
 				<unitPattern count="one">{0}Ꭴ</unitPattern>
 				<unitPattern count="other">{0}Ꭴ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/Ꭴ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>qtr</displayName>
+				<unitPattern count="one">{0} q</unitPattern>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>ᎧᎸᎢ</displayName>
 				<unitPattern count="one">{0}Ꭷ</unitPattern>
 				<unitPattern count="other">{0}Ꭷ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/Ꭷ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ᏒᎾ</displayName>
 				<unitPattern count="one">{0}Ꮢ</unitPattern>
 				<unitPattern count="other">{0}Ꮢ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/Ꮢ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ᎢᎦ</displayName>
 				<unitPattern count="one">{0}Ꭲ</unitPattern>
 				<unitPattern count="other">{0}Ꭲ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/Ꭲ</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ᏑᏟᎶᏓ</displayName>
 				<unitPattern count="one">{0}Ꮡ</unitPattern>
 				<unitPattern count="other">{0}Ꮡ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/Ꮡ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>ᎢᏯᏔ</displayName>
 				<unitPattern count="one">{0}Ꭲ</unitPattern>
 				<unitPattern count="other">{0}Ꭲ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ᎢᏯᏔ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ᎠᏎᏢ</displayName>
 				<unitPattern count="one">{0}ᎠᏎ</unitPattern>
 				<unitPattern count="other">{0}ᎠᏎ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ᎠᏎ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ᏌᎠ</displayName>
@@ -8343,13 +8343,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>μᏗᏎᏢ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ᎾᏃᏗᏎᏢ</displayName>
+				<unitPattern count="one">{0} ᎾᏃ</unitPattern>
+				<unitPattern count="other">{0} ᎾᏃ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amp</displayName>
@@ -8372,7 +8372,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0}kcal</unitPattern>
 				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
@@ -8412,7 +8412,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>US ᎤᏗᏞᎬᎢ</displayName>
 				<unitPattern count="one">{0}US ᎤᏗᏞᎬ</unitPattern>
 				<unitPattern count="other">{0}US ᎤᏗᏞᎬ</unitPattern>
 			</unit>
@@ -8452,29 +8452,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
@@ -8487,26 +8487,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ᎠᏗ</displayName>
 				<unitPattern count="one">{0}ᎠᏗ</unitPattern>
 				<unitPattern count="other">{0}ᎠᏗ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ᎠᏗ</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>ᎠᏟ</displayName>
 				<unitPattern count="one">{0}ᎠᏟ</unitPattern>
 				<unitPattern count="other">{0}ᎠᏟ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ᎠᏟ</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ᏌᏟ</displayName>
+				<unitPattern count="one">{0} ᏌᏟ</unitPattern>
+				<unitPattern count="other">{0} ᏌᏟ</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
@@ -8557,7 +8557,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᎢᏯᏆᏎᎦ</displayName>
 				<unitPattern count="one">{0}pc</unitPattern>
 				<unitPattern count="other">{0}pc</unitPattern>
 			</unit>
@@ -8573,13 +8573,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-furlong">
 				<displayName>ᎠᏰᏟ ᎩᏄᏘᏗ ᏑᏟᎶᏓ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>ᏑᏓᎵ ᎢᏗᎳᏏᏗ ᎠᏯᏱ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>nmi</displayName>
@@ -8602,7 +8602,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᎸᏏ</displayName>
 				<unitPattern count="one">{0}lx</unitPattern>
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
@@ -8649,7 +8649,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᏗᏈᏂ</displayName>
 				<unitPattern count="one">{0}tn</unitPattern>
 				<unitPattern count="other">{0}tn</unitPattern>
 			</unit>
@@ -8831,51 +8831,51 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>yd³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>ft³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>in³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ᎢᏳᏆᏗᏅᏛ</displayName>
@@ -8884,32 +8884,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᏑᏟᎶᏛ-ᎢᏗᎳᏏᏗ</displayName>
 				<unitPattern count="one">{0}ac ft</unitPattern>
 				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
@@ -8941,7 +8941,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᏧᎵᏍᏈᏗ</displayName>
 				<unitPattern count="one">{0}c</unitPattern>
 				<unitPattern count="other">{0}c</unitPattern>
 			</unit>
@@ -9037,26 +9037,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} ᎠᎴᏱᎩ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, ᎠᎴᏱᎩ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ᎠᎴᏱᎩ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, ᎠᎴᏱᎩ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ᎠᎴᏱᎩ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, &amp; {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, &amp; {1}</listPatternPart>
 			<listPatternPart type="2">{0} &amp; {1}</listPatternPart>
 		</listPattern>
@@ -9266,127 +9266,127 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern draft="provisional">↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern draft="provisional">↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern draft="provisional">↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern draft="provisional">↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern draft="provisional">↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given" draft="provisional">↑↑↑</nameField>

--- a/common/main/ckb.xml
+++ b/common/main/ckb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -404,7 +404,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="zgh">ئەمازیغیی مەغریب</language>
 			<language type="zh">چینی</language>
 			<language type="zh_Hans">چینی (چینیی ئاسانکراو)</language>
-			<language type="zh_Hans" alt="long" draft="unconfirmed">↑↑↑</language>
+			<language type="zh_Hans" alt="long" draft="unconfirmed">چینی (چینیی ئاسانکراو)</language>
 			<language type="zh_Hant">چینی (چینیی دێرین)</language>
 			<language type="zu">زوولوو</language>
 			<language type="zun">زوونی</language>
@@ -538,7 +538,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CG" alt="variant">کۆماری کۆنگۆ</territory>
 			<territory type="CH">سویسڕا</territory>
 			<territory type="CI">کۆتدیڤوار</territory>
-			<territory type="CI" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="CI" alt="variant" draft="unconfirmed">کۆتدیڤوار</territory>
 			<territory type="CK">دوورگەکانی کوک</territory>
 			<territory type="CL">چیلی</territory>
 			<territory type="CM">کامیرۆن</territory>
@@ -552,7 +552,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CX">دوورگەی کریسمس</territory>
 			<territory type="CY">قیبرس</territory>
 			<territory type="CZ">کۆماری چیک</territory>
-			<territory type="CZ" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="CZ" alt="variant" draft="unconfirmed">کۆماری چیک</territory>
 			<territory type="DE">ئەڵمانیا</territory>
 			<territory type="DG">دیەگۆ گارسیا</territory>
 			<territory type="DJ">جیبووتی</territory>
@@ -720,7 +720,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="SX">سینت مارتن</territory>
 			<territory type="SY">سووریا</territory>
 			<territory type="SZ">سوازیلاند</territory>
-			<territory type="SZ" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="SZ" alt="variant" draft="unconfirmed">سوازیلاند</territory>
 			<territory type="TA">تریستێن دا کوونا</territory>
 			<territory type="TC">دوورگەکانی تورکس و کایکۆس</territory>
 			<territory type="TD">چاد</territory>
@@ -730,7 +730,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TJ">تاجیکستان</territory>
 			<territory type="TK">تۆکێلاو</territory>
 			<territory type="TL">تیمۆری ڕۆژھەڵات</territory>
-			<territory type="TL" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="TL" alt="variant" draft="unconfirmed">تیمۆری ڕۆژھەڵات</territory>
 			<territory type="TM">تورکمانستان</territory>
 			<territory type="TN">توونس</territory>
 			<territory type="TO">تۆنگا</territory>
@@ -1507,14 +1507,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1" draft="unconfirmed">سبەی</relative>
 			</field>
 			<field type="day-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">دوێنێ</relative>
+				<relative type="0" draft="unconfirmed">ئەمڕۆ</relative>
+				<relative type="1" draft="unconfirmed">سبەی</relative>
 			</field>
 			<field type="day-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">دوێنێ</relative>
+				<relative type="0" draft="unconfirmed">ئەمڕۆ</relative>
+				<relative type="1" draft="unconfirmed">سبەی</relative>
 			</field>
 			<field type="weekday">
 				<displayName draft="unconfirmed">ڕۆژی ھەفتە</displayName>
@@ -1682,8 +1682,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="TTD">
 				<displayName draft="unconfirmed">دۆلاری ترینیداد و تۆباگۆ</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
-				<displayName count="other" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">دۆلاری ترینیداد و تۆباگۆ</displayName>
+				<displayName count="other" draft="unconfirmed">دۆلاری ترینیداد و تۆباگۆ</displayName>
 			</currency>
 			<currency type="XAU">
 				<displayName draft="unconfirmed">زێڕ</displayName>

--- a/common/main/co.xml
+++ b/common/main/co.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -83,7 +83,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CR" draft="unconfirmed">Costa Rica</territory>
 			<territory type="CU" draft="unconfirmed">Cuba</territory>
 			<territory type="CZ" draft="unconfirmed">Republica cecca</territory>
-			<territory type="CZ" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="CZ" alt="variant" draft="unconfirmed">Republica cecca</territory>
 			<territory type="DE" draft="unconfirmed">Alemagna</territory>
 			<territory type="DK" draft="unconfirmed">Danimarca</territory>
 			<territory type="DO" draft="unconfirmed">Republica Duminicana</territory>
@@ -411,10 +411,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4" draft="unconfirmed">T4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="1" draft="unconfirmed">1</quarter>
+							<quarter type="2" draft="unconfirmed">2</quarter>
+							<quarter type="3" draft="unconfirmed">3</quarter>
+							<quarter type="4" draft="unconfirmed">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1" draft="unconfirmed">1u trimestru</quarter>
@@ -451,8 +451,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
@@ -488,10 +488,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="1" alt="variant" draft="unconfirmed">EC</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="unconfirmed">↑↑↑</era>
-						<era type="0" alt="variant" draft="unconfirmed">↑↑↑</era>
-						<era type="1" draft="unconfirmed">↑↑↑</era>
-						<era type="1" alt="variant" draft="unconfirmed">↑↑↑</era>
+						<era type="0" draft="unconfirmed">nz à C.</era>
+						<era type="0" alt="variant" draft="unconfirmed">NEC</era>
+						<era type="1" draft="unconfirmed">dp à C.</era>
+						<era type="1" alt="variant" draft="unconfirmed">EC</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -552,7 +552,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -560,7 +560,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -568,7 +568,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} 'à' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} 'à' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -576,7 +576,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -712,15 +712,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName draft="unconfirmed">an.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">l’annu scorsu</relative>
+				<relative type="0" draft="unconfirmed">quist’annu</relative>
+				<relative type="1" draft="unconfirmed">l’annu chì vene</relative>
 			</field>
 			<field type="year-narrow">
 				<displayName draft="unconfirmed">a.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">l’annu scorsu</relative>
+				<relative type="0" draft="unconfirmed">quist’annu</relative>
+				<relative type="1" draft="unconfirmed">l’annu chì vene</relative>
 			</field>
 			<field type="quarter">
 				<displayName draft="unconfirmed">trimestru</displayName>
@@ -739,15 +739,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName draft="unconfirmed">m.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">u mese scorsu</relative>
+				<relative type="0" draft="unconfirmed">stu mese</relative>
+				<relative type="1" draft="unconfirmed">u mese chì vene</relative>
 			</field>
 			<field type="month-narrow">
 				<displayName draft="unconfirmed">m.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">u mese scorsu</relative>
+				<relative type="0" draft="unconfirmed">stu mese</relative>
+				<relative type="1" draft="unconfirmed">u mese chì vene</relative>
 			</field>
 			<field type="week">
 				<displayName draft="unconfirmed">settimana</displayName>
@@ -758,17 +758,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName draft="unconfirmed">sett.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
-				<relativePeriod draft="unconfirmed">↑↑↑</relativePeriod>
+				<relative type="-1" draft="unconfirmed">a settimana scorsa</relative>
+				<relative type="0" draft="unconfirmed">sta settimana</relative>
+				<relative type="1" draft="unconfirmed">a settimana chì vene</relative>
+				<relativePeriod draft="unconfirmed">a settimana di u {0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
 				<displayName draft="unconfirmed">st.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
-				<relativePeriod draft="unconfirmed">↑↑↑</relativePeriod>
+				<relative type="-1" draft="unconfirmed">a settimana scorsa</relative>
+				<relative type="0" draft="unconfirmed">sta settimana</relative>
+				<relative type="1" draft="unconfirmed">a settimana chì vene</relative>
+				<relativePeriod draft="unconfirmed">a settimana di u {0}</relativePeriod>
 			</field>
 			<field type="day">
 				<displayName draft="unconfirmed">ghjornu</displayName>
@@ -778,15 +778,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName draft="unconfirmed">ghj.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">eri</relative>
+				<relative type="0" draft="unconfirmed">oghje</relative>
+				<relative type="1" draft="unconfirmed">dumane</relative>
 			</field>
 			<field type="day-narrow">
 				<displayName draft="unconfirmed">g</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">eri</relative>
+				<relative type="0" draft="unconfirmed">oghje</relative>
+				<relative type="1" draft="unconfirmed">dumane</relative>
 			</field>
 			<field type="weekday">
 				<displayName draft="unconfirmed">ghjornu di a settimana</displayName>
@@ -1077,7 +1077,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -1091,7 +1091,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -1105,7 +1105,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -1119,11 +1119,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00 ¤;(#,##0.00) ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -1136,7 +1136,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisko</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turecko</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turecko</territory>
 			<territory type="TT">Trinidad a Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tchaj-wan</territory>
@@ -19187,7 +19187,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="few">{0} bar</unitPattern>
 				<unitPattern count="many">{0} bar</unitPattern>

--- a/common/main/cv.xml
+++ b/common/main/cv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -656,30 +656,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<monthWidth type="abbreviated">
 							<month type="1">кӑр.</month>
 							<month type="2">нар.</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
+							<month type="3">пуш</month>
+							<month type="4">ака</month>
+							<month type="5">ҫу</month>
 							<month type="6">ҫӗр.</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">утӑ</month>
 							<month type="8">ҫур.</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
+							<month type="9">авӑн</month>
+							<month type="10">юпа</month>
+							<month type="11">чӳк</month>
 							<month type="12">раш.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">К</month>
+							<month type="2">Н</month>
+							<month type="3">П</month>
+							<month type="4">А</month>
+							<month type="5">Ҫ</month>
+							<month type="6">Ҫ</month>
+							<month type="7">У</month>
+							<month type="8">Ҫ</month>
+							<month type="9">А</month>
+							<month type="10">Ю</month>
+							<month type="11">Ч</month>
+							<month type="12">Р</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">кӑрлач</month>
@@ -698,18 +698,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">кӑр.</month>
+							<month type="2">нар.</month>
+							<month type="3">пуш</month>
+							<month type="4">ака</month>
+							<month type="5">ҫу</month>
+							<month type="6">ҫӗр.</month>
+							<month type="7">утӑ</month>
+							<month type="8">ҫур.</month>
+							<month type="9">авӑн</month>
+							<month type="10">юпа</month>
+							<month type="11">чӳк</month>
+							<month type="12">раш.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">К</month>
@@ -726,18 +726,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Р</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">кӑрлач</month>
+							<month type="2">нарӑс</month>
+							<month type="3">пуш</month>
+							<month type="4">ака</month>
+							<month type="5">ҫу</month>
+							<month type="6">ҫӗртме</month>
+							<month type="7">утӑ</month>
+							<month type="8">ҫурла</month>
+							<month type="9">авӑн</month>
+							<month type="10">юпа</month>
+							<month type="11">чӳк</month>
+							<month type="12">раштав</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -809,13 +809,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">шӑм.</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">вырсарникун</day>
+							<day type="mon">тунтикун</day>
+							<day type="tue">ытларикун</day>
+							<day type="wed">юнкун</day>
+							<day type="thu">кӗҫнерникун</day>
+							<day type="fri">эрнекун</day>
+							<day type="sat">шӑматкун</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -828,10 +828,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">4-мӗш кв.</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">1</quarter>
+							<quarter type="2">2</quarter>
+							<quarter type="3">3</quarter>
+							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1">1-мӗш квартал</quarter>
@@ -868,26 +868,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -955,7 +955,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -963,7 +963,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1182,15 +1182,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>ҫ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">пӗлтӗр</relative>
+				<relative type="0">кӑҫал</relative>
 				<relative type="1">ҫитес ҫ.</relative>
 			</field>
 			<field type="year-narrow">
 				<displayName>ҫ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">пӗлтӗр</relative>
+				<relative type="0">кӑҫал</relative>
+				<relative type="1">ҫитес ҫ.</relative>
 			</field>
 			<field type="quarter">
 				<displayName>квартал</displayName>
@@ -1215,9 +1215,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>уй.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">иртнӗ уй.</relative>
+				<relative type="0">ку уй.</relative>
+				<relative type="1">ҫитес уй.</relative>
 			</field>
 			<field type="week">
 				<displayName>эрне</displayName>
@@ -1231,14 +1231,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="-1">иртнӗ эр.</relative>
 				<relative type="0">ҫак эр.</relative>
 				<relative type="1">ҫитес эр.</relative>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>эрнере {0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
 				<displayName>эр.</displayName>
 				<relative type="-1">иртнӗ эр.</relative>
 				<relative type="0">ҫак эр.</relative>
 				<relative type="1">ҫитес эр.</relative>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>эрнере {0}</relativePeriod>
 			</field>
 			<field type="day">
 				<displayName>кун</displayName>
@@ -3523,8 +3523,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other">↑↑↑</unitPattern>
@@ -4426,10 +4426,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<coordinateUnit>
 				<displayName>енӗ</displayName>
@@ -4456,10 +4456,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<coordinateUnit>
 				<displayName>енӗ</displayName>
@@ -4493,28 +4493,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} е {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} е {1}</listPatternPart>
 			<listPatternPart type="2">{0} е {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} е {1}</listPatternPart>
 			<listPatternPart type="2">{0} е {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} тата {1}</listPatternPart>
+			<listPatternPart type="2">{0} тата {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0} {1}</listPatternPart>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -111,8 +111,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">Tsierocî</language>
 			<language type="chy">Cheyenne</language>
 			<language type="ckb">Cwrdeg Sorani</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">Cwrdeg Sorani</language>
+			<language type="ckb" alt="variant">Cwrdeg Sorani</language>
 			<language type="clc">Chilcotin</language>
 			<language type="co">Corseg</language>
 			<language type="cop">Copteg</language>
@@ -1206,7 +1206,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1670,9 +1670,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="midnight">canol nos</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
 							<dayPeriod type="noon">canol dydd</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 							<dayPeriod type="morning1">y bore</dayPeriod>
 							<dayPeriod type="afternoon1">y prynhawn</dayPeriod>
 							<dayPeriod type="evening1">yr hwyr</dayPeriod>
@@ -2027,9 +2027,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>bl.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">llynedd</relative>
+				<relative type="0">eleni</relative>
+				<relative type="1">blwyddyn nesaf</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">ymhen {0} mlynedd</relativeTimePattern>
 					<relativeTimePattern count="one">ymhen blwyddyn</relativeTimePattern>
@@ -2049,8 +2049,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>bl.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">llynedd</relative>
+				<relative type="0">eleni</relative>
 				<relative type="1">bl. nesaf</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">ymhen {0} mlynedd</relativeTimePattern>
@@ -2153,9 +2153,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>mis</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mis diwethaf</relative>
+				<relative type="0">y mis hwn</relative>
+				<relative type="1">mis nesaf</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">ymhen {0} mis</relativeTimePattern>
 					<relativeTimePattern count="one">ymhen mis</relativeTimePattern>
@@ -2175,9 +2175,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>mis</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mis diwethaf</relative>
+				<relative type="0">y mis hwn</relative>
+				<relative type="1">mis nesaf</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">ymhen {0} mis</relativeTimePattern>
 					<relativeTimePattern count="one">ymhen mis</relativeTimePattern>
@@ -2298,7 +2298,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>diwrnod</displayName>
 				<relative type="-2">echdoe</relative>
 				<relative type="-1">ddoe</relative>
 				<relative type="0">heddiw</relative>
@@ -2323,9 +2323,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>diwrnod</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ddoe</relative>
+				<relative type="0">heddiw</relative>
+				<relative type="1">yfory</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">ymhen {0} diwrnod</relativeTimePattern>
 					<relativeTimePattern count="one">ymhen {0} diwrnod</relativeTimePattern>
@@ -2665,24 +2665,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Iau diwethaf</relative>
+				<relative type="0">Iau yma</relative>
+				<relative type="1">Iau nesaf</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">ymhen {0} dydd Iau</relativeTimePattern>
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ymhen {0} Iau</relativeTimePattern>
 					<relativeTimePattern count="two">ymhen {0} dydd Iau</relativeTimePattern>
 					<relativeTimePattern count="few">ymhen {0} dydd Iau</relativeTimePattern>
 					<relativeTimePattern count="many">ymhen {0} dydd Iau</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ymhen {0} Iau</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="zero">{0} dydd Iau yn ôl</relativeTimePattern>
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Iau yn ôl</relativeTimePattern>
 					<relativeTimePattern count="two">{0} dydd Iau yn ôl</relativeTimePattern>
 					<relativeTimePattern count="few">{0} dydd Iau yn ôl</relativeTimePattern>
 					<relativeTimePattern count="many">{0} dydd Iau yn ôl</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Iau yn ôl</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -2791,24 +2791,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Sad. diwethaf</relative>
+				<relative type="0">Sad. yma</relative>
+				<relative type="1">Sad. nesaf</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">ymhen {0} dydd Sadwrn</relativeTimePattern>
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ymhen {0} Sad.</relativeTimePattern>
 					<relativeTimePattern count="two">ymhen {0} dydd Sadwrn</relativeTimePattern>
 					<relativeTimePattern count="few">ymhen {0} dydd Sadwrn</relativeTimePattern>
 					<relativeTimePattern count="many">ymhen {0} dydd Sadwrn</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ymhen {0} Sad.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="zero">{0} dydd Sadwrn yn ôl</relativeTimePattern>
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Sad. yn ôl</relativeTimePattern>
 					<relativeTimePattern count="two">{0} dydd Sadwrn yn ôl</relativeTimePattern>
 					<relativeTimePattern count="few">{0} dydd Sadwrn yn ôl</relativeTimePattern>
 					<relativeTimePattern count="many">{0} dydd Sadwrn yn ôl</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Sad. yn ôl</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
@@ -2920,19 +2920,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="minute-narrow">
 				<displayName>mun.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="zero">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="zero">ymhen {0} munud</relativeTimePattern>
 					<relativeTimePattern count="one">ymhen {0} mun.</relativeTimePattern>
 					<relativeTimePattern count="two">ymhen {0} mun.</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="many">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">ymhen {0} munud</relativeTimePattern>
+					<relativeTimePattern count="many">ymhen {0} munud</relativeTimePattern>
 					<relativeTimePattern count="other">ymhen {0} mun.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="zero">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="zero">{0} munud yn ôl</relativeTimePattern>
 					<relativeTimePattern count="one">{0} mun. yn ôl</relativeTimePattern>
 					<relativeTimePattern count="two">{0} mun. yn ôl</relativeTimePattern>
 					<relativeTimePattern count="few">{0} mun. yn ôl</relativeTimePattern>
-					<relativeTimePattern count="many">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="many">{0} munud yn ôl</relativeTimePattern>
 					<relativeTimePattern count="other">{0} mun. yn ôl</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -5774,7 +5774,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="AUD">
 				<displayName>Doler Awstralia</displayName>
 				<displayName count="zero">doler Awstralia</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Awstralia</displayName>
 				<displayName count="two">ddoler Awstralia</displayName>
 				<displayName count="few">doler Awstralia</displayName>
 				<displayName count="many">doler Awstralia</displayName>
@@ -5928,8 +5928,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="BMD">
 				<displayName>Doler Bermuda</displayName>
-				<displayName count="zero">↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="zero">doler Bermuda</displayName>
+				<displayName count="one">doler Bermuda</displayName>
 				<displayName count="two">ddoler Bermuda</displayName>
 				<displayName count="few">doler Bermuda</displayName>
 				<displayName count="many">doler Bermuda</displayName>
@@ -5940,7 +5940,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="BND">
 				<displayName>Doler Brunei</displayName>
 				<displayName count="zero">doler Brunei</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Brunei</displayName>
 				<displayName count="two">ddoler Brunei</displayName>
 				<displayName count="few">doler Brunei</displayName>
 				<displayName count="many">doler Brunei</displayName>
@@ -6126,7 +6126,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="BZD">
 				<displayName>Doler Belize</displayName>
 				<displayName count="zero">doler Belize</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Belize</displayName>
 				<displayName count="two">ddoler Belize</displayName>
 				<displayName count="few">doler Belize</displayName>
 				<displayName count="many">doler Belize</displayName>
@@ -6137,8 +6137,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="CAD">
 				<displayName>Doler Canada</displayName>
 				<displayName count="zero">doler Canada</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="two">↑↑↑</displayName>
+				<displayName count="one">doler Canada</displayName>
+				<displayName count="two">doler Canada</displayName>
 				<displayName count="few">doler Canada</displayName>
 				<displayName count="many">doler Canada</displayName>
 				<displayName count="other">doler Canada</displayName>
@@ -6427,10 +6427,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="EGP">
 				<displayName>Punt Yr Aifft</displayName>
 				<displayName count="zero">punt yr Aifft</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">punt yr Aifft</displayName>
 				<displayName count="two">bunt yr Aifft</displayName>
 				<displayName count="few">punt yr Aifft</displayName>
-				<displayName count="many">↑↑↑</displayName>
+				<displayName count="many">punt yr Aifft</displayName>
 				<displayName count="other">punt yr Aifft</displayName>
 				<symbol>EGP</symbol>
 				<symbol alt="narrow">E£</symbol>
@@ -6482,7 +6482,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="FJD">
 				<displayName>Doler Ffiji</displayName>
 				<displayName count="zero">doler Ffiji</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Ffiji</displayName>
 				<displayName count="two">ddoler Ffiji</displayName>
 				<displayName count="few">doler Ffiji</displayName>
 				<displayName count="many">doler Ffiji</displayName>
@@ -6496,7 +6496,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">punt Ynysoedd Falkland/Malvinas</displayName>
 				<displayName count="two">bunt Ynysoedd Falkland/Malvinas</displayName>
 				<displayName count="few">punt Ynysoedd Falkland/Malvinas</displayName>
-				<displayName count="many">↑↑↑</displayName>
+				<displayName count="many">punt Ynysoedd Falkland/Malvinas</displayName>
 				<displayName count="other">punt Ynysoedd Falkland/Malvinas</displayName>
 				<symbol>FKP</symbol>
 				<symbol alt="narrow">£</symbol>
@@ -6517,7 +6517,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">bunt Prydain</displayName>
 				<displayName count="two">bunt Prydain</displayName>
 				<displayName count="few">punt Prydain</displayName>
-				<displayName count="many">↑↑↑</displayName>
+				<displayName count="many">punt Prydain</displayName>
 				<displayName count="other">punt Prydain</displayName>
 				<symbol>£</symbol>
 				<symbol alt="narrow">£</symbol>
@@ -6570,7 +6570,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">punt Gibraltar</displayName>
 				<displayName count="two">bunt Gibraltar</displayName>
 				<displayName count="few">punt Gibraltar</displayName>
-				<displayName count="many">↑↑↑</displayName>
+				<displayName count="many">punt Gibraltar</displayName>
 				<displayName count="other">punt Gibraltar</displayName>
 				<symbol>GIP</symbol>
 				<symbol alt="narrow">£</symbol>
@@ -6646,7 +6646,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="GYD">
 				<displayName>Doler Guyana</displayName>
 				<displayName count="zero">doler Guyana</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Guyana</displayName>
 				<displayName count="two">ddoler Guyana</displayName>
 				<displayName count="few">doler Guyana</displayName>
 				<displayName count="many">doler Guyana</displayName>
@@ -6657,7 +6657,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="HKD">
 				<displayName>Doler Hong Kong</displayName>
 				<displayName count="zero">doler Hong Kong</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Hong Kong</displayName>
 				<displayName count="two">ddoler Hong Kong</displayName>
 				<displayName count="few">doler Hong Kong</displayName>
 				<displayName count="many">doler Hong Kong</displayName>
@@ -6819,7 +6819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="JMD">
 				<displayName>Doler Jamaica</displayName>
 				<displayName count="zero">doler Jamaica</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Jamaica</displayName>
 				<displayName count="two">ddoler Jamaica</displayName>
 				<displayName count="few">doler Jamaica</displayName>
 				<displayName count="many">doler Jamaica</displayName>
@@ -6945,7 +6945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="KYD">
 				<displayName>Doler Ynysoedd Cayman</displayName>
 				<displayName count="zero">doler Ynysoedd Cayman</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Ynysoedd Cayman</displayName>
 				<displayName count="two">ddoler Ynysoedd Cayman</displayName>
 				<displayName count="few">doler Ynysoedd Cayman</displayName>
 				<displayName count="many">doler Ynysoedd Cayman</displayName>
@@ -6981,7 +6981,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">punt Libanus</displayName>
 				<displayName count="two">bunt Libanus</displayName>
 				<displayName count="few">punt Libanus</displayName>
-				<displayName count="many">↑↑↑</displayName>
+				<displayName count="many">punt Libanus</displayName>
 				<displayName count="other">punt Libanus</displayName>
 				<symbol>LBP</symbol>
 				<symbol alt="narrow">L£</symbol>
@@ -7341,7 +7341,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="NAD">
 				<displayName>Doler Namibia</displayName>
 				<displayName count="zero">doler Namibia</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Namibia</displayName>
 				<displayName count="two">ddoler Namibia</displayName>
 				<displayName count="few">doler Namibia</displayName>
 				<displayName count="many">doler Namibia</displayName>
@@ -7416,7 +7416,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="NZD">
 				<displayName>Doler Seland Newydd</displayName>
 				<displayName count="zero">doler Seland Newydd</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Seland Newydd</displayName>
 				<displayName count="two">ddoler Seland Newydd</displayName>
 				<displayName count="few">doler Seland Newydd</displayName>
 				<displayName count="many">doler Seland Newydd</displayName>
@@ -7607,7 +7607,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="SBD">
 				<displayName>Doler Ynysoedd Solomon</displayName>
 				<displayName count="zero">doler Ynysoedd Solomon</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Ynysoedd Solomon</displayName>
 				<displayName count="two">ddoler Ynysoedd Solomon</displayName>
 				<displayName count="few">doler Ynysoedd Solomon</displayName>
 				<displayName count="many">doler Ynysoedd Solomon</displayName>
@@ -7638,10 +7638,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="SDG">
 				<displayName>Punt Sudan</displayName>
 				<displayName count="zero">punt Sudan</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">punt Sudan</displayName>
 				<displayName count="two">bunt Sudan</displayName>
 				<displayName count="few">punt Sudan</displayName>
-				<displayName count="many">↑↑↑</displayName>
+				<displayName count="many">punt Sudan</displayName>
 				<displayName count="other">punt Sudan</displayName>
 				<symbol>SDG</symbol>
 			</currency>
@@ -7669,7 +7669,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="SGD">
 				<displayName>Doler Singapore</displayName>
 				<displayName count="zero">doler Singapore</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Singapore</displayName>
 				<displayName count="two">ddoler Singapore</displayName>
 				<displayName count="few">doler Singapore</displayName>
 				<displayName count="many">doler Singapore</displayName>
@@ -7680,10 +7680,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="SHP">
 				<displayName>Punt St Helena</displayName>
 				<displayName count="zero">punt St. Helena</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">punt St. Helena</displayName>
 				<displayName count="two">bunt St. Helena</displayName>
 				<displayName count="few">punt St. Helena</displayName>
-				<displayName count="many">↑↑↑</displayName>
+				<displayName count="many">punt St. Helena</displayName>
 				<displayName count="other">punt St. Helena</displayName>
 				<symbol>SHP</symbol>
 				<symbol alt="narrow">£</symbol>
@@ -7714,7 +7714,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="SRD">
 				<displayName>Doler Surinam</displayName>
 				<displayName count="zero">doler Surinam</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Surinam</displayName>
 				<displayName count="two">ddoler Surinam</displayName>
 				<displayName count="few">doler Surinam</displayName>
 				<displayName count="many">doler Surinam</displayName>
@@ -7738,7 +7738,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">punt De Sudan</displayName>
 				<displayName count="two">bunt De Sudan</displayName>
 				<displayName count="few">punt De Sudan</displayName>
-				<displayName count="many">↑↑↑</displayName>
+				<displayName count="many">punt De Sudan</displayName>
 				<displayName count="other">punt De Sudan</displayName>
 				<symbol>SSP</symbol>
 				<symbol alt="narrow">£</symbol>
@@ -7902,7 +7902,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="TTD">
 				<displayName>Doler Trinidad a Tobago</displayName>
 				<displayName count="zero">doler Trinidad a Tobago</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Trinidad a Tobago</displayName>
 				<displayName count="two">ddoler Trinidad a Tobago</displayName>
 				<displayName count="few">doler Trinidad a Tobago</displayName>
 				<displayName count="many">doler Trinidad a Tobago</displayName>
@@ -7913,7 +7913,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="TWD">
 				<displayName>Doler Newydd Taiwan</displayName>
 				<displayName count="zero">doler newydd Taiwan</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler newydd Taiwan</displayName>
 				<displayName count="two">ddoler newydd Taiwan</displayName>
 				<displayName count="few">doler newydd Taiwan</displayName>
 				<displayName count="many">doler newydd Taiwan</displayName>
@@ -7965,7 +7965,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="USD">
 				<displayName>Doler UDA</displayName>
 				<displayName count="zero">doler UDA</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler UDA</displayName>
 				<displayName count="two">ddoler UDA</displayName>
 				<displayName count="few">doler UDA</displayName>
 				<displayName count="many">doler UDA</displayName>
@@ -8136,7 +8136,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XCD">
 				<displayName>Doler Dwyrain y Caribî</displayName>
 				<displayName count="zero">doler Dwyrain y Caribî</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">doler Dwyrain y Caribî</displayName>
 				<displayName count="two">ddoler Dwyrain y Caribî</displayName>
 				<displayName count="few">doler Dwyrain y Caribî</displayName>
 				<displayName count="many">doler Dwyrain y Caribî</displayName>
@@ -8453,24 +8453,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0} ciwbig</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>grym disgyrchedd</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} G</unitPattern>
 				<unitPattern count="one">{0} grym disgyrchedd</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} G</unitPattern>
+				<unitPattern count="few">{0} G</unitPattern>
+				<unitPattern count="many">{0} G</unitPattern>
 				<unitPattern count="other">{0} grym disgyrchedd</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>metrau yr eiliad sgwâr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} m/eil²</unitPattern>
 				<unitPattern count="one">{0} metr yr eiliad sgwâr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} m/eil²</unitPattern>
+				<unitPattern count="few">{0} m/eil²</unitPattern>
+				<unitPattern count="many">{0} m/eil²</unitPattern>
 				<unitPattern count="other">{0} metr yr eiliad sgwâr</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
@@ -8484,11 +8484,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-radian">
 				<displayName>radianau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} rad</unitPattern>
 				<unitPattern count="one">{0} radian</unitPattern>
 				<unitPattern count="two">{0} radian</unitPattern>
 				<unitPattern count="few">{0} radian</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="many">{0} rad</unitPattern>
 				<unitPattern count="other">{0} radian</unitPattern>
 			</unit>
 			<unit type="angle-degree">
@@ -8520,40 +8520,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>cilometrau sgwâr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} km²</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="two">{0} km²</unitPattern>
+				<unitPattern count="few">{0} km²</unitPattern>
+				<unitPattern count="many">{0} km²</unitPattern>
 				<unitPattern count="other">{0} cilometr sgwâr</unitPattern>
 				<perUnitPattern>{0} y cilometr sgwâr</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hectarau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ha</unitPattern>
 				<unitPattern count="one">{0} hectar</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} ha</unitPattern>
+				<unitPattern count="few">{0} ha</unitPattern>
+				<unitPattern count="many">{0} ha</unitPattern>
 				<unitPattern count="other">{0} hectar</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>metrau sgwâr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} m²</unitPattern>
 				<unitPattern count="one">{0} metr sgwâr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} m²</unitPattern>
+				<unitPattern count="few">{0} m²</unitPattern>
+				<unitPattern count="many">{0} m²</unitPattern>
 				<unitPattern count="other">{0} metr sgwâr</unitPattern>
 				<perUnitPattern>{0} y metr sgwâr</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>centimetrau sgwâr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cm²</unitPattern>
 				<unitPattern count="one">{0} centimetr sgwâr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="many">{0} cm²</unitPattern>
 				<unitPattern count="other">{0} centimetr sgwâr</unitPattern>
 				<perUnitPattern>{0} y centimetr sgwâr</perUnitPattern>
 			</unit>
@@ -8606,38 +8606,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunamau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dunam</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="two">{0} ddunam</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} dunam</unitPattern>
+				<unitPattern count="many">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karatau</displayName>
 				<unitPattern count="zero">{0} karat</unitPattern>
 				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="many">{0} kt</unitPattern>
 				<unitPattern count="other">{0} karat</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>miligramau y declilitr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mg/dL</unitPattern>
 				<unitPattern count="one">{0} miligram y decilitr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mg/dL</unitPattern>
+				<unitPattern count="few">{0} mg/dL</unitPattern>
+				<unitPattern count="many">{0} mg/dL</unitPattern>
 				<unitPattern count="other">{0} miligram y decilitr</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>milimolau y litr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mmol/L</unitPattern>
 				<unitPattern count="one">{0} milimôl y litr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mmol/L</unitPattern>
+				<unitPattern count="few">{0} mmol/L</unitPattern>
+				<unitPattern count="many">{0} mmol/L</unitPattern>
 				<unitPattern count="other">{0} milimôl y litr</unitPattern>
 			</unit>
 			<unit type="concentr-item">
@@ -8678,11 +8678,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>permyriad</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0}‱</unitPattern>
 				<unitPattern count="one">{0} permyriad</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
 				<unitPattern count="other">{0} permyriad</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -8696,119 +8696,119 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litrau y cilometr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} L/km</unitPattern>
 				<unitPattern count="one">{0} litr y cilometr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} L/km</unitPattern>
+				<unitPattern count="few">{0} L/km</unitPattern>
+				<unitPattern count="many">{0} L/km</unitPattern>
 				<unitPattern count="other">{0} litr y cilometr</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>litrau y 100 cilometr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} L/100km</unitPattern>
 				<unitPattern count="one">{0} litr y 100 cilometr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} L/100km</unitPattern>
+				<unitPattern count="few">{0} L/100km</unitPattern>
+				<unitPattern count="many">{0} L/100km</unitPattern>
 				<unitPattern count="other">{0} litr y 100 cilometr</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>milltiroedd y galwyn</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mpg</unitPattern>
 				<unitPattern count="one">{0} filltir y galwyn</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mpg</unitPattern>
+				<unitPattern count="few">{0} mpg</unitPattern>
+				<unitPattern count="many">{0} mpg</unitPattern>
 				<unitPattern count="other">{0} milltir y galwyn</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>milltiroedd y galwyn Imp.</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mpg Imp.</unitPattern>
 				<unitPattern count="one">{0} milltir y galwyn Imp.</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mpg Imp.</unitPattern>
+				<unitPattern count="few">{0} mpg Imp.</unitPattern>
+				<unitPattern count="many">{0} mpg Imp.</unitPattern>
 				<unitPattern count="other">{0} milltir y galwyn Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>petabyte</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} PB</unitPattern>
 				<unitPattern count="one">{0} petabyte</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="many">{0} PB</unitPattern>
 				<unitPattern count="other">{0} petabyte</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>terabeitiau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} TB</unitPattern>
 				<unitPattern count="one">{0} terabeit</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="many">{0} TB</unitPattern>
 				<unitPattern count="other">{0} terabeit</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>teradidau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Tb</unitPattern>
 				<unitPattern count="one">{0} teradid</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="many">{0} Tb</unitPattern>
 				<unitPattern count="other">{0} teradid</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>gigabeitiau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} GB</unitPattern>
 				<unitPattern count="one">{0} gigabeit</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="many">{0} GB</unitPattern>
 				<unitPattern count="other">{0} gigabeit</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>gigadidau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Gb</unitPattern>
 				<unitPattern count="one">{0} gigadid</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="many">{0} Gb</unitPattern>
 				<unitPattern count="other">{0} gigadid</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>megabeitiau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MB</unitPattern>
 				<unitPattern count="one">{0} megabeit</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="many">{0} MB</unitPattern>
 				<unitPattern count="other">{0} megabeit</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>megadidau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Mb</unitPattern>
 				<unitPattern count="one">{0} megadid</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="many">{0} Mb</unitPattern>
 				<unitPattern count="other">{0} megadid</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>cilobeitiau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kB</unitPattern>
 				<unitPattern count="one">{0} cilobeit</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="many">{0} kB</unitPattern>
 				<unitPattern count="other">{0} cilobeit</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>cilodidau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kb</unitPattern>
 				<unitPattern count="one">{0} cilodid</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="many">{0} kb</unitPattern>
 				<unitPattern count="other">{0} cilodid</unitPattern>
 			</unit>
 			<unit type="digital-byte">
@@ -8824,7 +8824,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>didau</displayName>
 				<unitPattern count="zero">{0} did</unitPattern>
 				<unitPattern count="one">{0} did</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} did</unitPattern>
 				<unitPattern count="few">{0} did</unitPattern>
 				<unitPattern count="many">{0} did</unitPattern>
 				<unitPattern count="other">{0} did</unitPattern>
@@ -8956,343 +8956,343 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amperau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} A</unitPattern>
 				<unitPattern count="one">{0} amper</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="many">{0} A</unitPattern>
 				<unitPattern count="other">{0} amper</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>miliamperau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mA</unitPattern>
 				<unitPattern count="one">{0} miliamper</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="many">{0} mA</unitPattern>
 				<unitPattern count="other">{0} miliamper</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>ohmau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Ω</unitPattern>
 				<unitPattern count="one">{0} ohm</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="many">{0} Ω</unitPattern>
 				<unitPattern count="other">{0} ohm</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>foltiau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} V</unitPattern>
 				<unitPattern count="one">{0} folt</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="many">{0} V</unitPattern>
 				<unitPattern count="other">{0} folt</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>cilocalorïau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kcal</unitPattern>
 				<unitPattern count="one">{0} cilocalori</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
 				<unitPattern count="other">{0} cilocalori</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>calorïau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cal</unitPattern>
 				<unitPattern count="one">{0} calori</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="many">{0} cal</unitPattern>
 				<unitPattern count="other">{0} calori</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>Calorïau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Cal</unitPattern>
 				<unitPattern count="one">{0} Calori</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
 				<unitPattern count="other">{0} Calori</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>cilojouleau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kJ</unitPattern>
 				<unitPattern count="one">{0} cilojoule</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="many">{0} kJ</unitPattern>
 				<unitPattern count="other">{0} cilojoule</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>jouleau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} J</unitPattern>
 				<unitPattern count="one">{0} joule</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="many">{0} J</unitPattern>
 				<unitPattern count="other">{0} joule</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>cilowat oriau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kW-awr</unitPattern>
 				<unitPattern count="one">{0} cilowat awr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kW-awr</unitPattern>
+				<unitPattern count="few">{0} kW-awr</unitPattern>
+				<unitPattern count="many">{0} kW-awr</unitPattern>
 				<unitPattern count="other">{0} cilowat awr</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>electronfoltiau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} eV</unitPattern>
 				<unitPattern count="one">{0} electronfolt</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
 				<unitPattern count="other">{0} electronfolt</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>unedau thermol Prydain</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Btu</unitPattern>
 				<unitPattern count="one">{0} uned thermol Prydain</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
 				<unitPattern count="other">{0} uned thermol Prydain</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="zero">{0} US therm</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
+				<unitPattern count="many">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>pwysau o rym</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} lbf</unitPattern>
 				<unitPattern count="one">{0} pwys o rym</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
 				<unitPattern count="other">{0} pwysau o rym</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newtonau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} N</unitPattern>
 				<unitPattern count="one">{0} newton</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
 				<unitPattern count="other">{0} newton</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>cilowat-awr fesul 100 cilomedr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kWh/100km</unitPattern>
 				<unitPattern count="one">{0} cilowat-awr fesul 100 cilomedr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">{0} cilowat-awr fesul 100 cilomedr</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>gigaherts</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} GHz</unitPattern>
 				<unitPattern count="one">{0} gigaherts</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="many">{0} GHz</unitPattern>
 				<unitPattern count="other">{0} gigaherts</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>megaherts</displayName>
 				<unitPattern count="zero">{0} megaherts</unitPattern>
 				<unitPattern count="one">{0} megaherts</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="many">{0} MHz</unitPattern>
 				<unitPattern count="other">{0} megaherts</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>ciloherts</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kHz</unitPattern>
 				<unitPattern count="one">{0} ciloherts</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="many">{0} kHz</unitPattern>
 				<unitPattern count="other">{0} ciloherts</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>herts</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Hz</unitPattern>
 				<unitPattern count="one">{0} herts</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="many">{0} Hz</unitPattern>
 				<unitPattern count="other">{0} herts</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em argraffyddol</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} em</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="two">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="many">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>picseli</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} px</unitPattern>
 				<unitPattern count="one">{0} picsel</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
 				<unitPattern count="other">{0} picsel</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapicseli</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MP</unitPattern>
 				<unitPattern count="one">{0} megapicsel</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="many">{0} MP</unitPattern>
 				<unitPattern count="other">{0} megapicsel</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>picseli mewn centimedr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppcm</unitPattern>
 				<unitPattern count="one">{0} picsel mewn centimedr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} picsel mewn centimedr</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>picseli mewn modfedd</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppi</unitPattern>
 				<unitPattern count="one">{0} picsel mewn modfedd</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} picsel mewn modfedd</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dotiau mewn centimedr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppcm</unitPattern>
 				<unitPattern count="one">{0} dot mewn centimedr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} mewn centimedr</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dotiau mewn modfedd</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppi</unitPattern>
 				<unitPattern count="one">{0} dot mewn modfedd</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dot mewn modfedd</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>picseli</displayName>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="two">{0} ddot</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>radiws y Ddaear</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} R⊕</unitPattern>
 				<unitPattern count="one">{0} radiws y Ddaear</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">{0} radiws y Ddaear</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>cilometrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} km</unitPattern>
 				<unitPattern count="one">{0} cilometr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} km</unitPattern>
+				<unitPattern count="few">{0} km</unitPattern>
+				<unitPattern count="many">{0} km</unitPattern>
 				<unitPattern count="other">{0} cilometr</unitPattern>
 				<perUnitPattern>{0} y cilometr</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>metrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} m</unitPattern>
 				<unitPattern count="one">{0} metr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} m</unitPattern>
+				<unitPattern count="few">{0} m</unitPattern>
+				<unitPattern count="many">{0} m</unitPattern>
 				<unitPattern count="other">{0} metr</unitPattern>
 				<perUnitPattern>{0} y metr</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>decimetrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dm</unitPattern>
 				<unitPattern count="one">{0} decimetr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="many">{0} dm</unitPattern>
 				<unitPattern count="other">{0} decimetr</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>centimetrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cm</unitPattern>
 				<unitPattern count="one">{0} centimetr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} cm</unitPattern>
+				<unitPattern count="few">{0} cm</unitPattern>
+				<unitPattern count="many">{0} cm</unitPattern>
 				<unitPattern count="other">{0} centimetr</unitPattern>
 				<perUnitPattern>{0} y centimetr</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>milimetrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mm</unitPattern>
 				<unitPattern count="one">{0} milimetr</unitPattern>
 				<unitPattern count="two">{0} filimetr</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} mm</unitPattern>
+				<unitPattern count="many">{0} mm</unitPattern>
 				<unitPattern count="other">{0} milimetr</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>micrometrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} μm</unitPattern>
 				<unitPattern count="one">{0} micrometr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="many">{0} μm</unitPattern>
 				<unitPattern count="other">{0} micrometr</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>nanometrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} nm</unitPattern>
 				<unitPattern count="one">{0} nanometr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="many">{0} nm</unitPattern>
 				<unitPattern count="other">{0} nanometr</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>picometrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} pm</unitPattern>
 				<unitPattern count="one">{0} picometr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} pm</unitPattern>
+				<unitPattern count="few">{0} pm</unitPattern>
+				<unitPattern count="many">{0} pm</unitPattern>
 				<unitPattern count="other">{0} picometr</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>milltiroedd</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mi</unitPattern>
 				<unitPattern count="one">{0} filltir</unitPattern>
 				<unitPattern count="two">{0} filltir</unitPattern>
 				<unitPattern count="few">{0} milltir</unitPattern>
@@ -9332,9 +9332,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>parsecau</displayName>
 				<unitPattern count="zero">{0} parsec</unitPattern>
 				<unitPattern count="one">{0} parsec</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="many">{0} pc</unitPattern>
 				<unitPattern count="other">{0} parsec</unitPattern>
 			</unit>
 			<unit type="length-light-year">
@@ -9396,81 +9396,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="zero">{0} pwynt</unitPattern>
 				<unitPattern count="one">{0} pwynt</unitPattern>
 				<unitPattern count="two">{0} bwynt</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="many">{0} pt</unitPattern>
 				<unitPattern count="other">{0} pwynt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>radiysau solar</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} R☉</unitPattern>
 				<unitPattern count="one">{0} radiws solar</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
 				<unitPattern count="other">{0} radiws solar</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lycsau</displayName>
 				<unitPattern count="zero">{0} lwcs</unitPattern>
 				<unitPattern count="one">{0} lwcs</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="many">{0} lx</unitPattern>
 				<unitPattern count="other">{0} lwcs</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>candela</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cd</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>lwmen</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} lm</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>goleueddau solar</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} L☉</unitPattern>
 				<unitPattern count="one">{0} goleuedd solar</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
 				<unitPattern count="other">{0} goleueddau solar</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>tunelli metrig</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} t</unitPattern>
 				<unitPattern count="one">{0} dunnell fetrig</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="many">{0} t</unitPattern>
 				<unitPattern count="other">{0} tunnell fetrig</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>cilogramau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kg</unitPattern>
 				<unitPattern count="one">{0} cilogram</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kg</unitPattern>
+				<unitPattern count="few">{0} kg</unitPattern>
+				<unitPattern count="many">{0} kg</unitPattern>
 				<unitPattern count="other">{0} cilogram</unitPattern>
 				<perUnitPattern>{0} y cilogram</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gramau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} g</unitPattern>
 				<unitPattern count="one">{0} gram</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} g</unitPattern>
+				<unitPattern count="few">{0} g</unitPattern>
+				<unitPattern count="many">{0} g</unitPattern>
 				<unitPattern count="other">{0} gram</unitPattern>
 				<perUnitPattern>{0} y gram</perUnitPattern>
 			</unit>
@@ -9479,22 +9479,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="zero">{0} miligram</unitPattern>
 				<unitPattern count="one">{0} miligram</unitPattern>
 				<unitPattern count="two">{0} filigram</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="many">{0} mg</unitPattern>
 				<unitPattern count="other">{0} miligram</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>microgramau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} μg</unitPattern>
 				<unitPattern count="one">{0} microgram</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="many">{0} μg</unitPattern>
 				<unitPattern count="other">{0} microgram</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>tunelli</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} tn</unitPattern>
 				<unitPattern count="one">{0} dunnell</unitPattern>
 				<unitPattern count="two">{0} dunnell</unitPattern>
 				<unitPattern count="few">{0} tunnell</unitPattern>
@@ -9543,36 +9543,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>caratau</displayName>
 				<unitPattern count="zero">{0} carat</unitPattern>
 				<unitPattern count="one">{0} carat</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} CD</unitPattern>
+				<unitPattern count="few">{0} CD</unitPattern>
+				<unitPattern count="many">{0} CD</unitPattern>
 				<unitPattern count="other">{0} carat</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>daltonau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Da</unitPattern>
 				<unitPattern count="one">{0} dalton</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
 				<unitPattern count="other">{0} dalton</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>masau ddaear</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} M⊕</unitPattern>
 				<unitPattern count="one">{0} más ddaear</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
 				<unitPattern count="other">{0} más ddaear</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>masau solar</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} M☉</unitPattern>
 				<unitPattern count="one">{0} más solar</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
 				<unitPattern count="other">{0} más solar</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -9598,17 +9598,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="zero">{0} megawat</unitPattern>
 				<unitPattern count="one">{0} megawat</unitPattern>
 				<unitPattern count="two">{0} fegawat</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} MW</unitPattern>
+				<unitPattern count="many">{0} MW</unitPattern>
 				<unitPattern count="other">{0} megawat</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>cilowatiau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kW</unitPattern>
 				<unitPattern count="one">{0} cilowat</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kW</unitPattern>
+				<unitPattern count="few">{0} kW</unitPattern>
+				<unitPattern count="many">{0} kW</unitPattern>
 				<unitPattern count="other">{0} cilowat</unitPattern>
 			</unit>
 			<unit type="power-watt">
@@ -9622,20 +9622,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>miliwatiau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mW</unitPattern>
 				<unitPattern count="one">{0} miliwat</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mW</unitPattern>
+				<unitPattern count="few">{0} mW</unitPattern>
+				<unitPattern count="many">{0} mW</unitPattern>
 				<unitPattern count="other">{0} miliwat</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>marchnerth</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} hp</unitPattern>
 				<unitPattern count="one">{0} marchnerth</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} hp</unitPattern>
+				<unitPattern count="few">{0} hp</unitPattern>
+				<unitPattern count="many">{0} hp</unitPattern>
 				<unitPattern count="other">{0} marchnerth</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -9649,11 +9649,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>pwysau y fodfedd sgwar</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} psi</unitPattern>
 				<unitPattern count="one">{0} pwys y fodfedd sgwar</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} psi</unitPattern>
+				<unitPattern count="few">{0} psi</unitPattern>
+				<unitPattern count="many">{0} psi</unitPattern>
 				<unitPattern count="other">{0} pwys y fodfedd sgwar</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
@@ -9666,21 +9666,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} modfedd o fercwri</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="zero">{0} bar</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="two">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="many">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>milibarau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mbar</unitPattern>
 				<unitPattern count="one">{0} milibar</unitPattern>
 				<unitPattern count="two">{0} filibar</unitPattern>
 				<unitPattern count="few">{0} milibar</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="many">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} milibar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
@@ -9694,38 +9694,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>pascalau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Pa</unitPattern>
 				<unitPattern count="one">{0} pascal</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
 				<unitPattern count="other">{0} pascal</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hectopascalau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} hPa</unitPattern>
 				<unitPattern count="one">{0} hectopascal</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hectopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>cilopascalau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kPa</unitPattern>
 				<unitPattern count="one">{0} cilopascal</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
 				<unitPattern count="other">{0} cilopascalau</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>megapascalau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MPa</unitPattern>
 				<unitPattern count="one">{0} megapascal</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
 				<unitPattern count="other">{0} megapascalau</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -9777,73 +9777,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>graddau Celsius</displayName>
 				<unitPattern count="zero">{0} gradd Celsius</unitPattern>
 				<unitPattern count="one">{0} radd Celsius</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0}°C</unitPattern>
+				<unitPattern count="few">{0}°C</unitPattern>
+				<unitPattern count="many">{0}°C</unitPattern>
 				<unitPattern count="other">{0} gradd Celsius</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>gradd Fahrenheit</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0}°F</unitPattern>
 				<unitPattern count="one">{0} radd Fahrenheit</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0}°F</unitPattern>
+				<unitPattern count="few">{0}°F</unitPattern>
+				<unitPattern count="many">{0}°F</unitPattern>
 				<unitPattern count="other">{0} gradd Fahrenheit</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>celfinau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} K</unitPattern>
 				<unitPattern count="one">{0} celfin</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} K</unitPattern>
+				<unitPattern count="few">{0} K</unitPattern>
+				<unitPattern count="many">{0} K</unitPattern>
 				<unitPattern count="other">{0} celfin</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>pwys-troedfeddi</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="one">{0} pwys o rym⋅droedfedd</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0} pwys-troedfeddi</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>newton-metrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} N⋅m</unitPattern>
 				<unitPattern count="one">{0} newton-metr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
+				<unitPattern count="many">{0} N⋅m</unitPattern>
 				<unitPattern count="other">{0} newton-metrau</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>cilometrau ciwbig</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} km³</unitPattern>
 				<unitPattern count="one">{0} cilometr ciwbig</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} km³</unitPattern>
+				<unitPattern count="few">{0} km³</unitPattern>
+				<unitPattern count="many">{0} km³</unitPattern>
 				<unitPattern count="other">{0} cilometr ciwbig</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>metrau ciwbig</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} m³</unitPattern>
 				<unitPattern count="one">{0} metr ciwbig</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="many">{0} m³</unitPattern>
 				<unitPattern count="other">{0} metr ciwbig</unitPattern>
 				<perUnitPattern>{0} y metr ciwbig</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>centimetrau ciwbig</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cm³</unitPattern>
 				<unitPattern count="one">{0} centimetr ciwbig</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="many">{0} cm³</unitPattern>
 				<unitPattern count="other">{0} chentimetr ciwbig</unitPattern>
 				<perUnitPattern>{0} y centimetr ciwbig</perUnitPattern>
 			</unit>
@@ -9851,27 +9851,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>milltiroedd ciwbig</displayName>
 				<unitPattern count="zero">{0} milltir giwbig</unitPattern>
 				<unitPattern count="one">{0} filltir giwbig</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mi³</unitPattern>
+				<unitPattern count="few">{0} mi³</unitPattern>
+				<unitPattern count="many">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} milltir giwbig</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>llathenni ciwbig</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} llath³</unitPattern>
 				<unitPattern count="one">{0} llathen giwbig</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} lath³</unitPattern>
+				<unitPattern count="few">{0} llath³</unitPattern>
+				<unitPattern count="many">{0} llath³</unitPattern>
 				<unitPattern count="other">{0} llath giwbig</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>troedfeddi ciwbig</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} tr³</unitPattern>
 				<unitPattern count="one">{0} droedfedd giwbig</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} tr³</unitPattern>
+				<unitPattern count="few">{0} tr³</unitPattern>
+				<unitPattern count="many">{0} tr³</unitPattern>
 				<unitPattern count="other">{0} troedfedd giwbig</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
@@ -9885,20 +9885,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>megalitrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ML</unitPattern>
 				<unitPattern count="one">{0} megalitr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} ML</unitPattern>
+				<unitPattern count="few">{0} ML</unitPattern>
+				<unitPattern count="many">{0} ML</unitPattern>
 				<unitPattern count="other">{0} megalitr</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>hectolitrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} hL</unitPattern>
 				<unitPattern count="one">{0} hectolitr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} hL</unitPattern>
+				<unitPattern count="few">{0} hL</unitPattern>
+				<unitPattern count="many">{0} hL</unitPattern>
 				<unitPattern count="other">{0} hectolitr</unitPattern>
 			</unit>
 			<unit type="volume-liter">
@@ -9906,54 +9906,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="zero">{0} litr</unitPattern>
 				<unitPattern count="one">{0} litr</unitPattern>
 				<unitPattern count="two">{0} litr</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} L</unitPattern>
+				<unitPattern count="many">{0} L</unitPattern>
 				<unitPattern count="other">{0} litr</unitPattern>
 				<perUnitPattern>{0} y litr</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>decilitrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dL</unitPattern>
 				<unitPattern count="one">{0} decilitr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dL</unitPattern>
+				<unitPattern count="few">{0} dL</unitPattern>
+				<unitPattern count="many">{0} dL</unitPattern>
 				<unitPattern count="other">{0} decilitr</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>centilitrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cL</unitPattern>
 				<unitPattern count="one">{0} centilitr</unitPattern>
 				<unitPattern count="two">{0} gentilitr</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} cL</unitPattern>
+				<unitPattern count="many">{0} cL</unitPattern>
 				<unitPattern count="other">{0} centilitr</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>mililitrau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mL</unitPattern>
 				<unitPattern count="one">{0} mililitr</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mL</unitPattern>
+				<unitPattern count="few">{0} mL</unitPattern>
+				<unitPattern count="many">{0} mL</unitPattern>
 				<unitPattern count="other">{0} mililitr</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>peintiau metrig</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mpt</unitPattern>
 				<unitPattern count="one">{0} peint metrig</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="many">{0} mpt</unitPattern>
 				<unitPattern count="other">{0} peint metrig</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>cwpaneidiau metrig</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mc</unitPattern>
 				<unitPattern count="one">{0} cwpanaid metrig</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mc</unitPattern>
+				<unitPattern count="few">{0} mc</unitPattern>
+				<unitPattern count="many">{0} mc</unitPattern>
 				<unitPattern count="other">{0} cwpanaid metrig</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
@@ -10034,9 +10034,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Ownsiau hylifol Imp.</displayName>
 				<unitPattern count="zero">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="one">{0} owns hylifol Imp.</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="few">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="many">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">{0} owns hylifol Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -10059,29 +10059,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>bareli</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} bbl</unitPattern>
 				<unitPattern count="one">{0} barel</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="many">{0} bbl</unitPattern>
 				<unitPattern count="other">{0} barel</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>llond llwy bwdin</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dstspn</unitPattern>
 				<unitPattern count="one">{0} llond llwy bwdin</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
+				<unitPattern count="many">{0} dstspn</unitPattern>
 				<unitPattern count="other">{0} llond llwy bwdin</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>llond llwy bwdin imp.</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dstspn Imp</unitPattern>
 				<unitPattern count="one">{0} llond llwy bwdin imp.</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dstspn Imp</unitPattern>
+				<unitPattern count="few">{0} dstspn Imp</unitPattern>
+				<unitPattern count="many">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">{0} llond llwy bwdin imp.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -10227,20 +10227,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10248,11 +10248,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>grym disgyrchedd</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} G</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="two">{0} G</unitPattern>
+				<unitPattern count="few">{0} G</unitPattern>
+				<unitPattern count="many">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
@@ -10330,7 +10330,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} m²</unitPattern>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="two">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
@@ -10397,11 +10397,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunamau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dunam</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="two">{0} ddunam</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} dunam</unitPattern>
+				<unitPattern count="many">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -10415,9 +10415,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mg/dL</unitPattern>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="two">{0} mg/dL</unitPattern>
 				<unitPattern count="few">{0} mg/dL</unitPattern>
 				<unitPattern count="many">{0} mg/dL</unitPattern>
 				<unitPattern count="other">{0} mg/dL</unitPattern>
@@ -10425,7 +10425,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="concentr-millimole-per-liter">
 				<displayName>milimôl/litr</displayName>
 				<unitPattern count="zero">{0} mmol/L</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
 				<unitPattern count="two">{0} mmol/L</unitPattern>
 				<unitPattern count="few">{0} mmol/L</unitPattern>
 				<unitPattern count="many">{0} mmol/L</unitPattern>
@@ -10469,11 +10469,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>permyriad</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0}‱</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -10487,7 +10487,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litrau/km</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} L/km</unitPattern>
 				<unitPattern count="one">{0} L/km</unitPattern>
 				<unitPattern count="two">{0} L/km</unitPattern>
 				<unitPattern count="few">{0} L/km</unitPattern>
@@ -10559,47 +10559,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gbit</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Gb</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="two">{0} Gb</unitPattern>
 				<unitPattern count="few">{0} Gb</unitPattern>
 				<unitPattern count="many">{0} Gb</unitPattern>
 				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MBeit</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MB</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="two">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="many">{0} MB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mbit</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Mb</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="two">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="many">{0} Mb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kBeit</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kB</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="two">{0} kB</unitPattern>
 				<unitPattern count="few">{0} kB</unitPattern>
 				<unitPattern count="many">{0} kB</unitPattern>
 				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kbit</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kb</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="two">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="many">{0} kb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-byte">
@@ -10783,47 +10783,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kcal</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="two">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cal</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="two">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="many">{0} cal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>Cal</displayName>
 				<unitPattern count="zero">{0} Cal</unitPattern>
 				<unitPattern count="one">{0} Cal</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>cilojouleau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kJ</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="two">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="many">{0} kJ</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>jouleau</displayName>
 				<unitPattern count="zero">{0} J</unitPattern>
 				<unitPattern count="one">{0} J</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="many">{0} J</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
@@ -10837,63 +10837,63 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>electronfolt</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} eV</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="two">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Btu</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="two">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} US therm</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
+				<unitPattern count="many">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>pwys-grym</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} lbf</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} N</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kWh/100km</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>GHz</displayName>
 				<unitPattern count="zero">{0} GHz</unitPattern>
 				<unitPattern count="one">{0} GHz</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} GHz</unitPattern>
 				<unitPattern count="few">{0} GHz</unitPattern>
 				<unitPattern count="many">{0} GHz</unitPattern>
 				<unitPattern count="other">{0} GHz</unitPattern>
@@ -10909,7 +10909,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>kHz</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kHz</unitPattern>
 				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="two">{0} kHz</unitPattern>
 				<unitPattern count="few">{0} kHz</unitPattern>
@@ -10927,83 +10927,83 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} em</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="two">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="many">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>picseli</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapicseli</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MP</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="many">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppcm</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppi</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="zero">{0} ppcm</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="zero">{0} ppi</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>picseli</displayName>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="two">{0} ddot</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} R⊕</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -11193,11 +11193,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>radiysau solar</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} R☉</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="two">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -11211,29 +11211,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cd</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} lm</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>goleueddau solar</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} L☉</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -11341,29 +11341,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>daltonau</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Da</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>masau ddaear</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} M⊕</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>masau solar</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} M☉</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -11422,11 +11422,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} hp</unitPattern>
+				<unitPattern count="one">{0} hp</unitPattern>
+				<unitPattern count="two">{0} hp</unitPattern>
+				<unitPattern count="few">{0} hp</unitPattern>
+				<unitPattern count="many">{0} hp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -11458,11 +11458,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} bar</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="two">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="many">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -11485,11 +11485,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Pa</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -11503,20 +11503,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kPa</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="two">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MPa</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="two">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -11539,11 +11539,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>milltir/awr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} m.y.a.</unitPattern>
+				<unitPattern count="one">{0} m.y.a.</unitPattern>
+				<unitPattern count="two">{0} m.y.a.</unitPattern>
+				<unitPattern count="few">{0} m.y.a.</unitPattern>
+				<unitPattern count="many">{0} m.y.a.</unitPattern>
 				<unitPattern count="other">{0} m.y.a.</unitPattern>
 			</unit>
 			<unit type="speed-knot">
@@ -11566,47 +11566,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>gradd C</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0}°C</unitPattern>
+				<unitPattern count="one">{0}°C</unitPattern>
+				<unitPattern count="two">{0}°C</unitPattern>
+				<unitPattern count="few">{0}°C</unitPattern>
+				<unitPattern count="many">{0}°C</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>gradd F</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0}°F</unitPattern>
+				<unitPattern count="one">{0}°F</unitPattern>
+				<unitPattern count="two">{0}°F</unitPattern>
+				<unitPattern count="few">{0}°F</unitPattern>
+				<unitPattern count="many">{0}°F</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} K</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="two">{0} K</unitPattern>
+				<unitPattern count="few">{0} K</unitPattern>
+				<unitPattern count="many">{0} K</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} N⋅m</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="two">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
+				<unitPattern count="many">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -11642,7 +11642,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mi³</displayName>
 				<unitPattern count="zero">{0} mi³</unitPattern>
 				<unitPattern count="one">{0} mi³</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mi³</unitPattern>
 				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="many">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
@@ -11706,7 +11706,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>dL</displayName>
 				<unitPattern count="zero">{0} dL</unitPattern>
 				<unitPattern count="one">{0} dL</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dL</unitPattern>
 				<unitPattern count="few">{0} dL</unitPattern>
 				<unitPattern count="many">{0} dL</unitPattern>
 				<unitPattern count="other">{0} dL</unitPattern>
@@ -11823,11 +11823,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="two">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="few">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="many">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -11850,29 +11850,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>barel</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} bbl</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="two">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="many">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dstspn</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="two">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
+				<unitPattern count="many">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dstspn Imp</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="two">{0} dstspn Imp</unitPattern>
+				<unitPattern count="few">{0} dstspn Imp</unitPattern>
+				<unitPattern count="many">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -11930,115 +11930,115 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>grym disgyrchedd</displayName>
 				<unitPattern count="zero">{0}G</unitPattern>
 				<unitPattern count="one">{0}G</unitPattern>
 				<unitPattern count="two">{0}G</unitPattern>
@@ -12047,13 +12047,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metrau/eil²</displayName>
+				<unitPattern count="zero">{0} m/eil²</unitPattern>
+				<unitPattern count="one">{0} m/eil²</unitPattern>
+				<unitPattern count="two">{0} m/eil²</unitPattern>
+				<unitPattern count="few">{0} m/eil²</unitPattern>
+				<unitPattern count="many">{0} m/eil²</unitPattern>
+				<unitPattern count="other">{0} m/eil²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>rev</displayName>
@@ -12066,7 +12066,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-radian">
 				<displayName>rad</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} rad</unitPattern>
 				<unitPattern count="one">{0}rad</unitPattern>
 				<unitPattern count="two">{0} rad</unitPattern>
 				<unitPattern count="few">{0} rad</unitPattern>
@@ -12083,12 +12083,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>archfunudau</displayName>
+				<unitPattern count="zero">{0} archfun</unitPattern>
 				<unitPattern count="one">{0}′</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} archfun</unitPattern>
+				<unitPattern count="few">{0} archfun</unitPattern>
+				<unitPattern count="many">{0} archfun</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
@@ -12108,7 +12108,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0}km²</unitPattern>
 				<unitPattern count="many">{0}km²</unitPattern>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hectar</displayName>
@@ -12147,7 +12147,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0}mi²</unitPattern>
 				<unitPattern count="many">{0}mi²</unitPattern>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>erw</displayName>
@@ -12159,16 +12159,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}erw</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>llath²</displayName>
+				<unitPattern count="zero">{0} llath²</unitPattern>
+				<unitPattern count="one">{0} llath²</unitPattern>
+				<unitPattern count="two">{0} llath²</unitPattern>
+				<unitPattern count="few">{0} llath²</unitPattern>
+				<unitPattern count="many">{0} llath²</unitPattern>
+				<unitPattern count="other">{0} llath²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>troedfedd²</displayName>
 				<unitPattern count="zero">{0}ft²</unitPattern>
 				<unitPattern count="one">{0}ft²</unitPattern>
 				<unitPattern count="two">{0}ft²</unitPattern>
@@ -12177,50 +12177,50 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>modfedd²</displayName>
+				<unitPattern count="zero">{0} mod²</unitPattern>
+				<unitPattern count="one">{0} mod²</unitPattern>
+				<unitPattern count="two">{0} mod²</unitPattern>
+				<unitPattern count="few">{0} mod²</unitPattern>
+				<unitPattern count="many">{0} mod²</unitPattern>
+				<unitPattern count="other">{0} mod²</unitPattern>
+				<perUnitPattern>{0} y mod²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dunam</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="two">{0} ddunam</unitPattern>
+				<unitPattern count="few">{0} dunam</unitPattern>
+				<unitPattern count="many">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>carat</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kt</unitPattern>
 				<unitPattern count="one">{0}kt</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="many">{0} kt</unitPattern>
 				<unitPattern count="other">{0}kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="zero">{0} mg/dL</unitPattern>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="two">{0} mg/dL</unitPattern>
+				<unitPattern count="few">{0} mg/dL</unitPattern>
+				<unitPattern count="many">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milimôl/litr</displayName>
+				<unitPattern count="zero">{0} mmol/L</unitPattern>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="two">{0} mmol/L</unitPattern>
+				<unitPattern count="few">{0} mmol/L</unitPattern>
+				<unitPattern count="many">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>eitem</displayName>
@@ -12232,13 +12232,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} eitem</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rhan/miliwn</displayName>
+				<unitPattern count="zero">{0} ppm</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="two">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="many">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -12250,31 +12250,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>permille</displayName>
+				<unitPattern count="zero">{0}‰</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="two">{0}‰</unitPattern>
+				<unitPattern count="few">{0}‰</unitPattern>
+				<unitPattern count="many">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>permyriad</displayName>
+				<unitPattern count="zero">{0}‱</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>môl</displayName>
+				<unitPattern count="zero">{0} môl</unitPattern>
+				<unitPattern count="one">{0} môl</unitPattern>
+				<unitPattern count="two">{0} môl</unitPattern>
+				<unitPattern count="few">{0} môl</unitPattern>
+				<unitPattern count="many">{0} môl</unitPattern>
+				<unitPattern count="other">{0} môl</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>L/km</displayName>
@@ -12295,31 +12295,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="zero">{0} mpg</unitPattern>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="two">{0} mpg</unitPattern>
+				<unitPattern count="few">{0} mpg</unitPattern>
+				<unitPattern count="many">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>milltir/gal Imp.</displayName>
+				<unitPattern count="zero">{0} mpg Imp.</unitPattern>
 				<unitPattern count="one">{0}m/gUK</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} mpg Imp.</unitPattern>
+				<unitPattern count="few">{0} mpg Imp.</unitPattern>
+				<unitPattern count="many">{0} mpg Imp.</unitPattern>
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PByte</displayName>
+				<unitPattern count="zero">{0} PB</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="two">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="many">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TBeit</displayName>
@@ -12331,13 +12331,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="zero">{0} Tb</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="two">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="many">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>GBeit</displayName>
@@ -12359,47 +12359,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MB</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MB</unitPattern>
 				<unitPattern count="one">{0}MB</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="many">{0} MB</unitPattern>
 				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mbit</displayName>
+				<unitPattern count="zero">{0} Mb</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="two">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="many">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kBeit</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kB</unitPattern>
 				<unitPattern count="one">{0}kB</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="many">{0} kB</unitPattern>
 				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kb</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kb</unitPattern>
 				<unitPattern count="one">{0}kb</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="many">{0} kb</unitPattern>
 				<unitPattern count="other">{0}kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} beit</unitPattern>
 				<unitPattern count="one">{0}B</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} feit</unitPattern>
+				<unitPattern count="few">{0} beit</unitPattern>
+				<unitPattern count="many">{0} beit</unitPattern>
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
@@ -12421,13 +12421,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}c</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>deg</displayName>
+				<unitPattern count="zero">{0} deg</unitPattern>
+				<unitPattern count="one">{0} deg</unitPattern>
+				<unitPattern count="two">{0} degawd</unitPattern>
+				<unitPattern count="few">{0} deg</unitPattern>
+				<unitPattern count="many">{0} deg</unitPattern>
+				<unitPattern count="other">{0} deg</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>bl</displayName>
@@ -12461,11 +12461,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-week">
 				<displayName>ws</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ws</unitPattern>
 				<unitPattern count="one">{0}w</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} ws</unitPattern>
+				<unitPattern count="few">{0} ws</unitPattern>
+				<unitPattern count="many">{0} ws</unitPattern>
 				<unitPattern count="other">{0}w</unitPattern>
 				<perUnitPattern>{0}/w</perUnitPattern>
 			</unit>
@@ -12519,22 +12519,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="zero">{0} μs</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="two">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="many">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="zero">{0} ns</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="two">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="many">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amp</displayName>
@@ -12618,53 +12618,53 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW-awr</displayName>
+				<unitPattern count="zero">{0} kW-awr</unitPattern>
+				<unitPattern count="one">{0} kW-awr</unitPattern>
+				<unitPattern count="two">{0} kW-awr</unitPattern>
+				<unitPattern count="few">{0} kW-awr</unitPattern>
+				<unitPattern count="many">{0} kW-awr</unitPattern>
+				<unitPattern count="other">{0} kW-awr</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>electronfolt</displayName>
+				<unitPattern count="zero">{0} eV</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="two">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="zero">{0} Btu</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="two">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="zero">{0} US therm</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
+				<unitPattern count="many">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} lbf</unitPattern>
 				<unitPattern count="one">{0}lbf</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
 				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} N</unitPattern>
 				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="two">{0} N</unitPattern>
 				<unitPattern count="few">{0} N</unitPattern>
@@ -12672,12 +12672,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="zero">{0} kWh/100km</unitPattern>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -12717,85 +12717,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="zero">{0} em</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="two">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="many">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>picseli</displayName>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapicseli</displayName>
+				<unitPattern count="zero">{0} MP</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="many">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="zero">{0} ppcm</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="zero">{0} ppi</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="zero">{0} ppcm</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="zero">{0} ppi</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>picseli</displayName>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} ddot</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="zero">{0} R⊕</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -12938,13 +12938,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}u.s.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ystadenni</displayName>
+				<unitPattern count="zero">{0} yst</unitPattern>
+				<unitPattern count="one">{0} yst</unitPattern>
+				<unitPattern count="two">{0} yst</unitPattern>
+				<unitPattern count="few">{0} yst</unitPattern>
+				<unitPattern count="many">{0} yst</unitPattern>
+				<unitPattern count="other">{0} yst</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>gwrhydau</displayName>
@@ -12974,21 +12974,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="zero">{0} pt</unitPattern>
 				<unitPattern count="one">{0}pt</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="many">{0} pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} R☉</unitPattern>
 				<unitPattern count="one">{0}R☉</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -13001,30 +13001,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="zero">{0} cd</unitPattern>
 				<unitPattern count="one">{0}cd</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="zero">{0} lm</unitPattern>
 				<unitPattern count="one">{0}lm</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} L☉</unitPattern>
 				<unitPattern count="one">{0}L☉</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -13038,11 +13038,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kg</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
+				<unitPattern count="two">{0} kg</unitPattern>
+				<unitPattern count="few">{0} kg</unitPattern>
+				<unitPattern count="many">{0} kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
 				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
@@ -13075,13 +13075,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="zero">{0} tn</unitPattern>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="two">{0} tn</unitPattern>
+				<unitPattern count="few">{0} tn</unitPattern>
+				<unitPattern count="many">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>stôn</displayName>
@@ -13113,13 +13113,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/owns</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="zero">{0} oz t</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="two">{0} oz t</unitPattern>
+				<unitPattern count="few">{0} oz t</unitPattern>
+				<unitPattern count="many">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>carat</displayName>
@@ -13131,40 +13131,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>daltonau</displayName>
+				<unitPattern count="zero">{0} Da</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>masau ddaear</displayName>
+				<unitPattern count="zero">{0} M⊕</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>masau solar</displayName>
+				<unitPattern count="zero">{0} M☉</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>graen</displayName>
+				<unitPattern count="zero">{0} graen</unitPattern>
+				<unitPattern count="one">{0} graen</unitPattern>
+				<unitPattern count="two">{0} raen</unitPattern>
+				<unitPattern count="few">{0} graen</unitPattern>
+				<unitPattern count="many">{0} graen</unitPattern>
+				<unitPattern count="other">{0} graen</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>GW</displayName>
@@ -13248,13 +13248,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="zero">{0} bar</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="two">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="many">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -13266,21 +13266,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="zero">{0} atm</unitPattern>
 				<unitPattern count="one">{0}atm</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="zero">{0} Pa</unitPattern>
 				<unitPattern count="one">{0}Pa</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -13293,22 +13293,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="zero">{0} kPa</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="two">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="zero">{0} MPa</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="two">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -13358,11 +13358,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
 				<unitPattern count="zero">{0}°</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°C</unitPattern>
+				<unitPattern count="two">{0}°C</unitPattern>
+				<unitPattern count="few">{0}°C</unitPattern>
+				<unitPattern count="many">{0}°C</unitPattern>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>°F</displayName>
@@ -13383,21 +13383,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="zero">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="one">{0}lbf⋅ft</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="zero">{0} N⋅m</unitPattern>
 				<unitPattern count="one">{0}N⋅m</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
+				<unitPattern count="many">{0} N⋅m</unitPattern>
 				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -13439,22 +13439,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>llathenni³</displayName>
+				<unitPattern count="zero">{0} llath³</unitPattern>
+				<unitPattern count="one">{0} llathen³</unitPattern>
+				<unitPattern count="two">{0} lath³</unitPattern>
+				<unitPattern count="few">{0} llath³</unitPattern>
+				<unitPattern count="many">{0} llath³</unitPattern>
+				<unitPattern count="other">{0} llath³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>troedfedd³</displayName>
+				<unitPattern count="zero">{0} tr³</unitPattern>
+				<unitPattern count="one">{0} tr³</unitPattern>
+				<unitPattern count="two">{0} tr³</unitPattern>
+				<unitPattern count="few">{0} tr³</unitPattern>
+				<unitPattern count="many">{0} tr³</unitPattern>
+				<unitPattern count="other">{0} tr³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>in³</displayName>
@@ -13491,7 +13491,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} L</unitPattern>
 				<unitPattern count="many">{0} L</unitPattern>
 				<unitPattern count="other">{0} L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>dL</displayName>
@@ -13521,40 +13521,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="zero">{0} mpt</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="two">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="many">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cwpanaid metrig</displayName>
+				<unitPattern count="zero">{0} mc</unitPattern>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="two">{0} mc</unitPattern>
+				<unitPattern count="few">{0} mc</unitPattern>
+				<unitPattern count="many">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>erw tr</displayName>
+				<unitPattern count="zero">{0} erw tr</unitPattern>
+				<unitPattern count="one">{0} erw tr</unitPattern>
+				<unitPattern count="two">{0} erw tr</unitPattern>
+				<unitPattern count="few">{0} erw tr</unitPattern>
+				<unitPattern count="many">{0} erw tr</unitPattern>
+				<unitPattern count="other">{0} erw tr</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bwsielau</displayName>
+				<unitPattern count="zero">{0} bw</unitPattern>
+				<unitPattern count="one">{0} bw</unitPattern>
+				<unitPattern count="two">{0} bw</unitPattern>
+				<unitPattern count="few">{0} bw</unitPattern>
+				<unitPattern count="many">{0} bw</unitPattern>
+				<unitPattern count="other">{0} bw</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>gal</displayName>
@@ -13568,111 +13568,111 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>Imp gal</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} gal Imp.</unitPattern>
 				<unitPattern count="one">{0}galIm</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} gal Imp.</unitPattern>
+				<unitPattern count="few">{0} gal Imp.</unitPattern>
+				<unitPattern count="many">{0} gal Imp.</unitPattern>
 				<unitPattern count="other">{0}galIm</unitPattern>
 				<perUnitPattern>{0}/galIm</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="zero">{0} qt</unitPattern>
 				<unitPattern count="one">{0}qt</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} qt</unitPattern>
+				<unitPattern count="few">{0} qt</unitPattern>
+				<unitPattern count="many">{0} qt</unitPattern>
 				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pt</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} pt</unitPattern>
 				<unitPattern count="one">{0}pt</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="many">{0} pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>cwpan</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} c</unitPattern>
 				<unitPattern count="one">{0}c</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} c</unitPattern>
+				<unitPattern count="few">{0} c</unitPattern>
+				<unitPattern count="many">{0} c</unitPattern>
 				<unitPattern count="other">{0}c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="zero">{0} fl oz</unitPattern>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="two">{0} fl oz</unitPattern>
+				<unitPattern count="few">{0} fl oz</unitPattern>
+				<unitPattern count="many">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="zero">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="few">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="many">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="zero">{0} tbsp</unitPattern>
 				<unitPattern count="one">{0}tbsp</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} tbsp</unitPattern>
+				<unitPattern count="few">{0} tbsp</unitPattern>
+				<unitPattern count="many">{0} tbsp</unitPattern>
 				<unitPattern count="other">{0}tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="zero">{0} tsp</unitPattern>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="two">{0} tsp</unitPattern>
+				<unitPattern count="few">{0} tsp</unitPattern>
+				<unitPattern count="many">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>barel</displayName>
+				<unitPattern count="zero">{0} bbl</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="two">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="many">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="zero">{0} dstspn</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="two">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
+				<unitPattern count="many">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>dsp Imp</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} dstspn Imp</unitPattern>
 				<unitPattern count="one">{0}dsp-Imp</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dstspn Imp</unitPattern>
+				<unitPattern count="few">{0} dstspn Imp</unitPattern>
+				<unitPattern count="many">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>dr</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} diferyn</unitPattern>
 				<unitPattern count="one">{0}dr</unitPattern>
 				<unitPattern count="two">{0} diferyn</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} diferyn</unitPattern>
+				<unitPattern count="many">{0} diferyn</unitPattern>
 				<unitPattern count="other">{0}dr</unitPattern>
 			</unit>
 			<unit type="volume-dram">
@@ -13685,21 +13685,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>joch</displayName>
+				<unitPattern count="zero">{0} joch</unitPattern>
 				<unitPattern count="one">{0}joch</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} joch</unitPattern>
+				<unitPattern count="few">{0} joch</unitPattern>
+				<unitPattern count="many">{0} joch</unitPattern>
 				<unitPattern count="other">{0}joch</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<displayName>pinsiad</displayName>
+				<unitPattern count="zero">{0} pinsiad</unitPattern>
 				<unitPattern count="one">{0}pn</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} binsiad</unitPattern>
+				<unitPattern count="few">{0} phinsiad</unitPattern>
+				<unitPattern count="many">{0} pinsiad</unitPattern>
 				<unitPattern count="other">{0}pn</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
@@ -13743,16 +13743,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} neu {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} neu {1}</listPatternPart>
+			<listPatternPart type="2">{0} neu {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} neu {1}</listPatternPart>
+			<listPatternPart type="2">{0} neu {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -593,9 +593,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="zh">kinesisk</language>
 			<language type="zh" alt="menu">mandarin (Kina)</language>
 			<language type="zh_Hans">forenklet kinesisk</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">forenklet kinesisk</language>
 			<language type="zh_Hant">traditionelt kinesisk</language>
-			<language type="zh_Hant" alt="long">↑↑↑</language>
+			<language type="zh_Hant" alt="long">traditionelt kinesisk</language>
 			<language type="zu">zulu</language>
 			<language type="zun">zuni</language>
 			<language type="zxx">intet sprogligt indhold</language>
@@ -891,7 +891,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="FR">Frankrig</territory>
 			<territory type="GA">Gabon</territory>
 			<territory type="GB">Storbritannien</territory>
-			<territory type="GB" alt="short">↑↑↑</territory>
+			<territory type="GB" alt="short">Storbritannien</territory>
 			<territory type="GD">Grenada</territory>
 			<territory type="GE">Georgien</territory>
 			<territory type="GF">Fransk Guyana</territory>
@@ -1049,7 +1049,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunesien</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Tyrkiet</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Tyrkiet</territory>
 			<territory type="TT">Trinidad og Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1482,7 +1482,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1490,7 +1490,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1498,7 +1498,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1506,7 +1506,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1801,12 +1801,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">lør.</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
+							<day type="sun">S</day>
+							<day type="mon">M</day>
+							<day type="tue">T</day>
 							<day type="wed">O</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
+							<day type="thu">T</day>
+							<day type="fri">F</day>
 							<day type="sat">L</day>
 						</dayWidth>
 						<dayWidth type="short">
@@ -1830,13 +1830,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
+							<day type="sun">søn.</day>
+							<day type="mon">man.</day>
 							<day type="tue">tirs.</day>
-							<day type="wed">↑↑↑</day>
+							<day type="wed">ons.</day>
 							<day type="thu">tors.</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="fri">fre.</day>
+							<day type="sat">lør.</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">↑↑↑</day>
@@ -2069,7 +2069,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2077,7 +2077,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3095,7 +3095,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>sek.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">nu</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">om {0} sek.</relativeTimePattern>
 					<relativeTimePattern count="other">om {0} sek.</relativeTimePattern>
@@ -3107,7 +3107,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>s</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">nu</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">om {0} sek.</relativeTimePattern>
 					<relativeTimePattern count="other">om {0} sek.</relativeTimePattern>
@@ -5602,7 +5602,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="ANG">
 				<displayName>Nederlandske Antiller-gylden</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Nederlandske Antiller-gylden</displayName>
 				<displayName count="other">Nederlandske Antiller-gylden</displayName>
 				<symbol>ANG</symbol>
 			</currency>
@@ -7381,22 +7381,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1>kvadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kvadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">kvadrat{0}s</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="common">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="common">kvadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="common" case="genitive">kvadrat{0}s</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kvadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="genitive">kvadrat{0}s</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="common">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="common">kvadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="common" case="genitive">kvadrat{0}s</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">kubik{0}s</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="common">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="common">kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="common" case="genitive">kubik{0}s</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="genitive">kubik{0}s</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="common">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="common">kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="common" case="genitive">kubik{0}s</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7524,9 +7524,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} pr. kvadrattomme</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<gender>common</gender>
@@ -7583,18 +7583,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="one" case="genitive">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mols</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mols</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7910,19 +7910,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} elektronvolt</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<gender>common</gender>
@@ -8198,9 +8198,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<gender>neuter</gender>
@@ -8283,9 +8283,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<gender>common</gender>
@@ -8367,10 +8367,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bars</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 				<unitPattern count="other" case="genitive">{0} bars</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -8479,9 +8479,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="genitive">{0} kelvins</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<gender>common</gender>
@@ -8654,7 +8654,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="one">{0} Imp. fluid ounce</unitPattern>
 				<unitPattern count="other">{0} Imp. fluid ounces</unitPattern>
 			</unit>
@@ -8701,7 +8701,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>jigger</displayName>
 				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
@@ -8815,12 +8815,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8913,7 +8913,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -8958,7 +8958,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -9161,22 +9161,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronvolt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
@@ -9186,7 +9186,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -9211,38 +9211,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>prik</displayName>
@@ -9251,7 +9251,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9336,7 +9336,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
@@ -9361,7 +9361,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>solradier</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9371,17 +9371,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9418,7 +9418,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -9445,17 +9445,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>solmasser</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -9510,7 +9510,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -9525,7 +9525,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -9535,12 +9535,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -9585,12 +9585,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -9715,7 +9715,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -9755,7 +9755,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -9838,64 +9838,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>G-kraft</displayName>
 				<unitPattern count="one">{0}G</unitPattern>
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>omdr.</displayName>
+				<unitPattern count="one">{0} omdr.</unitPattern>
+				<unitPattern count="other">{0} omdr.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>radian</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} radian</unitPattern>
+				<unitPattern count="other">{0} radian</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>gr.</displayName>
@@ -9903,53 +9903,53 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>buemin.</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>buesek.</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0}km²</unitPattern>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektar</displayName>
 				<unitPattern count="one">{0}ha</unitPattern>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>acre</displayName>
 				<unitPattern count="one">{0}ac</unitPattern>
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>fod²</displayName>
@@ -9957,35 +9957,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fod²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="one">{0} kt.</unitPattern>
+				<unitPattern count="other">{0} kt.</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>mg/dL</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/L</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>enhed</displayName>
 				<unitPattern count="one">{0} enhed</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} enheder</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
@@ -9998,24 +9998,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -10023,24 +10023,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil/eng. gal</displayName>
 				<unitPattern count="one">{0}mpgUK</unitPattern>
 				<unitPattern count="other">{0}mpgUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>Tb</displayName>
@@ -10048,19 +10048,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gbit</displayName>
+				<unitPattern count="one">{0} Gbit</unitPattern>
+				<unitPattern count="other">{0} Gbit</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mb</displayName>
@@ -10068,9 +10068,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kb</displayName>
@@ -10078,14 +10078,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>årh.</displayName>
@@ -10093,9 +10093,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} årh.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>årti</displayName>
+				<unitPattern count="one">{0} årti</unitPattern>
+				<unitPattern count="other">{0} årtier</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>år</displayName>
@@ -10151,159 +10151,159 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>μs</displayName>
 				<unitPattern count="one">{0}μs</unitPattern>
 				<unitPattern count="other">{0}μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ns</displayName>
 				<unitPattern count="one">{0}ns</unitPattern>
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joule</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>prik</displayName>
+				<unitPattern count="one">{0} p</unitPattern>
+				<unitPattern count="other">{0} p</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -10339,12 +10339,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>nm</displayName>
 				<unitPattern count="one">{0}nm</unitPattern>
 				<unitPattern count="other">{0}nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0}pm</unitPattern>
 				<unitPattern count="other">{0}pm</unitPattern>
 			</unit>
@@ -10371,7 +10371,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/tomme</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>pc</displayName>
 				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
@@ -10386,14 +10386,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>favne</displayName>
+				<unitPattern count="one">{0} favn</unitPattern>
+				<unitPattern count="other">{0} favne</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>sm</displayName>
@@ -10412,33 +10412,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
@@ -10453,17 +10453,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>tn</displayName>
 				<unitPattern count="one">{0} tn</unitPattern>
 				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
@@ -10480,52 +10480,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>oz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
 				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt.</displayName>
+				<unitPattern count="one">{0} kt.</unitPattern>
+				<unitPattern count="other">{0} kt.</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>solmasser</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gran</displayName>
+				<unitPattern count="one">{0} gran</unitPattern>
+				<unitPattern count="other">{0} gran</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
@@ -10535,12 +10535,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hk</displayName>
 				<unitPattern count="one">{0}hk</unitPattern>
 				<unitPattern count="other">{0}hk</unitPattern>
 			</unit>
@@ -10560,9 +10560,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -10570,14 +10570,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -10585,14 +10585,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/t</displayName>
@@ -10610,9 +10610,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>knob</displayName>
+				<unitPattern count="one">{0} knob</unitPattern>
+				<unitPattern count="other">{0} knob</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
@@ -10635,187 +10635,187 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">{0}m³</unitPattern>
 				<unitPattern count="other">{0}m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0}cm³</unitPattern>
 				<unitPattern count="other">{0}cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft³</displayName>
 				<unitPattern count="one">{0} fod³</unitPattern>
 				<unitPattern count="other">{0} fod³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in³</displayName>
 				<unitPattern count="one">{0} in³</unitPattern>
 				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ML</displayName>
 				<unitPattern count="one">{0}ML</unitPattern>
 				<unitPattern count="other">{0}ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>liter</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0}dl</unitPattern>
 				<unitPattern count="other">{0}dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpt</displayName>
 				<unitPattern count="one">{0} mpt</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>skp.</displayName>
+				<unitPattern count="one">{0} skp.</unitPattern>
+				<unitPattern count="other">{0} skp.</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>eng. gal</displayName>
+				<unitPattern count="one">{0} eng. gal</unitPattern>
+				<unitPattern count="other">{0} eng. gal</unitPattern>
+				<perUnitPattern>{0} eng. gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cups</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>spsk.</displayName>
+				<unitPattern count="one">{0} spsk.</unitPattern>
+				<unitPattern count="other">{0} spsk.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsk.</displayName>
+				<unitPattern count="one">{0} tsk.</unitPattern>
+				<unitPattern count="other">{0} tsk.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>td.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} td.</unitPattern>
+				<unitPattern count="other">{0} tdr.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dsk.</displayName>
+				<unitPattern count="one">{0} dsk.</unitPattern>
+				<unitPattern count="other">{0} dsk.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>brit. dsk.</displayName>
 				<unitPattern count="one">{0}brit.dsk.</unitPattern>
 				<unitPattern count="other">{0}brit.dsk.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dråbe</displayName>
+				<unitPattern count="one">{0} dråbe</unitPattern>
+				<unitPattern count="other">{0} dråber</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>br. fl. dr.</displayName>
 				<unitPattern count="one">{0}br.fl.dr.</unitPattern>
 				<unitPattern count="other">{0}br.fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>knsp.</displayName>
+				<unitPattern count="one">{0} knsp.</unitPattern>
+				<unitPattern count="other">{0} knsp.</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>britisk qt</displayName>
 				<unitPattern count="one">{0} br. qt.</unitPattern>
 				<unitPattern count="other">{0} br. qt.</unitPattern>
 			</unit>
@@ -10851,22 +10851,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} eller {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} el. {1}</listPatternPart>
 			<listPatternPart type="2">{0} el. {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} el. {1}</listPatternPart>
 			<listPatternPart type="2">{0} el. {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} og {1}</listPatternPart>
+			<listPatternPart type="2">{0} og {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -11147,7 +11147,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname}, {given} {given2-initial}, {credentials}</namePattern>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -125,7 +125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">Cheyenne</language>
 			<language type="ckb">Zentralkurdisch</language>
 			<language type="ckb" alt="menu">Kurdisch (Sorani)</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">Zentralkurdisch</language>
 			<language type="clc">Chilcotin</language>
 			<language type="co">Korsisch</language>
 			<language type="cop">Koptisch</language>
@@ -1151,7 +1151,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunesien</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Türkei</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Türkei</territory>
 			<territory type="TT">Trinidad und Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1774,7 +1774,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1782,7 +1782,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2079,13 +2079,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">Sa.</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
+							<day type="sun">S</day>
+							<day type="mon">M</day>
 							<day type="tue">D</day>
 							<day type="wed">M</day>
 							<day type="thu">D</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="fri">F</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">So.</day>
@@ -2202,8 +2202,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">Mitternacht</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 							<dayPeriod type="morning1">morgens</dayPeriod>
 							<dayPeriod type="morning2">vorm.</dayPeriod>
 							<dayPeriod type="afternoon1">mittags</dayPeriod>
@@ -2237,8 +2237,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">Mitternacht</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 							<dayPeriod type="morning1">Morgen</dayPeriod>
 							<dayPeriod type="morning2">Vorm.</dayPeriod>
 							<dayPeriod type="afternoon1">Mittag</dayPeriod>
@@ -2353,7 +2353,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2361,7 +2361,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2627,17 +2627,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="1" draft="contributed">Tischri</month>
 							<month type="2" draft="contributed">Cheschwan</month>
 							<month type="3" draft="contributed">Kislew</month>
-							<month type="4" draft="contributed">↑↑↑</month>
+							<month type="4" draft="contributed">Tevet</month>
 							<month type="5" draft="contributed">Schevat</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
+							<month type="6" draft="contributed">Adar I</month>
+							<month type="7" draft="contributed">Adar</month>
+							<month type="7" yeartype="leap" draft="contributed">Adar II</month>
+							<month type="8" draft="contributed">Nisan</month>
 							<month type="9" draft="contributed">Ijjar</month>
 							<month type="10" draft="contributed">Siwan</month>
 							<month type="11" draft="contributed">Tammus</month>
 							<month type="12" draft="contributed">Aw</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -2776,16 +2776,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12" draft="contributed">Dhuʻl-H.</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Muharram</month>
+							<month type="2" draft="contributed">Safar</month>
+							<month type="3" draft="contributed">Rabiʻ I</month>
+							<month type="4" draft="contributed">Rabiʻ II</month>
 							<month type="5" draft="contributed">Dschumada I</month>
 							<month type="6" draft="contributed">Dschumada II</month>
 							<month type="7" draft="contributed">Radschab</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
+							<month type="8" draft="contributed">Shaʻban</month>
+							<month type="9" draft="contributed">Ramadan</month>
+							<month type="10" draft="contributed">Shawwal</month>
 							<month type="11" draft="contributed">Dhu l-qaʿda</month>
 							<month type="12" draft="contributed">Dhu l-Hiddscha</month>
 						</monthWidth>
@@ -5989,7 +5989,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -7278,7 +7278,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="PGK">
 				<displayName>Papua-neuguineischer Kina</displayName>
 				<displayName count="one">Papua-neuguineischer Kina</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Papua-neuguineischer Kina</displayName>
 				<symbol>PGK</symbol>
 			</currency>
 			<currency type="PHP">
@@ -8040,59 +8040,59 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>Quadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">Quadrat{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="dative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="dative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">Quadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">Quadrat{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="dative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="dative">Quadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">Quadrat{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>Kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">Kubik{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="dative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="dative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">Kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">Kubik{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="dative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="dative">Kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">Kubik{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>feminine</gender>
@@ -8122,21 +8122,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>Umdrehung</displayName>
 				<unitPattern count="one">{0} Umdrehung</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Umdrehung</unitPattern>
+				<unitPattern count="one" case="dative">{0} Umdrehung</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Umdrehung</unitPattern>
 				<unitPattern count="other">{0} Umdrehungen</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Umdrehungen</unitPattern>
+				<unitPattern count="other" case="dative">{0} Umdrehungen</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Umdrehungen</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>masculine</gender>
 				<displayName>Radiant</displayName>
 				<unitPattern count="one">{0} Radiant</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Radiant</unitPattern>
+				<unitPattern count="one" case="dative">{0} Radiant</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Radiant</unitPattern>
 				<unitPattern count="other">{0} Radiant</unitPattern>
 				<unitPattern count="other" case="accusative">{0} Radiant</unitPattern>
 				<unitPattern count="other" case="dative">{0} Radiant</unitPattern>
@@ -8158,25 +8158,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>Winkelminuten</displayName>
 				<unitPattern count="one">{0} Winkelminute</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Winkelminute</unitPattern>
+				<unitPattern count="one" case="dative">{0} Winkelminute</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Winkelminute</unitPattern>
 				<unitPattern count="other">{0} Winkelminuten</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Winkelminuten</unitPattern>
+				<unitPattern count="other" case="dative">{0} Winkelminuten</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Winkelminuten</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>feminine</gender>
 				<displayName>Winkelsekunden</displayName>
 				<unitPattern count="one">{0} Winkelsekunde</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Winkelsekunde</unitPattern>
+				<unitPattern count="one" case="dative">{0} Winkelsekunde</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Winkelsekunde</unitPattern>
 				<unitPattern count="other">{0} Winkelsekunden</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Winkelsekunden</unitPattern>
+				<unitPattern count="other" case="dative">{0} Winkelsekunden</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Winkelsekunden</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>masculine</gender>
@@ -8286,13 +8286,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>Karat</displayName>
 				<unitPattern count="one">{0} Karat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Karat</unitPattern>
+				<unitPattern count="one" case="dative">{0} Karat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} Karats</unitPattern>
 				<unitPattern count="other">{0} Karat</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Karat</unitPattern>
+				<unitPattern count="other" case="dative">{0} Karat</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Karat</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>Milligramm pro Deziliter</displayName>
@@ -8303,25 +8303,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">neuter</gender>
 				<displayName>Millimol pro Liter</displayName>
 				<unitPattern count="one">{0} Millimol pro Liter</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Millimol pro Liter</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Millimol pro Liter</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Millimol pro Liter</unitPattern>
 				<unitPattern count="other">{0} Millimol pro Liter</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Millimol pro Liter</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Millimol pro Liter</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Millimol pro Liter</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Elemente</displayName>
 				<unitPattern count="one">{0} Element</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Element</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Element</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Elements</unitPattern>
 				<unitPattern count="other">{0} Elemente</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Elemente</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Elementen</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Elemente</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>neuter</gender>
@@ -8351,13 +8351,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>Promille</displayName>
 				<unitPattern count="one">{0} Promille</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Promille</unitPattern>
+				<unitPattern count="one" case="dative">{0} Promille</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Promille</unitPattern>
 				<unitPattern count="other">{0} Promille</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Promille</unitPattern>
+				<unitPattern count="other" case="dative">{0} Promille</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Promille</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>neuter</gender>
@@ -8387,13 +8387,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">masculine</gender>
 				<displayName>Liter pro Kilometer</displayName>
 				<unitPattern count="one">{0} Liter pro Kilometer</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Liter pro Kilometer</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Liter pro Kilometer</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Liters pro Kilometer</unitPattern>
 				<unitPattern count="other">{0} Liter pro Kilometer</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Liter pro Kilometer</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Litern pro Kilometer</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Liter pro Kilometer</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>masculine</gender>
@@ -8411,37 +8411,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>Meilen pro Gallone</displayName>
 				<unitPattern count="one">{0} Meile pro Gallone</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Meile pro Gallone</unitPattern>
+				<unitPattern count="one" case="dative">{0} Meile pro Gallone</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Meile pro Gallone</unitPattern>
 				<unitPattern count="other">{0} Meilen pro Gallone</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Meilen pro Gallone</unitPattern>
+				<unitPattern count="other" case="dative">{0} Meilen pro Gallone</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Meilen pro Gallone</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<gender>feminine</gender>
 				<displayName>Meilen pro Imp. Gallone</displayName>
 				<unitPattern count="one">{0} Meile pro Imp. Gallone</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Meile pro Imp. Gallone</unitPattern>
+				<unitPattern count="one" case="dative">{0} Meile pro Imp. Gallone</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Meile pro Imp. Gallone</unitPattern>
 				<unitPattern count="other">{0} Meilen pro Imp. Gallone</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Meilen pro Imp. Gallone</unitPattern>
+				<unitPattern count="other" case="dative">{0} Meilen pro Imp. Gallone</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Meilen pro Imp. Gallone</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Petabytes</displayName>
 				<unitPattern count="one">{0} Petabyte</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Petabyte</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Petabyte</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Petabyte</unitPattern>
 				<unitPattern count="other">{0} Petabyte</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Petabyte</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Petabyte</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Petabyte</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>neuter</gender>
@@ -8449,7 +8449,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Terabyte</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Terabyte</unitPattern>
 				<unitPattern count="one" case="dative">{0} Terabyte</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Terabyte</unitPattern>
 				<unitPattern count="other">{0} Terabyte</unitPattern>
 				<unitPattern count="other" case="accusative">{0} Terabyte</unitPattern>
 				<unitPattern count="other" case="dative">{0} Terabyte</unitPattern>
@@ -8459,13 +8459,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">neuter</gender>
 				<displayName>Terabits</displayName>
 				<unitPattern count="one">{0} Terabit</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Terabit</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Terabit</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Terabit</unitPattern>
 				<unitPattern count="other">{0} Terabit</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Terabit</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Terabit</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Terabit</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>neuter</gender>
@@ -8473,7 +8473,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Gigabyte</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Gigabyte</unitPattern>
 				<unitPattern count="one" case="dative">{0} Gigabyte</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Gigabyte</unitPattern>
 				<unitPattern count="other">{0} Gigabyte</unitPattern>
 				<unitPattern count="other" case="accusative">{0} Gigabyte</unitPattern>
 				<unitPattern count="other" case="dative">{0} Gigabyte</unitPattern>
@@ -8485,7 +8485,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Gigabit</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Gigabit</unitPattern>
 				<unitPattern count="one" case="dative">{0} Gigabit</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Gigabit</unitPattern>
 				<unitPattern count="other">{0} Gigabit</unitPattern>
 				<unitPattern count="other" case="accusative">{0} Gigabit</unitPattern>
 				<unitPattern count="other" case="dative">{0} Gigabit</unitPattern>
@@ -8509,7 +8509,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Megabit</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Megabit</unitPattern>
 				<unitPattern count="one" case="dative">{0} Megabit</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Megabit</unitPattern>
 				<unitPattern count="other">{0} Megabit</unitPattern>
 				<unitPattern count="other" case="accusative">{0} Megabit</unitPattern>
 				<unitPattern count="other" case="dative">{0} Megabit</unitPattern>
@@ -8521,7 +8521,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Kilobyte</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Kilobyte</unitPattern>
 				<unitPattern count="one" case="dative">{0} Kilobyte</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Kilobyte</unitPattern>
 				<unitPattern count="other">{0} Kilobyte</unitPattern>
 				<unitPattern count="other" case="accusative">{0} Kilobyte</unitPattern>
 				<unitPattern count="other" case="dative">{0} Kilobyte</unitPattern>
@@ -8533,7 +8533,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Kilobit</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Kilobit</unitPattern>
 				<unitPattern count="one" case="dative">{0} Kilobit</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Kilobit</unitPattern>
 				<unitPattern count="other">{0} Kilobit</unitPattern>
 				<unitPattern count="other" case="accusative">{0} Kilobit</unitPattern>
 				<unitPattern count="other" case="dative">{0} Kilobit</unitPattern>
@@ -8545,7 +8545,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Byte</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Byte</unitPattern>
 				<unitPattern count="one" case="dative">{0} Byte</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Byte</unitPattern>
 				<unitPattern count="other">{0} Byte</unitPattern>
 				<unitPattern count="other" case="accusative">{0} Byte</unitPattern>
 				<unitPattern count="other" case="dative">{0} Byte</unitPattern>
@@ -8567,25 +8567,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>Jahrhunderte</displayName>
 				<unitPattern count="one">{0} Jahrhundert</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Jahrhundert</unitPattern>
+				<unitPattern count="one" case="dative">{0} Jahrhundert</unitPattern>
 				<unitPattern count="one" case="genitive">{0} Jahrhunderts</unitPattern>
 				<unitPattern count="other">{0} Jahrhunderte</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Jahrhunderte</unitPattern>
 				<unitPattern count="other" case="dative">{0} Jahrhunderten</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Jahrhunderte</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>neuter</gender>
 				<displayName>Jahrzehnte</displayName>
 				<unitPattern count="one">{0} Jahrzehnt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Jahrzehnt</unitPattern>
+				<unitPattern count="one" case="dative">{0} Jahrzehnt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} Jahrzehnts</unitPattern>
 				<unitPattern count="other">{0} Jahrzehnte</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Jahrzehnte</unitPattern>
 				<unitPattern count="other" case="dative">{0} Jahrzehnten</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Jahrzehnte</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>neuter</gender>
@@ -8604,13 +8604,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>Quartale</displayName>
 				<unitPattern count="one">{0} Quartal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Quartal</unitPattern>
+				<unitPattern count="one" case="dative">{0} Quartal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} Quartals</unitPattern>
 				<unitPattern count="other">{0} Quartale</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Quartale</unitPattern>
 				<unitPattern count="other" case="dative">{0} Quartalen</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Quartale</unitPattern>
 				<perUnitPattern>{0}/Quartal</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
@@ -8706,73 +8706,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>Millisekunden</displayName>
 				<unitPattern count="one">{0} Millisekunde</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Millisekunde</unitPattern>
+				<unitPattern count="one" case="dative">{0} Millisekunde</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Millisekunde</unitPattern>
 				<unitPattern count="other">{0} Millisekunden</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Millisekunden</unitPattern>
+				<unitPattern count="other" case="dative">{0} Millisekunden</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Millisekunden</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>feminine</gender>
 				<displayName>Mikrosekunden</displayName>
 				<unitPattern count="one">{0} Mikrosekunde</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Mikrosekunde</unitPattern>
+				<unitPattern count="one" case="dative">{0} Mikrosekunde</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Mikrosekunde</unitPattern>
 				<unitPattern count="other">{0} Mikrosekunden</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Mikrosekunden</unitPattern>
+				<unitPattern count="other" case="dative">{0} Mikrosekunden</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Mikrosekunden</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>feminine</gender>
 				<displayName>Nanosekunden</displayName>
 				<unitPattern count="one">{0} Nanosekunde</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Nanosekunde</unitPattern>
+				<unitPattern count="one" case="dative">{0} Nanosekunde</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Nanosekunde</unitPattern>
 				<unitPattern count="other">{0} Nanosekunden</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Nanosekunden</unitPattern>
+				<unitPattern count="other" case="dative">{0} Nanosekunden</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Nanosekunden</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Ampere</displayName>
 				<unitPattern count="one">{0} Ampere</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Ampere</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Ampere</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Ampere</unitPattern>
 				<unitPattern count="other">{0} Ampere</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Ampere</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Ampere</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Ampere</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Milliampere</displayName>
 				<unitPattern count="one">{0} Milliampere</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Milliampere</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Milliampere</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Milliampere</unitPattern>
 				<unitPattern count="other">{0} Milliampere</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Milliampere</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Milliampere</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Milliampere</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Ohm</displayName>
 				<unitPattern count="one">{0} Ohm</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Ohm</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Ohm</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Ohms</unitPattern>
 				<unitPattern count="other">{0} Ohm</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Ohm</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Ohm</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Ohm</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>neuter</gender>
@@ -8802,13 +8802,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">feminine</gender>
 				<displayName>Kalorien</displayName>
 				<unitPattern count="one">{0} Kalorie</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Kalorie</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Kalorie</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Kalorie</unitPattern>
 				<unitPattern count="other">{0} Kalorien</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Kalorien</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Kalorien</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Kalorien</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<gender>feminine</gender>
@@ -8818,45 +8818,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} Kilokalorie</unitPattern>
 				<unitPattern count="one" case="genitive">{0} Kilokalorie</unitPattern>
 				<unitPattern count="other">{0} Kilokalorien</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Kilokalorien</unitPattern>
+				<unitPattern count="other" case="dative">{0} Kilokalorien</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Kilokalorien</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Kilojoule</displayName>
 				<unitPattern count="one">{0} Kilojoule</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Kilojoule</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Kilojoule</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Kilojoule</unitPattern>
 				<unitPattern count="other">{0} Kilojoule</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Kilojoule</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Kilojoule</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Kilojoule</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Joule</displayName>
 				<unitPattern count="one">{0} Joule</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Joule</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Joule</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Joule</unitPattern>
 				<unitPattern count="other">{0} Joule</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Joule</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Joule</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Joule</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender draft="contributed">feminine</gender>
 				<displayName>Kilowattstunden</displayName>
 				<unitPattern count="one">{0} Kilowattstunde</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Kilowattstunde</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Kilowattstunde</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Kilowattstunde</unitPattern>
 				<unitPattern count="other">{0} Kilowattstunden</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Kilowattstunden</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Kilowattstunden</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Kilowattstunden</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>Elektronenvolt</displayName>
@@ -8894,109 +8894,109 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">feminine</gender>
 				<displayName>Kilowattstunde pro 100 Kilometer</displayName>
 				<unitPattern count="one">{0} Kilowattstunde pro 100 Kilometer</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Kilowattstunde pro 100 Kilometer</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Kilowattstunde pro 100 Kilometer</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Kilowattstunde pro 100 Kilometer</unitPattern>
 				<unitPattern count="other">{0} Kilowattstunden pro 100 Kilometer</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Kilowattstunden pro 100 Kilometer</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Kilowattstunden pro 100 Kilometer</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Kilowattstunden pro 100 Kilometer</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Gigahertz</displayName>
 				<unitPattern count="one">{0} Gigahertz</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Gigahertz</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Gigahertz</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Gigahertz</unitPattern>
 				<unitPattern count="other">{0} Gigahertz</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Gigahertz</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Gigahertz</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Gigahertz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Megahertz</displayName>
 				<unitPattern count="one">{0} Megahertz</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Megahertz</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Megahertz</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Megahertz</unitPattern>
 				<unitPattern count="other">{0} Megahertz</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Megahertz</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Megahertz</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Megahertz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Kilohertz</displayName>
 				<unitPattern count="one">{0} Kilohertz</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Kilohertz</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Kilohertz</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Kilohertz</unitPattern>
 				<unitPattern count="other">{0} Kilohertz</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Kilohertz</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Kilohertz</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Kilohertz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Hertz</displayName>
 				<unitPattern count="one">{0} Hertz</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Hertz</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Hertz</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Hertz</unitPattern>
 				<unitPattern count="other">{0} Hertz</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Hertz</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Hertz</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Hertz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender draft="contributed">neuter</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Pixel</displayName>
 				<unitPattern count="one">{0} Pixel</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Pixel</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Pixel</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Pixels</unitPattern>
 				<unitPattern count="other">{0} Pixel</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Pixel</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Pixeln</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Pixel</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Megapixel</displayName>
 				<unitPattern count="one">{0} Megapixel</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Megapixel</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Megapixel</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Megapixels</unitPattern>
 				<unitPattern count="other">{0} Megapixel</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Megapixel</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Megapixeln</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Megapixel</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Pixel pro Zentimeter</displayName>
 				<unitPattern count="one">{0} Pixel pro Zentimeter</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Pixel pro Zentimeter</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Pixel pro Zentimeter</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Pixels pro Zentimeter</unitPattern>
 				<unitPattern count="other">{0} Pixel pro Zentimeter</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Pixel pro Zentimeter</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Pixeln pro Zentimeter</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Pixel pro Zentimeter</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>Pixel pro Inch</displayName>
@@ -9053,13 +9053,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">masculine</gender>
 				<displayName>Dezimeter</displayName>
 				<unitPattern count="one">{0} Dezimeter</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Dezimeter</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Dezimeter</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Dezimeters</unitPattern>
 				<unitPattern count="other">{0} Dezimeter</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Dezimeter</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Dezimetern</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Dezimeter</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>masculine</gender>
@@ -9090,25 +9090,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">masculine</gender>
 				<displayName>Mikrometer</displayName>
 				<unitPattern count="one">{0} Mikrometer</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Mikrometer</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Mikrometer</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Mikrometers</unitPattern>
 				<unitPattern count="other">{0} Mikrometer</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Mikrometer</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Mikrometern</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Mikrometer</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender draft="contributed">masculine</gender>
 				<displayName>Nanometer</displayName>
 				<unitPattern count="one">{0} Nanometer</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Nanometer</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Nanometer</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Nanometers</unitPattern>
 				<unitPattern count="other">{0} Nanometer</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Nanometer</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Nanometern</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Nanometer</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>masculine</gender>
@@ -9142,9 +9142,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} Yard</unitPattern>
 				<unitPattern count="one" case="genitive">{0} Yards</unitPattern>
 				<unitPattern count="other">{0} Yards</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Yards</unitPattern>
+				<unitPattern count="other" case="dative">{0} Yards</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Yards</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<gender>masculine</gender>
@@ -9213,11 +9213,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>skandinavische Meilen</displayName>
 				<unitPattern count="one">{0} skandinavische Meile</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} skandinavische Meile</unitPattern>
 				<unitPattern count="one" case="dative">{0} skandinavischen Meile</unitPattern>
 				<unitPattern count="one" case="genitive">{0} skandinavischen Meile</unitPattern>
 				<unitPattern count="other">{0} skandinavische Meilen</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} skandinavische Meilen</unitPattern>
 				<unitPattern count="other" case="dative">{0} skandinavischen Meilen</unitPattern>
 				<unitPattern count="other" case="genitive">{0} skandinavischen Meilen</unitPattern>
 			</unit>
@@ -9242,37 +9242,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>Lux</displayName>
 				<unitPattern count="one">{0} Lux</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Lux</unitPattern>
+				<unitPattern count="one" case="dative">{0} Lux</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Lux</unitPattern>
 				<unitPattern count="other">{0} Lux</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Lux</unitPattern>
+				<unitPattern count="other" case="dative">{0} Lux</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Lux</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
 				<displayName>Candela</displayName>
 				<unitPattern count="one">{0} Candela</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Candela</unitPattern>
+				<unitPattern count="one" case="dative">{0} Candela</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Candela</unitPattern>
 				<unitPattern count="other">{0} Candela</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Candela</unitPattern>
+				<unitPattern count="other" case="dative">{0} Candela</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Candela</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>neuter</gender>
 				<displayName>Lumen</displayName>
 				<unitPattern count="one">{0} Lumen</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Lumen</unitPattern>
+				<unitPattern count="one" case="dative">{0} Lumen</unitPattern>
 				<unitPattern count="one" case="genitive">{0} Lumens</unitPattern>
 				<unitPattern count="other">{0} Lumen</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Lumen</unitPattern>
+				<unitPattern count="other" case="dative">{0} Lumen</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Lumen</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<gender>feminine</gender>
@@ -9290,13 +9290,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">feminine</gender>
 				<displayName>Tonnen</displayName>
 				<unitPattern count="one">{0} Tonne</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Tonne</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Tonne</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Tonne</unitPattern>
 				<unitPattern count="other">{0} Tonnen</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Tonnen</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Tonnen</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Tonnen</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>neuter</gender>
@@ -9340,13 +9340,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">neuter</gender>
 				<displayName>Mikrogramm</displayName>
 				<unitPattern count="one">{0} Mikrogramm</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Mikrogramm</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Mikrogramm</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Mikrogramms</unitPattern>
 				<unitPattern count="other">{0} Mikrogramm</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Mikrogramm</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Mikrogramm</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Mikrogramm</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>Short Tons</displayName>
@@ -9393,25 +9393,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">neuter</gender>
 				<displayName>Karat</displayName>
 				<unitPattern count="one">{0} Karat</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Karat</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Karat</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Karats</unitPattern>
 				<unitPattern count="other">{0} Karat</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Karat</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Karat</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Karat</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<gender>neuter</gender>
 				<displayName>Dalton</displayName>
 				<unitPattern count="one">{0} Dalton</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Dalton</unitPattern>
+				<unitPattern count="one" case="dative">{0} Dalton</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Dalton</unitPattern>
 				<unitPattern count="other">{0} Dalton</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Dalton</unitPattern>
+				<unitPattern count="other" case="dative">{0} Dalton</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Dalton</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<gender>feminine</gender>
@@ -9453,13 +9453,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">neuter</gender>
 				<displayName>Gigawatt</displayName>
 				<unitPattern count="one">{0} Gigawatt</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Gigawatt</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Gigawatt</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Gigawatts</unitPattern>
 				<unitPattern count="other">{0} Gigawatt</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Gigawatt</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Gigawatt</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Gigawatt</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>neuter</gender>
@@ -9501,13 +9501,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">neuter</gender>
 				<displayName>Milliwatt</displayName>
 				<unitPattern count="one">{0} Milliwatt</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Milliwatt</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Milliwatt</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Milliwatts</unitPattern>
 				<unitPattern count="other">{0} Milliwatt</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Milliwatt</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Milliwatt</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Milliwatt</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>Pferdestärke</displayName>
@@ -9533,61 +9533,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">neuter</gender>
 				<displayName>Bar</displayName>
 				<unitPattern count="one">{0} Bar</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Bar</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Bar</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Bars</unitPattern>
 				<unitPattern count="other">{0} Bar</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Bar</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Bar</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Millibar</displayName>
 				<unitPattern count="one">{0} Millibar</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Millibar</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Millibar</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Millibars</unitPattern>
 				<unitPattern count="other">{0} Millibar</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Millibar</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Millibar</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Millibar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender draft="contributed">feminine</gender>
 				<displayName>Atmosphären</displayName>
 				<unitPattern count="one">{0} Atmosphäre</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Atmosphäre</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Atmosphäre</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} Atmosphäre</unitPattern>
 				<unitPattern count="other">{0} Atmosphären</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Atmosphären</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Atmosphären</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Atmosphären</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Pascal</displayName>
 				<unitPattern count="one">{0} Pascal</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Pascal</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Pascal</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Pascals</unitPattern>
 				<unitPattern count="other">{0} Pascal</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Pascal</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Pascal</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Pascal</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender draft="contributed">neuter</gender>
 				<displayName>Hektopascal</displayName>
 				<unitPattern count="one">{0} Hektopascal</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Hektopascal</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Hektopascal</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Hektopascals</unitPattern>
 				<unitPattern count="other">{0} Hektopascal</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Hektopascal</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Hektopascal</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Hektopascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>neuter</gender>
@@ -9605,20 +9605,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">neuter</gender>
 				<displayName>Megapascal</displayName>
 				<unitPattern count="one">{0} Megapascal</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Megapascal</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Megapascal</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Megapascals</unitPattern>
 				<unitPattern count="other">{0} Megapascal</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Megapascal</unitPattern>
+				<unitPattern count="other" case="dative" draft="contributed">{0} Megapascal</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Megapascal</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>masculine</gender>
 				<displayName>Kilometer pro Stunde</displayName>
 				<unitPattern count="one">{0} Kilometer pro Stunde</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Kilometer pro Stunde</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="dative">{0} Kilometer pro Stunde</unitPattern>
 				<unitPattern count="one" case="genitive">{0} Kilometers pro Stunde</unitPattern>
 				<unitPattern count="other">{0} Kilometer pro Stunde</unitPattern>
 				<unitPattern count="other" case="accusative">{0} Kilometer pro Stunde</unitPattern>
@@ -9711,25 +9711,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">masculine</gender>
 				<displayName>Newtonmeter</displayName>
 				<unitPattern count="one">{0} Newtonmeter</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Newtonmeter</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Newtonmeter</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Newtonmeters</unitPattern>
 				<unitPattern count="other">{0} Newtonmeter</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Newtonmeter</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Newtonmetern</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Newtonmeter</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender draft="contributed">masculine</gender>
 				<displayName>Kubikkilometer</displayName>
 				<unitPattern count="one">{0} Kubikkilometer</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Kubikkilometer</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Kubikkilometer</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Kubikkilometers</unitPattern>
 				<unitPattern count="other">{0} Kubikkilometer</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Kubikkilometer</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Kubikkilometern</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Kubikkilometer</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>masculine</gender>
@@ -9795,25 +9795,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">masculine</gender>
 				<displayName>Megaliter</displayName>
 				<unitPattern count="one">{0} Megaliter</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Megaliter</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Megaliter</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Megaliters</unitPattern>
 				<unitPattern count="other">{0} Megaliter</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Megaliter</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Megalitern</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Megaliter</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender draft="contributed">masculine</gender>
 				<displayName>Hektoliter</displayName>
 				<unitPattern count="one">{0} Hektoliter</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} Hektoliter</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} Hektoliter</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} Hektoliters</unitPattern>
 				<unitPattern count="other">{0} Hektoliter</unitPattern>
-				<unitPattern count="other" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative" draft="contributed">{0} Hektoliter</unitPattern>
 				<unitPattern count="other" case="dative" draft="contributed">{0} Hektolitern</unitPattern>
-				<unitPattern count="other" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive" draft="contributed">{0} Hektoliter</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>masculine</gender>
@@ -9880,7 +9880,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">feminine</gender>
 				<displayName>metrische Tassen</displayName>
 				<unitPattern count="one">{0} metrische Tasse</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} metrische Tasse</unitPattern>
 				<unitPattern count="one" case="dative" draft="contributed">{0} metrischen Tasse</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} metrischen Tasse</unitPattern>
 				<unitPattern count="other">{0} metrische Tassen</unitPattern>
@@ -9902,26 +9902,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>Gallone</displayName>
 				<unitPattern count="one">{0} Gallone</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Gallone</unitPattern>
+				<unitPattern count="one" case="dative">{0} Gallone</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Gallone</unitPattern>
 				<unitPattern count="other">{0} Gallonen</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Gallonen</unitPattern>
+				<unitPattern count="other" case="dative">{0} Gallonen</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Gallonen</unitPattern>
 				<perUnitPattern>{0} pro Gallone</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<gender>feminine</gender>
 				<displayName>Imp. Gallonen</displayName>
 				<unitPattern count="one">{0} Imp. Gallone</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Imp. Gallone</unitPattern>
+				<unitPattern count="one" case="dative">{0} Imp. Gallone</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Imp. Gallone</unitPattern>
 				<unitPattern count="other">{0} Imp. Gallonen</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Imp. Gallonen</unitPattern>
+				<unitPattern count="other" case="dative">{0} Imp. Gallonen</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Imp. Gallonen</unitPattern>
 				<perUnitPattern>{0} pro Imp. Gallone</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
@@ -9930,11 +9930,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Quart</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Quart</unitPattern>
 				<unitPattern count="one" case="dative">{0} Quart</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Quart</unitPattern>
 				<unitPattern count="other">{0} Quart</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Quart</unitPattern>
+				<unitPattern count="other" case="dative">{0} Quart</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Quart</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<gender>neuter</gender>
@@ -9976,13 +9976,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>Imp. Flüssigunzen</displayName>
 				<unitPattern count="one">{0} Imp. Flüssigunze</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Imp. Flüssigunze</unitPattern>
+				<unitPattern count="one" case="dative">{0} Imp. Flüssigunze</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Imp. Flüssigunze</unitPattern>
 				<unitPattern count="other">{0} Imp. Flüssigunzen</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Imp. Flüssigunzen</unitPattern>
+				<unitPattern count="other" case="dative">{0} Imp. Flüssigunzen</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Imp. Flüssigunzen</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<gender>masculine</gender>
@@ -10195,12 +10195,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10208,12 +10208,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-Kraft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
@@ -10243,24 +10243,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>Hektar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -10338,7 +10338,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -10363,7 +10363,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
@@ -10476,7 +10476,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
@@ -10486,32 +10486,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>Ampere</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>Ohm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>Volt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>kcal</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
@@ -10541,27 +10541,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -10571,89 +10571,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>MHz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>Meter</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -10664,7 +10664,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
@@ -10674,22 +10674,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-picometer">
 				<displayName>Pikometer</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>Meilen</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>Yards</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>Fuß</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -10731,7 +10731,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
@@ -10741,7 +10741,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -10751,44 +10751,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>Gramm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
@@ -10803,13 +10803,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-pound">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -10825,22 +10825,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>Gran</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} gr</unitPattern>
 				<unitPattern count="other">{0} gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -10865,7 +10865,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
@@ -10890,7 +10890,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -10905,7 +10905,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -10915,32 +10915,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>kn</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
@@ -10965,22 +10965,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -11022,7 +11022,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-liter">
 				<displayName>Liter</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -11043,7 +11043,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
@@ -11080,7 +11080,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-pint">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup">
@@ -11110,7 +11110,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -11158,104 +11158,104 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -11293,10 +11293,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">km²</displayName>
 				<unitPattern count="one" draft="contributed">{0} km²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} km²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName draft="contributed">ha</displayName>
@@ -11304,48 +11304,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">m²</displayName>
 				<unitPattern count="one" draft="contributed">{0} m²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} m²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">cm²</displayName>
 				<unitPattern count="one" draft="contributed">{0} cm²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} cm²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mi²</displayName>
 				<unitPattern count="one" draft="contributed">{0} mi²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} mi²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ac</displayName>
 				<unitPattern count="one" draft="contributed">{0} ac</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">yd²</displayName>
 				<unitPattern count="one" draft="contributed">{0} yd²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ft²</displayName>
 				<unitPattern count="one" draft="contributed">{0} ft²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">in²</displayName>
 				<unitPattern count="one" draft="contributed">{0} in²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} in²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName draft="contributed">Dunam</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Dunam</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>kt</displayName>
@@ -11368,32 +11368,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Elem.</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
+				<displayName>%</displayName>
 				<unitPattern count="one">{0} %</unitPattern>
 				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>‰</displayName>
 				<unitPattern count="one">{0}‰</unitPattern>
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0}mol</unitPattern>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>l/km</displayName>
 				<unitPattern count="one">{0}l/km</unitPattern>
 				<unitPattern count="other">{0}l/km</unitPattern>
 			</unit>
@@ -11403,7 +11403,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpg</displayName>
 				<unitPattern count="one">{0}mpg</unitPattern>
 				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
@@ -11413,17 +11413,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mpg UK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">PB</displayName>
+				<unitPattern count="one" draft="contributed">{0} PB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">TB</displayName>
 				<unitPattern count="one" draft="contributed">{0} TB</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">Tb</displayName>
 				<unitPattern count="one" draft="contributed">{0} Tb</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} Tb</unitPattern>
 			</unit>
@@ -11473,9 +11473,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Jh.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Jz.</displayName>
+				<unitPattern count="one">{0} Jz.</unitPattern>
+				<unitPattern count="other">{0} Jz.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>J</displayName>
@@ -11521,14 +11521,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-second">
 				<displayName>Sek.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Sek.</unitPattern>
+				<unitPattern count="other">{0} Sek.</unitPattern>
 				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ms</displayName>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>μs</displayName>
@@ -11536,7 +11536,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ns</displayName>
 				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
@@ -11546,7 +11546,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mA</displayName>
 				<unitPattern count="one">{0}mA</unitPattern>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
@@ -11561,17 +11561,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">kcal</displayName>
 				<unitPattern count="one" draft="contributed">{0} kcal</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">cal</displayName>
 				<unitPattern count="one" draft="contributed">{0} cal</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">kcal</displayName>
 				<unitPattern count="one" draft="contributed">{0} kcal</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} kcal</unitPattern>
 			</unit>
@@ -11586,32 +11586,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">kWh</displayName>
 				<unitPattern count="one" draft="contributed">{0} kWh</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">eV</displayName>
+				<unitPattern count="one" draft="contributed">{0} eV</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Btu</displayName>
+				<unitPattern count="one" draft="contributed">{0} Btu</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">US therm</displayName>
+				<unitPattern count="one" draft="contributed">{0} US therm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf</displayName>
 				<unitPattern count="one">{0}lbf</unitPattern>
 				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>N</displayName>
 				<unitPattern count="one">{0}N</unitPattern>
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
@@ -11621,80 +11621,80 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">GHz</displayName>
 				<unitPattern count="one">{0}GHz</unitPattern>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">MHz</displayName>
 				<unitPattern count="one">{0}MHz</unitPattern>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">kHz</displayName>
 				<unitPattern count="one">{0}kHz</unitPattern>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">Hz</displayName>
 				<unitPattern count="one">{0}Hz</unitPattern>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">em</displayName>
+				<unitPattern count="one" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">px</displayName>
+				<unitPattern count="one" draft="contributed">{0} px</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">MP</displayName>
+				<unitPattern count="one" draft="contributed">{0} MP</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppcm</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppcm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppi</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppi</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppcm</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppcm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppi</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppi</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">px</displayName>
+				<unitPattern count="one" draft="contributed">{0} px</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">R⊕</displayName>
+				<unitPattern count="one" draft="contributed">{0} R⊕</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
 				<perUnitPattern draft="contributed">{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>Meter</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
 				<perUnitPattern draft="contributed">{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
@@ -11703,15 +11703,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
 				<perUnitPattern draft="contributed">{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName draft="contributed">μm</displayName>
@@ -11745,23 +11745,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">in</displayName>
+				<unitPattern count="one" draft="contributed">{0} in</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} in</unitPattern>
+				<perUnitPattern draft="contributed">{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">pc</displayName>
 				<unitPattern count="one" draft="contributed">{0} pc</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>Lj</displayName>
 				<unitPattern count="one">{0}Lj</unitPattern>
 				<unitPattern count="other">{0}Lj</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>AE</displayName>
 				<unitPattern count="one">{0}AE</unitPattern>
 				<unitPattern count="other">{0}AE</unitPattern>
 			</unit>
@@ -11776,22 +11776,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fm</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>sm</displayName>
 				<unitPattern count="one">{0}sm</unitPattern>
 				<unitPattern count="other">{0}sm</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
+				<displayName>smi</displayName>
 				<unitPattern count="one">{0}smi</unitPattern>
 				<unitPattern count="other">{0}smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>p</displayName>
+				<unitPattern count="one">{0} p</unitPattern>
+				<unitPattern count="other">{0} p</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R☉</displayName>
 				<unitPattern count="one">{0}R☉</unitPattern>
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
@@ -11801,17 +11801,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">{0}cd</unitPattern>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>L☉</displayName>
 				<unitPattern count="one">{0}L☉</unitPattern>
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
@@ -11821,15 +11821,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="one">{0} kg</unitPattern>
+				<unitPattern count="other">{0} kg</unitPattern>
 				<perUnitPattern draft="contributed">{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>Gramm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
 				<perUnitPattern draft="contributed">{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
@@ -11875,37 +11875,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} Kt</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Da</displayName>
+				<unitPattern count="one" draft="contributed">{0} Da</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">M⊕</displayName>
+				<unitPattern count="one" draft="contributed">{0} M⊕</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">M☉</displayName>
+				<unitPattern count="one" draft="contributed">{0} M☉</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName draft="contributed">gr</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} gr</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">GW</displayName>
 				<unitPattern count="one" draft="contributed">{0} GW</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">MW</displayName>
 				<unitPattern count="one" draft="contributed">{0} MW</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">kW</displayName>
 				<unitPattern count="one" draft="contributed">{0} kW</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} kW</unitPattern>
 			</unit>
@@ -11915,12 +11915,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mW</displayName>
 				<unitPattern count="one" draft="contributed">{0} mW</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">PS</displayName>
 				<unitPattern count="one" draft="contributed">{0} PS</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} PS</unitPattern>
 			</unit>
@@ -11940,9 +11940,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">bar</displayName>
+				<unitPattern count="one" draft="contributed">{0} bar</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName draft="contributed">Millibar</displayName>
@@ -11950,14 +11950,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">atm</displayName>
+				<unitPattern count="one" draft="contributed">{0} atm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Pa</displayName>
+				<unitPattern count="one" draft="contributed">{0} Pa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName draft="contributed">hPa</displayName>
@@ -11965,19 +11965,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kPa</displayName>
+				<unitPattern count="one" draft="contributed">{0} kPa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">MPa</displayName>
+				<unitPattern count="one" draft="contributed">{0} MPa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="one">{0} km/h</unitPattern>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName draft="contributed">m/s</displayName>
@@ -12001,8 +12001,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} °C</unitPattern>
+				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName draft="contributed">°F</displayName>
@@ -12015,92 +12015,92 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="one">{0}lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>N⋅m</displayName>
 				<unitPattern count="one">{0}N⋅m</unitPattern>
 				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">km³</displayName>
 				<unitPattern count="one" draft="contributed">{0} km³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">m³</displayName>
 				<unitPattern count="one" draft="contributed">{0} m³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} m³</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">cm³</displayName>
 				<unitPattern count="one" draft="contributed">{0} cm³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} cm³</unitPattern>
 				<perUnitPattern draft="contributed">{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mi³</displayName>
 				<unitPattern count="one" draft="contributed">{0} mi³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">yd³</displayName>
 				<unitPattern count="one" draft="contributed">{0} yd³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ft³</displayName>
 				<unitPattern count="one" draft="contributed">{0} ft³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">in³</displayName>
 				<unitPattern count="one" draft="contributed">{0} in³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">Ml</displayName>
 				<unitPattern count="one" draft="contributed">{0} Ml</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">hl</displayName>
 				<unitPattern count="one" draft="contributed">{0} hl</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="other">{0} l</unitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">dl</displayName>
 				<unitPattern count="one" draft="contributed">{0} dl</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">cl</displayName>
 				<unitPattern count="one" draft="contributed">{0} cl</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ml</displayName>
 				<unitPattern count="one" draft="contributed">{0} ml</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mpt</displayName>
+				<unitPattern count="one" draft="contributed">{0} mpt</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Ta</displayName>
+				<unitPattern count="one" draft="contributed">{0} Ta</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Ta</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName draft="contributed">ac ft</displayName>
@@ -12113,10 +12113,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">gal</displayName>
 				<unitPattern count="one" draft="contributed">{0} gal</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} gal</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName draft="contributed">Imp.gal</displayName>
@@ -12125,22 +12125,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/Imp.gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">qt</displayName>
 				<unitPattern count="one" draft="contributed">{0} qt</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">pt</displayName>
 				<unitPattern count="one" draft="contributed">{0} pt</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">Cups</displayName>
 				<unitPattern count="one" draft="contributed">{0} Cup</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} Cups</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">fl oz</displayName>
 				<unitPattern count="one" draft="contributed">{0} fl oz</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} fl oz</unitPattern>
 			</unit>
@@ -12150,27 +12150,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Im.fl.oz</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>EL</displayName>
 				<unitPattern count="one">{0} EL</unitPattern>
 				<unitPattern count="other">{0} EL</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>TL</displayName>
 				<unitPattern count="one">{0} TL</unitPattern>
 				<unitPattern count="other">{0} TL</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bbl</displayName>
 				<unitPattern count="one">{0}bbl</unitPattern>
 				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>DL</displayName>
+				<unitPattern count="one">{0} DL</unitPattern>
+				<unitPattern count="other">{0} DL</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. DL</displayName>
 				<unitPattern count="one">{0} Imp.DL</unitPattern>
 				<unitPattern count="other">{0} Imp.DL</unitPattern>
 			</unit>
@@ -12185,9 +12185,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Jigger</displayName>
+				<unitPattern count="one">{0} Jigger</unitPattern>
+				<unitPattern count="other">{0} Jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>Pr.</displayName>
@@ -12231,22 +12231,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} oder {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} oder {1}</listPatternPart>
+			<listPatternPart type="2">{0} oder {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} oder {1}</listPatternPart>
+			<listPatternPart type="2">{0} oder {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} und {1}</listPatternPart>
+			<listPatternPart type="2">{0} und {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/doi.xml
+++ b/common/main/doi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -242,9 +242,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">दि</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
+							<month type="1">जनवरी</month>
+							<month type="2">फरवरी</month>
+							<month type="3">मार्च</month>
 							<month type="4">अप्रैल</month>
 							<month type="5">मेई</month>
 							<month type="6">जून</month>
@@ -409,12 +409,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</dayPeriods>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">ई.पू.</era>
 						<era type="1">ई. सन्</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">ई.पू.</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">ई.पू.</era>
 						<era type="1">ईसवी</era>
 						<era type="1" alt="variant">सन्</era>
 					</eraAbbr>
@@ -533,7 +533,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="one">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMW" count="one">MMMM दा हफ्ता W</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="other">MMMM दा हफ्ता W</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">y</dateFormatItem>
@@ -745,13 +745,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>दिन</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">जंदा कल</relative>
 				<relative type="0">अज्ज</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">औंदे कल</relative>
 			</field>
 			<field type="day-narrow">
 				<displayName>दिन</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">जंदा कल</relative>
 				<relative type="0">अज्ज</relative>
 				<relative type="1">औंदे कल</relative>
 			</field>

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -46,7 +46,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="awa">awandhišćina</language>
 			<language type="ay">aymaršćina</language>
 			<language type="az">azerbajdžanšćina</language>
-			<language type="az" alt="short">↑↑↑</language>
+			<language type="az" alt="short">azerbajdžanšćina</language>
 			<language type="ba">baškiršćina</language>
 			<language type="ban">balinezišćina</language>
 			<language type="bas">basaa</language>
@@ -80,7 +80,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyennešćina</language>
 			<language type="ckb">sorani</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">sorani</language>
 			<language type="ckb" alt="variant">centralna kurdišćina</language>
 			<language type="clc">chilcotinšćina</language>
 			<language type="co">korsišćina</language>
@@ -630,7 +630,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CX">Gódowne kupy</territory>
 			<territory type="CY">Cypriska</territory>
 			<territory type="CZ">Česka republika</territory>
-			<territory type="CZ" alt="variant">↑↑↑</territory>
+			<territory type="CZ" alt="variant">Česka republika</territory>
 			<territory type="DE">Nimska</territory>
 			<territory type="DG">Diego Garcia</territory>
 			<territory type="DJ">Džibuti</territory>
@@ -800,7 +800,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="SX">Sint Maarten</territory>
 			<territory type="SY">Syriska</territory>
 			<territory type="SZ">Swasiska</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
+			<territory type="SZ" alt="variant">Swasiska</territory>
 			<territory type="TA">Tristan da Cunha</territory>
 			<territory type="TC">Turks a Caicos kupy</territory>
 			<territory type="TD">Čad</territory>
@@ -815,7 +815,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tuneziska</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkojska</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkojska</territory>
 			<territory type="TT">Trinidad a Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1041,7 +1041,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1049,7 +1049,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1537,7 +1537,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1545,7 +1545,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1756,10 +1756,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>epocha</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>epocha</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>epocha</displayName>
 			</field>
 			<field type="year">
 				<displayName>lěto</displayName>
@@ -2050,10 +2050,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>źeń tyźenja</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>źeń tyźenja</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>źeń tyźenja</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>źeń tyźenja w mjasecu</displayName>
@@ -2422,7 +2422,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>połojca dnja</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>połojca dnja</displayName>
@@ -2572,7 +2572,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>casowe pasmo</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>casowe pasmo</displayName>
 			</field>
 			<field type="zone-narrow">
 				<displayName>cas. pasmo</displayName>
@@ -7808,15 +7808,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7942,7 +7942,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="area-dunam">
 				<displayName>dun.</displayName>
 				<unitPattern count="one">{0} dun.</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dun.</unitPattern>
 				<unitPattern count="few">{0} dun.</unitPattern>
 				<unitPattern count="other">{0} dun.</unitPattern>
 			</unit>
@@ -8012,7 +8012,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>l/km</displayName>
 				<unitPattern count="one">{0} l/km</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} l/km</unitPattern>
 				<unitPattern count="few">{0} l/km</unitPattern>
 				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
@@ -8999,7 +8999,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="volume-gallon-imperial">
 				<displayName>brit. gal.</displayName>
 				<unitPattern count="one">{0} brit. gal.</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} brit. gal.</unitPattern>
 				<unitPattern count="few">{0} brit. gal.</unitPattern>
 				<unitPattern count="other">{0} brit. gal.</unitPattern>
 				<perUnitPattern>{0}/brit. gal.</perUnitPattern>
@@ -9119,329 +9119,329 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>G</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="two">{0} G</unitPattern>
 				<unitPattern count="few">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="two">{0} m/s²</unitPattern>
+				<unitPattern count="few">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>wobr.</displayName>
+				<unitPattern count="one">{0} wobr.</unitPattern>
+				<unitPattern count="two">{0} wobr.</unitPattern>
+				<unitPattern count="few">{0} wobr.</unitPattern>
+				<unitPattern count="other">{0} wobr.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="two">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="two">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>′</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="two">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>″</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="two">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="two">{0} km²</unitPattern>
 				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ha</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="two">{0} ha</unitPattern>
 				<unitPattern count="few">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="two">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="two">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="two">{0} mi²</unitPattern>
 				<unitPattern count="few">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ac</displayName>
 				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="two">{0} ac</unitPattern>
 				<unitPattern count="few">{0} ac</unitPattern>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="two">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="two">{0} ft²</unitPattern>
 				<unitPattern count="few">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="two">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dun.</displayName>
+				<unitPattern count="one">{0} dun.</unitPattern>
+				<unitPattern count="two">{0} dun.</unitPattern>
+				<unitPattern count="few">{0} dun.</unitPattern>
+				<unitPattern count="other">{0} dun.</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="two">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="two">{0} mg/dl</unitPattern>
+				<unitPattern count="few">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/l</displayName>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="two">{0} mmol/l</unitPattern>
+				<unitPattern count="few">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kus</displayName>
+				<unitPattern count="one">{0} kus</unitPattern>
+				<unitPattern count="two">{0} kusa</unitPattern>
+				<unitPattern count="few">{0} kuse</unitPattern>
+				<unitPattern count="other">{0} kusow</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="two">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="one">{0} %</unitPattern>
+				<unitPattern count="two">{0} %</unitPattern>
+				<unitPattern count="few">{0} %</unitPattern>
+				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="two">{0} ‰</unitPattern>
+				<unitPattern count="few">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="two">{0} ‱</unitPattern>
+				<unitPattern count="few">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="two">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
 				<unitPattern count="two">{0} l/km</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/100km</displayName>
+				<unitPattern count="one">{0} l/100km</unitPattern>
+				<unitPattern count="two">{0} l/100km</unitPattern>
+				<unitPattern count="few">{0} l/100km</unitPattern>
+				<unitPattern count="other">{0} l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="two">{0} mpg</unitPattern>
+				<unitPattern count="few">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg brit.</displayName>
+				<unitPattern count="one">{0} mpg brit.</unitPattern>
+				<unitPattern count="two">{0} mpg brit.</unitPattern>
+				<unitPattern count="few">{0} mpg brit.</unitPattern>
+				<unitPattern count="other">{0} mpg brit.</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lětst.</displayName>
+				<unitPattern count="one">{0} lětst.</unitPattern>
+				<unitPattern count="two">{0} lětst.</unitPattern>
+				<unitPattern count="few">{0} lětst.</unitPattern>
+				<unitPattern count="other">{0} lětst.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lětź.</displayName>
+				<unitPattern count="one">{0} lětź.</unitPattern>
+				<unitPattern count="two">{0} lětź.</unitPattern>
+				<unitPattern count="few">{0} lětź.</unitPattern>
+				<unitPattern count="other">{0} lětź.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>l.</displayName>
@@ -9449,7 +9449,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} l.</unitPattern>
 				<unitPattern count="few">{0} l.</unitPattern>
 				<unitPattern count="other">{0} l.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>kw.</displayName>
@@ -9465,7 +9465,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} mjas.</unitPattern>
 				<unitPattern count="few">{0} mjas.</unitPattern>
 				<unitPattern count="other">{0} mjas.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} /mjas.</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>tyź.</displayName>
@@ -9473,7 +9473,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} tyź.</unitPattern>
 				<unitPattern count="few">{0} tyź.</unitPattern>
 				<unitPattern count="other">{0} tyź.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} /tyź.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>d</displayName>
@@ -9481,7 +9481,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} d</unitPattern>
 				<unitPattern count="few">{0} d</unitPattern>
 				<unitPattern count="other">{0} d</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ź.</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>g</displayName>
@@ -9489,7 +9489,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} g</unitPattern>
 				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
@@ -9497,7 +9497,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} min</unitPattern>
 				<unitPattern count="few">{0} min</unitPattern>
 				<unitPattern count="other">{0} min</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min.</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
@@ -9505,7 +9505,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} s</unitPattern>
 				<unitPattern count="few">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -9515,81 +9515,81 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="two">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="two">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="two">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -9597,7 +9597,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} km</unitPattern>
 				<unitPattern count="few">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
@@ -9605,14 +9605,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="two">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
@@ -9620,7 +9620,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} cm</unitPattern>
 				<unitPattern count="few">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -9630,153 +9630,153 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="two">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="two">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="two">{0} pm</unitPattern>
 				<unitPattern count="few">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi</displayName>
 				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="two">{0} mi</unitPattern>
 				<unitPattern count="few">{0} mi</unitPattern>
 				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd</displayName>
 				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="two">{0} yd</unitPattern>
 				<unitPattern count="few">{0} yd</unitPattern>
 				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft</displayName>
 				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="two">{0} ft</unitPattern>
 				<unitPattern count="few">{0} ft</unitPattern>
 				<unitPattern count="other">{0} ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in</displayName>
 				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="two">{0} in</unitPattern>
 				<unitPattern count="few">{0} in</unitPattern>
 				<unitPattern count="other">{0} in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/col</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="two">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>ly</displayName>
 				<unitPattern count="one">{0} ly</unitPattern>
 				<unitPattern count="two">{0} ly</unitPattern>
 				<unitPattern count="few">{0} ly</unitPattern>
 				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="two">{0} au</unitPattern>
+				<unitPattern count="few">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="two">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fth</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="two">{0} fth</unitPattern>
+				<unitPattern count="few">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="two">{0} nmi</unitPattern>
+				<unitPattern count="few">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="two">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="two">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="two">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="two">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="two">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
@@ -9784,7 +9784,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} kg</unitPattern>
 				<unitPattern count="few">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
@@ -9792,93 +9792,93 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} g</unitPattern>
 				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="two">{0} mg</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="two">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>am.tony</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="two">{0} tn</unitPattern>
+				<unitPattern count="few">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="two">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="two">{0} lb</unitPattern>
 				<unitPattern count="few">{0} lb</unitPattern>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="two">{0} oz</unitPattern>
 				<unitPattern count="few">{0} oz</unitPattern>
 				<unitPattern count="other">{0} oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz. tr.</displayName>
+				<unitPattern count="one">{0} oz. tr.</unitPattern>
+				<unitPattern count="two">{0} oz. tr.</unitPattern>
+				<unitPattern count="few">{0} oz. tr.</unitPattern>
+				<unitPattern count="other">{0} oz. tr.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kt</displayName>
+				<unitPattern count="one">{0} Kt</unitPattern>
+				<unitPattern count="two">{0} Kt</unitPattern>
+				<unitPattern count="few">{0} Kt</unitPattern>
+				<unitPattern count="other">{0} Kt</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="two">{0} graina</unitPattern>
+				<unitPattern count="few">{0} grainy</unitPattern>
+				<unitPattern count="other">{0} grainow</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<unitPattern count="one">{0} kW</unitPattern>
@@ -9924,25 +9924,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="two">{0} m/s</unitPattern>
 				<unitPattern count="few">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mph</displayName>
 				<unitPattern count="one">{0} mph</unitPattern>
 				<unitPattern count="two">{0} mph</unitPattern>
 				<unitPattern count="few">{0} mph</unitPattern>
 				<unitPattern count="other">{0} mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sk</displayName>
+				<unitPattern count="one">{0} sk</unitPattern>
+				<unitPattern count="two">{0} sk</unitPattern>
+				<unitPattern count="few">{0} sk</unitPattern>
+				<unitPattern count="other">{0} sk</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9958,83 +9958,83 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nm</displayName>
+				<unitPattern count="one">{0} Nm</unitPattern>
+				<unitPattern count="two">{0} Nm</unitPattern>
+				<unitPattern count="few">{0} Nm</unitPattern>
+				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="two">{0} km³</unitPattern>
 				<unitPattern count="few">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="two">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="two">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="two">{0} mi³</unitPattern>
 				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="two">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="two">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="two">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="two">{0} Ml</unitPattern>
+				<unitPattern count="few">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="two">{0} hl</unitPattern>
+				<unitPattern count="few">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
@@ -10042,163 +10042,163 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} l</unitPattern>
 				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="two">{0} dl</unitPattern>
+				<unitPattern count="few">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="two">{0} cl</unitPattern>
+				<unitPattern count="few">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="two">{0} ml</unitPattern>
+				<unitPattern count="few">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="two">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mc</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="two">{0} mc</unitPattern>
+				<unitPattern count="few">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="two">{0} ac ft</unitPattern>
+				<unitPattern count="few">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="two">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="two">{0} gal</unitPattern>
+				<unitPattern count="few">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>brit. gal.</displayName>
+				<unitPattern count="one">{0} brit. gal.</unitPattern>
 				<unitPattern count="two">{0} brit. gal.</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="few">{0} brit. gal.</unitPattern>
+				<unitPattern count="other">{0} brit. gal.</unitPattern>
+				<perUnitPattern>{0}/brit. gal.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="two">{0} qt</unitPattern>
+				<unitPattern count="few">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="two">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="two">{0} c</unitPattern>
+				<unitPattern count="few">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl. oz.</displayName>
+				<unitPattern count="one">{0} fl. oz.</unitPattern>
+				<unitPattern count="two">{0} fl. oz.</unitPattern>
+				<unitPattern count="few">{0} fl. oz.</unitPattern>
+				<unitPattern count="other">{0} fl. oz.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>brit. fl oz</displayName>
+				<unitPattern count="one">{0} brit. fl oz</unitPattern>
+				<unitPattern count="two">{0} brit. fl oz</unitPattern>
+				<unitPattern count="few">{0} brit. fl oz</unitPattern>
+				<unitPattern count="other">{0} brit. fl oz</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>łž.</displayName>
+				<unitPattern count="one">{0} łž.</unitPattern>
+				<unitPattern count="two">{0} łž.</unitPattern>
+				<unitPattern count="few">{0} łž.</unitPattern>
+				<unitPattern count="other">{0} łž.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>łžk.</displayName>
+				<unitPattern count="one">{0} łžk.</unitPattern>
+				<unitPattern count="two">{0} łžk.</unitPattern>
+				<unitPattern count="few">{0} łžk.</unitPattern>
+				<unitPattern count="other">{0} łžk.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="two">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dess. łžk.</displayName>
+				<unitPattern count="one">{0} dess. łžk.</unitPattern>
+				<unitPattern count="two">{0} dess. łžk.</unitPattern>
+				<unitPattern count="few">{0} dess. łžk.</unitPattern>
+				<unitPattern count="other">{0} dess. łžk.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp. łžk.</displayName>
+				<unitPattern count="one">{0} imp. łžk.</unitPattern>
+				<unitPattern count="two">{0} imp. łžk.</unitPattern>
+				<unitPattern count="few">{0} imp. łžk.</unitPattern>
+				<unitPattern count="other">{0} imp. łžk.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>chpk.</displayName>
+				<unitPattern count="one">{0} chpk.</unitPattern>
+				<unitPattern count="two">{0} chpk.</unitPattern>
+				<unitPattern count="few">{0} chpk.</unitPattern>
+				<unitPattern count="other">{0} chpk.</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dr</displayName>
+				<unitPattern count="one">{0} dr</unitPattern>
+				<unitPattern count="two">{0} dr</unitPattern>
+				<unitPattern count="few">{0} dr</unitPattern>
+				<unitPattern count="other">{0} dr</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jiggery</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="two">{0} jiggera</unitPattern>
+				<unitPattern count="few">{0} jiggery</unitPattern>
+				<unitPattern count="other">{0} jiggerow</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>šć</displayName>
@@ -10208,18 +10208,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} šć</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="two">{0} qt Imp.</unitPattern>
+				<unitPattern count="few">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>směr</displayName>
+				<coordinateUnitPattern type="east">{0} pz</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} pn</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0} pł</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0} pw</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -10246,28 +10246,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} abo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} abo {1}</listPatternPart>
+			<listPatternPart type="2">{0} abo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} abo {1}</listPatternPart>
 			<listPatternPart type="2">{0} abo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} a {1}</listPatternPart>
+			<listPatternPart type="2">{0} a {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} a {1}</listPatternPart>
+			<listPatternPart type="2">{0} a {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -1014,7 +1014,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Τυνησία</territory>
 			<territory type="TO">Τόνγκα</territory>
 			<territory type="TR">Τουρκία</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Τουρκία</territory>
 			<territory type="TT">Τρινιντάντ και Τομπάγκο</territory>
 			<territory type="TV">Τουβαλού</territory>
 			<territory type="TW">Ταϊβάν</territory>
@@ -1683,7 +1683,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1691,7 +1691,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2236,7 +2236,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2244,7 +2244,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2935,7 +2935,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="month-short">
 				<displayName>μήν.</displayName>
 				<relative type="-1">προηγ. μήνας</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">τρέχων μήνας</relative>
 				<relative type="1">επόμ. μήνας</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">σε {0} μήνα</relativeTimePattern>
@@ -7664,16 +7664,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>τετραγωνικό {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">τετραγωνικό {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">τετραγωνικό {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">τετραγωνικού {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine">τετραγωνική {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">τετραγωνική {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">τετραγωνικής {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine">τετραγωνικός {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">τετραγωνικό {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">τετραγωνικού {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">τετραγωνικά {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">τετραγωνικά {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="genitive">τετραγωνικών {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine">τετραγωνικές {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">τετραγωνικές {0}</compoundUnitPattern1>
@@ -7685,16 +7685,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>κυβικό {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">κυβικό {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">κυβικό {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">κυβικού {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine">κυβική {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">κυβική {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">κυβικής {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine">κυβικός {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">κυβικό {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">κυβικού {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">κυβικά {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">κυβικά {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="genitive">κυβικών {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine">κυβικές {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">κυβικές {0}</compoundUnitPattern1>
@@ -7704,13 +7704,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">κυβικών {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>feminine</gender>
 				<displayName>δύναμη επιτάχυνσης</displayName>
 				<unitPattern count="one">{0} δύναμη επιτάχυνσης</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} δύναμη επιτάχυνσης</unitPattern>
 				<unitPattern count="one" case="genitive">{0} δύναμης επιτάχυνσης</unitPattern>
 				<unitPattern count="other">{0} δυνάμεις επιτάχυνσης</unitPattern>
 				<unitPattern count="other" case="accusative">{0} δυνάμεις επιτάχυνσης</unitPattern>
@@ -7720,70 +7720,70 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>μέτρα ανά τετραγωνικό δευτερόλεπτο</displayName>
 				<unitPattern count="one">{0} μέτρο ανά τετραγωνικό δευτερόλεπτο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μέτρο ανά τετραγωνικό δευτερόλεπτο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μέτρου ανά τετραγωνικό δευτερόλεπτο</unitPattern>
 				<unitPattern count="other">{0} μέτρα ανά τετραγωνικό δευτερόλεπτο</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μέτρα ανά τετραγωνικό δευτερόλεπτο</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μέτρων ανά τετραγωνικό δευτερόλεπτο</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>feminine</gender>
 				<displayName>στροφή</displayName>
 				<unitPattern count="one">{0} στροφή</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} στροφή</unitPattern>
 				<unitPattern count="one" case="genitive">{0} στροφής</unitPattern>
 				<unitPattern count="other">{0} στροφές</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} στροφές</unitPattern>
 				<unitPattern count="other" case="genitive">{0} στροφών</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>neuter</gender>
 				<displayName>ακτίνια</displayName>
 				<unitPattern count="one">{0} ακτίνιο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ακτίνιο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ακτίνιου</unitPattern>
 				<unitPattern count="other">{0} ακτίνια</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ακτίνια</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ακτίνιων</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>feminine</gender>
 				<displayName>μοίρες</displayName>
 				<unitPattern count="one">{0} μοίρα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μοίρα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μοίρας</unitPattern>
 				<unitPattern count="other">{0} μοίρες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μοίρες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μοιρών</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>neuter</gender>
 				<displayName>λεπτά του τόξου</displayName>
 				<unitPattern count="one">{0} λεπτό του τόξου</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} λεπτό του τόξου</unitPattern>
 				<unitPattern count="one" case="genitive">{0} λεπτού του τόξου</unitPattern>
 				<unitPattern count="other">{0} λεπτά του τόξου</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} λεπτά του τόξου</unitPattern>
 				<unitPattern count="other" case="genitive">{0} λεπτών του τόξου</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>neuter</gender>
 				<displayName>δευτερόλεπτα του τόξου</displayName>
 				<unitPattern count="one">{0} δευτερόλεπτο του τόξου</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} δευτερόλεπτο του τόξου</unitPattern>
 				<unitPattern count="one" case="genitive">{0} δευτερολέπτου του τόξου</unitPattern>
 				<unitPattern count="other">{0} δευτερόλεπτα του τόξου</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} δευτερόλεπτα του τόξου</unitPattern>
 				<unitPattern count="other" case="genitive">{0} δευτερολέπτων του τόξου</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>neuter</gender>
 				<displayName>τετραγωνικά χιλιόμετρα</displayName>
 				<unitPattern count="one">{0} τετραγωνικό χιλιόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} τετραγωνικό χιλιόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} τετραγωνικού χιλιομέτρου</unitPattern>
 				<unitPattern count="other">{0} τετραγωνικά χιλιόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} τετραγωνικά χιλιόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} τετραγωνικών χιλιομέτρων</unitPattern>
 				<perUnitPattern>{0}/τετραγωνικό χιλιόμετρο</perUnitPattern>
 			</unit>
@@ -7791,20 +7791,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>εκτάρια</displayName>
 				<unitPattern count="one">{0} εκτάριο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} εκτάριο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} εκτάριου</unitPattern>
 				<unitPattern count="other">{0} εκτάρια</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} εκτάρια</unitPattern>
 				<unitPattern count="other" case="genitive">{0} εκτάριων</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>neuter</gender>
 				<displayName>τετραγωνικά μέτρα</displayName>
 				<unitPattern count="one">{0} τετραγωνικό μέτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} τετραγωνικό μέτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} τετραγωνικού μέτρου</unitPattern>
 				<unitPattern count="other">{0} τετραγωνικά μέτρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} τετραγωνικά μέτρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} τετραγωνικών μέτρων</unitPattern>
 				<perUnitPattern>{0}/τετραγωνικό μέτρο</perUnitPattern>
 			</unit>
@@ -7812,10 +7812,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>τετραγωνικά εκατοστά</displayName>
 				<unitPattern count="one">{0} τετραγωνικό εκατοστό</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} τετραγωνικό εκατοστό</unitPattern>
 				<unitPattern count="one" case="genitive">{0} τετραγωνικού εκατοστού</unitPattern>
 				<unitPattern count="other">{0} τετραγωνικά εκατοστά</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} τετραγωνικά εκατοστά</unitPattern>
 				<unitPattern count="other" case="genitive">{0} τετραγωνικών εκατοστών</unitPattern>
 				<perUnitPattern>{0}/τετραγωνικό εκατοστό</perUnitPattern>
 			</unit>
@@ -7855,10 +7855,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>καράτια</displayName>
 				<unitPattern count="one">{0} καράτι</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} καράτι</unitPattern>
 				<unitPattern count="one" case="genitive">{0} καρατίου</unitPattern>
 				<unitPattern count="other">{0} καράτια</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} καράτια</unitPattern>
 				<unitPattern count="other" case="genitive">{0} καρατίων</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
@@ -7870,51 +7870,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>χιλιοστογραμμομόρια ανά λίτρο</displayName>
 				<unitPattern count="one">{0} χιλιοστογραμμομόριο ανά λίτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} χιλιοστογραμμομόριο ανά λίτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} χιλιοστογραμμομορίου ανά λίτρο</unitPattern>
 				<unitPattern count="other">{0} χιλιοστογραμμομόρια ανά λίτρο</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} χιλιοστογραμμομόρια ανά λίτρο</unitPattern>
 				<unitPattern count="other" case="genitive">{0} χιλιοστογραμμομορίων ανά λίτρο</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>neuter</gender>
 				<displayName>στοιχείο</displayName>
 				<unitPattern count="one">{0} στοιχείο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} στοιχείο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} στοιχείου</unitPattern>
 				<unitPattern count="other">{0} στοιχεία</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} στοιχεία</unitPattern>
 				<unitPattern count="other" case="genitive">{0} στοιχείων</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>neuter</gender>
 				<displayName>μέρη ανά εκατομμύριο</displayName>
 				<unitPattern count="one">{0} μέρος ανά εκατομμύριο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μέρος ανά εκατομμύριο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μέρους ανά εκατομμύριο</unitPattern>
 				<unitPattern count="other">{0} μέρη ανά εκατομμύριο</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μέρη ανά εκατομμύριο</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μερών ανά εκατομμύριο</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>neuter</gender>
 				<displayName>τοις εκατό</displayName>
 				<unitPattern count="one">{0} τοις εκατό</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} τοις εκατό</unitPattern>
+				<unitPattern count="one" case="genitive">{0} τοις εκατό</unitPattern>
 				<unitPattern count="other">{0} τοις εκατό</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} τοις εκατό</unitPattern>
+				<unitPattern count="other" case="genitive">{0} τοις εκατό</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>neuter</gender>
 				<displayName>τοις χιλίοις</displayName>
 				<unitPattern count="one">{0} τοις χιλίοις</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} τοις χιλίοις</unitPattern>
+				<unitPattern count="one" case="genitive">{0} τοις χιλίοις</unitPattern>
 				<unitPattern count="other">{0} τοις χιλίοις</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} τοις χιλίοις</unitPattern>
+				<unitPattern count="other" case="genitive">{0} τοις χιλίοις</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>neuter</gender>
@@ -7930,30 +7930,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>μολ</displayName>
 				<unitPattern count="one">{0} μολ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μολ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} μολ</unitPattern>
 				<unitPattern count="other">{0} μολ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μολ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} μολ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>neuter</gender>
 				<displayName>λίτρα ανά χιλιόμετρο</displayName>
 				<unitPattern count="one">{0} λίτρο ανά χιλιόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} λίτρο ανά χιλιόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} λίτρου ανά χιλιόμετρο</unitPattern>
 				<unitPattern count="other">{0} λίτρα ανά χιλιόμετρο</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} λίτρα ανά χιλιόμετρο</unitPattern>
 				<unitPattern count="other" case="genitive">{0} λίτρων ανά χιλιόμετρο</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>neuter</gender>
 				<displayName>λίτρα ανά 100 χιλιόμετρα</displayName>
 				<unitPattern count="one">{0} λίτρο ανά 100 χιλιόμετρα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} λίτρο ανά 100 χιλιόμετρα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} λίτρου ανά 100 χιλιόμετρα</unitPattern>
 				<unitPattern count="other">{0} λίτρα ανά 100 χιλιόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} λίτρα ανά 100 χιλιόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} λίτρων ανά 100 χιλιόμετρα</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
@@ -7970,111 +7970,111 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>petabyte</displayName>
 				<unitPattern count="one">{0} petabyte</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} petabyte</unitPattern>
+				<unitPattern count="one" case="genitive">{0} petabyte</unitPattern>
 				<unitPattern count="other">{0} petabyte</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} petabyte</unitPattern>
+				<unitPattern count="other" case="genitive">{0} petabyte</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>neuter</gender>
 				<displayName>terabyte</displayName>
 				<unitPattern count="one">{0} terabyte</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabyte</unitPattern>
+				<unitPattern count="one" case="genitive">{0} terabyte</unitPattern>
 				<unitPattern count="other">{0} terabyte</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabyte</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabyte</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>neuter</gender>
 				<displayName>terabit</displayName>
 				<unitPattern count="one">{0} terabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabit</unitPattern>
+				<unitPattern count="one" case="genitive">{0} terabit</unitPattern>
 				<unitPattern count="other">{0} terabit</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabit</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabit</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>neuter</gender>
 				<displayName>gigabyte</displayName>
 				<unitPattern count="one">{0} gigabyte</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabyte</unitPattern>
+				<unitPattern count="one" case="genitive">{0} gigabyte</unitPattern>
 				<unitPattern count="other">{0} gigabyte</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabyte</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabyte</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>neuter</gender>
 				<displayName>gigabit</displayName>
 				<unitPattern count="one">{0} gigabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabit</unitPattern>
+				<unitPattern count="one" case="genitive">{0} gigabit</unitPattern>
 				<unitPattern count="other">{0} gigabit</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabit</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabit</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>neuter</gender>
 				<displayName>megabyte</displayName>
 				<unitPattern count="one">{0} megabyte</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabyte</unitPattern>
+				<unitPattern count="one" case="genitive">{0} megabyte</unitPattern>
 				<unitPattern count="other">{0} megabyte</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabyte</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabyte</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>neuter</gender>
 				<displayName>megabit</displayName>
 				<unitPattern count="one">{0} megabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabit</unitPattern>
+				<unitPattern count="one" case="genitive">{0} megabit</unitPattern>
 				<unitPattern count="other">{0} megabit</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabit</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabit</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>neuter</gender>
 				<displayName>kilobyte</displayName>
 				<unitPattern count="one">{0} kilobyte</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobyte</unitPattern>
+				<unitPattern count="one" case="genitive">{0} kilobyte</unitPattern>
 				<unitPattern count="other">{0} kilobyte</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobyte</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobyte</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>neuter</gender>
 				<displayName>kilobit</displayName>
 				<unitPattern count="one">{0} kilobit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobit</unitPattern>
+				<unitPattern count="one" case="genitive">{0} kilobit</unitPattern>
 				<unitPattern count="other">{0} kilobit</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobit</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobit</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender draft="contributed">neuter</gender>
 				<displayName>byte</displayName>
 				<unitPattern count="one">{0} byte</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} byte</unitPattern>
+				<unitPattern count="one" case="genitive">{0} byte</unitPattern>
 				<unitPattern count="other">{0} byte</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} byte</unitPattern>
+				<unitPattern count="other" case="genitive">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender draft="contributed">neuter</gender>
 				<displayName>bit</displayName>
 				<unitPattern count="one">{0} bit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bit</unitPattern>
+				<unitPattern count="one" case="genitive">{0} bit</unitPattern>
 				<unitPattern count="other">{0} bit</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bit</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>masculine</gender>
@@ -8083,27 +8083,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} αιώνα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} αιώνα</unitPattern>
 				<unitPattern count="other">{0} αιώνες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} αιώνες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} αιώνων</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>feminine</gender>
 				<displayName>δεκαετίες</displayName>
 				<unitPattern count="one">{0} δεκαετία</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} δεκαετία</unitPattern>
 				<unitPattern count="one" case="genitive">{0} δεκαετίας</unitPattern>
 				<unitPattern count="other">{0} δεκαετίες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} δεκαετίες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} δεκαετιών</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender draft="contributed">neuter</gender>
 				<displayName>έτη</displayName>
 				<unitPattern count="one">{0} έτος</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} έτος</unitPattern>
 				<unitPattern count="one" case="genitive">{0} έτους</unitPattern>
 				<unitPattern count="other">{0} έτη</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} έτη</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ετών</unitPattern>
 				<perUnitPattern>{0} ανά έτος</perUnitPattern>
 			</unit>
@@ -8125,7 +8125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} μήνα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μήνα</unitPattern>
 				<unitPattern count="other">{0} μήνες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μήνες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μηνών</unitPattern>
 				<perUnitPattern>{0} ανά μήνα</perUnitPattern>
 			</unit>
@@ -8133,10 +8133,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>εβδομάδες</displayName>
 				<unitPattern count="one">{0} εβδομάδα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} εβδομάδα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} εβδομάδας</unitPattern>
 				<unitPattern count="other">{0} εβδομάδες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} εβδομάδες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} εβδομάδων</unitPattern>
 				<perUnitPattern>{0} ανά εβδομάδα</perUnitPattern>
 			</unit>
@@ -8144,30 +8144,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>ημέρες</displayName>
 				<unitPattern count="one">{0} ημέρα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ημέρα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ημέρας</unitPattern>
 				<unitPattern count="other">{0} ημέρες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ημέρες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ημερών</unitPattern>
 				<perUnitPattern>{0} ανά ημέρα</perUnitPattern>
 			</unit>
 			<unit type="duration-day-person">
 				<gender>feminine</gender>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ημέρα</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ημέρα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ημέρας</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ημέρες</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ημέρες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ημερών</unitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<gender draft="contributed">feminine</gender>
 				<displayName>ώρες</displayName>
 				<unitPattern count="one">{0} ώρα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ώρα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ώρας</unitPattern>
 				<unitPattern count="other">{0} ώρες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ώρες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ωρών</unitPattern>
 				<perUnitPattern>{0} ανά ώρα</perUnitPattern>
 			</unit>
@@ -8175,10 +8175,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>λεπτά</displayName>
 				<unitPattern count="one">{0} λεπτό</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} λεπτό</unitPattern>
 				<unitPattern count="one" case="genitive">{0} λεπτού</unitPattern>
 				<unitPattern count="other">{0} λεπτά</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} λεπτά</unitPattern>
 				<unitPattern count="other" case="genitive">{0} λεπτών</unitPattern>
 				<perUnitPattern>{0} ανά λεπτό</perUnitPattern>
 			</unit>
@@ -8186,10 +8186,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>δευτερόλεπτα</displayName>
 				<unitPattern count="one">{0} δευτερόλεπτο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} δευτερόλεπτο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} δευτερολέπτου</unitPattern>
 				<unitPattern count="other">{0} δευτερόλεπτα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} δευτερόλεπτα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} δευτερολέπτων</unitPattern>
 				<perUnitPattern>{0} ανά δευτερόλεπτο</perUnitPattern>
 			</unit>
@@ -8197,71 +8197,71 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>χιλιοστά του δευτερολέπτου</displayName>
 				<unitPattern count="one">{0} χιλιοστό του δευτερολέπτου</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} χιλιοστό του δευτερολέπτου</unitPattern>
 				<unitPattern count="one" case="genitive">{0} χιλιοστού του δευτερολέπτου</unitPattern>
 				<unitPattern count="other">{0} χιλιοστά του δευτερολέπτου</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} χιλιοστά του δευτερολέπτου</unitPattern>
 				<unitPattern count="other" case="genitive">{0} χιλιοστών του δευτερολέπτου</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>neuter</gender>
 				<displayName>μικροδευτερόλεπτα</displayName>
 				<unitPattern count="one">{0} μικροδευτερόλεπτο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μικροδευτερόλεπτο</unitPattern>
 				<unitPattern count="one" case="genitive">μικροδευτερόλεπτου</unitPattern>
 				<unitPattern count="other">{0} μικροδευτερόλεπτα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μικροδευτερόλεπτα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μικροδευτερόλεπτων</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>neuter</gender>
 				<displayName>νανοδευτερόλεπτα</displayName>
 				<unitPattern count="one">{0} νανοδευτερόλεπτο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} νανοδευτερόλεπτο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} νανοδευτερόλεπτου</unitPattern>
 				<unitPattern count="other">{0} νανοδευτερόλεπτα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} νανοδευτερόλεπτα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} νανοδευτερόλεπτων</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>neuter</gender>
 				<displayName>αμπέρ</displayName>
 				<unitPattern count="one">{0} αμπέρ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} αμπέρ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} αμπέρ</unitPattern>
 				<unitPattern count="other">{0} αμπέρ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} αμπέρ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} αμπέρ</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>neuter</gender>
 				<displayName>μιλιαμπέρ</displayName>
 				<unitPattern count="one">{0} μιλιαμπέρ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μιλιαμπέρ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} μιλιαμπέρ</unitPattern>
 				<unitPattern count="other">{0} μιλιαμπέρ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μιλιαμπέρ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} μιλιαμπέρ</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>neuter</gender>
 				<displayName>ωμ</displayName>
 				<unitPattern count="one">{0} ωμ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ωμ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} ωμ</unitPattern>
 				<unitPattern count="other">{0} ωμ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ωμ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ωμ</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>neuter</gender>
 				<displayName>βολτ</displayName>
 				<unitPattern count="one">{0} βολτ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} βολτ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} βολτ</unitPattern>
 				<unitPattern count="other">{0} βολτ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} βολτ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} βολτ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>χιλιοθερμίδες</displayName>
@@ -8272,10 +8272,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>θερμίδες</displayName>
 				<unitPattern count="one">{0} θερμίδα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} θερμίδα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} θερμίδας</unitPattern>
 				<unitPattern count="other">{0} θερμίδες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} θερμίδες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} θερμίδων</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
@@ -8287,30 +8287,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>κιλοτζάουλ</displayName>
 				<unitPattern count="one">{0} κιλοτζάουλ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} κιλοτζάουλ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} κιλοτζάουλ</unitPattern>
 				<unitPattern count="other">{0} κιλοτζάουλ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} κιλοτζάουλ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} κιλοτζάουλ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>neuter</gender>
 				<displayName>τζάουλ</displayName>
 				<unitPattern count="one">{0} τζάουλ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} τζάουλ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} τζάουλ</unitPattern>
 				<unitPattern count="other">{0} τζάουλ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} τζάουλ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} τζάουλ</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>feminine</gender>
 				<displayName>κιλοβατώρες</displayName>
 				<unitPattern count="one">{0} κιλοβατώρα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} κιλοβατώρα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} κιλοβατώρας</unitPattern>
 				<unitPattern count="other">{0} κιλοβατώρες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} κιλοβατώρες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} κιλοβατωρών</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
@@ -8337,101 +8337,101 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>νιούτον</displayName>
 				<unitPattern count="one">{0} νιούτον</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} νιούτον</unitPattern>
+				<unitPattern count="one" case="genitive">{0} νιούτον</unitPattern>
 				<unitPattern count="other">{0} νιούτον</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} νιούτον</unitPattern>
+				<unitPattern count="other" case="genitive">{0} νιούτον</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>feminine</gender>
 				<displayName>κιλοβατώρες ανά 100 χιλιόμετρα</displayName>
 				<unitPattern count="one">{0} κιλοβατώρα ανά 100 χιλιόμετρα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} κιλοβατώρα ανά 100 χιλιόμετρα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} κιλοβατώρας ανά 100 χιλιόμετρα</unitPattern>
 				<unitPattern count="other">{0} κιλοβατώρες ανά 100 χιλιόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} κιλοβατώρες ανά 100 χιλιόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} κιλοβατωρών ανά 100 χιλιόμετρα</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>neuter</gender>
 				<displayName>γιγαχέρτζ</displayName>
 				<unitPattern count="one">{0} γιγαχέρτζ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} γιγαχέρτζ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} γιγαχέρτζ</unitPattern>
 				<unitPattern count="other">{0} γιγαχέρτζ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} γιγαχέρτζ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} γιγαχέρτζ</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>neuter</gender>
 				<displayName>μεγαχέρτζ</displayName>
 				<unitPattern count="one">{0} μεγαχέρτζ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μεγαχέρτζ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} μεγαχέρτζ</unitPattern>
 				<unitPattern count="other">{0} μεγαχέρτζ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μεγαχέρτζ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} μεγαχέρτζ</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>neuter</gender>
 				<displayName>κιλοχέρτζ</displayName>
 				<unitPattern count="one">{0} κιλοχέρτζ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} κιλοχέρτζ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} κιλοχέρτζ</unitPattern>
 				<unitPattern count="other">{0} κιλοχέρτζ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} κιλοχέρτζ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} κιλοχέρτζ</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>neuter</gender>
 				<displayName>χερτζ</displayName>
 				<unitPattern count="one">{0} χερτζ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} χερτζ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} χερτζ</unitPattern>
 				<unitPattern count="other">{0} χερτζ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} χερτζ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} χερτζ</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender draft="contributed">neuter</gender>
 				<displayName>τυπογραφικό em</displayName>
 				<unitPattern count="one">{0} τυπογραφικό em</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} τυπογραφικό em</unitPattern>
 				<unitPattern count="one" case="genitive">{0} τυπογραφικού em</unitPattern>
 				<unitPattern count="other">{0} τυπογραφικά em</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} τυπογραφικά em</unitPattern>
 				<unitPattern count="other" case="genitive">{0} τυπογραφικών em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>neuter</gender>
 				<displayName>pixel</displayName>
 				<unitPattern count="one">{0} pixel</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} pixel</unitPattern>
+				<unitPattern count="one" case="genitive">{0} pixel</unitPattern>
 				<unitPattern count="other">{0} pixel</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pixel</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pixel</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>neuter</gender>
 				<displayName>megapixel</displayName>
 				<unitPattern count="one">{0} megapixel</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapixel</unitPattern>
+				<unitPattern count="one" case="genitive">{0} megapixel</unitPattern>
 				<unitPattern count="other">{0} megapixel</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapixel</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapixel</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>neuter</gender>
 				<displayName>pixel ανά εκατοστό</displayName>
 				<unitPattern count="one">{0} pixel ανά εκατοστό</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} pixel ανά εκατοστό</unitPattern>
+				<unitPattern count="one" case="genitive">{0} pixel ανά εκατοστό</unitPattern>
 				<unitPattern count="other">{0} pixel ανά εκατοστό</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pixel ανά εκατοστό</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pixel ανά εκατοστό</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>pixel ανά ίντσα</displayName>
@@ -8462,10 +8462,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>χιλιόμετρα</displayName>
 				<unitPattern count="one">{0} χιλιόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} χιλιόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">χιλιομέτρου</unitPattern>
 				<unitPattern count="other">{0} χιλιόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} χιλιόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} χιλιομέτρων</unitPattern>
 				<perUnitPattern>{0} ανά χιλιόμετρο</perUnitPattern>
 			</unit>
@@ -8473,10 +8473,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>μέτρα</displayName>
 				<unitPattern count="one">{0} μέτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μέτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μέτρου</unitPattern>
 				<unitPattern count="other">{0} μέτρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μέτρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μέτρων</unitPattern>
 				<perUnitPattern>{0} ανά μέτρο</perUnitPattern>
 			</unit>
@@ -8484,20 +8484,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>δεκατόμετρα</displayName>
 				<unitPattern count="one">{0} δεκατόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} δεκατόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} δεκατομέτρου</unitPattern>
 				<unitPattern count="other">{0} δεκατόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} δεκατόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} δεκατόμετρων</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>neuter</gender>
 				<displayName>εκατοστά</displayName>
 				<unitPattern count="one">{0} εκατοστό</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} εκατοστό</unitPattern>
 				<unitPattern count="one" case="genitive">{0} εκατοστού</unitPattern>
 				<unitPattern count="other">{0} εκατοστά</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} εκατοστά</unitPattern>
 				<unitPattern count="other" case="genitive">{0} εκατοστών</unitPattern>
 				<perUnitPattern>{0} ανά εκατοστό</perUnitPattern>
 			</unit>
@@ -8505,40 +8505,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>χιλιοστόμετρα</displayName>
 				<unitPattern count="one">{0} χιλιοστόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} χιλιοστόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} χιλιοστόμετρου</unitPattern>
 				<unitPattern count="other">{0} χιλιοστόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} χιλιοστόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} χιλιοστόμετρων</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>μικρόμετρα</displayName>
 				<unitPattern count="one">{0} μικρόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μικρόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μικρομέτρου</unitPattern>
 				<unitPattern count="other">{0} μικρόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μικρόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μικρομέτρων</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>neuter</gender>
 				<displayName>νανόμετρα</displayName>
 				<unitPattern count="one">{0} νανόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} νανόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} νανομέτρου</unitPattern>
 				<unitPattern count="other">{0} νανόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} νανόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} νανομέτρων</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>neuter</gender>
 				<displayName>πικόμετρα</displayName>
 				<unitPattern count="one">{0} πικόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} πικόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} πικόμετρου</unitPattern>
 				<unitPattern count="other">{0} πικόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} πικόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} πικόμετρων</unitPattern>
 			</unit>
 			<unit type="length-mile">
@@ -8597,14 +8597,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>σκανδιναβικά μίλια</displayName>
 				<unitPattern count="one">{0} σκανδιναβικό μίλι</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} σκανδιναβικό μίλι</unitPattern>
 				<unitPattern count="one" case="genitive">{0} σκανδιναβικού μιλίου</unitPattern>
 				<unitPattern count="other">{0} σκανδιναβικά μίλια</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} σκανδιναβικά μίλια</unitPattern>
 				<unitPattern count="other" case="genitive">{0} σκανδιναβικών μιλίων</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>στιγμές</displayName>
 				<unitPattern count="one">{0} στιγμή</unitPattern>
 				<unitPattern count="other">{0} στιγμές</unitPattern>
 			</unit>
@@ -8617,34 +8617,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>λουξ</displayName>
 				<unitPattern count="one">{0} λουξ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} λουξ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} λουξ</unitPattern>
 				<unitPattern count="other">{0} λουξ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} λουξ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} λουξ</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
 				<displayName>καντέλα</displayName>
 				<unitPattern count="one">{0} καντέλα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} καντέλα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} καντέλας</unitPattern>
 				<unitPattern count="other">{0} καντέλα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} καντέλα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} καντέλων</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>neuter</gender>
 				<displayName>λούμεν</displayName>
 				<unitPattern count="one">{0} λούμεν</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} λούμεν</unitPattern>
+				<unitPattern count="one" case="genitive">{0} λούμεν</unitPattern>
 				<unitPattern count="other">{0} λούμεν</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} λούμεν</unitPattern>
+				<unitPattern count="other" case="genitive">{0} λούμεν</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>ηλιακές φωτεινότητες</displayName>
 				<unitPattern count="one">{0} ηλιακή φωτεινότητα</unitPattern>
 				<unitPattern count="other">{0} ηλιακές φωτεινότητες</unitPattern>
 			</unit>
@@ -8662,10 +8662,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>χιλιόγραμμα</displayName>
 				<unitPattern count="one">{0} χιλιόγραμμο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} χιλιόγραμμο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} χιλιόγραμμου</unitPattern>
 				<unitPattern count="other">{0} χιλιόγραμμα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} χιλιόγραμμα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} χιλιόγραμμων</unitPattern>
 				<perUnitPattern>{0} ανά χιλιόγραμμο</perUnitPattern>
 			</unit>
@@ -8673,10 +8673,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>γραμμάρια</displayName>
 				<unitPattern count="one">{0} γραμμάριο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} γραμμάριο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} γραμμάριου</unitPattern>
 				<unitPattern count="other">{0} γραμμάρια</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} γραμμάρια</unitPattern>
 				<unitPattern count="other" case="genitive">{0} γραμμάριων</unitPattern>
 				<perUnitPattern>{0} ανά γραμμάριο</perUnitPattern>
 			</unit>
@@ -8684,20 +8684,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>χιλιοστόγραμμα</displayName>
 				<unitPattern count="one">{0} χιλιοστόγραμμο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} χιλιοστόγραμμο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} χιλιοστόγραμμου</unitPattern>
 				<unitPattern count="other">{0} χιλιοστόγραμμα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} χιλιοστόγραμμα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} χιλιοστόγραμμων</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>neuter</gender>
 				<displayName>μικρογραμμάρια</displayName>
 				<unitPattern count="one">{0} μικρογραμμάριο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μικρογραμμάριο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μικρογραμμάριου</unitPattern>
 				<unitPattern count="other">{0} μικρογραμμάρια</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μικρογραμμάρια</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μικρογραμμαρίων</unitPattern>
 			</unit>
 			<unit type="mass-ton">
@@ -8731,10 +8731,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>καράτια</displayName>
 				<unitPattern count="one">{0} καράτι</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} καράτι</unitPattern>
 				<unitPattern count="one" case="genitive">{0} καρατίου</unitPattern>
 				<unitPattern count="other">{0} καράτια</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} καράτια</unitPattern>
 				<unitPattern count="other" case="genitive">{0} καρατίων</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
@@ -8761,51 +8761,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>γιγαβάτ</displayName>
 				<unitPattern count="one">{0} γιγαβάτ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} γιγαβάτ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} γιγαβάτ</unitPattern>
 				<unitPattern count="other">{0} γιγαβάτ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} γιγαβάτ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} γιγαβάτ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>neuter</gender>
 				<displayName>μεγαβάτ</displayName>
 				<unitPattern count="one">{0} μεγαβάτ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μεγαβάτ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} μεγαβάτ</unitPattern>
 				<unitPattern count="other">{0} μεγαβάτ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μεγαβάτ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} μεγαβάτ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>neuter</gender>
 				<displayName>κιλοβάτ</displayName>
 				<unitPattern count="one">{0} κιλοβάτ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} κιλοβάτ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} κιλοβάτ</unitPattern>
 				<unitPattern count="other">{0} κιλοβάτ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} κιλοβάτ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} κιλοβάτ</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>neuter</gender>
 				<displayName>βατ</displayName>
 				<unitPattern count="one">{0} βατ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} βατ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} βατ</unitPattern>
 				<unitPattern count="other">{0} βατ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} βατ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} βατ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>neuter</gender>
 				<displayName>μιλιβάτ</displayName>
 				<unitPattern count="one">{0} μιλιβάτ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μιλιβάτ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} μιλιβάτ</unitPattern>
 				<unitPattern count="other">{0} μιλιβάτ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μιλιβάτ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} μιλιβάτ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>ίπποι</displayName>
@@ -8831,90 +8831,90 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>μπαρ</displayName>
 				<unitPattern count="one">{0} μπαρ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μπαρ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} μπαρ</unitPattern>
 				<unitPattern count="other">{0} μπαρ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μπαρ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} μπαρ</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>neuter</gender>
 				<displayName>μιλιμπάρ</displayName>
 				<unitPattern count="one">{0} μιλιμπάρ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μιλιμπάρ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} μιλιμπάρ</unitPattern>
 				<unitPattern count="other">{0} μιλιμπάρ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μιλιμπάρ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} μιλιμπάρ</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>feminine</gender>
 				<displayName>ατμόσφαιρες</displayName>
 				<unitPattern count="one">{0} ατμόσφαιρα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ατμόσφαιρα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ατμόσφαιρας</unitPattern>
 				<unitPattern count="other">{0} ατμόσφαιρες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ατμόσφαιρες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ατμόσφαιρων</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>neuter</gender>
 				<displayName>πασκάλ</displayName>
 				<unitPattern count="one">{0} πασκάλ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} πασκάλ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} πασκάλ</unitPattern>
 				<unitPattern count="other">{0} πασκάλ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} πασκάλ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} πασκάλ</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>neuter</gender>
 				<displayName>εκτοπασκάλ</displayName>
 				<unitPattern count="one">{0} εκτοπασκάλ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} εκτοπασκάλ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} εκτοπασκάλ</unitPattern>
 				<unitPattern count="other">{0} εκτοπασκάλ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} εκτοπασκάλ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} εκτοπασκάλ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>neuter</gender>
 				<displayName>κιλοπασκάλ</displayName>
 				<unitPattern count="one">{0} κιλοπασκάλ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} κιλοπασκάλ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} κιλοπασκάλ</unitPattern>
 				<unitPattern count="other">{0} κιλοπασκάλ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} κιλοπασκάλ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} κιλοπασκάλ</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>neuter</gender>
 				<displayName>μεγαπασκάλ</displayName>
 				<unitPattern count="one">{0} μεγαπασκάλ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μεγαπασκάλ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} μεγαπασκάλ</unitPattern>
 				<unitPattern count="other">{0} μεγαπασκάλ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μεγαπασκάλ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} μεγαπασκάλ</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>neuter</gender>
 				<displayName>χιλιόμετρα ανά ώρα</displayName>
 				<unitPattern count="one">{0} χιλιόμετρο ανά ώρα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} χιλιόμετρο ανά ώρα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} χιλιόμετρου ανά ώρα</unitPattern>
 				<unitPattern count="other">{0} χιλιόμετρα ανά ώρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} χιλιόμετρα ανά ώρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} χιλιομέτρων ανά ώρα</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>neuter</gender>
 				<displayName>μέτρα ανά δευτερόλεπτο</displayName>
 				<unitPattern count="one">{0} μέτρο ανά δευτερόλεπτο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μέτρο ανά δευτερόλεπτο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μέτρου ανά δευτερόλεπτο</unitPattern>
 				<unitPattern count="other">{0} μέτρα ανά δευτερόλεπτο</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μέτρα ανά δευτερόλεπτο</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μέτρων ανά δευτερόλεπτο</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
@@ -8971,30 +8971,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>νιουτόμετρα</displayName>
 				<unitPattern count="one">{0} νιουτόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} νιουτόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} νιουτόμετρου</unitPattern>
 				<unitPattern count="other">{0} νιουτόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} νιουτόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} νιουτόμετρων</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>neuter</gender>
 				<displayName>κυβικά χιλιόμετρα</displayName>
 				<unitPattern count="one">{0} κυβικό χιλιόμετρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} κυβικό χιλιόμετρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} κυβικού χιλιομέτρου</unitPattern>
 				<unitPattern count="other">{0} κυβικά χιλιόμετρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} κυβικά χιλιόμετρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} κυβικών χιλιομέτρων</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>neuter</gender>
 				<displayName>κυβικά μέτρα</displayName>
 				<unitPattern count="one">{0} κυβικό μέτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} κυβικό μέτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} κυβικού μέτρου</unitPattern>
 				<unitPattern count="other">{0} κυβικά μέτρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} κυβικά μέτρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} κυβικών μέτρων</unitPattern>
 				<perUnitPattern>{0} ανά κυβικό μέτρο</perUnitPattern>
 			</unit>
@@ -9002,10 +9002,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>κυβικά εκατοστά</displayName>
 				<unitPattern count="one">{0} κυβικό εκατοστό</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} κυβικό εκατοστό</unitPattern>
 				<unitPattern count="one" case="genitive">{0} κυβικού εκατοστού</unitPattern>
 				<unitPattern count="other">{0} κυβικά εκατοστά</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} κυβικά εκατοστά</unitPattern>
 				<unitPattern count="other" case="genitive">{0} κυβικών εκατοστών</unitPattern>
 				<perUnitPattern>{0} ανά κυβικό εκατοστό</perUnitPattern>
 			</unit>
@@ -9033,30 +9033,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>μεγαλίτρα</displayName>
 				<unitPattern count="one">{0} μεγαλίτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μεγαλίτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μεγαλίτρου</unitPattern>
 				<unitPattern count="other">{0} μεγαλίτρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μεγαλίτρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μεγαλίτρων</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>neuter</gender>
 				<displayName>εκτόλιτρα</displayName>
 				<unitPattern count="one">{0} εκτόλιτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} εκτόλιτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} εκτόλιτρου</unitPattern>
 				<unitPattern count="other">{0} εκτόλιτρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} εκτόλιτρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} εκτόλιτρων</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>neuter</gender>
 				<displayName>λίτρα</displayName>
 				<unitPattern count="one">{0} λίτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} λίτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} λίτρου</unitPattern>
 				<unitPattern count="other">{0} λίτρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} λίτρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} λίτρων</unitPattern>
 				<perUnitPattern>{0} ανά λίτρο</perUnitPattern>
 			</unit>
@@ -9064,50 +9064,50 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>δεκατόλιτρα</displayName>
 				<unitPattern count="one">{0} δεκατόλιτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} δεκατόλιτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} δεκατόλιτρου</unitPattern>
 				<unitPattern count="other">{0} δεκατόλιτρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} δεκατόλιτρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} δεκατόλιτρων</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>neuter</gender>
 				<displayName>εκατοστόλιτρα</displayName>
 				<unitPattern count="one">{0} εκατοστόλιτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} εκατοστόλιτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} εκατοστόλιτρου</unitPattern>
 				<unitPattern count="other">{0} εκατοστόλιτρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} εκατοστόλιτρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} εκατοστόλιτρων</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>neuter</gender>
 				<displayName>χιλιοστόλιτρα</displayName>
 				<unitPattern count="one">{0} χιλιοστόλιτρο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} χιλιοστόλιτρο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} χιλιοστόλιτρου</unitPattern>
 				<unitPattern count="other">{0} χιλιοστόλιτρα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} χιλιοστόλιτρα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} χιλιοστόλιτρων</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>feminine</gender>
 				<displayName>μετρικές πίντες</displayName>
 				<unitPattern count="one">{0} μετρική πίντα</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μετρική πίντα</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μετρικής πίντας</unitPattern>
 				<unitPattern count="other">{0} μετρικές πίντες</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μετρικές πίντες</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μετρικών πιντών</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>neuter</gender>
 				<displayName>μετρικά κύπελλα</displayName>
 				<unitPattern count="one">{0} μετρικό κύπελλο</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} μετρικό κύπελλο</unitPattern>
 				<unitPattern count="one" case="genitive">{0} μετρικού κύπελλου</unitPattern>
 				<unitPattern count="other">{0} μετρικά κύπελλα</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} μετρικά κύπελλα</unitPattern>
 				<unitPattern count="other" case="genitive">{0} μετρικών κύπελλων</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
@@ -9305,7 +9305,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
@@ -9701,27 +9701,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pixel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapixel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -9851,7 +9851,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>ακτίνες Ήλιου</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9935,7 +9935,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Ντάλτον</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
@@ -10355,17 +10355,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName draft="contributed">G</displayName>
@@ -10374,18 +10374,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName draft="contributed">m/s²</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} m/s²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">στρφ</displayName>
+				<unitPattern count="one" draft="contributed">{0} στρφ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} στρφ</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ακτν</displayName>
+				<unitPattern count="one" draft="contributed">{0} ακτν</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ακτν</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>°</displayName>
@@ -10403,10 +10403,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>τ.χλμ.</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/τ.χλμ.</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ha</displayName>
@@ -10415,62 +10415,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>τ.μ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} τ.μ.</unitPattern>
+				<unitPattern count="other">{0} τ.μ.</unitPattern>
+				<perUnitPattern>{0}/τ.μ.</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>τ.εκ.</displayName>
+				<unitPattern count="one">{0} τ.εκ.</unitPattern>
+				<unitPattern count="other">{0} τ.εκ.</unitPattern>
+				<perUnitPattern>{0}/τ.εκ.</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>τ.μίλι</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} τ.μίλι</unitPattern>
+				<unitPattern count="other">{0} τ.μίλια</unitPattern>
+				<perUnitPattern>{0}/τ.μίλι</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ακρ</displayName>
+				<unitPattern count="one">{0} ακρ</unitPattern>
+				<unitPattern count="other">{0} ακρ</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>τ.γρδ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} τ.γρδ</unitPattern>
+				<unitPattern count="other">{0} τ.γρδ</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>τ.πδ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} τ.πδ</unitPattern>
+				<unitPattern count="other">{0} τ.πδ</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>τ. ίντσες</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} τ. ίντσα</unitPattern>
+				<unitPattern count="other">{0} τ. ίντσες</unitPattern>
+				<perUnitPattern>{0}/τ. ίντσα</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ντούναμ</displayName>
+				<unitPattern count="one">{0} ντούναμ</unitPattern>
+				<unitPattern count="other">{0} ντούναμ</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>κρτ</displayName>
+				<unitPattern count="one">{0} κρτ</unitPattern>
+				<unitPattern count="other">{0} κρτ</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>στοιχείο</displayName>
@@ -10479,8 +10479,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -10489,18 +10489,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μολ</displayName>
+				<unitPattern count="one">{0} μολ</unitPattern>
+				<unitPattern count="other">{0} μολ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>λ/χλμ</displayName>
@@ -10514,78 +10514,78 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μίλια/αγγλ. γαλόνι</displayName>
+				<unitPattern count="one">{0} μίλι/αγγλ. γαλόνι</unitPattern>
+				<unitPattern count="other">{0} μίλια/αγγλ. γαλόνι</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName draft="contributed">PB</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} PB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">TB</displayName>
+				<unitPattern count="one" draft="contributed">{0} TB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Tb</displayName>
+				<unitPattern count="one" draft="contributed">{0} Tb</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">GB</displayName>
+				<unitPattern count="one" draft="contributed">{0} GB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Gb</displayName>
+				<unitPattern count="one" draft="contributed">{0} Gb</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">MB</displayName>
+				<unitPattern count="one" draft="contributed">{0} MB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Mb</displayName>
+				<unitPattern count="one" draft="contributed">{0} Mb</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">kB</displayName>
+				<unitPattern count="one" draft="contributed">{0} kB</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>byte</displayName>
+				<unitPattern count="one">{0} byte</unitPattern>
+				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>αιών.</displayName>
+				<unitPattern count="one">{0} αιών.</unitPattern>
+				<unitPattern count="other">{0} αιών.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>δεκ.</displayName>
+				<unitPattern count="one">{0} δεκ.</unitPattern>
+				<unitPattern count="other">{0} δεκ.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>έτ.</displayName>
@@ -10594,7 +10594,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/έ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">τετ.</displayName>
 				<unitPattern count="one">{0} τέτ.</unitPattern>
 				<unitPattern count="other">{0} τέτ.</unitPattern>
 				<perUnitPattern>{0}/τέτ.</perUnitPattern>
@@ -10642,58 +10642,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>μs</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>ns</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">θερμ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} θερμ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} θερμ.</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">θερμ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} θερμ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} θερμ.</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kJ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>J</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kW/ώ.</displayName>
@@ -10702,78 +10702,78 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} BTU</unitPattern>
+				<unitPattern count="other">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>θερμ. μονάδες ΗΠΑ</displayName>
+				<unitPattern count="one">{0} θερμ. μονάδα ΗΠΑ</unitPattern>
+				<unitPattern count="other">{0} θερμ. μονάδες ΗΠΑ</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100 χλμ.</displayName>
+				<unitPattern count="one">{0} kWh/100 χλμ.</unitPattern>
+				<unitPattern count="other">{0} kWh/100 χλμ.</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Hz</displayName>
+				<unitPattern count="one" draft="contributed">{0} Hz</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pixel</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
@@ -10786,37 +10786,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pixel</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>χλμ.</displayName>
 				<unitPattern count="one">{0} χλμ.</unitPattern>
 				<unitPattern count="other">{0} χλμ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/χλμ.</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>μέτρο</displayName>
 				<unitPattern count="one">{0} μ.</unitPattern>
 				<unitPattern count="other">{0} μ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/μ.</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>δεκ.</displayName>
+				<unitPattern count="one">{0} δεκ.</unitPattern>
+				<unitPattern count="other">{0} δεκ.</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>εκ.</displayName>
 				<unitPattern count="one">{0} εκ.</unitPattern>
 				<unitPattern count="other">{0} εκ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/εκ.</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>χλστ.</displayName>
@@ -10825,16 +10825,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>μm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
@@ -10852,18 +10852,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>πδ</displayName>
 				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="other">{0} ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/πδ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>ίν.</displayName>
 				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="other">{0} in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ίν.</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>pc</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>έ.φ.</displayName>
@@ -10871,49 +10871,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>α.μ.</displayName>
+				<unitPattern count="one">{0} α.μ.</unitPattern>
+				<unitPattern count="other">{0} α.μ.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>φέρλ.</displayName>
+				<unitPattern count="one">{0} φέρλ.</unitPattern>
+				<unitPattern count="other">{0} φέρλ.</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>οργ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} οργ.</unitPattern>
+				<unitPattern count="other">{0} οργ.</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ν.μ.</displayName>
+				<unitPattern count="one">{0} ν.μ.</unitPattern>
+				<unitPattern count="other">{0} ν.μ.</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
+				<displayName>σκανδ. μίλια</displayName>
 				<unitPattern count="one">{0}smi</unitPattern>
 				<unitPattern count="other">{0}smi</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>στ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} στ.</unitPattern>
+				<unitPattern count="other">{0} στ.</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>λουξ</displayName>
+				<unitPattern count="one">{0} λουξ</unitPattern>
+				<unitPattern count="other">{0} λουξ</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>καντ.</displayName>
+				<unitPattern count="one">{0} καντ.</unitPattern>
+				<unitPattern count="other">{0} καντ.</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>λμ.</displayName>
@@ -10922,13 +10922,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>τ.</displayName>
+				<unitPattern count="one">{0} τ.</unitPattern>
+				<unitPattern count="other">{0} τ.</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
@@ -10940,79 +10940,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>γρ.</displayName>
 				<unitPattern count="one">{0} γρ.</unitPattern>
 				<unitPattern count="other">{0} γρ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/γρ.</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mg</displayName>
+				<unitPattern count="one" draft="contributed">{0} mg</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">μg</displayName>
+				<unitPattern count="one" draft="contributed">{0} μg</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName draft="contributed">τ. ΗΠΑ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} τ. ΗΠΑ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} τ. ΗΠΑ</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">st</displayName>
+				<unitPattern count="one" draft="contributed">{0} st</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>λβ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} λβ</unitPattern>
+				<unitPattern count="other">{0} λβ</unitPattern>
+				<perUnitPattern>{0}/λβ</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz t</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName draft="contributed">κρτ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} κρτ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} κρτ</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName draft="contributed">Da</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Da</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName draft="contributed">M⊕</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} M⊕</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName draft="contributed">M☉</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} M☉</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">κόκ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} κόκ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} κόκ.</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>GW</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>MW</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>kW</displayName>
@@ -11026,8 +11026,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>mW</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>hp</displayName>
@@ -11035,54 +11035,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mmHg</displayName>
+				<unitPattern count="one" draft="contributed">{0} mmHg</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">psi</displayName>
+				<unitPattern count="one" draft="contributed">{0} psi</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μπαρ</displayName>
+				<unitPattern count="one">{0} μπαρ</unitPattern>
+				<unitPattern count="other">{0} μπαρ</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one" draft="contributed">{0} kPa</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>χλμ/ώ.</displayName>
@@ -11100,14 +11100,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} μίλια/ώ.</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">κμβ</displayName>
+				<unitPattern count="one" draft="contributed">{0} κμβ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} κμβ</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -11120,19 +11120,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>λβρ⋅πδ</displayName>
+				<unitPattern count="one">{0} λβρ⋅πδ</unitPattern>
+				<unitPattern count="other">{0} λβρ⋅πδ</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>km³</displayName>
@@ -11140,16 +11140,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">m³</displayName>
+				<unitPattern count="one" draft="contributed">{0} m³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} m³</unitPattern>
+				<perUnitPattern draft="contributed">{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">cm³</displayName>
+				<unitPattern count="one" draft="contributed">{0} cm³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cm³</unitPattern>
+				<perUnitPattern draft="contributed">{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>mi³</displayName>
@@ -11158,49 +11158,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName draft="contributed">yd³</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} κυβ. γιάρδα</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} κυβ. γιάρδες</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ft³</displayName>
+				<unitPattern count="one" draft="contributed">{0} ft³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">in³</displayName>
+				<unitPattern count="one" draft="contributed">{0} in³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ML</displayName>
+				<unitPattern count="one" draft="contributed">{0} ML</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">hL</displayName>
+				<unitPattern count="one" draft="contributed">{0} hL</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>λίτρο</displayName>
 				<unitPattern count="one">{0} λ.</unitPattern>
 				<unitPattern count="other">{0} λ.</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/λ.</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">dL</displayName>
+				<unitPattern count="one" draft="contributed">{0} dL</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">cL</displayName>
+				<unitPattern count="one" draft="contributed">{0} cL</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>μ. πίντες</displayName>
@@ -11214,70 +11214,70 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName draft="contributed">ακρ πδ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ακρ πδ</unitPattern>
+				<unitPattern count="other">{0} ακρ πδ</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μπ.</displayName>
+				<unitPattern count="one">{0} μπ.</unitPattern>
+				<unitPattern count="other">{0} μπ.</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>γαλ.</displayName>
+				<unitPattern count="one">{0} γαλ.</unitPattern>
+				<unitPattern count="other">{0} γαλ.</unitPattern>
+				<perUnitPattern>{0}/γαλ.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">αγγλοσαξ. γαλόνια</displayName>
+				<unitPattern count="one" draft="contributed">{0} αγγλοσαξ. γαλόνι</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} αγγλοσαξ. γαλόνια</unitPattern>
+				<perUnitPattern draft="contributed">{0}/αγγλοσαξ. γαλόνι</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName draft="contributed">τέτ. γαλ.</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} τέτ. γαλ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} τέτ. γαλ.</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName draft="contributed">πντ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} πντ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} πντ</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">κύπ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} κύπ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} κύπ.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">fl oz</displayName>
+				<unitPattern count="one" draft="contributed">{0} fl oz</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">αγγλ. ουγγιές όγκου</displayName>
+				<unitPattern count="one" draft="contributed">{0} αγγλ. ουγγιά όγκου</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} αγγλ. ουγγιές όγκου</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">κ.σ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} κ.σ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} κ.σ.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">κ.γ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} κ.γ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} κ.γ.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName draft="contributed">βρλ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} βρλ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} βρλ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">κ.φρ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} κ.φρ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} κ.φρ.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName draft="contributed">αγγλ. κ.φρ.</displayName>
@@ -11285,29 +11285,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} αγγλ. κ.φρ.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">σταγ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} σταγ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} σταγ.</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName draft="contributed">δρ. όγκου</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} δρ. όγκου</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} δρ. όγκου</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">μεζ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} μεζ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} μεζ.</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">πρ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} πρ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} πρ.</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">αγγλ. τέτ. γαλ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} αγγλ. τέτ. γαλ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} αγγλ. τέτ. γαλ.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>σημεία</displayName>
@@ -11341,20 +11341,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ή {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ή {1}</listPatternPart>
+			<listPatternPart type="2">{0} ή {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ή {1}</listPatternPart>
+			<listPatternPart type="2">{0} ή {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -11584,43 +11584,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
 			<namePattern>{given}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
@@ -11638,7 +11638,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2-initial} {credentials}</namePattern>
@@ -11653,10 +11653,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{surname} {given-initial} {given2-initial}</namePattern>
@@ -11671,10 +11671,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>{surname-core}, {surname-prefix} {given} {given2}</namePattern>
@@ -11683,13 +11683,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {surname-prefix} {given} {given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {surname-prefix} {given} {given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/eo.xml
+++ b/common/main/eo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -522,7 +522,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CG" alt="variant" draft="unconfirmed">Respubliko Kongo</territory>
 			<territory type="CH">Svisujo</territory>
 			<territory type="CI">Ebur-Bordo</territory>
-			<territory type="CI" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="CI" alt="variant" draft="unconfirmed">Ebur-Bordo</territory>
 			<territory type="CK">Kukinsuloj</territory>
 			<territory type="CL">Ĉilio</territory>
 			<territory type="CM">Kameruno</territory>
@@ -557,7 +557,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="FI">Finnlando</territory>
 			<territory type="FJ">Fiĝoj</territory>
 			<territory type="FK" draft="unconfirmed">Falklandoj</territory>
-			<territory type="FK" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="FK" alt="variant" draft="unconfirmed">Falklandoj</territory>
 			<territory type="FM">Mikronezio</territory>
 			<territory type="FO">Ferooj</territory>
 			<territory type="FR">Francujo</territory>
@@ -582,7 +582,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="GW">Gvineo-Bisaŭo</territory>
 			<territory type="GY">Gujano</territory>
 			<territory type="HK" draft="unconfirmed">Honkongo</territory>
-			<territory type="HK" alt="short" draft="unconfirmed">↑↑↑</territory>
+			<territory type="HK" alt="short" draft="unconfirmed">Honkongo</territory>
 			<territory type="HM">Herda kaj Makdonaldaj Insuloj</territory>
 			<territory type="HN">Honduro</territory>
 			<territory type="HR">Kroatujo</territory>
@@ -661,7 +661,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">Nauro</territory>
 			<territory type="NU">Niuo</territory>
 			<territory type="NZ">Nov-Zelando</territory>
-			<territory type="NZ" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="NZ" alt="variant" draft="unconfirmed">Nov-Zelando</territory>
 			<territory type="OM">Omano</territory>
 			<territory type="PA">Panamo</territory>
 			<territory type="PE">Peruo</territory>
@@ -706,7 +706,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="SX" draft="unconfirmed">Sint-Maarten</territory>
 			<territory type="SY">Sirio</territory>
 			<territory type="SZ">Svazilando</territory>
-			<territory type="SZ" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="SZ" alt="variant" draft="unconfirmed">Svazilando</territory>
 			<territory type="TA" draft="unconfirmed">Tristan da Cunha</territory>
 			<territory type="TC" draft="unconfirmed">Turkoj kaj Kajkoj</territory>
 			<territory type="TD">Ĉado</territory>
@@ -721,7 +721,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunizio</territory>
 			<territory type="TO">Tongo</territory>
 			<territory type="TR">Turkujo</territory>
-			<territory type="TR" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="TR" alt="variant" draft="unconfirmed">Turkujo</territory>
 			<territory type="TT">Trinidado kaj Tobago</territory>
 			<territory type="TV">Tuvalo</territory>
 			<territory type="TW">Tajvano</territory>
@@ -731,7 +731,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UM">Usonaj malgrandaj insuloj</territory>
 			<territory type="UN" draft="unconfirmed">Unuiĝintaj Nacioj</territory>
 			<territory type="US">Usono</territory>
-			<territory type="US" alt="short" draft="unconfirmed">↑↑↑</territory>
+			<territory type="US" alt="short" draft="unconfirmed">Usono</territory>
 			<territory type="UY">Urugvajo</territory>
 			<territory type="UZ">Uzbekujo</territory>
 			<territory type="VA">Vatikano</territory>
@@ -838,7 +838,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -846,7 +846,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1051,18 +1051,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">dec</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">J</month>
+							<month type="2" draft="unconfirmed">F</month>
+							<month type="3" draft="unconfirmed">M</month>
+							<month type="4" draft="unconfirmed">A</month>
+							<month type="5" draft="unconfirmed">M</month>
+							<month type="6" draft="unconfirmed">J</month>
+							<month type="7" draft="unconfirmed">J</month>
+							<month type="8" draft="unconfirmed">A</month>
+							<month type="9" draft="unconfirmed">S</month>
+							<month type="10" draft="unconfirmed">O</month>
+							<month type="11" draft="unconfirmed">N</month>
+							<month type="12" draft="unconfirmed">D</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">januaro</month>
@@ -1136,22 +1136,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">sa</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">D</day>
+							<day type="mon" draft="unconfirmed">L</day>
+							<day type="tue" draft="unconfirmed">M</day>
+							<day type="wed" draft="unconfirmed">M</day>
+							<day type="thu" draft="unconfirmed">Ĵ</day>
+							<day type="fri" draft="unconfirmed">V</day>
+							<day type="sat" draft="unconfirmed">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">di</day>
+							<day type="mon" draft="unconfirmed">lu</day>
+							<day type="tue" draft="unconfirmed">ma</day>
+							<day type="wed" draft="unconfirmed">me</day>
+							<day type="thu" draft="unconfirmed">ĵa</day>
+							<day type="fri" draft="unconfirmed">ve</day>
+							<day type="sat" draft="unconfirmed">sa</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">dimanĉo</day>
@@ -1165,13 +1165,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">di</day>
+							<day type="mon" draft="unconfirmed">lu</day>
+							<day type="tue" draft="unconfirmed">ma</day>
+							<day type="wed" draft="unconfirmed">me</day>
+							<day type="thu" draft="unconfirmed">ĵa</day>
+							<day type="fri" draft="unconfirmed">ve</day>
+							<day type="sat" draft="unconfirmed">sa</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun" draft="unconfirmed">D</day>
@@ -1183,13 +1183,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat" draft="unconfirmed">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">di</day>
+							<day type="mon" draft="unconfirmed">lu</day>
+							<day type="tue" draft="unconfirmed">ma</day>
+							<day type="wed" draft="unconfirmed">me</day>
+							<day type="thu" draft="unconfirmed">ĵa</day>
+							<day type="fri" draft="unconfirmed">ve</day>
+							<day type="sat" draft="unconfirmed">sa</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">dimanĉo</day>
@@ -1211,10 +1211,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4" draft="unconfirmed">4. jk.</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="1" draft="unconfirmed">1</quarter>
+							<quarter type="2" draft="unconfirmed">2</quarter>
+							<quarter type="3" draft="unconfirmed">3</quarter>
+							<quarter type="4" draft="unconfirmed">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1" draft="unconfirmed">1-a jarkvarono</quarter>
@@ -1261,16 +1261,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">atm</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">ptm</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="am" draft="unconfirmed">a</dayPeriod>
 							<dayPeriod type="pm" draft="unconfirmed">p</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">atm</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">ptm</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -1289,7 +1289,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">aK</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">aK</era>
 						<era type="1">pK</era>
 						<era type="1" alt="variant" draft="unconfirmed">KE</era>
 					</eraNarrow>
@@ -1368,7 +1368,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1376,7 +1376,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1583,10 +1583,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">erao</displayName>
 			</field>
 			<field type="era-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">erao</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">erao</displayName>
 			</field>
 			<field type="year">
 				<displayName draft="unconfirmed">jaro</displayName>
@@ -1603,21 +1603,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="year-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<displayName draft="unconfirmed">jaro</displayName>
+				<relative type="-1" draft="unconfirmed">pasinta jaro</relative>
+				<relative type="0" draft="unconfirmed">nuna jaro</relative>
+				<relative type="1" draft="unconfirmed">venonta jaro</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">post {0} jaro</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">post {0} jaroj</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">antaŭ {0} jaro</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">antaŭ {0} jaroj</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">jaro</displayName>
 				<relative type="-1" draft="unconfirmed">pasinta j.</relative>
 				<relative type="0" draft="unconfirmed">nuna j.</relative>
 				<relative type="1" draft="unconfirmed">venonta j.</relative>
@@ -1645,14 +1645,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">jarkvarono</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">post {0} jarkvarono</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">post {0} jarkvaronoj</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">antaŭ {0} jarkvarono</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">antaŭ {0} jarkvaronoj</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
@@ -1695,7 +1695,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mon.</displayName>
 				<relative type="-1" draft="unconfirmed">pasinta mon.</relative>
 				<relative type="0" draft="unconfirmed">nuna mon.</relative>
 				<relative type="1" draft="unconfirmed">venonta mon.</relative>
@@ -1739,7 +1739,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativePeriod draft="unconfirmed">la semajno de {0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">sem.</displayName>
 				<relative type="-1" draft="unconfirmed">pasinta sem.</relative>
 				<relative type="0" draft="unconfirmed">nuna sem.</relative>
 				<relative type="1" draft="unconfirmed">venonta sem.</relative>
@@ -1760,7 +1760,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">sem. de mon.</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">sem. de mon.</displayName>
 			</field>
 			<field type="day">
 				<displayName draft="unconfirmed">tago</displayName>
@@ -1777,24 +1777,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<displayName draft="unconfirmed">tago</displayName>
+				<relative type="-1" draft="unconfirmed">hieraŭ</relative>
+				<relative type="0" draft="unconfirmed">hodiaŭ</relative>
+				<relative type="1" draft="unconfirmed">morgaŭ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">post {0} tago</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">post {0} tagoj</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">antaŭ {0} tago</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">antaŭ {0} tagoj</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
 				<displayName draft="unconfirmed">t.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">hieraŭ</relative>
+				<relative type="0" draft="unconfirmed">hodiaŭ</relative>
+				<relative type="1" draft="unconfirmed">morgaŭ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">post {0} t.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">post {0} t.</relativeTimePattern>
@@ -1808,7 +1808,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">tago de jaro</displayName>
 			</field>
 			<field type="dayOfYear-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">tago de jaro</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
 				<displayName draft="unconfirmed">t. de j.</displayName>
@@ -1829,7 +1829,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">st. de monato</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">st. de monato</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1" draft="unconfirmed">pasinta dimanĉo</relative>
@@ -2126,14 +2126,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="hour-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">horo</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">post {0} horo</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">post {0} horoj</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">antaŭ {0} horo</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">antaŭ {0} horoj</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
@@ -2219,7 +2219,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">horzono</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">horzono</displayName>
 			</field>
 			<field type="zone-narrow">
 				<displayName draft="unconfirmed">zono</displayName>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -107,7 +107,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cheroqui</language>
 			<language type="chy">cheyene</language>
 			<language type="ckb">kurdo sorani</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">kurdo sorani</language>
 			<language type="ckb" alt="variant">kurdo central</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">corso</language>
@@ -1014,7 +1014,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Túnez</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turquía</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turquía</territory>
 			<territory type="TT">Trinidad y Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwán</territory>
@@ -1635,7 +1635,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1643,7 +1643,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1651,7 +1651,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1659,7 +1659,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1965,7 +1965,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="wed">X</day>
 							<day type="thu">J</day>
 							<day type="fri">V</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">DO</day>
@@ -2199,7 +2199,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2207,7 +2207,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2215,7 +2215,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2223,7 +2223,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -7900,7 +7900,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="concentr-mole">
 				<gender>masculine</gender>
 				<displayName>moles</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">{0} moles</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -9286,7 +9286,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -9301,12 +9301,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -9376,7 +9376,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9461,7 +9461,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>fur</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
@@ -9486,7 +9486,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9496,17 +9496,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9543,7 +9543,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -9570,17 +9570,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -9660,12 +9660,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -9803,7 +9803,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -9963,28 +9963,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
 				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
@@ -10003,22 +10003,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fg</displayName>
 				<unitPattern count="one">{0}Fg</unitPattern>
 				<unitPattern count="other">{0}Fg</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s²</displayName>
 				<unitPattern count="one">{0}m/s²</unitPattern>
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
+				<displayName>rev</displayName>
 				<unitPattern count="one">{0}rev</unitPattern>
 				<unitPattern count="other">{0}rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>rad</displayName>
 				<unitPattern count="one">{0}rad</unitPattern>
 				<unitPattern count="other">{0}rad</unitPattern>
 			</unit>
@@ -10028,64 +10028,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcmin</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcsec</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0}km²</unitPattern>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ha</displayName>
 				<unitPattern count="one">{0}ha</unitPattern>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm²</displayName>
 				<unitPattern count="one">{0}cm²</unitPattern>
 				<unitPattern count="other">{0}cm²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0}mi²</unitPattern>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ac</displayName>
 				<unitPattern count="one">{0}ac</unitPattern>
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd²</displayName>
 				<unitPattern count="one">{0}yd²</unitPattern>
 				<unitPattern count="other">{0}yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">{0}ft²</unitPattern>
 				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in²</displayName>
 				<unitPattern count="one">{0}in²</unitPattern>
 				<unitPattern count="other">{0}in²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
@@ -10093,17 +10093,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>ct</displayName>
 				<unitPattern count="one">{0}ct</unitPattern>
 				<unitPattern count="other">{0}ct</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg/dL</displayName>
 				<unitPattern count="one">{0}mg/dL</unitPattern>
 				<unitPattern count="other">{0}mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mmol/L</displayName>
 				<unitPattern count="one">{0}mmol/L</unitPattern>
 				<unitPattern count="other">{0}mmol/L</unitPattern>
 			</unit>
@@ -10113,7 +10113,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ít</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppm</displayName>
 				<unitPattern count="one">{0}ppm</unitPattern>
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
@@ -10123,22 +10123,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>por mil</displayName>
 				<unitPattern count="one">{0}‰</unitPattern>
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>por diez mil</displayName>
 				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0}mol</unitPattern>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>l/km</displayName>
 				<unitPattern count="one">{0}l/km</unitPattern>
 				<unitPattern count="other">{0}l/km</unitPattern>
 			</unit>
@@ -10148,7 +10148,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/gal</displayName>
 				<unitPattern count="one">{0}mi/gal</unitPattern>
 				<unitPattern count="other">{0}mi/gal</unitPattern>
 			</unit>
@@ -10158,57 +10158,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}m/g imp</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>PB</displayName>
 				<unitPattern count="one">{0}PB</unitPattern>
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>TB</displayName>
 				<unitPattern count="one">{0}TB</unitPattern>
 				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Tb</displayName>
 				<unitPattern count="one">{0}Tb</unitPattern>
 				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>GB</displayName>
 				<unitPattern count="one">{0}GB</unitPattern>
 				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gb</displayName>
 				<unitPattern count="one">{0}Gb</unitPattern>
 				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="one">{0}MB</unitPattern>
 				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mb</displayName>
 				<unitPattern count="one">{0}Mb</unitPattern>
 				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>kB</displayName>
 				<unitPattern count="one">{0}kB</unitPattern>
 				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>kb</displayName>
 				<unitPattern count="one">{0}kb</unitPattern>
 				<unitPattern count="other">{0}kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>B</displayName>
 				<unitPattern count="one">{0}B</unitPattern>
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>b</displayName>
 				<unitPattern count="one">{0}b</unitPattern>
 				<unitPattern count="other">{0}b</unitPattern>
 			</unit>
@@ -10286,147 +10286,147 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>A</displayName>
 				<unitPattern count="one">{0}A</unitPattern>
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>mA</displayName>
 				<unitPattern count="one">{0}mA</unitPattern>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ω</displayName>
 				<unitPattern count="one">{0}Ω</unitPattern>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>V</displayName>
 				<unitPattern count="one">{0}V</unitPattern>
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0}kcal</unitPattern>
 				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="one">{0}cal</unitPattern>
 				<unitPattern count="other">{0}cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0}kcal</unitPattern>
 				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kJ</displayName>
 				<unitPattern count="one">{0}kJ</unitPattern>
 				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>J</displayName>
 				<unitPattern count="one">{0}J</unitPattern>
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh</displayName>
 				<unitPattern count="one">{0}kWh</unitPattern>
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>eV</displayName>
 				<unitPattern count="one">{0}eV</unitPattern>
 				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>BTU</displayName>
 				<unitPattern count="one">{0}BTU</unitPattern>
 				<unitPattern count="other">{0}BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>thm EE. UU.</displayName>
 				<unitPattern count="one">{0}thm EEUU</unitPattern>
 				<unitPattern count="other">{0}thm EEUU</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf</displayName>
 				<unitPattern count="one">{0}lbf</unitPattern>
 				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>N</displayName>
 				<unitPattern count="one">{0}N</unitPattern>
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100 km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="one">{0}GHz</unitPattern>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="one">{0}MHz</unitPattern>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="one">{0}kHz</unitPattern>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="one">{0}Hz</unitPattern>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="one">{0}px</unitPattern>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mpx</displayName>
 				<unitPattern count="one">{0}Mpx</unitPattern>
 				<unitPattern count="other">{0}Mpx</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>px/cm</displayName>
 				<unitPattern count="one">{0}px/cm</unitPattern>
 				<unitPattern count="other">{0}px/cm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>px/in</displayName>
 				<unitPattern count="one">{0}px/in</unitPattern>
 				<unitPattern count="other">{0}px/in</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppp</displayName>
 				<unitPattern count="one">{0}ppp</unitPattern>
 				<unitPattern count="other">{0}ppp</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="one">{0}pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">{0}R⊕</unitPattern>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
@@ -10511,17 +10511,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>fur</displayName>
 				<unitPattern count="one">{0}fur</unitPattern>
 				<unitPattern count="other">{0}fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>ftm</displayName>
 				<unitPattern count="one">{0}ftm</unitPattern>
 				<unitPattern count="other">{0}ftm</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>M</displayName>
 				<unitPattern count="one">{0}M</unitPattern>
 				<unitPattern count="other">{0}M</unitPattern>
 			</unit>
@@ -10536,32 +10536,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pto</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R☉</displayName>
 				<unitPattern count="one">{0}R☉</unitPattern>
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lx</displayName>
 				<unitPattern count="one">{0}lx</unitPattern>
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">{0}cd</unitPattern>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>L☉</displayName>
 				<unitPattern count="one">{0}L☉</unitPattern>
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>t</displayName>
 				<unitPattern count="one">{0}t</unitPattern>
 				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
@@ -10578,17 +10578,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="one">{0}mg</unitPattern>
 				<unitPattern count="other">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>μg</displayName>
 				<unitPattern count="one">{0}μg</unitPattern>
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>tc</displayName>
 				<unitPattern count="one">{0}tc</unitPattern>
 				<unitPattern count="other">{0}tc</unitPattern>
 			</unit>
@@ -10610,62 +10610,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz t</displayName>
 				<unitPattern count="one">{0}oz t</unitPattern>
 				<unitPattern count="other">{0}oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>ct</displayName>
 				<unitPattern count="one">{0}ct</unitPattern>
 				<unitPattern count="other">{0}ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>Da</displayName>
 				<unitPattern count="one">{0}Da</unitPattern>
 				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M⊕</displayName>
 				<unitPattern count="one">{0}M⊕</unitPattern>
 				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M☉</displayName>
 				<unitPattern count="one">{0}M☉</unitPattern>
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>gr</displayName>
 				<unitPattern count="one">{0}gr</unitPattern>
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="one">{0}GW</unitPattern>
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="one">{0}MW</unitPattern>
 				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0}W</unitPattern>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">{0}mW</unitPattern>
 				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>CV</displayName>
 				<unitPattern count="one">{0}CV</unitPattern>
 				<unitPattern count="other">{0}CV</unitPattern>
 			</unit>
@@ -10685,7 +10685,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="one">{0}bar</unitPattern>
 				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
@@ -10695,12 +10695,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm</displayName>
 				<unitPattern count="one">{0}atm</unitPattern>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="one">{0}Pa</unitPattern>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
@@ -10710,12 +10710,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="one">{0}kPa</unitPattern>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="one">{0}MPa</unitPattern>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
@@ -10735,7 +10735,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kn</displayName>
 				<unitPattern count="one">{0}kn</unitPattern>
 				<unitPattern count="other">{0}kn</unitPattern>
 			</unit>
@@ -10760,59 +10760,59 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf ft</displayName>
 				<unitPattern count="one">{0}lbf ft</unitPattern>
 				<unitPattern count="other">{0}lbf ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Nm</displayName>
 				<unitPattern count="one">{0}Nm</unitPattern>
 				<unitPattern count="other">{0}Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">{0}m³</unitPattern>
 				<unitPattern count="other">{0}m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0}cm³</unitPattern>
 				<unitPattern count="other">{0}cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0}mi³</unitPattern>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd³</displayName>
 				<unitPattern count="one">{0}yd³</unitPattern>
 				<unitPattern count="other">{0}yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft³</displayName>
 				<unitPattern count="one">{0}ft³</unitPattern>
 				<unitPattern count="other">{0}ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in³</displayName>
 				<unitPattern count="one">{0}in³</unitPattern>
 				<unitPattern count="other">{0}in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ml</displayName>
 				<unitPattern count="one">{0}Ml</unitPattern>
 				<unitPattern count="other">{0}Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>hl</displayName>
 				<unitPattern count="one">{0}hl</unitPattern>
 				<unitPattern count="other">{0}hl</unitPattern>
 			</unit>
@@ -10820,48 +10820,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>l</displayName>
 				<unitPattern count="one">{0}l</unitPattern>
 				<unitPattern count="other">{0}l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0}dl</unitPattern>
 				<unitPattern count="other">{0}dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cl</displayName>
 				<unitPattern count="one">{0}cl</unitPattern>
 				<unitPattern count="other">{0}cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpt</displayName>
 				<unitPattern count="one">{0}mpt</unitPattern>
 				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>tza m</displayName>
 				<unitPattern count="one">{0}tza m</unitPattern>
 				<unitPattern count="other">{0}tza m</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ac ft</displayName>
 				<unitPattern count="one">{0}ac ft</unitPattern>
 				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bu</displayName>
 				<unitPattern count="one">{0}bu</unitPattern>
 				<unitPattern count="other">{0}bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">{0}gal</unitPattern>
 				<unitPattern count="other">{0}gal</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>gal imp</displayName>
@@ -10870,22 +10870,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/gal imp</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt</displayName>
 				<unitPattern count="one">{0}qt</unitPattern>
 				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>p</displayName>
 				<unitPattern count="one">{0}p</unitPattern>
 				<unitPattern count="other">{0}p</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>tza</displayName>
 				<unitPattern count="one">{0}tza</unitPattern>
 				<unitPattern count="other">{0}tza</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz</displayName>
 				<unitPattern count="one">{0}fl oz</unitPattern>
 				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
@@ -10895,22 +10895,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl oz im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>cda</displayName>
 				<unitPattern count="one">{0}cda</unitPattern>
 				<unitPattern count="other">{0}cda</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>cdta</displayName>
 				<unitPattern count="one">{0}cdta</unitPattern>
 				<unitPattern count="other">{0}cdta</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>c/p</displayName>
 				<unitPattern count="one">{0}c/p</unitPattern>
 				<unitPattern count="other">{0}c/p</unitPattern>
 			</unit>
@@ -10925,7 +10925,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}gt</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl dr</displayName>
 				<unitPattern count="one">{0}fl dr</unitPattern>
 				<unitPattern count="other">{0}fl dr</unitPattern>
 			</unit>
@@ -10935,7 +10935,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}med</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>pzc</displayName>
 				<unitPattern count="one">{0}pzc</unitPattern>
 				<unitPattern count="other">{0}pzc</unitPattern>
 			</unit>
@@ -10976,22 +10976,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} o {1}</listPatternPart>
+			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} o {1}</listPatternPart>
+			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} y {1}</listPatternPart>
+			<listPatternPart type="2">{0} y {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -11327,7 +11327,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern alt="1">{surname} {surname2}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname}, {title} {given} {given2}</namePattern>
 			<namePattern alt="1">{surname}, {given-initial} {given2-initial}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -1146,7 +1146,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tuneesia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Türgi</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Türgi</territory>
 			<territory type="TT">Trinidad ja Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1566,7 +1566,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1574,7 +1574,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2555,9 +2555,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>p</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">eile</relative>
+				<relative type="0">täna</relative>
+				<relative type="1">homme</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} p pärast</relativeTimePattern>
 					<relativeTimePattern count="other">{0} p pärast</relativeTimePattern>
@@ -2569,9 +2569,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>p</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">eile</relative>
+				<relative type="0">täna</relative>
+				<relative type="1">homme</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} p pärast</relativeTimePattern>
 					<relativeTimePattern count="other">{0} p pärast</relativeTimePattern>
@@ -5706,7 +5706,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">Valgevene rubla</displayName>
 				<displayName count="other">Valgevene rubla</displayName>
 				<symbol>BYN</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<symbol alt="narrow">BYN</symbol>
 			</currency>
 			<currency type="BYR">
 				<displayName>Valgevene rubla (2000–2016)</displayName>
@@ -8169,12 +8169,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8575,7 +8575,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapikslid</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
@@ -8589,7 +8589,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0} dpcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
@@ -8605,7 +8605,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -8690,7 +8690,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>furlongid</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
@@ -8725,12 +8725,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -8772,7 +8772,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>kivid</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -8879,7 +8879,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -9032,7 +9032,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>buššelid</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -9089,7 +9089,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
@@ -9132,209 +9132,209 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>Maa raskuskiirendus</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pööre</displayName>
+				<unitPattern count="one">{0} pööre</unitPattern>
+				<unitPattern count="other">{0} pööret</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>radiaanid</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kraadid</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>kaareminut</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>″</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektarid</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>aakrid</displayName>
 				<unitPattern count="one">{0} aaker</unitPattern>
 				<unitPattern count="other">{0} aakrit</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ruutjardid</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ruutjalad</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ruuttollid</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunamid</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunami</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>karaat</displayName>
 				<unitPattern count="one">{0} ct</unitPattern>
 				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/l</displayName>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>üksus</displayName>
@@ -9342,9 +9342,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} üksust</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>osa/miljon</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9352,24 +9352,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>promüriaad</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mol</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -9378,8 +9378,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg UK</displayName>
@@ -9387,75 +9387,75 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>bait</displayName>
 				<unitPattern count="one">{0} B</unitPattern>
 				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bitt</displayName>
+				<unitPattern count="one">{0} b</unitPattern>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>saj</displayName>
+				<unitPattern count="one">{0} saj</unitPattern>
+				<unitPattern count="other">{0} saj</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dek</displayName>
+				<unitPattern count="one">{0} dek</unitPattern>
+				<unitPattern count="other">{0} dek</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>a</displayName>
 				<unitPattern count="one">{0} a</unitPattern>
 				<unitPattern count="other">{0} a</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/a</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>kv</displayName>
@@ -9467,31 +9467,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kuud</displayName>
 				<unitPattern count="one">{0} k</unitPattern>
 				<unitPattern count="other">{0} k</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/k</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>n</displayName>
 				<unitPattern count="one">{0} n</unitPattern>
 				<unitPattern count="other">{0} n</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/näd</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>päev</displayName>
 				<unitPattern count="one">{0} p</unitPattern>
 				<unitPattern count="other">{0} p</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ööp</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>t</displayName>
 				<unitPattern count="one">{0} t</unitPattern>
 				<unitPattern count="other">{0} t</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/t</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
 				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">{0} min</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
@@ -9505,171 +9505,171 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amprid</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milliamprid</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oomid</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>voldid</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>džaulid</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW-tund</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>elektronvolt</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Briti soojusühik</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>USA term</displayName>
+				<unitPattern count="one">{0} USA term</unitPattern>
+				<unitPattern count="other">{0} USA termi</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jõunael</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh / 100 km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>emm</displayName>
+				<unitPattern count="one">{0} emm</unitPattern>
+				<unitPattern count="other">{0} emmi</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pikslid</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapikslid</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>p</displayName>
+				<unitPattern count="one">{0} p</unitPattern>
+				<unitPattern count="other">{0} p</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>dm</displayName>
@@ -9680,7 +9680,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -9688,22 +9688,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi</displayName>
 				<unitPattern count="one">{0} miil</unitPattern>
 				<unitPattern count="other">{0} miili</unitPattern>
 			</unit>
@@ -9713,21 +9713,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} jardi</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft</displayName>
 				<unitPattern count="one">{0} jalg</unitPattern>
 				<unitPattern count="other">{0} jalga</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>tollid</displayName>
 				<unitPattern count="one">{0} toll</unitPattern>
 				<unitPattern count="other">{0} tolli</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>parsekid</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>valgusaastad</displayName>
@@ -9741,8 +9741,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>furlongid</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>süllad</displayName>
@@ -9750,71 +9750,71 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>punktid</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Päikese raadiused</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Päikese heledus</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gramm</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>lüh t</displayName>
@@ -9823,25 +9823,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>kivid</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>naelad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>ct</displayName>
@@ -9849,52 +9849,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>daltonid</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Maa massid</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Päikese massid</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>graan</displayName>
+				<unitPattern count="one">{0} graan</unitPattern>
+				<unitPattern count="other">{0} graani</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>vatid</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hj</displayName>
 				<unitPattern count="one">{0} hj</unitPattern>
 				<unitPattern count="other">{0} hj</unitPattern>
 			</unit>
@@ -9904,9 +9904,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>″ Hg</displayName>
@@ -9914,9 +9914,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} tolli Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>baar</displayName>
+				<unitPattern count="one">{0} baar</unitPattern>
+				<unitPattern count="other">{0} baari</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -9924,29 +9924,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -9954,24 +9954,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/h</displayName>
+				<unitPattern count="one">{0} mi/h</unitPattern>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9979,7 +9979,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0} °F</unitPattern>
 				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
@@ -9989,134 +9989,134 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nm</displayName>
+				<unitPattern count="one">{0} Nm</unitPattern>
+				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kuupmiilid</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kuupjardid</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kuuptollid</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>liiter</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>aakerjalg</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>buššelid</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. gal</displayName>
 				<unitPattern count="one">{0} gal Im</unitPattern>
 				<unitPattern count="other">{0} gal Im</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kvart</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pindid</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tass</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>Imp fl oz</displayName>
@@ -10124,34 +10124,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>spl</displayName>
+				<unitPattern count="one">{0} spl</unitPattern>
+				<unitPattern count="other">{0} spl</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tl</displayName>
+				<unitPattern count="one">{0} tl</unitPattern>
+				<unitPattern count="other">{0} tl</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>barrel</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ingl dl</displayName>
+				<unitPattern count="one">{0} ingl dl</unitPattern>
+				<unitPattern count="other">{0} ingl dl</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tilk</displayName>
+				<unitPattern count="one">{0} tilk</unitPattern>
+				<unitPattern count="other">{0} tilka</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>d. ved.</displayName>
@@ -10159,9 +10159,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} d. ved.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pits</displayName>
+				<unitPattern count="one">{0} pits</unitPattern>
+				<unitPattern count="other">{0} pitsi</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>näp.</displayName>
@@ -10205,20 +10205,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} või {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} või {1}</listPatternPart>
+			<listPatternPart type="2">{0} või {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} või {1}</listPatternPart>
+			<listPatternPart type="2">{0} või {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -10446,10 +10446,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given} {surname}</namePattern>
@@ -10461,10 +10461,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
@@ -10479,10 +10479,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
@@ -10500,10 +10500,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given}</namePattern>
@@ -10515,10 +10515,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{surname}, {given-initial} {given2-initial}</namePattern>
@@ -10545,7 +10545,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}, {given} {given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname}, {given} {given2}, {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -82,8 +82,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">txerokiera</language>
 			<language type="chy">txeienera</language>
 			<language type="ckb">erdialdeko kurduera</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">erdialdeko kurduera</language>
+			<language type="ckb" alt="variant">erdialdeko kurduera</language>
 			<language type="clc">chilcotinera</language>
 			<language type="co">korsikera</language>
 			<language type="crg">metisera</language>
@@ -923,7 +923,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="SX">Sint Maarten</territory>
 			<territory type="SY">Siria</territory>
 			<territory type="SZ">Swazilandia</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
+			<territory type="SZ" alt="variant">Swazilandia</territory>
 			<territory type="TA">Tristan da Cunha</territory>
 			<territory type="TC">Turk eta Caico uharteak</territory>
 			<territory type="TD">Txad</territory>
@@ -933,12 +933,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TJ">Tajikistan</territory>
 			<territory type="TK">Tokelau</territory>
 			<territory type="TL">Ekialdeko Timor</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">Ekialdeko Timor</territory>
 			<territory type="TM">Turkmenistan</territory>
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkia</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkia</territory>
 			<territory type="TT">Trinidad eta Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1323,248 +1323,248 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="buddhist">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">BG</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">BG</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">BG</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y('e')'ko' MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, EEEE</dateFormatItem>
+						<dateFormatItem id="Gy">G. 'aroko' y. 'urtea'</dateFormatItem>
+						<dateFormatItem id="GyMd">y-MM-dd (GGGGG)</dateFormatItem>
+						<dateFormatItem id="GyMMM">G. 'aroko' y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G. 'aroko' y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G. 'aroko' y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'k' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">y/MM</dateFormatItem>
+						<dateFormatItem id="yMd">y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yMEd">y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yMMM">y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMd">y('e')'ko' MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="yMMMEd">y('e')'ko' MMMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="yQQQ">y('e')'ko' QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y('e')'ko' QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">G y/MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">G('e')'ko' y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">G('e')'ko' y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G, y('e')'ko' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">G y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">G y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y('e')'ko' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h – B h</greatestDifference>
+							<greatestDifference id="h">B h–h</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h:mm – B h:mm</greatestDifference>
+							<greatestDifference id="h">B h:mm–h:mm</greatestDifference>
+							<greatestDifference id="m">B h:mm–h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y, MMM – G y, MMM</greatestDifference>
+							<greatestDifference id="M">G y, MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y, MMM – G y, MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y, MMM d – G y, MMM d</greatestDifference>
+							<greatestDifference id="M">G y, MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y, MMM d – G y, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y, MMM d, E – G y, MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y, MMM d, E – G y, MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd – MM/dd</greatestDifference>
+							<greatestDifference id="M">MM/dd – MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM'k' d – MMMM'k' d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
+							<greatestDifference id="M">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y/MM – y/MM</greatestDifference>
+							<greatestDifference id="y">G y/MM – y/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd – y/MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd–dd</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd – MMMM dd</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd – y('e')'ko' MMMM dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd, EEEE – y('e')'ko' MMMM dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM – MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1573,32 +1573,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">M01</month>
+							<month type="2">M02</month>
+							<month type="3">M03</month>
+							<month type="4">M04</month>
+							<month type="5">M05</month>
+							<month type="6">M06</month>
+							<month type="7">M07</month>
+							<month type="8">M08</month>
+							<month type="9">M09</month>
+							<month type="10">M10</month>
+							<month type="11">M11</month>
+							<month type="12">M12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -1617,18 +1617,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">M01</month>
+							<month type="2">M02</month>
+							<month type="3">M03</month>
+							<month type="4">M04</month>
+							<month type="5">M05</month>
+							<month type="6">M06</month>
+							<month type="7">M07</month>
+							<month type="8">M08</month>
+							<month type="9">M09</month>
+							<month type="10">M10</month>
+							<month type="11">M11</month>
+							<month type="12">M12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -1645,28 +1645,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">M01</month>
+							<month type="2">M02</month>
+							<month type="3">M03</month>
+							<month type="4">M04</month>
+							<month type="5">M05</month>
+							<month type="6">M06</month>
+							<month type="7">M07</month>
+							<month type="8">M08</month>
+							<month type="9">M09</month>
+							<month type="10">M10</month>
+							<month type="11">M11</month>
+							<month type="12">M12</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
 							<monthPattern type="leap">↑↑↑</monthPattern>
@@ -1679,13 +1679,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthPatternContext>
 					<monthPatternContext type="stand-alone">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
 							<monthPattern type="leap">↑↑↑</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 				</monthPatterns>
@@ -1707,412 +1707,412 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="12">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="months">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2145,56 +2145,56 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="24">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2263,174 +2263,174 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="60">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="zodiacs">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2463,7 +2463,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2471,7 +2471,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2479,7 +2479,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2487,7 +2487,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2649,34 +2649,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tout</month>
+							<month type="2">Baba</month>
+							<month type="3">Hator</month>
+							<month type="4">Kiahk</month>
+							<month type="5">Toba</month>
+							<month type="6">Amshir</month>
+							<month type="7">Baramhat</month>
+							<month type="8">Baramouda</month>
+							<month type="9">Bashans</month>
+							<month type="10">Paona</month>
+							<month type="11">Epep</month>
+							<month type="12">Mesra</month>
+							<month type="13">Nasie</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -2696,19 +2696,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tout</month>
+							<month type="2">Baba</month>
+							<month type="3">Hator</month>
+							<month type="4">Kiahk</month>
+							<month type="5">Toba</month>
+							<month type="6">Amshir</month>
+							<month type="7">Baramhat</month>
+							<month type="8">Baramouda</month>
+							<month type="9">Bashans</month>
+							<month type="10">Paona</month>
+							<month type="11">Epep</month>
+							<month type="12">Mesra</month>
+							<month type="13">Nasie</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -2726,269 +2726,269 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="13">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tout</month>
+							<month type="2">Baba</month>
+							<month type="3">Hator</month>
+							<month type="4">Kiahk</month>
+							<month type="5">Toba</month>
+							<month type="6">Amshir</month>
+							<month type="7">Baramhat</month>
+							<month type="8">Baramouda</month>
+							<month type="9">Bashans</month>
+							<month type="10">Paona</month>
+							<month type="11">Epep</month>
+							<month type="12">Mesra</month>
+							<month type="13">Nasie</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 						<era type="1">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y('e')'ko' MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, EEEE</dateFormatItem>
+						<dateFormatItem id="Gy">G. 'aroko' y. 'urtea'</dateFormatItem>
+						<dateFormatItem id="GyMd">y-MM-dd (GGGGG)</dateFormatItem>
+						<dateFormatItem id="GyMMM">G. 'aroko' y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G. 'aroko' y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G. 'aroko' y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'k' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">y/MM</dateFormatItem>
+						<dateFormatItem id="yMd">y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yMEd">y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yMMM">y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMd">y('e')'ko' MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="yMMMEd">y('e')'ko' MMMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="yQQQ">y('e')'ko' QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y('e')'ko' QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">G y/MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">G('e')'ko' y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">G('e')'ko' y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G, y('e')'ko' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">G y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">G y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y('e')'ko' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h – B h</greatestDifference>
+							<greatestDifference id="h">B h–h</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h:mm – B h:mm</greatestDifference>
+							<greatestDifference id="h">B h:mm–h:mm</greatestDifference>
+							<greatestDifference id="m">B h:mm–h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y, MMM – G y, MMM</greatestDifference>
+							<greatestDifference id="M">G y, MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y, MMM – G y, MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y, MMM d – G y, MMM d</greatestDifference>
+							<greatestDifference id="M">G y, MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y, MMM d – G y, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y, MMM d, E – G y, MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y, MMM d, E – G y, MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd – MM/dd</greatestDifference>
+							<greatestDifference id="M">MM/dd – MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM'k' d – MMMM'k' d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
+							<greatestDifference id="M">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y/MM – y/MM</greatestDifference>
+							<greatestDifference id="y">G y/MM – y/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd – y/MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd–dd</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd – MMMM dd</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd – y('e')'ko' MMMM dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd, EEEE – y('e')'ko' MMMM dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM – MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2997,119 +2997,119 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">M01</month>
+							<month type="2">M02</month>
+							<month type="3">M03</month>
+							<month type="4">M04</month>
+							<month type="5">M05</month>
+							<month type="6">M06</month>
+							<month type="7">M07</month>
+							<month type="8">M08</month>
+							<month type="9">M09</month>
+							<month type="10">M10</month>
+							<month type="11">M11</month>
+							<month type="12">M12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">M01</month>
+							<month type="2">M02</month>
+							<month type="3">M03</month>
+							<month type="4">M04</month>
+							<month type="5">M05</month>
+							<month type="6">M06</month>
+							<month type="7">M07</month>
+							<month type="8">M08</month>
+							<month type="9">M09</month>
+							<month type="10">M10</month>
+							<month type="11">M11</month>
+							<month type="12">M12</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">M01</month>
+							<month type="2">M02</month>
+							<month type="3">M03</month>
+							<month type="4">M04</month>
+							<month type="5">M05</month>
+							<month type="6">M06</month>
+							<month type="7">M07</month>
+							<month type="8">M08</month>
+							<month type="9">M09</month>
+							<month type="10">M10</month>
+							<month type="11">M11</month>
+							<month type="12">M12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">M01</month>
+							<month type="2">M02</month>
+							<month type="3">M03</month>
+							<month type="4">M04</month>
+							<month type="5">M05</month>
+							<month type="6">M06</month>
+							<month type="7">M07</month>
+							<month type="8">M08</month>
+							<month type="9">M09</month>
+							<month type="10">M10</month>
+							<month type="11">M11</month>
+							<month type="12">M12</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 					<monthPatternContext type="numeric">
 						<monthPatternWidth type="all">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 					<monthPatternContext type="stand-alone">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 				</monthPatterns>
@@ -3117,744 +3117,744 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<cyclicNameSet type="dayParts">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="months">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="solarTerms">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="years">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="zodiacs">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -3862,197 +3862,197 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>r(U) MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>r(U) MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>r MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>r-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">r U</dateFormatItem>
+						<dateFormatItem id="GyMMM">r MMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">r MMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">r MMM d, E</dateFormatItem>
+						<dateFormatItem id="GyMMMM">r(U) MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMMd">r(U) MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd">r(U) MMMM d, E</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM-dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM-dd, E</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM d, E</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="UM">U MM</dateFormatItem>
+						<dateFormatItem id="UMd">U MM-d</dateFormatItem>
+						<dateFormatItem id="UMMM">U MMM</dateFormatItem>
+						<dateFormatItem id="UMMMd">U MMM d</dateFormatItem>
+						<dateFormatItem id="y">r(U)</dateFormatItem>
+						<dateFormatItem id="yMd">r-MM-dd</dateFormatItem>
+						<dateFormatItem id="yyyy">r(U)</dateFormatItem>
+						<dateFormatItem id="yyyyM">r-MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">r-MM-dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">r-MM-dd, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">r MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">r MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">r MMM d, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">r(U) MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">r(U) MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">r(U) MMMM d, E</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">r(U) QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">r(U) QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">U–U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">U MMM–MMM</greatestDifference>
+							<greatestDifference id="y">U MMM – U MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">U MMM d–d</greatestDifference>
+							<greatestDifference id="M">U MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">U MMM d – U MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">U MMM d, E – U MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">U MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">U MMMM – U MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4061,34 +4061,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Meskerem</month>
+							<month type="2">Tekemt</month>
+							<month type="3">Hedar</month>
+							<month type="4">Tahsas</month>
+							<month type="5">Ter</month>
+							<month type="6">Yekatit</month>
+							<month type="7">Megabit</month>
+							<month type="8">Miazia</month>
+							<month type="9">Genbot</month>
+							<month type="10">Sene</month>
+							<month type="11">Hamle</month>
+							<month type="12">Nehasse</month>
+							<month type="13">Pagumen</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -4108,19 +4108,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Meskerem</month>
+							<month type="2">Tekemt</month>
+							<month type="3">Hedar</month>
+							<month type="4">Tahsas</month>
+							<month type="5">Ter</month>
+							<month type="6">Yekatit</month>
+							<month type="7">Megabit</month>
+							<month type="8">Miazia</month>
+							<month type="9">Genbot</month>
+							<month type="10">Sene</month>
+							<month type="11">Hamle</month>
+							<month type="12">Nehasse</month>
+							<month type="13">Pagumen</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -4138,269 +4138,269 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="13">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Meskerem</month>
+							<month type="2">Tekemt</month>
+							<month type="3">Hedar</month>
+							<month type="4">Tahsas</month>
+							<month type="5">Ter</month>
+							<month type="6">Yekatit</month>
+							<month type="7">Megabit</month>
+							<month type="8">Miazia</month>
+							<month type="9">Genbot</month>
+							<month type="10">Sene</month>
+							<month type="11">Hamle</month>
+							<month type="12">Nehasse</month>
+							<month type="13">Pagumen</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 						<era type="1">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y('e')'ko' MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, EEEE</dateFormatItem>
+						<dateFormatItem id="Gy">G. 'aroko' y. 'urtea'</dateFormatItem>
+						<dateFormatItem id="GyMd">y-MM-dd (GGGGG)</dateFormatItem>
+						<dateFormatItem id="GyMMM">G. 'aroko' y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G. 'aroko' y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G. 'aroko' y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'k' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">y/MM</dateFormatItem>
+						<dateFormatItem id="yMd">y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yMEd">y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yMMM">y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMd">y('e')'ko' MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="yMMMEd">y('e')'ko' MMMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="yQQQ">y('e')'ko' QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y('e')'ko' QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">G y/MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">G('e')'ko' y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">G('e')'ko' y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G, y('e')'ko' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">G y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">G y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y('e')'ko' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h – B h</greatestDifference>
+							<greatestDifference id="h">B h–h</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h:mm – B h:mm</greatestDifference>
+							<greatestDifference id="h">B h:mm–h:mm</greatestDifference>
+							<greatestDifference id="m">B h:mm–h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y, MMM – G y, MMM</greatestDifference>
+							<greatestDifference id="M">G y, MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y, MMM – G y, MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y, MMM d – G y, MMM d</greatestDifference>
+							<greatestDifference id="M">G y, MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y, MMM d – G y, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y, MMM d, E – G y, MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y, MMM d, E – G y, MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd – MM/dd</greatestDifference>
+							<greatestDifference id="M">MM/dd – MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM'k' d – MMMM'k' d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
+							<greatestDifference id="M">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y/MM – y/MM</greatestDifference>
+							<greatestDifference id="y">G y/MM – y/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd – y/MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd–dd</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd – MMMM dd</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd – y('e')'ko' MMMM dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd, EEEE – y('e')'ko' MMMM dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM – MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4408,13 +4408,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="ethiopic-amete-alem">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">ERA0</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">ERA0</era>
 					</eraNarrow>
 				</eras>
 			</calendar>
@@ -4974,9 +4974,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">a</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">G.a.a.</era>
 						<era type="1">o</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">G.a.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -5268,36 +5268,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tishri</month>
+							<month type="2">Heshvan</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
+							<month type="5">Shevat</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
+							<month type="9">Iyar</month>
+							<month type="10">Sivan</month>
+							<month type="11">Tamuz</month>
+							<month type="12">Av</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="7" yeartype="leap">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -5318,20 +5318,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tishri</month>
+							<month type="2">Heshvan</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
+							<month type="5">Shevat</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
+							<month type="9">Iyar</month>
+							<month type="10">Sivan</month>
+							<month type="11">Tamuz</month>
+							<month type="12">Av</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -5350,267 +5350,267 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="13">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tishri</month>
+							<month type="2">Heshvan</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
+							<month type="5">Shevat</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
+							<month type="9">Iyar</month>
+							<month type="10">Sivan</month>
+							<month type="11">Tamuz</month>
+							<month type="12">Av</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AM</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AM</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y('e')'ko' MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, EEEE</dateFormatItem>
+						<dateFormatItem id="Gy">G. 'aroko' y. 'urtea'</dateFormatItem>
+						<dateFormatItem id="GyMd">y-MM-dd (GGGGG)</dateFormatItem>
+						<dateFormatItem id="GyMMM">G. 'aroko' y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G. 'aroko' y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G. 'aroko' y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'k' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">y/MM</dateFormatItem>
+						<dateFormatItem id="yMd">y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yMEd">y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yMMM">y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMd">y('e')'ko' MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="yMMMEd">y('e')'ko' MMMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="yQQQ">y('e')'ko' QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y('e')'ko' QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">G y/MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">G('e')'ko' y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">G('e')'ko' y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G, y('e')'ko' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">G y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">G y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y('e')'ko' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h – B h</greatestDifference>
+							<greatestDifference id="h">B h–h</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h:mm – B h:mm</greatestDifference>
+							<greatestDifference id="h">B h:mm–h:mm</greatestDifference>
+							<greatestDifference id="m">B h:mm–h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y, MMM – G y, MMM</greatestDifference>
+							<greatestDifference id="M">G y, MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y, MMM – G y, MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y, MMM d – G y, MMM d</greatestDifference>
+							<greatestDifference id="M">G y, MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y, MMM d – G y, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y, MMM d, E – G y, MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y, MMM d, E – G y, MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd – MM/dd</greatestDifference>
+							<greatestDifference id="M">MM/dd – MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM'k' d – MMMM'k' d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
+							<greatestDifference id="M">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y/MM – y/MM</greatestDifference>
+							<greatestDifference id="y">G y/MM – y/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd – y/MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd–dd</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd – MMMM dd</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd – y('e')'ko' MMMM dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd, EEEE – y('e')'ko' MMMM dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM – MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5619,32 +5619,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Chaitra</month>
+							<month type="2">Vaisakha</month>
+							<month type="3">Jyaistha</month>
+							<month type="4">Asadha</month>
+							<month type="5">Sravana</month>
+							<month type="6">Bhadra</month>
+							<month type="7">Asvina</month>
+							<month type="8">Kartika</month>
+							<month type="9">Agrahayana</month>
+							<month type="10">Pausa</month>
+							<month type="11">Magha</month>
+							<month type="12">Phalguna</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -5663,18 +5663,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Chaitra</month>
+							<month type="2">Vaisakha</month>
+							<month type="3">Jyaistha</month>
+							<month type="4">Asadha</month>
+							<month type="5">Sravana</month>
+							<month type="6">Bhadra</month>
+							<month type="7">Asvina</month>
+							<month type="8">Kartika</month>
+							<month type="9">Agrahayana</month>
+							<month type="10">Pausa</month>
+							<month type="11">Magha</month>
+							<month type="12">Phalguna</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -5691,265 +5691,265 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Chaitra</month>
+							<month type="2">Vaisakha</month>
+							<month type="3">Jyaistha</month>
+							<month type="4">Asadha</month>
+							<month type="5">Sravana</month>
+							<month type="6">Bhadra</month>
+							<month type="7">Asvina</month>
+							<month type="8">Kartika</month>
+							<month type="9">Agrahayana</month>
+							<month type="10">Pausa</month>
+							<month type="11">Magha</month>
+							<month type="12">Phalguna</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">Saka</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">Saka</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y('e')'ko' MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, EEEE</dateFormatItem>
+						<dateFormatItem id="Gy">G. 'aroko' y. 'urtea'</dateFormatItem>
+						<dateFormatItem id="GyMd">y-MM-dd (GGGGG)</dateFormatItem>
+						<dateFormatItem id="GyMMM">G. 'aroko' y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G. 'aroko' y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G. 'aroko' y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'k' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">y/MM</dateFormatItem>
+						<dateFormatItem id="yMd">y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yMEd">y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yMMM">y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMd">y('e')'ko' MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="yMMMEd">y('e')'ko' MMMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="yQQQ">y('e')'ko' QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y('e')'ko' QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">G y/MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">G('e')'ko' y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">G('e')'ko' y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G, y('e')'ko' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">G y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">G y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y('e')'ko' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h – B h</greatestDifference>
+							<greatestDifference id="h">B h–h</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h:mm – B h:mm</greatestDifference>
+							<greatestDifference id="h">B h:mm–h:mm</greatestDifference>
+							<greatestDifference id="m">B h:mm–h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y, MMM – G y, MMM</greatestDifference>
+							<greatestDifference id="M">G y, MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y, MMM – G y, MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y, MMM d – G y, MMM d</greatestDifference>
+							<greatestDifference id="M">G y, MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y, MMM d – G y, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y, MMM d, E – G y, MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y, MMM d, E – G y, MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd – MM/dd</greatestDifference>
+							<greatestDifference id="M">MM/dd – MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM'k' d – MMMM'k' d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
+							<greatestDifference id="M">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y/MM – y/MM</greatestDifference>
+							<greatestDifference id="y">G y/MM – y/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd – y/MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd–dd</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd – MMMM dd</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd – y('e')'ko' MMMM dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd, EEEE – y('e')'ko' MMMM dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM – MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5972,18 +5972,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -6002,18 +6002,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Muh.</month>
+							<month type="2">Saf.</month>
+							<month type="3">Rab. I</month>
+							<month type="4">Rab. II</month>
+							<month type="5">Jum. I</month>
+							<month type="6">Jum. II</month>
+							<month type="7">Raj.</month>
+							<month type="8">Sha.</month>
+							<month type="9">Ram.</month>
+							<month type="10">Shaw.</month>
+							<month type="11">Dhuʻl-Q.</month>
+							<month type="12">Dhuʻl-H.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -6030,265 +6030,265 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Muharram</month>
+							<month type="2">Safar</month>
+							<month type="3">Rabiʻ I</month>
+							<month type="4">Rabiʻ II</month>
+							<month type="5">Jumada I</month>
+							<month type="6">Jumada II</month>
+							<month type="7">Rajab</month>
+							<month type="8">Shaʻban</month>
+							<month type="9">Ramadan</month>
+							<month type="10">Shawwal</month>
+							<month type="11">Dhuʻl-Qiʻdah</month>
+							<month type="12">Dhuʻl-Hijjah</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AH</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AH</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y('e')'ko' MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, EEEE</dateFormatItem>
+						<dateFormatItem id="Gy">G. 'aroko' y. 'urtea'</dateFormatItem>
+						<dateFormatItem id="GyMd">y-MM-dd (GGGGG)</dateFormatItem>
+						<dateFormatItem id="GyMMM">G. 'aroko' y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G. 'aroko' y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G. 'aroko' y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'k' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">y/MM</dateFormatItem>
+						<dateFormatItem id="yMd">y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yMEd">y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yMMM">y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMd">y('e')'ko' MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="yMMMEd">y('e')'ko' MMMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="yQQQ">y('e')'ko' QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y('e')'ko' QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">G y/MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">G('e')'ko' y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">G('e')'ko' y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G, y('e')'ko' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">G y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">G y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y('e')'ko' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h – B h</greatestDifference>
+							<greatestDifference id="h">B h–h</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h:mm – B h:mm</greatestDifference>
+							<greatestDifference id="h">B h:mm–h:mm</greatestDifference>
+							<greatestDifference id="m">B h:mm–h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y, MMM – G y, MMM</greatestDifference>
+							<greatestDifference id="M">G y, MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y, MMM – G y, MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y, MMM d – G y, MMM d</greatestDifference>
+							<greatestDifference id="M">G y, MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y, MMM d – G y, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y, MMM d, E – G y, MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y, MMM d, E – G y, MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd – MM/dd</greatestDifference>
+							<greatestDifference id="M">MM/dd – MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM'k' d – MMMM'k' d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
+							<greatestDifference id="M">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y/MM – y/MM</greatestDifference>
+							<greatestDifference id="y">G y/MM – y/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd – y/MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd–dd</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd – MMMM dd</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd – y('e')'ko' MMMM dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd, EEEE – y('e')'ko' MMMM dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM – MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -6296,243 +6296,243 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="japanese">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="2">↑↑↑</era>
-						<era type="3">↑↑↑</era>
-						<era type="4">↑↑↑</era>
-						<era type="5">↑↑↑</era>
-						<era type="6">↑↑↑</era>
-						<era type="7">↑↑↑</era>
-						<era type="8">↑↑↑</era>
-						<era type="9">↑↑↑</era>
-						<era type="10">↑↑↑</era>
-						<era type="11">↑↑↑</era>
-						<era type="12">↑↑↑</era>
-						<era type="13">↑↑↑</era>
-						<era type="14">↑↑↑</era>
-						<era type="15">↑↑↑</era>
-						<era type="16">↑↑↑</era>
-						<era type="17">↑↑↑</era>
-						<era type="18">↑↑↑</era>
-						<era type="19">↑↑↑</era>
-						<era type="20">↑↑↑</era>
-						<era type="21">↑↑↑</era>
-						<era type="22">↑↑↑</era>
-						<era type="23">↑↑↑</era>
-						<era type="24">↑↑↑</era>
-						<era type="25">↑↑↑</era>
-						<era type="26">↑↑↑</era>
-						<era type="27">↑↑↑</era>
-						<era type="28">↑↑↑</era>
-						<era type="29">↑↑↑</era>
-						<era type="30">↑↑↑</era>
-						<era type="31">↑↑↑</era>
-						<era type="32">↑↑↑</era>
-						<era type="33">↑↑↑</era>
-						<era type="34">↑↑↑</era>
-						<era type="35">↑↑↑</era>
-						<era type="36">↑↑↑</era>
-						<era type="37">↑↑↑</era>
-						<era type="38">↑↑↑</era>
-						<era type="39">↑↑↑</era>
-						<era type="40">↑↑↑</era>
-						<era type="41">↑↑↑</era>
-						<era type="42">↑↑↑</era>
-						<era type="43">↑↑↑</era>
-						<era type="44">↑↑↑</era>
-						<era type="45">↑↑↑</era>
-						<era type="46">↑↑↑</era>
-						<era type="47">↑↑↑</era>
-						<era type="48">↑↑↑</era>
-						<era type="49">↑↑↑</era>
-						<era type="50">↑↑↑</era>
-						<era type="51">↑↑↑</era>
-						<era type="52">↑↑↑</era>
-						<era type="53">↑↑↑</era>
-						<era type="54">↑↑↑</era>
-						<era type="55">↑↑↑</era>
-						<era type="56">↑↑↑</era>
-						<era type="57">↑↑↑</era>
-						<era type="58">↑↑↑</era>
-						<era type="59">↑↑↑</era>
-						<era type="60">↑↑↑</era>
-						<era type="61">↑↑↑</era>
-						<era type="62">↑↑↑</era>
-						<era type="63">↑↑↑</era>
-						<era type="64">↑↑↑</era>
-						<era type="65">↑↑↑</era>
-						<era type="66">↑↑↑</era>
-						<era type="67">↑↑↑</era>
-						<era type="68">↑↑↑</era>
-						<era type="69">↑↑↑</era>
-						<era type="70">↑↑↑</era>
-						<era type="71">↑↑↑</era>
-						<era type="72">↑↑↑</era>
-						<era type="73">↑↑↑</era>
-						<era type="74">↑↑↑</era>
-						<era type="75">↑↑↑</era>
-						<era type="76">↑↑↑</era>
-						<era type="77">↑↑↑</era>
-						<era type="78">↑↑↑</era>
-						<era type="79">↑↑↑</era>
-						<era type="80">↑↑↑</era>
-						<era type="81">↑↑↑</era>
-						<era type="82">↑↑↑</era>
-						<era type="83">↑↑↑</era>
-						<era type="84">↑↑↑</era>
-						<era type="85">↑↑↑</era>
-						<era type="86">↑↑↑</era>
-						<era type="87">↑↑↑</era>
-						<era type="88">↑↑↑</era>
-						<era type="89">↑↑↑</era>
-						<era type="90">↑↑↑</era>
-						<era type="91">↑↑↑</era>
-						<era type="92">↑↑↑</era>
-						<era type="93">↑↑↑</era>
-						<era type="94">↑↑↑</era>
-						<era type="95">↑↑↑</era>
-						<era type="96">↑↑↑</era>
-						<era type="97">↑↑↑</era>
-						<era type="98">↑↑↑</era>
-						<era type="99">↑↑↑</era>
-						<era type="100">↑↑↑</era>
-						<era type="101">↑↑↑</era>
-						<era type="102">↑↑↑</era>
-						<era type="103">↑↑↑</era>
-						<era type="104">↑↑↑</era>
-						<era type="105">↑↑↑</era>
-						<era type="106">↑↑↑</era>
-						<era type="107">↑↑↑</era>
-						<era type="108">↑↑↑</era>
-						<era type="109">↑↑↑</era>
-						<era type="110">↑↑↑</era>
-						<era type="111">↑↑↑</era>
-						<era type="112">↑↑↑</era>
-						<era type="113">↑↑↑</era>
-						<era type="114">↑↑↑</era>
-						<era type="115">↑↑↑</era>
-						<era type="116">↑↑↑</era>
-						<era type="117">↑↑↑</era>
-						<era type="118">↑↑↑</era>
-						<era type="119">↑↑↑</era>
-						<era type="120">↑↑↑</era>
-						<era type="121">↑↑↑</era>
-						<era type="122">↑↑↑</era>
-						<era type="123">↑↑↑</era>
-						<era type="124">↑↑↑</era>
-						<era type="125">↑↑↑</era>
-						<era type="126">↑↑↑</era>
-						<era type="127">↑↑↑</era>
-						<era type="128">↑↑↑</era>
-						<era type="129">↑↑↑</era>
-						<era type="130">↑↑↑</era>
-						<era type="131">↑↑↑</era>
-						<era type="132">↑↑↑</era>
-						<era type="133">↑↑↑</era>
-						<era type="134">↑↑↑</era>
-						<era type="135">↑↑↑</era>
-						<era type="136">↑↑↑</era>
-						<era type="137">↑↑↑</era>
-						<era type="138">↑↑↑</era>
-						<era type="139">↑↑↑</era>
-						<era type="140">↑↑↑</era>
-						<era type="141">↑↑↑</era>
-						<era type="142">↑↑↑</era>
-						<era type="143">↑↑↑</era>
-						<era type="144">↑↑↑</era>
-						<era type="145">↑↑↑</era>
-						<era type="146">↑↑↑</era>
-						<era type="147">↑↑↑</era>
-						<era type="148">↑↑↑</era>
-						<era type="149">↑↑↑</era>
-						<era type="150">↑↑↑</era>
-						<era type="151">↑↑↑</era>
-						<era type="152">↑↑↑</era>
-						<era type="153">↑↑↑</era>
-						<era type="154">↑↑↑</era>
-						<era type="155">↑↑↑</era>
-						<era type="156">↑↑↑</era>
-						<era type="157">↑↑↑</era>
-						<era type="158">↑↑↑</era>
-						<era type="159">↑↑↑</era>
-						<era type="160">↑↑↑</era>
-						<era type="161">↑↑↑</era>
-						<era type="162">↑↑↑</era>
-						<era type="163">↑↑↑</era>
-						<era type="164">↑↑↑</era>
-						<era type="165">↑↑↑</era>
-						<era type="166">↑↑↑</era>
-						<era type="167">↑↑↑</era>
-						<era type="168">↑↑↑</era>
-						<era type="169">↑↑↑</era>
-						<era type="170">↑↑↑</era>
-						<era type="171">↑↑↑</era>
-						<era type="172">↑↑↑</era>
-						<era type="173">↑↑↑</era>
-						<era type="174">↑↑↑</era>
-						<era type="175">↑↑↑</era>
-						<era type="176">↑↑↑</era>
-						<era type="177">↑↑↑</era>
-						<era type="178">↑↑↑</era>
-						<era type="179">↑↑↑</era>
-						<era type="180">↑↑↑</era>
-						<era type="181">↑↑↑</era>
-						<era type="182">↑↑↑</era>
-						<era type="183">↑↑↑</era>
-						<era type="184">↑↑↑</era>
-						<era type="185">↑↑↑</era>
-						<era type="186">↑↑↑</era>
-						<era type="187">↑↑↑</era>
-						<era type="188">↑↑↑</era>
-						<era type="189">↑↑↑</era>
-						<era type="190">↑↑↑</era>
-						<era type="191">↑↑↑</era>
-						<era type="192">↑↑↑</era>
-						<era type="193">↑↑↑</era>
-						<era type="194">↑↑↑</era>
-						<era type="195">↑↑↑</era>
-						<era type="196">↑↑↑</era>
-						<era type="197">↑↑↑</era>
-						<era type="198">↑↑↑</era>
-						<era type="199">↑↑↑</era>
-						<era type="200">↑↑↑</era>
-						<era type="201">↑↑↑</era>
-						<era type="202">↑↑↑</era>
-						<era type="203">↑↑↑</era>
-						<era type="204">↑↑↑</era>
-						<era type="205">↑↑↑</era>
-						<era type="206">↑↑↑</era>
-						<era type="207">↑↑↑</era>
-						<era type="208">↑↑↑</era>
-						<era type="209">↑↑↑</era>
-						<era type="210">↑↑↑</era>
-						<era type="211">↑↑↑</era>
-						<era type="212">↑↑↑</era>
-						<era type="213">↑↑↑</era>
-						<era type="214">↑↑↑</era>
-						<era type="215">↑↑↑</era>
-						<era type="216">↑↑↑</era>
-						<era type="217">↑↑↑</era>
-						<era type="218">↑↑↑</era>
-						<era type="219">↑↑↑</era>
-						<era type="220">↑↑↑</era>
-						<era type="221">↑↑↑</era>
-						<era type="222">↑↑↑</era>
-						<era type="223">↑↑↑</era>
-						<era type="224">↑↑↑</era>
-						<era type="225">↑↑↑</era>
-						<era type="226">↑↑↑</era>
-						<era type="227">↑↑↑</era>
-						<era type="228">↑↑↑</era>
-						<era type="229">↑↑↑</era>
-						<era type="230">↑↑↑</era>
-						<era type="231">↑↑↑</era>
-						<era type="232">↑↑↑</era>
-						<era type="233">↑↑↑</era>
-						<era type="234">↑↑↑</era>
-						<era type="235">↑↑↑</era>
-						<era type="236">↑↑↑</era>
+						<era type="0">Taika (645–650)</era>
+						<era type="1">Hakuchi (650–671)</era>
+						<era type="2">Hakuhō (672–686)</era>
+						<era type="3">Shuchō (686–701)</era>
+						<era type="4">Taihō (701–704)</era>
+						<era type="5">Keiun (704–708)</era>
+						<era type="6">Wadō (708–715)</era>
+						<era type="7">Reiki (715–717)</era>
+						<era type="8">Yōrō (717–724)</era>
+						<era type="9">Jinki (724–729)</era>
+						<era type="10">Tenpyō (729–749)</era>
+						<era type="11">Tenpyō-kampō (749–749)</era>
+						<era type="12">Tenpyō-shōhō (749–757)</era>
+						<era type="13">Tenpyō-hōji (757–765)</era>
+						<era type="14">Tenpyō-jingo (765–767)</era>
+						<era type="15">Jingo-keiun (767–770)</era>
+						<era type="16">Hōki (770–780)</era>
+						<era type="17">Ten-ō (781–782)</era>
+						<era type="18">Enryaku (782–806)</era>
+						<era type="19">Daidō (806–810)</era>
+						<era type="20">Kōnin (810–824)</era>
+						<era type="21">Tenchō (824–834)</era>
+						<era type="22">Jōwa (834–848)</era>
+						<era type="23">Kajō (848–851)</era>
+						<era type="24">Ninju (851–854)</era>
+						<era type="25">Saikō (854–857)</era>
+						<era type="26">Ten-an (857–859)</era>
+						<era type="27">Jōgan (859–877)</era>
+						<era type="28">Gangyō (877–885)</era>
+						<era type="29">Ninna (885–889)</era>
+						<era type="30">Kanpyō (889–898)</era>
+						<era type="31">Shōtai (898–901)</era>
+						<era type="32">Engi (901–923)</era>
+						<era type="33">Enchō (923–931)</era>
+						<era type="34">Jōhei (931–938)</era>
+						<era type="35">Tengyō (938–947)</era>
+						<era type="36">Tenryaku (947–957)</era>
+						<era type="37">Tentoku (957–961)</era>
+						<era type="38">Ōwa (961–964)</era>
+						<era type="39">Kōhō (964–968)</era>
+						<era type="40">Anna (968–970)</era>
+						<era type="41">Tenroku (970–973)</era>
+						<era type="42">Ten’en (973–976)</era>
+						<era type="43">Jōgen (976–978)</era>
+						<era type="44">Tengen (978–983)</era>
+						<era type="45">Eikan (983–985)</era>
+						<era type="46">Kanna (985–987)</era>
+						<era type="47">Eien (987–989)</era>
+						<era type="48">Eiso (989–990)</era>
+						<era type="49">Shōryaku (990–995)</era>
+						<era type="50">Chōtoku (995–999)</era>
+						<era type="51">Chōhō (999–1004)</era>
+						<era type="52">Kankō (1004–1012)</era>
+						<era type="53">Chōwa (1012–1017)</era>
+						<era type="54">Kannin (1017–1021)</era>
+						<era type="55">Jian (1021–1024)</era>
+						<era type="56">Manju (1024–1028)</era>
+						<era type="57">Chōgen (1028–1037)</era>
+						<era type="58">Chōryaku (1037–1040)</era>
+						<era type="59">Chōkyū (1040–1044)</era>
+						<era type="60">Kantoku (1044–1046)</era>
+						<era type="61">Eishō (1046–1053)</era>
+						<era type="62">Tengi (1053–1058)</era>
+						<era type="63">Kōhei (1058–1065)</era>
+						<era type="64">Jiryaku (1065–1069)</era>
+						<era type="65">Enkyū (1069–1074)</era>
+						<era type="66">Shōho (1074–1077)</era>
+						<era type="67">Shōryaku (1077–1081)</era>
+						<era type="68">Eihō (1081–1084)</era>
+						<era type="69">Ōtoku (1084–1087)</era>
+						<era type="70">Kanji (1087–1094)</era>
+						<era type="71">Kahō (1094–1096)</era>
+						<era type="72">Eichō (1096–1097)</era>
+						<era type="73">Jōtoku (1097–1099)</era>
+						<era type="74">Kōwa (1099–1104)</era>
+						<era type="75">Chōji (1104–1106)</era>
+						<era type="76">Kashō (1106–1108)</era>
+						<era type="77">Tennin (1108–1110)</era>
+						<era type="78">Ten-ei (1110–1113)</era>
+						<era type="79">Eikyū (1113–1118)</era>
+						<era type="80">Gen’ei (1118–1120)</era>
+						<era type="81">Hōan (1120–1124)</era>
+						<era type="82">Tenji (1124–1126)</era>
+						<era type="83">Daiji (1126–1131)</era>
+						<era type="84">Tenshō (1131–1132)</era>
+						<era type="85">Chōshō (1132–1135)</era>
+						<era type="86">Hōen (1135–1141)</era>
+						<era type="87">Eiji (1141–1142)</era>
+						<era type="88">Kōji (1142–1144)</era>
+						<era type="89">Ten’yō (1144–1145)</era>
+						<era type="90">Kyūan (1145–1151)</era>
+						<era type="91">Ninpei (1151–1154)</era>
+						<era type="92">Kyūju (1154–1156)</era>
+						<era type="93">Hōgen (1156–1159)</era>
+						<era type="94">Heiji (1159–1160)</era>
+						<era type="95">Eiryaku (1160–1161)</era>
+						<era type="96">Ōho (1161–1163)</era>
+						<era type="97">Chōkan (1163–1165)</era>
+						<era type="98">Eiman (1165–1166)</era>
+						<era type="99">Nin’an (1166–1169)</era>
+						<era type="100">Kaō (1169–1171)</era>
+						<era type="101">Shōan (1171–1175)</era>
+						<era type="102">Angen (1175–1177)</era>
+						<era type="103">Jishō (1177–1181)</era>
+						<era type="104">Yōwa (1181–1182)</era>
+						<era type="105">Juei (1182–1184)</era>
+						<era type="106">Genryaku (1184–1185)</era>
+						<era type="107">Bunji (1185–1190)</era>
+						<era type="108">Kenkyū (1190–1199)</era>
+						<era type="109">Shōji (1199–1201)</era>
+						<era type="110">Kennin (1201–1204)</era>
+						<era type="111">Genkyū (1204–1206)</era>
+						<era type="112">Ken’ei (1206–1207)</era>
+						<era type="113">Jōgen (1207–1211)</era>
+						<era type="114">Kenryaku (1211–1213)</era>
+						<era type="115">Kenpō (1213–1219)</era>
+						<era type="116">Jōkyū (1219–1222)</era>
+						<era type="117">Jōō (1222–1224)</era>
+						<era type="118">Gennin (1224–1225)</era>
+						<era type="119">Karoku (1225–1227)</era>
+						<era type="120">Antei (1227–1229)</era>
+						<era type="121">Kanki (1229–1232)</era>
+						<era type="122">Jōei (1232–1233)</era>
+						<era type="123">Tenpuku (1233–1234)</era>
+						<era type="124">Bunryaku (1234–1235)</era>
+						<era type="125">Katei (1235–1238)</era>
+						<era type="126">Ryakunin (1238–1239)</era>
+						<era type="127">En’ō (1239–1240)</era>
+						<era type="128">Ninji (1240–1243)</era>
+						<era type="129">Kangen (1243–1247)</era>
+						<era type="130">Hōji (1247–1249)</era>
+						<era type="131">Kenchō (1249–1256)</era>
+						<era type="132">Kōgen (1256–1257)</era>
+						<era type="133">Shōka (1257–1259)</era>
+						<era type="134">Shōgen (1259–1260)</era>
+						<era type="135">Bun’ō (1260–1261)</era>
+						<era type="136">Kōchō (1261–1264)</era>
+						<era type="137">Bun’ei (1264–1275)</era>
+						<era type="138">Kenji (1275–1278)</era>
+						<era type="139">Kōan (1278–1288)</era>
+						<era type="140">Shōō (1288–1293)</era>
+						<era type="141">Einin (1293–1299)</era>
+						<era type="142">Shōan (1299–1302)</era>
+						<era type="143">Kengen (1302–1303)</era>
+						<era type="144">Kagen (1303–1306)</era>
+						<era type="145">Tokuji (1306–1308)</era>
+						<era type="146">Enkyō (1308–1311)</era>
+						<era type="147">Ōchō (1311–1312)</era>
+						<era type="148">Shōwa (1312–1317)</era>
+						<era type="149">Bunpō (1317–1319)</era>
+						<era type="150">Genō (1319–1321)</era>
+						<era type="151">Genkō (1321–1324)</era>
+						<era type="152">Shōchū (1324–1326)</era>
+						<era type="153">Karyaku (1326–1329)</era>
+						<era type="154">Gentoku (1329–1331)</era>
+						<era type="155">Genkō (1331–1334)</era>
+						<era type="156">Kenmu (1334–1336)</era>
+						<era type="157">Engen (1336–1340)</era>
+						<era type="158">Kōkoku (1340–1346)</era>
+						<era type="159">Shōhei (1346–1370)</era>
+						<era type="160">Kentoku (1370–1372)</era>
+						<era type="161">Bunchū (1372–1375)</era>
+						<era type="162">Tenju (1375–1379)</era>
+						<era type="163">Kōryaku (1379–1381)</era>
+						<era type="164">Kōwa (1381–1384)</era>
+						<era type="165">Genchū (1384–1392)</era>
+						<era type="166">Meitoku (1384–1387)</era>
+						<era type="167">Kakei (1387–1389)</era>
+						<era type="168">Kōō (1389–1390)</era>
+						<era type="169">Meitoku (1390–1394)</era>
+						<era type="170">Ōei (1394–1428)</era>
+						<era type="171">Shōchō (1428–1429)</era>
+						<era type="172">Eikyō (1429–1441)</era>
+						<era type="173">Kakitsu (1441–1444)</era>
+						<era type="174">Bun’an (1444–1449)</era>
+						<era type="175">Hōtoku (1449–1452)</era>
+						<era type="176">Kyōtoku (1452–1455)</era>
+						<era type="177">Kōshō (1455–1457)</era>
+						<era type="178">Chōroku (1457–1460)</era>
+						<era type="179">Kanshō (1460–1466)</era>
+						<era type="180">Bunshō (1466–1467)</era>
+						<era type="181">Ōnin (1467–1469)</era>
+						<era type="182">Bunmei (1469–1487)</era>
+						<era type="183">Chōkyō (1487–1489)</era>
+						<era type="184">Entoku (1489–1492)</era>
+						<era type="185">Meiō (1492–1501)</era>
+						<era type="186">Bunki (1501–1504)</era>
+						<era type="187">Eishō (1504–1521)</era>
+						<era type="188">Taiei (1521–1528)</era>
+						<era type="189">Kyōroku (1528–1532)</era>
+						<era type="190">Tenbun (1532–1555)</era>
+						<era type="191">Kōji (1555–1558)</era>
+						<era type="192">Eiroku (1558–1570)</era>
+						<era type="193">Genki (1570–1573)</era>
+						<era type="194">Tenshō (1573–1592)</era>
+						<era type="195">Bunroku (1592–1596)</era>
+						<era type="196">Keichō (1596–1615)</era>
+						<era type="197">Genna (1615–1624)</era>
+						<era type="198">Kan’ei (1624–1644)</era>
+						<era type="199">Shōho (1644–1648)</era>
+						<era type="200">Keian (1648–1652)</era>
+						<era type="201">Jōō (1652–1655)</era>
+						<era type="202">Meireki (1655–1658)</era>
+						<era type="203">Manji (1658–1661)</era>
+						<era type="204">Kanbun (1661–1673)</era>
+						<era type="205">Enpō (1673–1681)</era>
+						<era type="206">Tenna (1681–1684)</era>
+						<era type="207">Jōkyō (1684–1688)</era>
+						<era type="208">Genroku (1688–1704)</era>
+						<era type="209">Hōei (1704–1711)</era>
+						<era type="210">Shōtoku (1711–1716)</era>
+						<era type="211">Kyōhō (1716–1736)</era>
+						<era type="212">Genbun (1736–1741)</era>
+						<era type="213">Kanpō (1741–1744)</era>
+						<era type="214">Enkyō (1744–1748)</era>
+						<era type="215">Kan’en (1748–1751)</era>
+						<era type="216">Hōreki (1751–1764)</era>
+						<era type="217">Meiwa (1764–1772)</era>
+						<era type="218">An’ei (1772–1781)</era>
+						<era type="219">Tenmei (1781–1789)</era>
+						<era type="220">Kansei (1789–1801)</era>
+						<era type="221">Kyōwa (1801–1804)</era>
+						<era type="222">Bunka (1804–1818)</era>
+						<era type="223">Bunsei (1818–1830)</era>
+						<era type="224">Tenpō (1830–1844)</era>
+						<era type="225">Kōka (1844–1848)</era>
+						<era type="226">Kaei (1848–1854)</era>
+						<era type="227">Ansei (1854–1860)</era>
+						<era type="228">Man’en (1860–1861)</era>
+						<era type="229">Bunkyū (1861–1864)</era>
+						<era type="230">Genji (1864–1865)</era>
+						<era type="231">Keiō (1865–1868)</era>
+						<era type="232">Meiji</era>
+						<era type="233">Taishō</era>
+						<era type="234">Shōwa</era>
+						<era type="235">Heisei</era>
+						<era type="236">Reiwa</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
@@ -7016,236 +7016,236 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y('e')'ko' MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, EEEE</dateFormatItem>
+						<dateFormatItem id="Gy">G. 'aroko' y. 'urtea'</dateFormatItem>
+						<dateFormatItem id="GyMd">y-MM-dd (GGGGG)</dateFormatItem>
+						<dateFormatItem id="GyMMM">G. 'aroko' y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G. 'aroko' y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G. 'aroko' y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'k' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">y/MM</dateFormatItem>
+						<dateFormatItem id="yMd">y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yMEd">y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yMMM">y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMd">y('e')'ko' MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="yMMMEd">y('e')'ko' MMMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="yQQQ">y('e')'ko' QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y('e')'ko' QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">G y/MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">G('e')'ko' y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">G('e')'ko' y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G, y('e')'ko' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">G y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">G y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y('e')'ko' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h – B h</greatestDifference>
+							<greatestDifference id="h">B h–h</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h:mm – B h:mm</greatestDifference>
+							<greatestDifference id="h">B h:mm–h:mm</greatestDifference>
+							<greatestDifference id="m">B h:mm–h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y, MMM – G y, MMM</greatestDifference>
+							<greatestDifference id="M">G y, MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y, MMM – G y, MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y, MMM d – G y, MMM d</greatestDifference>
+							<greatestDifference id="M">G y, MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y, MMM d – G y, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y, MMM d, E – G y, MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y, MMM d, E – G y, MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd – MM/dd</greatestDifference>
+							<greatestDifference id="M">MM/dd – MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM'k' d – MMMM'k' d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
+							<greatestDifference id="M">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y/MM – y/MM</greatestDifference>
+							<greatestDifference id="y">G y/MM – y/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd – y/MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd–dd</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd – MMMM dd</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd – y('e')'ko' MMMM dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd, EEEE – y('e')'ko' MMMM dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM – MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7254,32 +7254,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Farvardin</month>
+							<month type="2">Ordibehesht</month>
+							<month type="3">Khordad</month>
+							<month type="4">Tir</month>
+							<month type="5">Mordad</month>
+							<month type="6">Shahrivar</month>
+							<month type="7">Mehr</month>
+							<month type="8">Aban</month>
+							<month type="9">Azar</month>
+							<month type="10">Dey</month>
+							<month type="11">Bahman</month>
+							<month type="12">Esfand</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -7298,18 +7298,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Farvardin</month>
+							<month type="2">Ordibehesht</month>
+							<month type="3">Khordad</month>
+							<month type="4">Tir</month>
+							<month type="5">Mordad</month>
+							<month type="6">Shahrivar</month>
+							<month type="7">Mehr</month>
+							<month type="8">Aban</month>
+							<month type="9">Azar</month>
+							<month type="10">Dey</month>
+							<month type="11">Bahman</month>
+							<month type="12">Esfand</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -7326,265 +7326,265 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Farvardin</month>
+							<month type="2">Ordibehesht</month>
+							<month type="3">Khordad</month>
+							<month type="4">Tir</month>
+							<month type="5">Mordad</month>
+							<month type="6">Shahrivar</month>
+							<month type="7">Mehr</month>
+							<month type="8">Aban</month>
+							<month type="9">Azar</month>
+							<month type="10">Dey</month>
+							<month type="11">Bahman</month>
+							<month type="12">Esfand</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AP</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AP</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y('e')'ko' MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, EEEE</dateFormatItem>
+						<dateFormatItem id="Gy">G. 'aroko' y. 'urtea'</dateFormatItem>
+						<dateFormatItem id="GyMd">y-MM-dd (GGGGG)</dateFormatItem>
+						<dateFormatItem id="GyMMM">G. 'aroko' y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G. 'aroko' y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G. 'aroko' y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'k' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">y/MM</dateFormatItem>
+						<dateFormatItem id="yMd">y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yMEd">y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yMMM">y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMd">y('e')'ko' MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="yMMMEd">y('e')'ko' MMMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="yQQQ">y('e')'ko' QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y('e')'ko' QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">G y/MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">G('e')'ko' y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">G('e')'ko' y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G, y('e')'ko' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">G y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">G y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y('e')'ko' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h – B h</greatestDifference>
+							<greatestDifference id="h">B h–h</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h:mm – B h:mm</greatestDifference>
+							<greatestDifference id="h">B h:mm–h:mm</greatestDifference>
+							<greatestDifference id="m">B h:mm–h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y, MMM – G y, MMM</greatestDifference>
+							<greatestDifference id="M">G y, MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y, MMM – G y, MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y, MMM d – G y, MMM d</greatestDifference>
+							<greatestDifference id="M">G y, MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y, MMM d – G y, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y, MMM d, E – G y, MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y, MMM d, E – G y, MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd – MM/dd</greatestDifference>
+							<greatestDifference id="M">MM/dd – MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM'k' d – MMMM'k' d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
+							<greatestDifference id="M">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y/MM – y/MM</greatestDifference>
+							<greatestDifference id="y">G y/MM – y/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd – y/MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd–dd</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd – MMMM dd</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd – y('e')'ko' MMMM dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd, EEEE – y('e')'ko' MMMM dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM – MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7592,251 +7592,251 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="roc">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">R.O.C. aurretik</era>
+						<era type="1">R.O.C.</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">R.O.C. aurretik</era>
 						<era type="1">R.O.C.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">R.O.C. aurretik</era>
+						<era type="1">R.O.C.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d, EEEE</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y. 'urteko' MMMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G. 'aroko' y('e')'ko' MMM d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y-MM-dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} ({0})</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, EEEE</dateFormatItem>
+						<dateFormatItem id="Gy">G. 'aroko' y. 'urtea'</dateFormatItem>
+						<dateFormatItem id="GyMd">y-MM-dd (GGGGG)</dateFormatItem>
+						<dateFormatItem id="GyMMM">G. 'aroko' y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G. 'aroko' y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G. 'aroko' y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'k' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">y/MM</dateFormatItem>
+						<dateFormatItem id="yMd">y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yMEd">y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yMMM">y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yMMMd">y('e')'ko' MMMM'k' d</dateFormatItem>
+						<dateFormatItem id="yMMMEd">y('e')'ko' MMMM'k' d, EEEE</dateFormatItem>
+						<dateFormatItem id="yQQQ">y('e')'ko' QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y('e')'ko' QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">G y/MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">G('e')'ko' y/MM/dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">G('e')'ko' y/MM/dd, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G, y('e')'ko' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y('e')'ko' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">G y('e')'ko' MMMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">G y('e')'ko' MMMM d, EEEE</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y('e')'ko' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h – B h</greatestDifference>
+							<greatestDifference id="h">B h–h</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">B h:mm – B h:mm</greatestDifference>
+							<greatestDifference id="h">B h:mm–h:mm</greatestDifference>
+							<greatestDifference id="m">B h:mm–h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y, MMM – G y, MMM</greatestDifference>
+							<greatestDifference id="M">G y, MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y, MMM – G y, MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y, MMM d – G y, MMM d</greatestDifference>
+							<greatestDifference id="M">G y, MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y, MMM d – G y, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y, MMM d, E – G y, MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y, MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y, MMM d, E – G y, MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd – MM/dd</greatestDifference>
+							<greatestDifference id="M">MM/dd – MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">MM/dd, EEEE – MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM'k' d – MMMM'k' d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
+							<greatestDifference id="M">MMM'k' d, EEEE – MMM'k' d, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y/MM – y/MM</greatestDifference>
+							<greatestDifference id="y">G y/MM – y/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd – y/MM/dd</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd – y/MM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y/MM/dd, EEEE – y/MM/dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd–dd</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd – MMMM dd</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd – y('e')'ko' MMMM dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM dd, EEEE – MMMM dd, EEEE</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM dd, EEEE – y('e')'ko' MMMM dd, EEEE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y('e')'ko' MMMM – MMMM</greatestDifference>
+							<greatestDifference id="y">G y('e')'ko' MMMM – y('e')'ko' MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7952,9 +7952,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>hil.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">aurreko hilabetean</relative>
+				<relative type="0">hilabete honetan</relative>
+				<relative type="1">hurrengo hilabetean</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} hilabete barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} hilabete barru</relativeTimePattern>
@@ -7966,9 +7966,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>hil.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">aurreko hilabetean</relative>
+				<relative type="0">hilabete honetan</relative>
+				<relative type="1">hurrengo hilabetean</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} hilabete barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} hilabete barru</relativeTimePattern>
@@ -7995,9 +7995,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>ast.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">aurreko astean</relative>
+				<relative type="0">aste honetan</relative>
+				<relative type="1">hurrengo astean</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} aste barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} aste barru</relativeTimePattern>
@@ -8010,9 +8010,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>ast.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">aurreko astean</relative>
+				<relative type="0">aste honetan</relative>
+				<relative type="1">hurrengo astean</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} aste barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} aste barru</relativeTimePattern>
@@ -8050,11 +8050,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>eg.</displayName>
-				<relative type="-2">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="-2">herenegun</relative>
+				<relative type="-1">atzo</relative>
+				<relative type="0">gaur</relative>
+				<relative type="1">bihar</relative>
+				<relative type="2">etzi</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} egun barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} egun barru</relativeTimePattern>
@@ -8066,11 +8066,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>eg.</displayName>
-				<relative type="-2">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="-2">herenegun</relative>
+				<relative type="-1">atzo</relative>
+				<relative type="0">gaur</relative>
+				<relative type="1">bihar</relative>
+				<relative type="2">etzi</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} egun barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} egun barru</relativeTimePattern>
@@ -8403,7 +8403,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>h</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ordu honetan</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ordu barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ordu barru</relativeTimePattern>
@@ -8415,7 +8415,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>h</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ordu honetan</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ordu barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ordu barru</relativeTimePattern>
@@ -8439,7 +8439,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>min</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">minutu honetan</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} minutu barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} minutu barru</relativeTimePattern>
@@ -8451,7 +8451,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>min</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">minutu honetan</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} minutu barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} minutu barru</relativeTimePattern>
@@ -8475,7 +8475,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>s</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">orain</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} segundo barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} segundo barru</relativeTimePattern>
@@ -8487,7 +8487,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>s</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">orain</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} segundo barru</relativeTimePattern>
 					<relativeTimePattern count="other">{0} segundo barru</relativeTimePattern>
@@ -10855,19 +10855,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
@@ -10900,304 +10900,304 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
@@ -11215,501 +11215,501 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">−</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arab">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="bali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="beng">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="brah">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cakm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="deva">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="fullwide">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gonm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gujr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="guru">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="hanidec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="java">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="kali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="khmr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="knda">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lana">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lanatham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="laoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -11779,315 +11779,315 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="lepc">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="limb">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mlym">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mtei">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymrshan">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="nkoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="olck">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="orya">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="osma">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="rohg">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="saur">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="shrd">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sora">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sund">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="takr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="talu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tamldec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="telu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="thai">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tibt">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="vaii">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arab">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arabext">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="bali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="beng">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="brah">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cakm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="deva">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="fullwide">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gonm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gujr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="guru">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="hanidec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="java">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="kali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="khmr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="knda">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lana">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lanatham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="laoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -12101,168 +12101,168 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scientificFormats numberSystem="lepc">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="limb">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mlym">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mtei">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymrshan">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="nkoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="olck">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="orya">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="osma">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="rohg">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="saur">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="shrd">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sora">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sund">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="takr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="talu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tamldec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="telu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="thai">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tibt">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="vaii">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -12276,140 +12276,140 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<percentFormats numberSystem="arabext">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="bali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="beng">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="brah">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cakm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="deva">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="fullwide">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gonm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gujr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="guru">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="hanidec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="java">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="kali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="khmr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="knda">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lana">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lanatham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="laoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -12423,178 +12423,178 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<percentFormats numberSystem="lepc">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="limb">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mlym">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mtei">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymrshan">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="nkoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="olck">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="orya">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="osma">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="rohg">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="saur">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="shrd">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sora">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sund">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="takr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="talu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tamldec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="telu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="thai">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tibt">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="vaii">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>% #,##0</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12603,310 +12603,310 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -12954,347 +12954,347 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">
@@ -14870,7 +14870,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="TTD">
 				<displayName>dolar trinitatearra</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">dolar trinitatear</displayName>
 				<displayName count="other">dolar trinitatear</displayName>
 				<symbol>TTD</symbol>
 				<symbol alt="narrow">$</symbol>
@@ -15191,8 +15191,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="ZMK">
 				<displayName>Zambiako kwacha (1968–2012)</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Zambiako kwacha (1968–2012)</displayName>
+				<displayName count="other">Zambiako kwacha (1968–2012)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ZMW">
@@ -15234,136 +15234,136 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 		</currencies>
 		<miscPatterns numberSystem="adlm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arab">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arabext">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="bali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="beng">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="brah">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cakm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="deva">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="fullwide">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gonm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gujr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="guru">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="hanidec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="java">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="kali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="khmr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="knda">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lana">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lanatham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="laoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="latn">
 			<pattern type="approximately">~{0}</pattern>
@@ -15372,142 +15372,142 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lepc">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="limb">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mlym">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mtei">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymrshan">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="nkoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="olck">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="orya">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="osma">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="rohg">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="saur">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="shrd">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sora">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sund">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="takr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="talu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tamldec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="telu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="thai">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tibt">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="vaii">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}-{1}</pattern>
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one">{0} lagun etorri da</pluralMinimalPairs>
@@ -15703,9 +15703,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>kilateak</displayName>
@@ -15743,14 +15743,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">milako {0}</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">‱ {0}</unitPattern>
 				<unitPattern count="other">‱ {0}</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>molak</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litro kilometro bakoitzeko</displayName>
@@ -15951,14 +15951,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kilowatt-ordu</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>AEBko termiak</displayName>
@@ -16151,7 +16151,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} puntu tipografiko</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>eguzki-erradio</displayName>
 				<unitPattern count="one">{0} eguzki-erradio</unitPattern>
 				<unitPattern count="other">{0} eguzki-erradio</unitPattern>
 			</unit>
@@ -16235,17 +16235,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kilate</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>dalton</displayName>
 				<unitPattern count="one">{0} dalton</unitPattern>
 				<unitPattern count="other">{0} dalton</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>lur-masa</displayName>
 				<unitPattern count="one">{0} lur-masa</unitPattern>
 				<unitPattern count="other">{0} lur-masa</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>eguzki-masa</displayName>
 				<unitPattern count="one">{0} eguzki-masa</unitPattern>
 				<unitPattern count="other">{0} eguzki-masa</unitPattern>
 			</unit>
@@ -16300,7 +16300,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} merkurio-hazbete</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
@@ -16505,7 +16505,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} likido-ontza</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>likido-ontza inperial</displayName>
 				<unitPattern count="one">{0} likido-ontza inperial</unitPattern>
 				<unitPattern count="other">{0} likido-ontza inperial</unitPattern>
 			</unit>
@@ -16520,7 +16520,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} koilaratxokada</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
+				<displayName>upel</displayName>
 				<unitPattern count="one">{0} upel</unitPattern>
 				<unitPattern count="other">{0} upel</unitPattern>
 			</unit>
@@ -16657,12 +16657,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -16755,7 +16755,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -16780,7 +16780,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>zati/milioi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
@@ -16800,7 +16800,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mola</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -17003,12 +17003,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -17018,12 +17018,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>libra indar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newtona</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -17093,7 +17093,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -17203,7 +17203,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>eguzki-erradio</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -17213,7 +17213,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>cd</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
@@ -17223,7 +17223,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>eguzki-argitasun</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -17287,7 +17287,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
@@ -17620,64 +17620,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -17707,45 +17707,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}-{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>G</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bira</displayName>
+				<unitPattern count="one">{0} bira</unitPattern>
+				<unitPattern count="other">{0} bira</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>gradu</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>arku-min</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
@@ -17755,84 +17755,84 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektarea</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>milia karratu</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>akre</displayName>
 				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/l</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>elementua</displayName>
+				<unitPattern count="one">{0} elementu</unitPattern>
+				<unitPattern count="other">{0} elementu</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>zati/milioi</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -17840,24 +17840,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">% {0}</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">‰ {0}</unitPattern>
+				<unitPattern count="other">‰ {0}</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">‱ {0}</unitPattern>
+				<unitPattern count="other">‱ {0}</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mola</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -17865,72 +17865,72 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/gal</displayName>
+				<unitPattern count="one">mi/gal</unitPattern>
+				<unitPattern count="other">{0} mi/gal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>milia/galoi britainiar</displayName>
 				<unitPattern count="one">{0} m/g brit.</unitPattern>
 				<unitPattern count="other">{0} m/g brit.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>byte</displayName>
+				<unitPattern count="one">{0} byte</unitPattern>
+				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>m.</displayName>
 				<unitPattern count="one">{0}m.</unitPattern>
 				<unitPattern count="other">{0}m.</unitPattern>
 			</unit>
@@ -17943,7 +17943,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>urte</displayName>
 				<unitPattern count="one">{0} u.</unitPattern>
 				<unitPattern count="other">{0} u.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/u.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>laurden</displayName>
@@ -17955,37 +17955,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>hilabete</displayName>
 				<unitPattern count="one">{0} hil</unitPattern>
 				<unitPattern count="other">{0} hil</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/hil</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>aste</displayName>
 				<unitPattern count="one">{0} aste</unitPattern>
 				<unitPattern count="other">{0} aste</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/a.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>egun</displayName>
 				<unitPattern count="one">{0} e.</unitPattern>
 				<unitPattern count="other">{0} e.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/e.</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ordu</displayName>
 				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="other">{0} h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
 				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">{0} min</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -17993,89 +17993,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>AEBko termia</displayName>
 				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">{0} US therms</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>libra indar</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>newtona</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh / 100 km</displayName>
@@ -18083,92 +18083,92 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kWh / 100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pixel</displayName>
+				<unitPattern count="one">{0} p</unitPattern>
+				<unitPattern count="other">{0} p</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapixel</displayName>
+				<unitPattern count="one">{0} Mp</unitPattern>
+				<unitPattern count="other">{0} Mp</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>puntua</displayName>
+				<unitPattern count="one">{0} puntu</unitPattern>
+				<unitPattern count="other">{0} ptu</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -18176,265 +18176,265 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>milia</displayName>
 				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd</displayName>
 				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>oin</displayName>
 				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="other">{0} ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>hazbete</displayName>
 				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="other">{0} in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>argi-urte</displayName>
 				<unitPattern count="one">{0} ly</unitPattern>
 				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ua</displayName>
+				<unitPattern count="one">{0} ua</unitPattern>
+				<unitPattern count="other">{0} ua</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>furlong</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fm</unitPattern>
+				<unitPattern count="other">{0} fm</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milia eskandinaviar</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>puntu</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eguzki-erradio</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="one">{0} lux</unitPattern>
+				<unitPattern count="other">{0} lux</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gramo</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>AEBko tona</displayName>
 				<unitPattern count="one">{0}tn</unitPattern>
 				<unitPattern count="other">{0}tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>ontza</displayName>
 				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">{0} oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ontza</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>troy ontza</displayName>
 				<unitPattern count="one">{0} oz t</unitPattern>
 				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilate</displayName>
+				<unitPattern count="one">{0} kilate</unitPattern>
+				<unitPattern count="other">{0} kilate</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dalton</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>lur-masa</displayName>
 				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>eguzki-masa</displayName>
 				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>alea</displayName>
+				<unitPattern count="one">{0} ale</unitPattern>
+				<unitPattern count="other">{0} ale</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="one">{0} mm Hg</unitPattern>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mb</displayName>
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atmosfera</displayName>
 				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -18442,24 +18442,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>metro segundoko</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/h</displayName>
 				<unitPattern count="one">{0} mph</unitPattern>
 				<unitPattern count="other">{0} mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>korapilo</displayName>
 				<unitPattern count="one">{0}kn</unitPattern>
 				<unitPattern count="other">{0}kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -18467,17 +18467,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>oin-libra</displayName>
 				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
@@ -18487,179 +18487,179 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} N·m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litro</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>pinta metriko</displayName>
 				<unitPattern count="one">{0}mpt</unitPattern>
 				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>katilukada metriko</displayName>
 				<unitPattern count="one">{0}mc</unitPattern>
 				<unitPattern count="other">{0}mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>akre-oin</displayName>
 				<unitPattern count="one">{0}ac ft</unitPattern>
 				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bushelak</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>galoi</displayName>
+				<unitPattern count="one">{0} galoi</unitPattern>
+				<unitPattern count="other">{0} galoi</unitPattern>
+				<perUnitPattern>{0}/galoi estatubatuar</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal brit.</displayName>
+				<unitPattern count="one">{0} gal brit.</unitPattern>
+				<unitPattern count="other">{0} gal brit.</unitPattern>
+				<perUnitPattern>{0}/gal brit.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>galoi-laurden</displayName>
 				<unitPattern count="one">{0}qt</unitPattern>
 				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinta</displayName>
+				<unitPattern count="one">{0} pinta</unitPattern>
+				<unitPattern count="other">{0} pinta</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>katilukada</displayName>
 				<unitPattern count="one">{0}c</unitPattern>
 				<unitPattern count="other">{0}c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>likido-ontza</displayName>
 				<unitPattern count="one">{0}fl oz</unitPattern>
 				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>likido-ontza inperial</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>koilarakada</displayName>
 				<unitPattern count="one">{0}tbsp</unitPattern>
 				<unitPattern count="other">{0}tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>koilaratxokada</displayName>
 				<unitPattern count="one">{0}tsp</unitPattern>
 				<unitPattern count="other">{0}tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>upel</displayName>
+				<unitPattern count="one">{0} upel</unitPattern>
+				<unitPattern count="other">{0} upel</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>postre-koilar.</displayName>
 				<unitPattern count="one">{0}dsp</unitPattern>
 				<unitPattern count="other">{0}dsp</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>postre-koilar. inp.</displayName>
 				<unitPattern count="one">{0}dsp-Imp</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tanta</displayName>
+				<unitPattern count="one">{0} tanta</unitPattern>
+				<unitPattern count="other">{0} tanta</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram fluidoa</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>txupitoa</displayName>
+				<unitPattern count="one">{0} txupito</unitPattern>
+				<unitPattern count="other">{0} txupito</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch-a</displayName>
+				<unitPattern count="one">{0} pinch</unitPattern>
+				<unitPattern count="other">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>norabidea</displayName>
@@ -18693,28 +18693,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} edo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} edo {1}</listPatternPart>
+			<listPatternPart type="2">{0} edo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} edo {1}</listPatternPart>
+			<listPatternPart type="2">{0} edo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} eta {1}</listPatternPart>
+			<listPatternPart type="2">{0} eta {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -1013,7 +1013,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">تونس</territory>
 			<territory type="TO">تونگا</territory>
 			<territory type="TR">ترکیه</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ترکیه</territory>
 			<territory type="TT">ترینیداد و توباگو</territory>
 			<territory type="TV">تووالو</territory>
 			<territory type="TW">تایوان</territory>
@@ -1288,17 +1288,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">EEEE d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">d MMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
@@ -1322,32 +1322,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="12">خوک</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">موش</cyclicName>
+								<cyclicName type="2" draft="contributed">گاو</cyclicName>
+								<cyclicName type="3" draft="contributed">ببر</cyclicName>
+								<cyclicName type="4" draft="contributed">خرگوش</cyclicName>
+								<cyclicName type="5" draft="contributed">اژدها</cyclicName>
+								<cyclicName type="6" draft="contributed">مار</cyclicName>
+								<cyclicName type="7" draft="contributed">اسب</cyclicName>
+								<cyclicName type="8" draft="contributed">بز</cyclicName>
+								<cyclicName type="9" draft="contributed">میمون</cyclicName>
+								<cyclicName type="10" draft="contributed">خروس</cyclicName>
+								<cyclicName type="11" draft="contributed">سگ</cyclicName>
+								<cyclicName type="12" draft="contributed">خوک</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">موش</cyclicName>
+								<cyclicName type="2" draft="contributed">گاو</cyclicName>
+								<cyclicName type="3" draft="contributed">ببر</cyclicName>
+								<cyclicName type="4" draft="contributed">خرگوش</cyclicName>
+								<cyclicName type="5" draft="contributed">اژدها</cyclicName>
+								<cyclicName type="6" draft="contributed">مار</cyclicName>
+								<cyclicName type="7" draft="contributed">اسب</cyclicName>
+								<cyclicName type="8" draft="contributed">بز</cyclicName>
+								<cyclicName type="9" draft="contributed">میمون</cyclicName>
+								<cyclicName type="10" draft="contributed">خروس</cyclicName>
+								<cyclicName type="11" draft="contributed">سگ</cyclicName>
+								<cyclicName type="12" draft="contributed">خوک</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -1550,7 +1550,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1558,7 +1558,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1566,7 +1566,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}،‏ {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}،‏ {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1574,7 +1574,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}،‏ {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}،‏ {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2040,7 +2040,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="am">قبل‌ازظهر</dayPeriod>
 							<dayPeriod type="pm">بعدازظهر</dayPeriod>
 							<dayPeriod type="morning1">بامداد</dayPeriod>
-							<dayPeriod type="morning2">↑↑↑</dayPeriod>
+							<dayPeriod type="morning2">صبح</dayPeriod>
 							<dayPeriod type="afternoon1">ظهر</dayPeriod>
 							<dayPeriod type="afternoon2">عصر</dayPeriod>
 							<dayPeriod type="night1">شب</dayPeriod>
@@ -2625,9 +2625,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="1">محرم</month>
 							<month type="2">صفر</month>
 							<month type="3">ربیع‌الاول</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
+							<month type="4">ربیع‌الثانی</month>
+							<month type="5">جمادی‌الاول</month>
+							<month type="6">جمادی‌الثانی</month>
 							<month type="7">رجب</month>
 							<month type="8">شعبان</month>
 							<month type="9">رمضان</month>
@@ -2677,12 +2677,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2730,18 +2730,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} تا {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B تا h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h تا h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B تا h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm تا h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm تا h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d تا d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G" draft="contributed">y G تا y G</greatestDifference>
@@ -2782,45 +2782,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y" draft="contributed">E d MMM y تا E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a تا h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h تا h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H تا H</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a تا h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm تا h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm تا h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H:mm تا H:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm تا H:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M تا M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">M/d تا M/d</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/d تا M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E M/d تا E M/d</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E M/d تا E M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">LLL تا LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d تا d LLL</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d LLL تا d LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d LLL تا E d LLL</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d LLL تا E d LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y تا y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M" draft="contributed">y/M تا y/M GGGGG</greatestDifference>
@@ -2837,22 +2837,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y" draft="contributed">E y/M/d تا E y/M/d GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">LLL تا MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y تا MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d تا d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d LLL تا d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y تا d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d LLL تا E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d LLL تا E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y تا E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">LLLL تا MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMMM y تا MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3003,41 +3003,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}،‏ {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}،‏ {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">E dم</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">d LLL</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E d LLL</dateFormatItem>
+						<dateFormatItem id="MMMMd" draft="contributed">d LLLL</dateFormatItem>
+						<dateFormatItem id="MMMMEd" draft="contributed">E d LLLL</dateFormatItem>
 						<dateFormatItem id="y">y</dateFormatItem>
 						<dateFormatItem id="yyyy">y</dateFormatItem>
 						<dateFormatItem id="yyyyM">y/M</dateFormatItem>
@@ -3051,18 +3051,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">QQQQ y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} تا {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B تا h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h تا h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B تا h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm تا h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm تا h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d تا d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G" draft="contributed">y G تا y G</greatestDifference>
@@ -3103,42 +3103,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y" draft="contributed">E d MMM y تا E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a تا h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h تا h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H تا H</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a تا h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm تا h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm تا h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H:mm تا H:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm تا H:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M تا M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">M/d تا M/d</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/d تا M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E M/d تا E M/d</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E M/d تا E M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="contributed">LLL تا LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d تا d LLL</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d LLL تا d LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d LLL تا E d LLL</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d LLL تا E d LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y">y تا y</greatestDifference>
@@ -3196,30 +3196,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}، ساعت {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}،‏ {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}،‏ {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
+						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -6178,7 +6178,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
@@ -6198,7 +6198,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -6256,7 +6256,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="10000000000" count="other">00 میلیارد</pattern>
 					<pattern type="100000000000" count="one">000 میلیارد</pattern>
 					<pattern type="100000000000" count="other">000 میلیارد</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one">0 تریلیون</pattern>
 					<pattern type="1000000000000" count="other">0 تریلیون</pattern>
 					<pattern type="10000000000000" count="one">00 تریلیون</pattern>
 					<pattern type="10000000000000" count="other">00 تریلیون</pattern>
@@ -6536,8 +6536,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="BOP">
 				<displayName>پزوی بولیوی</displayName>
-				<displayName count="one" draft="contributed">↑↑↑</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="one" draft="contributed">پزوی بولیوی</displayName>
+				<displayName count="other" draft="contributed">پزوی بولیوی</displayName>
 			</currency>
 			<currency type="BRL">
 				<displayName>رئال برزیل</displayName>
@@ -7719,7 +7719,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="XXX">
 				<displayName>ارز نامشخص</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">(ارز نامشخص)</displayName>
 				<displayName count="other">(ارز نامشخص)</displayName>
 			</currency>
 			<currency type="YDD">
@@ -7767,8 +7767,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mtei">
-			<pattern type="approximately" draft="contributed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="contributed">↑↑↑</pattern>
+			<pattern type="approximately" draft="contributed">~{0}</pattern>
+			<pattern type="atLeast" draft="contributed">‎{0}+‎</pattern>
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one">{0} نفر در بازی شرکت کرد.</pluralMinimalPairs>
@@ -7965,8 +7965,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>دونوم</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} دونوم</unitPattern>
+				<unitPattern count="other">{0} دونوم</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>عیار</displayName>
@@ -8263,8 +8263,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em تایپوگرافی</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>پیکسل</displayName>
@@ -8616,7 +8616,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} گره</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
@@ -8812,8 +8812,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>سرانگشت</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} سرانگشت</unitPattern>
+				<unitPattern count="other">{0} سرانگشت</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>کوارت انگلیسی</displayName>
@@ -8918,12 +8918,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -9016,7 +9016,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>دونوم</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} دونوم</unitPattern>
 				<unitPattern count="other">{0} دونوم</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -9041,7 +9041,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>بخش/میلیون</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
@@ -9204,7 +9204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>میکروثانیه</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}μs</unitPattern>
 				<unitPattern count="other">{0}μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
@@ -9474,12 +9474,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -9494,7 +9494,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>کیلوگرم</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} کیلوگرم</unitPattern>
 				<unitPattern count="other">{0} کیلوگرم</unitPattern>
 				<perUnitPattern>{0}‎/kg</perUnitPattern>
 			</unit>
@@ -9838,12 +9838,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>قاشق دسرخوری</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ق.دس.خ.</unitPattern>
 				<unitPattern count="other">{0} ق.دس.خ.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>قاشق دسرخوری انگلیسی</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ق.دس. انگلیسی</unitPattern>
 				<unitPattern count="other">{0} ق.دس. انگلیسی</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -9863,7 +9863,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>سرانگشت</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} سرانگشت</unitPattern>
 				<unitPattern count="other">{0} سرانگشت</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
@@ -9941,44 +9941,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>یوتا{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>نیروی جاذبه</displayName>
@@ -9987,18 +9987,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>متر/مجذور ثانیه</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‎ m/s²</unitPattern>
+				<unitPattern count="other">{0}‎ m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>دور</displayName>
+				<unitPattern count="one">{0} دور</unitPattern>
+				<unitPattern count="other">{0} دور</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>رادیان</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} رادیان</unitPattern>
+				<unitPattern count="other">{0} رادیان</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>درجه</displayName>
@@ -10006,46 +10006,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>دقیقهٔ قوسی</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ثانیهٔ قوسی</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>کیلومتر مربع</displayName>
 				<unitPattern count="one">{0}km²</unitPattern>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>هکتار</displayName>
 				<unitPattern count="one">{0}ha</unitPattern>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>متر مربع</displayName>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}‎/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0}‎ cm²</unitPattern>
+				<unitPattern count="other">{0}‎ cm²</unitPattern>
+				<perUnitPattern>{0}‎/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>مایل مربع</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}‎/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>جریب</displayName>
 				<unitPattern count="one">{0}جریب</unitPattern>
 				<unitPattern count="other">{0} جریب</unitPattern>
 			</unit>
@@ -10055,35 +10055,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} یارد مربع</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>فوت مربع</displayName>
 				<unitPattern count="one">{0}ft²</unitPattern>
 				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>اینچ مربع</displayName>
 				<unitPattern count="one">{0}اینچ مربع</unitPattern>
 				<unitPattern count="other">{0}اینچ مربع</unitPattern>
 				<perUnitPattern>{0}/اینچ مربع</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>دونوم</displayName>
 				<unitPattern count="one">{0}دونوم</unitPattern>
 				<unitPattern count="other">{0}دونوم</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>عیار</displayName>
+				<unitPattern count="one">{0} عیار</unitPattern>
+				<unitPattern count="other">{0} عیار</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>میلی‌گرم در دسی‌لیتر</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>میلی‌مول/لیتر</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>مورد</displayName>
@@ -10091,7 +10091,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}مورد</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>بخش/میلیون</displayName>
 				<unitPattern count="one">{0}ppm</unitPattern>
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
@@ -10101,24 +10101,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}٪</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>هزارم</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ده‌هزارم</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مول</displayName>
+				<unitPattern count="one">{0} مول</unitPattern>
+				<unitPattern count="other">{0} مول</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>لیتر/کیلومتر</displayName>
+				<unitPattern count="one">{0} ل./ک.م.</unitPattern>
+				<unitPattern count="other">{0} ل./ک.م.</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>لیتر/۱۰۰ کیلومتر</displayName>
@@ -10126,69 +10126,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ل./۱۰۰ ک.م.</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مایل/گالن</displayName>
+				<unitPattern count="one">{0} مایل در گالن</unitPattern>
+				<unitPattern count="other">{0} مایل در گالن</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>مایل/امپریال گالن</displayName>
 				<unitPattern count="one">{0}m/gUK</unitPattern>
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>پتابایت</displayName>
 				<unitPattern count="one">{0}PB</unitPattern>
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>ترابایت</displayName>
 				<unitPattern count="one">{0}TB</unitPattern>
 				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ترابیت</displayName>
 				<unitPattern count="one">{0}Tb</unitPattern>
 				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>GB</displayName>
 				<unitPattern count="one">{0}GB</unitPattern>
 				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>گیگابیت</displayName>
 				<unitPattern count="one">{0}Gb</unitPattern>
 				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="one">{0}MB</unitPattern>
 				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>مگابیت</displayName>
 				<unitPattern count="one">{0}Mb</unitPattern>
 				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>کیلوبایت</displayName>
 				<unitPattern count="one">{0}kB</unitPattern>
 				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>کیلوبیت</displayName>
 				<unitPattern count="one">{0}kb</unitPattern>
 				<unitPattern count="other">{0}kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>بایت</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} بایت</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} بایت</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>بیت</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} بیت</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} بیت</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>سده</displayName>
@@ -10196,21 +10196,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} سده</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>دهه</displayName>
+				<unitPattern count="one">{0} دهه</unitPattern>
+				<unitPattern count="other">{0} دهه</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>سال</displayName>
 				<unitPattern count="one">{0} سال</unitPattern>
 				<unitPattern count="other">{0} سال</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/سال</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>سه‌ماه</displayName>
+				<unitPattern count="one">{0} سه‌ماهه</unitPattern>
+				<unitPattern count="other">{0} سه‌ماهه</unitPattern>
+				<perUnitPattern>{0}/سه‌ماه</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>ماه</displayName>
@@ -10254,7 +10254,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>میکروثانیه</displayName>
 				<unitPattern count="one">{0}μs</unitPattern>
 				<unitPattern count="other">{0}μs</unitPattern>
 			</unit>
@@ -10264,84 +10264,84 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>آمپر</displayName>
+				<unitPattern count="one">{0} آمپر</unitPattern>
+				<unitPattern count="other">{0} آمپر</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>میلی‌آمپر</displayName>
+				<unitPattern count="one">{0} میلی‌آمپر</unitPattern>
+				<unitPattern count="other">{0} میلی‌آمپر</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>اهم</displayName>
+				<unitPattern count="one">{0} اهم</unitPattern>
+				<unitPattern count="other">{0} اهم</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ولت</displayName>
+				<unitPattern count="one">{0} ولت</unitPattern>
+				<unitPattern count="other">{0} ولت</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ک.کالری</displayName>
+				<unitPattern count="one">{0} ک.کالری</unitPattern>
+				<unitPattern count="other">{0} ک.کالری</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>کالری</displayName>
+				<unitPattern count="one">{0} کالری</unitPattern>
+				<unitPattern count="other">{0} کالری</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>کالری</displayName>
+				<unitPattern count="one">{0} کالری</unitPattern>
+				<unitPattern count="other">{0} کالری</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ک.ژول</displayName>
+				<unitPattern count="one">{0} ک.ژول</unitPattern>
+				<unitPattern count="other">{0} ک.ژول</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ژول</displayName>
+				<unitPattern count="one">{0} ژول</unitPattern>
+				<unitPattern count="other">{0} ژول</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ک.وات‌ساعت</displayName>
+				<unitPattern count="one">{0} ک.و.ساعت</unitPattern>
+				<unitPattern count="other">{0} ک.و.ساعت</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>الکترون‌ولت</displayName>
 				<unitPattern count="one">{0}الکترون‌ولت</unitPattern>
 				<unitPattern count="other">{0}الکترون‌ولت</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بی‌تی‌یو</displayName>
+				<unitPattern count="one">{0} بی‌تی‌یو</unitPattern>
+				<unitPattern count="other">{0} بی‌تی‌یو</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ترم آمریکایی</displayName>
+				<unitPattern count="one">{0} ترم آمریکایی</unitPattern>
+				<unitPattern count="other">{0} ترم آمریکایی</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پوند-نیرو</displayName>
+				<unitPattern count="one">{0} پوند-نیرو</unitPattern>
+				<unitPattern count="other">{0} پوند-نیرو</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نیوتن</displayName>
+				<unitPattern count="one">{0} نیوتن</unitPattern>
+				<unitPattern count="other">{0} نیوتن</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>ک.وا.س/۱۰۰ ک.م</displayName>
 				<unitPattern count="one">{0}ک.وا.س/۱۰۰ ک.م</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ک.وا.س/۱۰۰ ک.م</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>گ‌.هرتز</displayName>
@@ -10359,39 +10359,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ک.هرتز</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>هرتز</displayName>
+				<unitPattern count="one">{0} هرتز</unitPattern>
+				<unitPattern count="other">{0} هرتز</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>پیکسل</displayName>
 				<unitPattern count="one">{0}px</unitPattern>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>مگاپیکسل</displayName>
 				<unitPattern count="one">{0}MP</unitPattern>
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
@@ -10399,25 +10399,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نقطه</displayName>
+				<unitPattern count="one">{0} نقطه</unitPattern>
+				<unitPattern count="other">{0} نقطه</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0}km</unitPattern>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}‎/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>متر</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
 				<perUnitPattern>{0}/متر</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
@@ -10429,7 +10429,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0}cm</unitPattern>
 				<unitPattern count="other">{0}cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/س.م</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -10437,7 +10437,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>μm</displayName>
 				<unitPattern count="one">{0}μm</unitPattern>
 				<unitPattern count="other">{0}μm</unitPattern>
 			</unit>
@@ -10471,7 +10471,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>اینچ</displayName>
 				<unitPattern count="one">{0}in</unitPattern>
 				<unitPattern count="other">{0}in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/اینچ</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>پارسک</displayName>
@@ -10489,12 +10489,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}واحد نجومی</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>فرلانگ</displayName>
 				<unitPattern count="one">{0}فرلانگ</unitPattern>
 				<unitPattern count="other">{0}فرلانگ</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>فاتوم</displayName>
 				<unitPattern count="one">{0}فاتوم</unitPattern>
 				<unitPattern count="other">{0}فاتوم</unitPattern>
 			</unit>
@@ -10504,39 +10504,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}مایل دریایی</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مایل اسکاندیناوی</displayName>
+				<unitPattern count="one">{0}‎ smi</unitPattern>
+				<unitPattern count="other">{0}‎ smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>پوینت</displayName>
 				<unitPattern count="one">{0}پوینت</unitPattern>
 				<unitPattern count="other">{0}پوینت</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>شعاع خورشید</displayName>
 				<unitPattern count="one">{0}شعاع خورشید</unitPattern>
 				<unitPattern count="other">{0}شعاع خورشید</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>لوکس</displayName>
+				<unitPattern count="one">{0} لوکس</unitPattern>
+				<unitPattern count="other">{0} لوکس</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>تابندگی خورشید</displayName>
+				<unitPattern count="one">{0} ☉L</unitPattern>
+				<unitPattern count="other">{0} ☉L</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>تن متریک</displayName>
@@ -10547,7 +10547,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}‎/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>گرم</displayName>
@@ -10588,62 +10588,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} در اونس</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>اونس تروا</displayName>
 				<unitPattern count="one">{0}اونس تروا</unitPattern>
 				<unitPattern count="other">{0}اونس تروا</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>قیراط</displayName>
 				<unitPattern count="one">{0}CD</unitPattern>
 				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>دالتون</displayName>
 				<unitPattern count="one">{0}Da</unitPattern>
 				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>جرم زمین</displayName>
 				<unitPattern count="one">{0}M⊕</unitPattern>
 				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>جرم خورشید</displayName>
 				<unitPattern count="one">{0}M☉</unitPattern>
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>دانه</displayName>
 				<unitPattern count="one">{0}gr</unitPattern>
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>گیگاوات</displayName>
+				<unitPattern count="one">{0} گیگاوات</unitPattern>
+				<unitPattern count="other">{0} گیگاوات</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مگاوات</displayName>
+				<unitPattern count="one">{0} مگاوات</unitPattern>
+				<unitPattern count="other">{0} مگاوات</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ک.وات</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>وات</displayName>
 				<unitPattern count="one">{0}W</unitPattern>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>میلی‌وات</displayName>
+				<unitPattern count="one">{0} میلی‌وات</unitPattern>
+				<unitPattern count="other">{0} میلی‌وات</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>اسب بخار</displayName>
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
@@ -10663,9 +10663,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بار</displayName>
+				<unitPattern count="one">{0} بار</unitPattern>
+				<unitPattern count="other">{0} بار</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>میلی‌بار</displayName>
@@ -10673,7 +10673,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>اتمسفر</displayName>
 				<unitPattern count="one">{0}اتمسفر</unitPattern>
 				<unitPattern count="other">{0}اتمسفر</unitPattern>
 			</unit>
@@ -10688,14 +10688,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ک.پاسکال</displayName>
+				<unitPattern count="one">{0} ک.پاسکال</unitPattern>
+				<unitPattern count="other">{0} ک.پاسکال</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مگاپاسکال</displayName>
+				<unitPattern count="one">{0} مگاپاسکال</unitPattern>
+				<unitPattern count="other">{0} مگاپاسکال</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>کیلومتر/ساعت</displayName>
@@ -10733,22 +10733,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>درجهٔ کلوین</displayName>
 				<unitPattern count="one">{0}K</unitPattern>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پوند-فوت</displayName>
+				<unitPattern count="one">{0} پوند-فوت</unitPattern>
+				<unitPattern count="other">{0} پوند-فوت</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نیوتن‌متر</displayName>
+				<unitPattern count="one">{0} نیوتن‌متر</unitPattern>
+				<unitPattern count="other">{0} نیوتن‌متر</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>کیلومتر مکعب</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
@@ -10756,16 +10756,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>m³</displayName>
 				<unitPattern count="one">{0}m³</unitPattern>
 				<unitPattern count="other">{0}m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}‎/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0}‎ cm³</unitPattern>
+				<unitPattern count="other">{0}‎ cm³</unitPattern>
+				<perUnitPattern>{0}‎ /cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0}mi³</unitPattern>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
@@ -10798,15 +10798,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>لیتر</displayName>
 				<unitPattern count="one">{0}L</unitPattern>
 				<unitPattern count="other">{0}L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}‎/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dL</displayName>
 				<unitPattern count="one">{0}dL</unitPattern>
 				<unitPattern count="other">{0}dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cL</displayName>
 				<unitPattern count="one">{0}cL</unitPattern>
 				<unitPattern count="other">{0}cL</unitPattern>
 			</unit>
@@ -10816,36 +10816,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>پاینت متریک</displayName>
 				<unitPattern count="one">{0}mpt</unitPattern>
 				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>پیمانهٔ متریک</displayName>
 				<unitPattern count="one">{0}mc</unitPattern>
 				<unitPattern count="other">{0}mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>جریب فوت</displayName>
 				<unitPattern count="one">{0}ac ft</unitPattern>
 				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>بوشل</displayName>
 				<unitPattern count="one">{0}bu</unitPattern>
 				<unitPattern count="other">{0}bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>گالن</displayName>
+				<unitPattern count="one">{0} گالن</unitPattern>
+				<unitPattern count="other">{0} گالن</unitPattern>
+				<perUnitPattern>{0} در گالن</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>گالن امپریال</displayName>
+				<unitPattern count="one">{0} گالن امپریال</unitPattern>
+				<unitPattern count="other">{0} گالن امپریال</unitPattern>
+				<perUnitPattern>{0}/گالن امپریال</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qt</displayName>
@@ -10858,64 +10858,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>پیمانه</displayName>
 				<unitPattern count="one">{0}c</unitPattern>
 				<unitPattern count="other">{0}c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>اونس سیال</displayName>
 				<unitPattern count="one">{0}fl oz</unitPattern>
 				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>اونس سیال انگلیسی</displayName>
 				<unitPattern count="one">{0}اونس سیال انگلیسی</unitPattern>
 				<unitPattern count="other">{0}اونس سیال انگلیسی</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>قاشق غ.</displayName>
+				<unitPattern count="one">{0} ق.غ.خ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} قاشق غ.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">قاشق چ.</displayName>
 				<unitPattern count="one">{0}ق.چ.</unitPattern>
 				<unitPattern count="other">{0}ق.چ.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بشکه</displayName>
+				<unitPattern count="one">{0} بشکه</unitPattern>
+				<unitPattern count="other">{0} بشکه</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قاشق دسرخوری</displayName>
+				<unitPattern count="one">{0} ق.دس.خ.</unitPattern>
+				<unitPattern count="other">{0} ق.دس.خ.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>قاشق دسرخوری انگلیسی</displayName>
 				<unitPattern count="one">{0} ق.دس. انگلیسی</unitPattern>
 				<unitPattern count="other">{0} ق.دس. انگلیسی</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قطره</displayName>
+				<unitPattern count="one">{0} قطره</unitPattern>
+				<unitPattern count="other">{0} قطره</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>درم سیال</displayName>
+				<unitPattern count="one">{0} درم سیال</unitPattern>
+				<unitPattern count="other">{0} درم سیال</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>گیلاس</displayName>
+				<unitPattern count="one">{0} گیلاس</unitPattern>
+				<unitPattern count="other">{0} گیلاس</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>سرانگشت</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} سرانگشت</unitPattern>
+				<unitPattern count="other">{0} سرانگشت</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>کوارت انگلیسی</displayName>
@@ -10956,14 +10956,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<listPattern type="or-narrow">
 			<listPatternPart type="start">{0}،‏ {1}</listPatternPart>
 			<listPatternPart type="middle">{0}،‏ {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0}، یا {1}</listPatternPart>
+			<listPatternPart type="2">{0} یا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
 			<listPatternPart type="start">{0}،‏ {1}</listPatternPart>
 			<listPatternPart type="middle">{0}،‏ {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0}، یا {1}</listPatternPart>
+			<listPatternPart type="2">{0} یا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}،‏ {1}</listPatternPart>
@@ -11195,10 +11195,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern draft="contributed">↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {generation}، {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -11210,10 +11210,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
@@ -11228,10 +11228,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{surname}، {title} {given} {given2} {generation}، {credentials}</namePattern>
@@ -11249,7 +11249,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern draft="contributed">↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname}، {given} {given2-initial} {generation}، {credentials}</namePattern>
@@ -11264,10 +11264,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern draft="contributed">↑↑↑</namePattern>
+			<namePattern draft="contributed">{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{surname}، {given-initial} {given2-initial}</namePattern>
@@ -11282,10 +11282,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>{surname-core}، {given} {given2} {surname-prefix}</namePattern>

--- a/common/main/ff_Adlm.xml
+++ b/common/main/ff_Adlm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -80,7 +80,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">𞤕𞤫𞥅𞤪𞤮𞤳𞤭𞥅𞤪𞤫</language>
 			<language type="chy">𞤅𞤢𞥄𞤴𞤢𞤲𞤪𞤫</language>
 			<language type="ckb">𞤑𞤵𞤪𞤣𞤵𞥅𞤪𞤫</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">𞤑𞤵𞤪𞤣𞤵𞥅𞤪𞤫</language>
 			<language type="ckb" alt="variant">𞤑𞤵𞤪𞤣𞤵𞥅𞤪𞤫 𞤅𞤮𞤪𞤢𞤲𞤭</language>
 			<language type="clc">𞤕𞤭𞤤𞤳𞤮𞤼𞤭𞤲𞤪𞤫</language>
 			<language type="co">𞤑𞤮𞤪𞤧𞤭𞤳𞤢𞥄𞤪𞤫</language>
@@ -872,7 +872,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="PN">𞤕𞤵𞤪𞤭𞥅𞤶𞤫 𞤆𞤭𞤼𞤳𞤭𞥅𞤪𞤲𞤵</territory>
 			<territory type="PR">𞤆𞤮𞤪𞤼𞤮 𞤈𞤭𞤳𞤮𞥅</territory>
 			<territory type="PS">𞤂𞤫𞤧𞤣𞤭𞥅𞤶𞤭 𞤊𞤢𞤤𞤫𞤧𞤼𞤭𞥅𞤲</territory>
-			<territory type="PS" alt="short">↑↑↑</territory>
+			<territory type="PS" alt="short">𞤂𞤫𞤧𞤣𞤭𞥅𞤶𞤭 𞤊𞤢𞤤𞤫𞤧𞤼𞤭𞥅𞤲</territory>
 			<territory type="PT">𞤆𞤮𞥅𞤪𞤼𞤵𞤺𞤢𞥄𞤤</territory>
 			<territory type="PW">𞤆𞤢𞤤𞤢𞤱</territory>
 			<territory type="PY">𞤆𞤢𞥄𞤪𞤢𞤺𞤵𞤱𞤢𞥄𞤴</territory>
@@ -1137,232 +1137,232 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="0">𞤘𞤄</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">𞤘𞤄</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d-M-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d-M</dateFormatItem>
+						<dateFormatItem id="MEd">E d-M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E⹁ d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1506,31 +1506,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
 								<cyclicName type="1">𞥁𞤭</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="2">𞤅𞤵</cyclicName>
+								<cyclicName type="3">𞤴𞤭𞤲</cyclicName>
+								<cyclicName type="4">𞤥𞤢𞤱𞤮</cyclicName>
+								<cyclicName type="5">𞤷𞤫𞤲</cyclicName>
+								<cyclicName type="6">𞤧𞤭</cyclicName>
+								<cyclicName type="7">𞤱𞤵</cyclicName>
+								<cyclicName type="8">𞤱𞤫𞤭</cyclicName>
+								<cyclicName type="9">𞥃𞤫𞥅𞤲</cyclicName>
+								<cyclicName type="10">𞤴𞤵𞥅</cyclicName>
+								<cyclicName type="11">𞤿𞤵</cyclicName>
+								<cyclicName type="12">𞤸𞤢𞤴</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">𞥁𞤭</cyclicName>
+								<cyclicName type="2">𞤅𞤵</cyclicName>
+								<cyclicName type="3">𞤴𞤭𞤲</cyclicName>
+								<cyclicName type="4">𞤥𞤢𞤱𞤮</cyclicName>
+								<cyclicName type="5">𞤷𞤫𞤲</cyclicName>
+								<cyclicName type="6">𞤧𞤭</cyclicName>
+								<cyclicName type="7">𞤱𞤵</cyclicName>
+								<cyclicName type="8">𞤱𞤫𞤭</cyclicName>
+								<cyclicName type="9">𞥃𞤫𞥅𞤲</cyclicName>
+								<cyclicName type="10">𞤴𞤵𞥅</cyclicName>
+								<cyclicName type="11">𞤿𞤵</cyclicName>
+								<cyclicName type="12">𞤸𞤢𞤴</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -1591,7 +1591,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 								<cyclicName type="52">𞤴𞤭-𞤥𞤢𞤱𞤮</cyclicName>
 								<cyclicName type="53">𞤦𞤭𞤲𞤺-𞤷𞤫𞥅𞤲</cyclicName>
 								<cyclicName type="54">𞤣𞤭𞤲𞤺-𞤧𞤭</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
+								<cyclicName type="55">𞤱𞤵𞥅-𞤱𞤵𞥅</cyclicName>
 								<cyclicName type="56">𞤶𞤭-𞤱𞤫𞥊𞥅</cyclicName>
 								<cyclicName type="57">𞤶𞤫𞤲𞤺-𞥃𞤫𞥅𞤲</cyclicName>
 								<cyclicName type="58">𞥃𞤭𞥅𞤲-𞤴𞤵𞥅</cyclicName>
@@ -1620,7 +1620,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 								<cyclicName type="19">𞤪𞤫𞥅𞤲-𞤱𞤵𞥅</cyclicName>
 								<cyclicName type="20">𞤺𞤮𞥅-𞤱𞤫𞥊𞥅</cyclicName>
 								<cyclicName type="21">𞤶𞤢𞥄-𞥃𞤫𞥅𞤲</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
+								<cyclicName type="22">𞤴𞤭-𞤴𞤵𞥅</cyclicName>
 								<cyclicName type="23">𞤦𞤭𞤲𞤺-𞥃𞤵𞥅</cyclicName>
 								<cyclicName type="24">𞤣𞤭𞤲𞤺-𞤸𞤢𞥄𞤴</cyclicName>
 								<cyclicName type="25">𞤱𞤵-𞥁𞤭</cyclicName>
@@ -1943,56 +1943,56 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 								<cyclicName type="24">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2261,7 +2261,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2269,7 +2269,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2277,7 +2277,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2285,7 +2285,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2556,226 +2556,226 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d-M-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d-M</dateFormatItem>
+						<dateFormatItem id="MEd">E d-M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E⹁ d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2784,18 +2784,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">𞥑𞤴𞤵𞤫𞥅</month>
+							<month type="2">𞥒𞤴𞤵𞤫𞥅</month>
+							<month type="3">𞥓𞤴𞤵𞤫𞥅</month>
+							<month type="4">𞥔𞤴𞤵𞤫𞥅</month>
+							<month type="5">𞥕𞤴𞤵𞤫𞥅</month>
+							<month type="6">𞥖𞤴𞤵𞤫𞥅</month>
+							<month type="7">𞥗𞤴𞤵𞤫𞥅</month>
+							<month type="8">𞥘𞤴𞤵𞤫𞥅</month>
+							<month type="9">𞥙𞤴𞤵𞤫𞥅</month>
+							<month type="10">𞥑𞥐𞤴𞤵𞤫𞥅</month>
+							<month type="11">𞥑𞥑𞤴𞤵𞤫𞥅</month>
+							<month type="12">𞥑𞥒𞤴𞤵𞤫𞥅</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">𞥑</month>
@@ -2812,34 +2812,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">𞥑𞥒</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">𞤟𞤫𞤲𞤺𞤵𞤴𞤵𞤫𞥅</month>
+							<month type="2">𞤉𞥅𞤪𞤴𞤵𞤫𞥅</month>
+							<month type="3">𞤅𞤢𞥄𞤲𞤴𞤵𞤫𞥅</month>
+							<month type="4">𞤅𞤭𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="5">𞤏𞤵𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="6">𞤂𞤭𞤵𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="7">𞤗𞤭𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="8">𞤄𞤢𞥄𞤴𞤵𞤫𞥅</month>
+							<month type="9">𞤔𞤭𞤵𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="10">𞤡𞤭𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="11">𞤡𞤭𞥅𞤴𞤭𞤴𞤵𞤫𞥅</month>
+							<month type="12">𞤡𞤭𞥅𞤫𞤪𞤴𞤵𞤫𞥅</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">𞥑𞤴𞤵𞤫𞥅</month>
+							<month type="2">𞥒𞤴𞤵𞤫𞥅</month>
+							<month type="3">𞥓𞤴𞤵𞤫𞥅</month>
+							<month type="4">𞥔𞤴𞤵𞤫𞥅</month>
+							<month type="5">𞥕𞤴𞤵𞤫𞥅</month>
+							<month type="6">𞥖𞤴𞤵𞤫𞥅</month>
+							<month type="7">𞥗𞤴𞤵𞤫𞥅</month>
+							<month type="8">𞥘𞤴𞤵𞤫𞥅</month>
+							<month type="9">𞥙𞤴𞤵𞤫𞥅</month>
+							<month type="10">𞥑𞥐𞤴𞤵𞤫𞥅</month>
+							<month type="11">𞥑𞥑𞤴𞤵𞤫𞥅</month>
+							<month type="12">𞥑𞥒𞤴𞤵𞤫𞥅</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">𞥑</month>
@@ -2856,47 +2856,47 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">𞥑𞥒</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">𞤟𞤫𞤲𞤺𞤵𞤴𞤵𞤫𞥅</month>
+							<month type="2">𞤉𞥅𞤪𞤴𞤵𞤫𞥅</month>
+							<month type="3">𞤅𞤢𞥄𞤲𞤴𞤵𞤫𞥅</month>
+							<month type="4">𞤅𞤭𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="5">𞤏𞤵𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="6">𞤂𞤭𞤵𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="7">𞤗𞤭𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="8">𞤄𞤢𞥄𞤴𞤵𞤫𞥅</month>
+							<month type="9">𞤔𞤭𞤵𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="10">𞤡𞤭𞥅𞤴𞤵𞤫𞥅</month>
+							<month type="11">𞤡𞤭𞥅𞤴𞤭𞤴𞤵𞤫𞥅</month>
+							<month type="12">𞤡𞤭𞥅𞤫𞤪𞤴𞤵𞤫𞥅</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}𞤦𞤭𞤧</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}𞤦</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}𞤦𞤭𞤧</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 					<monthPatternContext type="numeric">
 						<monthPatternWidth type="all">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}𞤦𞤭𞤧</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 					<monthPatternContext type="stand-alone">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}𞤦𞤭𞤧</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}𞤦</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}𞤦𞤭𞤧</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 				</monthPatterns>
@@ -2904,44 +2904,44 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<cyclicNameSet type="dayParts">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
+								<cyclicName type="1">𞥁𞤭</cyclicName>
 								<cyclicName type="2">𞥃𞤮𞥅</cyclicName>
 								<cyclicName type="3">𞤴𞤭𞥅𞤲</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
+								<cyclicName type="4">𞤥𞤢𞤱𞤮</cyclicName>
 								<cyclicName type="5">𞤷𞤫𞥅𞤲</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
+								<cyclicName type="6">𞤧𞤭</cyclicName>
 								<cyclicName type="7">𞤱𞤵𞥅</cyclicName>
 								<cyclicName type="8">𞤱𞤫𞥊𞥅</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
+								<cyclicName type="9">𞥃𞤫𞥅𞤲</cyclicName>
+								<cyclicName type="10">𞤴𞤵𞥅</cyclicName>
 								<cyclicName type="11">𞥃𞤵𞥅</cyclicName>
 								<cyclicName type="12">𞤸𞤢𞥄𞤴</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
+								<cyclicName type="1">𞥁𞤭</cyclicName>
 								<cyclicName type="2">𞥃𞤮𞥅</cyclicName>
 								<cyclicName type="3">𞤴𞤭𞥅𞤲</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
+								<cyclicName type="4">𞤥𞤢𞤱𞤮</cyclicName>
 								<cyclicName type="5">𞤷𞤫𞥅𞤲</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
+								<cyclicName type="6">𞤧𞤭</cyclicName>
 								<cyclicName type="7">𞤱𞤵𞥅</cyclicName>
 								<cyclicName type="8">𞤱𞤫𞥊𞥅</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
+								<cyclicName type="9">𞥃𞤫𞥅𞤲</cyclicName>
+								<cyclicName type="10">𞤴𞤵𞥅</cyclicName>
 								<cyclicName type="11">𞥃𞤵𞥅</cyclicName>
 								<cyclicName type="12">𞤸𞤢𞥄𞤴</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
+								<cyclicName type="1">𞥁𞤭</cyclicName>
 								<cyclicName type="2">𞥃𞤮𞥅</cyclicName>
 								<cyclicName type="3">𞤴𞤭𞥅𞤲</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
+								<cyclicName type="4">𞤥𞤢𞤱𞤮</cyclicName>
 								<cyclicName type="5">𞤷𞤫𞥅𞤲</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
+								<cyclicName type="6">𞤧𞤭</cyclicName>
 								<cyclicName type="7">𞤱𞤵𞥅</cyclicName>
 								<cyclicName type="8">𞤱𞤫𞥊𞥅</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
+								<cyclicName type="9">𞥃𞤫𞥅𞤲</cyclicName>
+								<cyclicName type="10">𞤴𞤵𞥅</cyclicName>
 								<cyclicName type="11">𞥃𞤵𞥅</cyclicName>
 								<cyclicName type="12">𞤸𞤢𞥄𞤴</cyclicName>
 							</cyclicNameWidth>
@@ -3330,82 +3330,82 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<cyclicNameSet type="solarTerms">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">spring begins</cyclicName>
+								<cyclicName type="2">rain water</cyclicName>
+								<cyclicName type="3">insects awaken</cyclicName>
+								<cyclicName type="4">spring equinox</cyclicName>
+								<cyclicName type="5">bright and clear</cyclicName>
+								<cyclicName type="6">grain rain</cyclicName>
+								<cyclicName type="7">summer begins</cyclicName>
+								<cyclicName type="8">grain full</cyclicName>
+								<cyclicName type="9">grain in ear</cyclicName>
+								<cyclicName type="10">summer solstice</cyclicName>
+								<cyclicName type="11">minor heat</cyclicName>
+								<cyclicName type="12">major heat</cyclicName>
+								<cyclicName type="13">autumn begins</cyclicName>
+								<cyclicName type="14">end of heat</cyclicName>
+								<cyclicName type="15">white dew</cyclicName>
+								<cyclicName type="16">autumn equinox</cyclicName>
+								<cyclicName type="17">cold dew</cyclicName>
+								<cyclicName type="18">frost descends</cyclicName>
+								<cyclicName type="19">winter begins</cyclicName>
+								<cyclicName type="20">minor snow</cyclicName>
+								<cyclicName type="21">major snow</cyclicName>
+								<cyclicName type="22">winter solstice</cyclicName>
+								<cyclicName type="23">minor cold</cyclicName>
+								<cyclicName type="24">major cold</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -3602,46 +3602,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<cyclicNameSet type="zodiacs">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">𞤐𞤺𞤵𞤶𞤮𞥅𞤪𞤵</cyclicName>
+								<cyclicName type="2">𞤐𞤺𞤢𞥄𞤪𞤧𞤢𞥄𞤪𞤭</cyclicName>
+								<cyclicName type="3">𞤐𞤺𞤢𞤼𞤢𞤥𞤪𞤭</cyclicName>
+								<cyclicName type="4">𞤅𞤢𞤪𞤭𞥅𞤪𞤫</cyclicName>
+								<cyclicName type="5">𞤕𞤢𞥄𞤲𞤢𞤦𞤵</cyclicName>
+								<cyclicName type="6">𞤐𞤦𞤮𞤣𞥆𞤭</cyclicName>
+								<cyclicName type="7">𞤆𞤵𞤷𞥆𞤵</cyclicName>
+								<cyclicName type="8">𞤄𞤫𞤭𞤤</cyclicName>
+								<cyclicName type="9">𞤑𞤵𞤤𞤢𞥄𞤪𞤵</cyclicName>
+								<cyclicName type="10">𞤐𞤣𞤮𞤲𞤼𞤮𞥅𞤪𞤭</cyclicName>
+								<cyclicName type="11">𞤈𞤢𞤱𞤢𞥄𞤲𞤣𞤵</cyclicName>
+								<cyclicName type="12">𞤘𞤭𞤪𞤢𞤴𞤲𞤺𞤭𞤤</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">𞤐𞤺𞤵𞤶𞤮𞥅𞤪𞤵</cyclicName>
+								<cyclicName type="2">𞤐𞤺𞤢𞥄𞤪𞤧𞤢𞥄𞤪𞤭</cyclicName>
+								<cyclicName type="3">𞤐𞤺𞤢𞤼𞤢𞤥𞤪𞤭</cyclicName>
+								<cyclicName type="4">𞤅𞤢𞤪𞤭𞥅𞤪𞤫</cyclicName>
+								<cyclicName type="5">𞤕𞤢𞥄𞤲𞤢𞤦𞤵</cyclicName>
+								<cyclicName type="6">𞤐𞤦𞤮𞤣𞥆𞤭</cyclicName>
+								<cyclicName type="7">𞤆𞤵𞤷𞥆𞤵</cyclicName>
+								<cyclicName type="8">𞤄𞤫𞤭𞤤</cyclicName>
+								<cyclicName type="9">𞤑𞤵𞤤𞤢𞥄𞤪𞤵</cyclicName>
+								<cyclicName type="10">𞤐𞤣𞤮𞤲𞤼𞤮𞥅𞤪𞤭</cyclicName>
+								<cyclicName type="11">𞤈𞤢𞤱𞤢𞥄𞤲𞤣𞤵</cyclicName>
+								<cyclicName type="12">𞤘𞤭𞤪𞤢𞤴𞤲𞤺𞤭𞤤</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">𞤐𞤺𞤵𞤶𞤮𞥅𞤪𞤵</cyclicName>
+								<cyclicName type="2">𞤐𞤺𞤢𞥄𞤪𞤧𞤢𞥄𞤪𞤭</cyclicName>
+								<cyclicName type="3">𞤐𞤺𞤢𞤼𞤢𞤥𞤪𞤭</cyclicName>
+								<cyclicName type="4">𞤅𞤢𞤪𞤭𞥅𞤪𞤫</cyclicName>
+								<cyclicName type="5">𞤕𞤢𞥄𞤲𞤢𞤦𞤵</cyclicName>
+								<cyclicName type="6">𞤐𞤦𞤮𞤣𞥆𞤭</cyclicName>
+								<cyclicName type="7">𞤆𞤵𞤷𞥆𞤵</cyclicName>
+								<cyclicName type="8">𞤄𞤫𞤭𞤤</cyclicName>
+								<cyclicName type="9">𞤑𞤵𞤤𞤢𞥄𞤪𞤵</cyclicName>
+								<cyclicName type="10">𞤐𞤣𞤮𞤲𞤼𞤮𞥅𞤪𞤭</cyclicName>
+								<cyclicName type="11">𞤈𞤢𞤱𞤢𞥄𞤲𞤣𞤵</cyclicName>
+								<cyclicName type="12">𞤘𞤭𞤪𞤢𞤴𞤲𞤺𞤭𞤤</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -3649,197 +3649,197 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE⹁ d MMMM U</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM U</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM U</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d-M-y</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">r U</dateFormatItem>
+						<dateFormatItem id="GyMMM">r MMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM r</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM U</dateFormatItem>
+						<dateFormatItem id="GyMMMM">r(U) MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMMd">r(U) d MMMM</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd">E⹁ d MMMM⹁ r(U)</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d MMM</dateFormatItem>
+						<dateFormatItem id="MEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="UM">U MM</dateFormatItem>
+						<dateFormatItem id="UMd">U d MM</dateFormatItem>
+						<dateFormatItem id="UMMM">U MMM</dateFormatItem>
+						<dateFormatItem id="UMMMd">U d MMM</dateFormatItem>
+						<dateFormatItem id="y">r(U)</dateFormatItem>
+						<dateFormatItem id="yMd">dd-MM-r</dateFormatItem>
+						<dateFormatItem id="yyyy">r(U)</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-r</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd-M-r</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d-M-r</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM r</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM r</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d MMM r</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM r</dateFormatItem>
 						<dateFormatItem id="yyyyMMMMd">d MMMM, r(U)</dateFormatItem>
 						<dateFormatItem id="yyyyMMMMEd">E, d MMMM, r(U)</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ U</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ U</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">U–U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">U MMM–MMM</greatestDifference>
+							<greatestDifference id="y">U MMM – U MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">U MMM d–d</greatestDifference>
+							<greatestDifference id="M">U MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">U MMM d – U MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">U MMM d, E – U MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">U MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">U MMMM – U MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3958,226 +3958,226 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d-M-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d-M</dateFormatItem>
+						<dateFormatItem id="MEd">E d-M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E⹁ d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4367,7 +4367,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<monthWidth type="abbreviated">
 							<month type="1">𞤅𞤭𞥅𞤤𞤮</month>
 							<month type="2">𞤕𞤮𞤤𞤼𞤮</month>
-							<month type="3">↑↑↑</month>
+							<month type="3">𞤐𞤦𞤮𞥅𞤴𞤮</month>
 							<month type="4">𞤅𞤫𞥅𞤼𞤮</month>
 							<month type="5">𞤁𞤵𞥅𞤶𞤮</month>
 							<month type="6">𞤑𞤮𞤪𞤧𞤮</month>
@@ -4439,7 +4439,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<monthWidth type="wide">
 							<month type="1">𞤅𞤭𞥅𞤤𞤮</month>
 							<month type="2">𞤕𞤮𞤤𞤼𞤮</month>
-							<month type="3">↑↑↑</month>
+							<month type="3">𞤐𞤦𞤮𞥅𞤴𞤮</month>
 							<month type="4">𞤅𞤫𞥅𞤼𞤮</month>
 							<month type="5">𞤁𞤵𞥅𞤶𞤮</month>
 							<month type="6">𞤑𞤮𞤪𞤧𞤮</month>
@@ -4523,7 +4523,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sun">𞤈𞤫𞤬𞤦𞤭𞤪𞥆𞤫</day>
 							<day type="mon">𞤀𞥄𞤩𞤵𞤲𞥋𞤣𞤫</day>
 							<day type="tue">𞤃𞤢𞤱𞤦𞤢𞥄𞤪𞤫</day>
-							<day type="wed">↑↑↑</day>
+							<day type="wed">𞤐𞤶𞤫𞤧𞤤𞤢𞥄𞤪𞤫</day>
 							<day type="thu">𞤐𞤢𞥄𞤧𞤢𞥄𞤲𞤣𞤫</day>
 							<day type="fri">𞤃𞤢𞤱𞤲𞤣𞤫</day>
 							<day type="sat">𞤖𞤮𞤪𞤦𞤭𞤪𞥆𞤫</day>
@@ -4616,10 +4616,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="1" alt="variant">𞤘𞤑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="0">𞤀𞤀𞤋</era>
+						<era type="0" alt="variant">𞤀𞤘𞤑</era>
+						<era type="1">𞤇𞤀𞤋</era>
+						<era type="1" alt="variant">𞤘𞤑</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -5016,226 +5016,226 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d-M-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d-M</dateFormatItem>
+						<dateFormatItem id="MEd">E d-M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E⹁ d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5345,226 +5345,226 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d-M-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d-M</dateFormatItem>
+						<dateFormatItem id="MEd">E d-M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E⹁ d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5662,242 +5662,242 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">𞤇𞤊</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">𞤇𞤊</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">𞤇𞤊</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d MMMM⹁ y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MMMM⹁ y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MMM⹁ y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d-M-y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d-M</dateFormatItem>
+						<dateFormatItem id="MEd">E d-M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E⹁ d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -6012,7 +6012,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="104">𞤒𞤮𞥅𞤱𞤢 (𞥑𞥑𞥘𞥑-𞥑𞥑𞥘𞥒)</era>
 						<era type="105">𞤔𞤵𞤫𞤴 (𞥑𞥑𞥘𞥒-𞥑𞥑𞥘𞥔)</era>
 						<era type="106">𞤘𞤫𞤲𞤪𞤭𞤴𞤢𞤳𞤵 (𞥑𞥑𞥘𞥔-𞥑𞥑𞥘𞥕)</era>
-						<era type="107">↑↑↑</era>
+						<era type="107">𞤄𞤵𞤲𞤶𞤭 (𞥑𞥑𞥘𞥕-𞥑𞥑𞥙𞥐)</era>
 						<era type="108">𞤑𞤫𞤲𞤳𞤭𞤴𞤵𞥅 (𞥑𞥑𞥙𞥐-𞥑𞥑𞥙𞥙)</era>
 						<era type="109">𞤡𞤮𞥅𞤶𞤭 (𞥑𞥑𞥙𞥙-𞥑𞥒𞥐𞥑)</era>
 						<era type="110">𞤑𞤫𞤲𞥆𞤭𞤲 (𞥑𞥒𞥐𞥑-𞥑𞥒𞥐𞥔)</era>
@@ -6625,29 +6625,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d-M-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
 							<pattern>{1} 𞤳𞤢 {0}</pattern>
@@ -6671,180 +6671,180 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
 							<pattern>{1}⹁ {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d-M</dateFormatItem>
+						<dateFormatItem id="MEd">E d-M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E⹁ d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G">y G – y G</greatestDifference>
 							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -6954,226 +6954,226 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d-M-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d-M</dateFormatItem>
+						<dateFormatItem id="MEd">E d-M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E⹁ d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7196,226 +7196,226 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM⹁ y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d-M-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d-M</dateFormatItem>
+						<dateFormatItem id="MEd">E d-M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E⹁ d-M-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E⹁ d MMM⹁ y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -10339,15 +10339,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<decimal>.</decimal>
 			<group>⹁</group>
 			<list>⁏</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>𞤉</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
 			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
@@ -10381,304 +10381,304 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -10696,501 +10696,501 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>.</decimal>
+			<group>⹁</group>
+			<list>⁏</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arab">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="bali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="beng">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="brah">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cakm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="deva">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="fullwide">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gonm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gujr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="guru">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="hanidec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="java">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="kali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="khmr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="knda">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lana">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lanatham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="laoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -11260,315 +11260,315 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<decimalFormats numberSystem="lepc">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="limb">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mlym">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mtei">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymrshan">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="nkoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="olck">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="orya">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="osma">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="rohg">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="saur">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="shrd">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sora">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sund">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="takr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="talu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tamldec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="telu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="thai">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tibt">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="vaii">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arab">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arabext">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="bali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="beng">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="brah">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cakm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="deva">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="fullwide">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gonm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gujr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="guru">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="hanidec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="java">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="kali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="khmr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="knda">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lana">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lanatham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="laoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -11582,168 +11582,168 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<scientificFormats numberSystem="lepc">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="limb">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mlym">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mtei">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymrshan">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="nkoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="olck">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="orya">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="osma">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="rohg">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="saur">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="shrd">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sora">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sund">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="takr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="talu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tamldec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="telu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="thai">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tibt">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="vaii">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -11757,140 +11757,140 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="arabext">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="bali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="beng">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="brah">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cakm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="deva">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="fullwide">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gonm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gujr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="guru">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="hanidec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="java">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="kali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="khmr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="knda">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lana">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lanatham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="laoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -11904,178 +11904,178 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="lepc">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="limb">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mlym">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mtei">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymrshan">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="nkoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="olck">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="orya">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="osma">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="rohg">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="saur">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="shrd">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sora">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sund">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="takr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="talu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tamldec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="telu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="thai">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tibt">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="vaii">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12084,310 +12084,310 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -12396,8 +12396,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -12429,353 +12429,353 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">
@@ -12879,7 +12879,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="BAM">
 				<displayName>𞤃𞤢𞤪𞤳 𞤄𞤮𞤧𞤲𞤭𞤴𞤢-𞤖𞤫𞤪𞤶𞤫𞤺𞤮𞤾𞤭𞤲𞤳𞤮 𞤱𞤢𞤴𞤤𞤮𞤼𞤮𞥅𞤯𞤭</displayName>
 				<displayName count="one">𞤃𞤢𞤪𞤳 𞤄𞤮𞤧𞤲𞤭𞤴𞤢-𞤖𞤫𞤪𞤶𞤫𞤺𞤮𞤾𞤭𞤲𞤳𞤮 𞤱𞤢𞤴𞤤𞤮𞤼𞤮𞥅𞤯𞤭</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">𞤃𞤢𞤪𞤳 𞤄𞤮𞤧𞤲𞤭𞤴𞤢-𞤖𞤫𞤪𞤶𞤫𞤺𞤮𞤾𞤭𞤲𞤳𞤮 𞤱𞤢𞤴𞤤𞤮𞤼𞤮𞥅𞤯𞤭</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -14077,135 +14077,135 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 		</currencies>
 		<miscPatterns numberSystem="adlm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arab">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arabext">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="bali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="beng">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="brah">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cakm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="deva">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="fullwide">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gonm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gujr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="guru">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="hanidec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="java">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="kali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="khmr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="knda">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lana">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lanatham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="laoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="latn">
 			<pattern type="approximately">↑↑↑</pattern>
@@ -14214,142 +14214,142 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lepc">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="limb">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mlym">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mtei">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymrshan">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="nkoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="olck">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="orya">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="osma">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="rohg">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="saur">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="shrd">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sora">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sund">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="takr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="talu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tamldec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="telu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="thai">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tibt">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="vaii">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one" draft="contributed">{0} 𞤻𞤢𞤤𞥆𞤢𞤤</pluralMinimalPairs>
@@ -15598,7 +15598,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>𞤳𞤢𞤪𞤼𞤭</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
@@ -16061,7 +16061,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>𞤲𞤣𞤢𞤴𞤲𞤺𞤵𞥅𞤶𞤭 𞤲𞤢𞥄𞤺𞤫𞤴𞤢𞤲𞤳𞤮</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -16245,7 +16245,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -127,7 +127,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">cheyenne</language>
 			<language type="ckb">soranî</language>
 			<language type="ckb" alt="menu">kurdi – soranî</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">soranî</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">korsika</language>
 			<language type="cop">kopti</language>
@@ -1176,7 +1176,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkki</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkki</territory>
 			<territory type="TT">Trinidad ja Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1609,37 +1609,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d.</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d.M.y G</dateFormatItem>
 						<dateFormatItem id="GyMMM">LLL y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d. MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d. MMM y G</dateFormatItem>
-						<dateFormatItem id="M" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
 						<dateFormatItem id="Md">d.M.</dateFormatItem>
 						<dateFormatItem id="MEd">E d.M.</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">ccc d. MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd" draft="contributed">d. MMMM</dateFormatItem>
@@ -1900,7 +1900,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2216,11 +2216,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">la</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
+							<day type="sun">S</day>
+							<day type="mon">M</day>
+							<day type="tue">T</day>
 							<day type="wed">K</day>
-							<day type="thu">↑↑↑</day>
+							<day type="thu">T</day>
 							<day type="fri">P</day>
 							<day type="sat">L</day>
 						</dayWidth>
@@ -2498,7 +2498,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2950,7 +2950,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="japanese">
 				<eras>
 					<eraNames>
-						<era type="236" draft="contributed">↑↑↑</era>
+						<era type="236" draft="contributed">Reiwa</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="236" draft="contributed">↑↑↑</era>
@@ -6046,7 +6046,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<nan draft="contributed">↑↑↑</nan>
+			<nan draft="contributed">epäluku</nan>
 		</symbols>
 		<decimalFormats numberSystem="latn">
 			<decimalFormatLength>
@@ -7600,7 +7600,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="SLE">
 				<displayName>Sierra Leonen leone</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Sierra Leonen leonea</displayName>
 				<displayName count="other">Sierra Leonen leonea</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -8214,7 +8214,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">kuutio{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G-voimat</displayName>
@@ -8227,7 +8227,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} G-voimasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} G-voiman</unitPattern>
 				<unitPattern count="other" case="illative">{0} G-voimaan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} G-voimaa</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>metrit per sekunti toiseen</displayName>
@@ -8240,7 +8240,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} metristä per sekunti toiseen</unitPattern>
 				<unitPattern count="other" case="genitive">{0} metrin per sekunti toiseen</unitPattern>
 				<unitPattern count="other" case="illative">{0} metriin per sekunti toiseen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} metriä per sekunti toiseen</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>kierros</displayName>
@@ -8253,7 +8253,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kierroksesta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kierroksen</unitPattern>
 				<unitPattern count="other" case="illative">{0} kierrokseen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kierrosta</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>radiaanit</displayName>
@@ -8266,7 +8266,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} radiaanista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} radiaanin</unitPattern>
 				<unitPattern count="other" case="illative">{0} radiaaniin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} radiaania</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>asteet</displayName>
@@ -8279,7 +8279,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} asteesta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} asteen</unitPattern>
 				<unitPattern count="other" case="illative">{0} asteeseen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} astetta</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>kulmaminuutit</displayName>
@@ -8292,7 +8292,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kulmaminuutista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kulmaminuutin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kulmaminuuttiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kulmaminuuttia</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>kulmasekunnit</displayName>
@@ -8305,7 +8305,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kulmasekunnista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kulmasekunnin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kulmasekuntiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kulmasekuntia</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>neliökilometrit</displayName>
@@ -8318,7 +8318,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} neliökilometristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} neliökilometrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} neliökilometriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} neliökilometriä</unitPattern>
 				<perUnitPattern>{0} / neliökilometri</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
@@ -8332,7 +8332,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} hehtaarista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} hehtaarin</unitPattern>
 				<unitPattern count="other" case="illative">{0} hehtaariin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} hehtaaria</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>neliömetrit</displayName>
@@ -8345,7 +8345,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} neliömetristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} neliömetrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} neliömetriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} neliömetriä</unitPattern>
 				<perUnitPattern>{0} / neliömetri</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
@@ -8359,7 +8359,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} neliösenttimetristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} neliösenttimetrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} neliösenttimetriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} neliösenttimetriä</unitPattern>
 				<perUnitPattern>{0} / neliösenttimetri</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -8391,7 +8391,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunamit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">{0} dunamia</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -8405,7 +8405,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} karaatista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} karaatin</unitPattern>
 				<unitPattern count="other" case="illative">{0} karaattiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} karaattia</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>milligrammat desilitrassa</displayName>
@@ -8423,7 +8423,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} millimoolista litrassa</unitPattern>
 				<unitPattern count="other" case="genitive">{0} millimoolin litrassa</unitPattern>
 				<unitPattern count="other" case="illative">{0} millimooliin litrassa</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} millimoolia litrassa</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>kohteet</displayName>
@@ -8436,7 +8436,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kohteesta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kohteen</unitPattern>
 				<unitPattern count="other" case="illative">{0} kohteeseen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kohdetta</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>miljoonasosat</displayName>
@@ -8449,7 +8449,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} miljoonasosasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} miljoonasosan</unitPattern>
 				<unitPattern count="other" case="illative">{0} miljoonasosaan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} miljoonasosaa</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>prosentit</displayName>
@@ -8462,7 +8462,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} prosentista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} prosentin</unitPattern>
 				<unitPattern count="other" case="illative">{0} prosenttiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} prosenttia</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>promillet</displayName>
@@ -8475,7 +8475,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} promillesta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} promillen</unitPattern>
 				<unitPattern count="other" case="illative">{0} promilleen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} promillea</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>peruspiste</displayName>
@@ -8488,7 +8488,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} peruspisteestä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} peruspisteen</unitPattern>
 				<unitPattern count="other" case="illative">{0} peruspisteeseen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} peruspistettä</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>moolit</displayName>
@@ -8501,7 +8501,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} moolista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} moolin</unitPattern>
 				<unitPattern count="other" case="illative">{0} mooliin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} moolia</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litrat / kilometri</displayName>
@@ -8527,7 +8527,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} litrasta / 100 km</unitPattern>
 				<unitPattern count="other" case="genitive">{0} litran / 100 km</unitPattern>
 				<unitPattern count="other" case="illative">{0} litraan / 100 km</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} litraa / 100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mailit / am. gallona</displayName>
@@ -8550,7 +8550,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} petatavusta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} petatavun</unitPattern>
 				<unitPattern count="other" case="illative">{0} petatavuun</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} petatavua</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>teratavut</displayName>
@@ -8563,7 +8563,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} teratavusta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} teratavun</unitPattern>
 				<unitPattern count="other" case="illative">{0} teratavuun</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} teratavua</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>terabitit</displayName>
@@ -8576,7 +8576,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} terabitistä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} terabitin</unitPattern>
 				<unitPattern count="other" case="illative">{0} terabittiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} terabittiä</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>gigatavut</displayName>
@@ -8641,7 +8641,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kilotavusta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilotavun</unitPattern>
 				<unitPattern count="other" case="illative">{0} kilotavuun</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kilotavua</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kilobitit</displayName>
@@ -8667,7 +8667,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} tavusta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} tavun</unitPattern>
 				<unitPattern count="other" case="illative">{0} tavuun</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} tavua</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>bitit</displayName>
@@ -8680,7 +8680,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} bitistä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} bitin</unitPattern>
 				<unitPattern count="other" case="illative">{0} bittiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} bittiä</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>vuosisadat</displayName>
@@ -8693,7 +8693,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} vuosisadasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} vuosisadan</unitPattern>
 				<unitPattern count="other" case="illative">{0} vuosisataan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} vuosisataa</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<displayName>vuosikymmenet</displayName>
@@ -8706,7 +8706,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} vuosikymmenestä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} vuosikymmenen</unitPattern>
 				<unitPattern count="other" case="illative">{0} vuosikymmeneen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} vuosikymmentä</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>vuodet</displayName>
@@ -8775,7 +8775,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} päivästä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} päivän</unitPattern>
 				<unitPattern count="other" case="illative">{0} päivään</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} päivää</unitPattern>
 				<perUnitPattern>{0} / päivä</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -8789,7 +8789,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} tunnista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} tunnin</unitPattern>
 				<unitPattern count="other" case="illative">{0} tuntiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} tuntia</unitPattern>
 				<perUnitPattern>{0} / tunti</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -8831,7 +8831,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} millisekunnista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} millisekunnin</unitPattern>
 				<unitPattern count="other" case="illative">{0} millisekuntiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} millisekuntia</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>mikrosekunnit</displayName>
@@ -8844,7 +8844,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} mikrosekunnista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mikrosekunnin</unitPattern>
 				<unitPattern count="other" case="illative">{0} mikrosekuntiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} mikrosekuntia</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>nanosekunnit</displayName>
@@ -8870,7 +8870,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} ampeerista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ampeerin</unitPattern>
 				<unitPattern count="other" case="illative">{0} ampeeriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} ampeeria</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>milliampeerit</displayName>
@@ -8883,7 +8883,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} milliampeerista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} milliampeerin</unitPattern>
 				<unitPattern count="other" case="illative">{0} milliampeeriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} milliampeeria</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>ohmit</displayName>
@@ -8896,7 +8896,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} ohmista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ohmin</unitPattern>
 				<unitPattern count="other" case="illative">{0} ohmiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} ohmia</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>voltit</displayName>
@@ -8909,7 +8909,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} voltista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} voltin</unitPattern>
 				<unitPattern count="other" case="illative">{0} volttiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} volttia</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>kilokalorit</displayName>
@@ -8927,7 +8927,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kalorista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kalorin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kaloriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kaloria</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>kilokalorit</displayName>
@@ -8945,7 +8945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kilojoulesta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilojoulen</unitPattern>
 				<unitPattern count="other" case="illative">{0} kilojouleen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kilojoulea</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>joulet</displayName>
@@ -8958,7 +8958,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} joulesta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} joulen</unitPattern>
 				<unitPattern count="other" case="illative">{0} jouleen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} joulea</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kilowattitunnit</displayName>
@@ -8971,7 +8971,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kilowattitunnista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilowattitunnin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kilowattituntiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kilowattituntia</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronivoltit</displayName>
@@ -8984,9 +8984,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} brittiläistä termistä yksikköä</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>pauna-voimat</displayName>
@@ -9004,7 +9004,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} newtonista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} newtonin</unitPattern>
 				<unitPattern count="other" case="illative">{0} newtoniin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} newtonia</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kilowattitunnit / 100 kilometriä</displayName>
@@ -9030,7 +9030,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} gigahertsistä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} gigahertsin</unitPattern>
 				<unitPattern count="other" case="illative">{0} gigahertsiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} gigahertsiä</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>megahertsit</displayName>
@@ -9043,7 +9043,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} megahertsistä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} megahertsin</unitPattern>
 				<unitPattern count="other" case="illative">{0} megahertsiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} megahertsiä</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>kilohertsit</displayName>
@@ -9056,7 +9056,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kilohertsistä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilohertsin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kilohertsiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kilohertsiä</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>hertsit</displayName>
@@ -9069,7 +9069,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} hertsistä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} hertsin</unitPattern>
 				<unitPattern count="other" case="illative">{0} hertsiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} hertsiä</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em-väli</displayName>
@@ -9124,14 +9124,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="partitive">{0} pikseliä / senttimetri</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
@@ -9159,7 +9159,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kilometristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilometrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kilometriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kilometriä</unitPattern>
 				<perUnitPattern>{0} / kilometri</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
@@ -9187,7 +9187,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} desimetristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} desimetrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} desimetriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} desimetriä</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>senttimetrit</displayName>
@@ -9200,7 +9200,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} senttimetristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} senttimetrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} senttimetriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} senttimetriä</unitPattern>
 				<perUnitPattern>{0} / senttimetri</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
@@ -9214,7 +9214,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} millimetristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} millimetrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} millimetriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} millimetriä</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>mikrometrit</displayName>
@@ -9253,7 +9253,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} pikometristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} pikometrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} pikometriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} pikometriä</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mailit</displayName>
@@ -9318,7 +9318,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} peninkulmasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} peninkulman</unitPattern>
 				<unitPattern count="other" case="illative">{0} peninkulmaan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} peninkulmaa</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pt</displayName>
@@ -9341,7 +9341,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} luksista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} luksin</unitPattern>
 				<unitPattern count="other" case="illative">{0} luksiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} luksia</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>kandelat</displayName>
@@ -9367,7 +9367,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} luumenista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} luumenin</unitPattern>
 				<unitPattern count="other" case="illative">{0} luumeniin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} luumenia</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>Auringon luminositeetit</displayName>
@@ -9385,7 +9385,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} tonnista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} tonnin</unitPattern>
 				<unitPattern count="other" case="illative">{0} tonniin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} tonnia</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kilogrammat</displayName>
@@ -9398,7 +9398,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kilogrammasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilogramman</unitPattern>
 				<unitPattern count="other" case="illative">{0} kilogrammaan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kilogrammaa</unitPattern>
 				<perUnitPattern>{0} / kilogramma</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
@@ -9412,7 +9412,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} grammasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} gramman</unitPattern>
 				<unitPattern count="other" case="illative">{0} grammaan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} grammaa</unitPattern>
 				<perUnitPattern>{0} / gramma</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
@@ -9426,7 +9426,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} milligrammasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} milligramman</unitPattern>
 				<unitPattern count="other" case="illative">{0} milligrammaan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} milligrammaa</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>mikrogrammat</displayName>
@@ -9479,7 +9479,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} karaatista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} karaatin</unitPattern>
 				<unitPattern count="other" case="illative">{0} karaattiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} karaattia</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>atomimassayksiköt</displayName>
@@ -9512,7 +9512,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} gigawatista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} gigawatin</unitPattern>
 				<unitPattern count="other" case="illative">{0} gigawattiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} gigawattia</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>megawatit</displayName>
@@ -9525,7 +9525,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} megawatista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} megawatin</unitPattern>
 				<unitPattern count="other" case="illative">{0} megawattiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} megawattia</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>kilowatit</displayName>
@@ -9551,7 +9551,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} watista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} watin</unitPattern>
 				<unitPattern count="other" case="illative">{0} wattiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} wattia</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>milliwatit</displayName>
@@ -9597,7 +9597,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} baarista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} baarin</unitPattern>
 				<unitPattern count="other" case="illative">{0} baariin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} baaria</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>millibaarit</displayName>
@@ -9610,7 +9610,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} millibaarista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} millibaarin</unitPattern>
 				<unitPattern count="other" case="illative">{0} millibaariin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} millibaaria</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>normaali-ilmakehät</displayName>
@@ -9623,7 +9623,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} normaali-ilmakehästä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} normaali-ilmakehän</unitPattern>
 				<unitPattern count="other" case="illative">{0} normaali-ilmakehään</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} normaali-ilmakehää</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>pascalit</displayName>
@@ -9636,7 +9636,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} pascalista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} pascalin</unitPattern>
 				<unitPattern count="other" case="illative">{0} pascaliin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} pascalia</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hehtopascalit</displayName>
@@ -9649,7 +9649,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} hehtopascalista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} hehtopascalin</unitPattern>
 				<unitPattern count="other" case="illative">{0} hehtopascaliin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} hehtopascalia</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kilopascalit</displayName>
@@ -9662,7 +9662,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kilopascalista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilopascalin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kilopascaliin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kilopascalia</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>megapascalit</displayName>
@@ -9675,7 +9675,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} megapascalista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} megapascalin</unitPattern>
 				<unitPattern count="other" case="illative">{0} megapascaliin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} megapascalia</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>kilometrit tunnissa</displayName>
@@ -9688,7 +9688,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kilometristä tunnissa</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilometrin tunnissa</unitPattern>
 				<unitPattern count="other" case="illative">{0} kilometriin tunnissa</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kilometriä tunnissa</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>metrit sekunnissa</displayName>
@@ -9737,7 +9737,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} celsiusasteesta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} celsiusasteen</unitPattern>
 				<unitPattern count="other" case="illative">{0} celsiusasteeseen</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} celsiusastetta</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>fahrenheitasteet</displayName>
@@ -9755,7 +9755,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kelvinistä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kelvinin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kelviniin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kelviniä</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>pauna-jalat</displayName>
@@ -9786,7 +9786,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kuutiokilometristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kuutiokilometrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kuutiokilometriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kuutiokilometriä</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>kuutiometrit</displayName>
@@ -9799,7 +9799,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} kuutiometristä</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kuutiometrin</unitPattern>
 				<unitPattern count="other" case="illative">{0} kuutiometriin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} kuutiometriä</unitPattern>
 				<perUnitPattern>{0} / kuutiometri</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
@@ -9847,7 +9847,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} megalitrasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} megalitran</unitPattern>
 				<unitPattern count="other" case="illative">{0} megalitraan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} megalitraa</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>hehtolitrat</displayName>
@@ -9860,7 +9860,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} hehtolitrasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} hehtolitran</unitPattern>
 				<unitPattern count="other" case="illative">{0} hehtolitraan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} hehtolitraa</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litrat</displayName>
@@ -9873,7 +9873,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} litrasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} litran</unitPattern>
 				<unitPattern count="other" case="illative">{0} litraan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} litraa</unitPattern>
 				<perUnitPattern>{0} / litra</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
@@ -9887,7 +9887,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} desilitrasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} desilitran</unitPattern>
 				<unitPattern count="other" case="illative">{0} desilitraan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} desilitraa</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>senttilitrat</displayName>
@@ -9900,7 +9900,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} senttilitrasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} senttilitran</unitPattern>
 				<unitPattern count="other" case="illative">{0} senttilitraan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} senttilitraa</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>millilitrat</displayName>
@@ -9913,7 +9913,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} millilitrasta</unitPattern>
 				<unitPattern count="other" case="genitive">{0} millilitran</unitPattern>
 				<unitPattern count="other" case="illative">{0} millilitraan</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} millilitraa</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>tuopit</displayName>
@@ -9926,7 +9926,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} tuopista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} tuopin</unitPattern>
 				<unitPattern count="other" case="illative">{0} tuoppiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} tuoppia</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>teekupit</displayName>
@@ -9939,7 +9939,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="elative">{0} teekupista</unitPattern>
 				<unitPattern count="other" case="genitive">{0} teekupin</unitPattern>
 				<unitPattern count="other" case="illative">{0} teekuppiin</unitPattern>
-				<unitPattern count="other" case="partitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="partitive">{0} teekuppia</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>eekkerijalat</displayName>
@@ -10364,7 +10364,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-decade">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dec</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -10375,7 +10375,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>q</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} q</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -10447,7 +10447,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="electric-volt">
 				<displayName>V</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
@@ -10492,7 +10492,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
@@ -10502,7 +10502,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -10532,38 +10532,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>piste</displayName>
@@ -10572,7 +10572,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10682,7 +10682,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>auringon säteet</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -10692,12 +10692,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -10766,12 +10766,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>atomimassayksiköt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>Maan massat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
@@ -10831,7 +10831,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -10841,12 +10841,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -10856,12 +10856,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -11051,7 +11051,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>barrelit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -11099,104 +11099,104 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -11284,7 +11284,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>dunamit</displayName>
 				<unitPattern count="one">{0}dunam</unitPattern>
 				<unitPattern count="other">{0}dunam</unitPattern>
 			</unit>
@@ -11314,12 +11314,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
+				<displayName>%</displayName>
 				<unitPattern count="one">{0} %</unitPattern>
 				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>‰</displayName>
 				<unitPattern count="one">{0}‰</unitPattern>
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
@@ -11414,9 +11414,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} vs</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="one">{0} dec</unitPattern>
+				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>v</displayName>
@@ -11426,9 +11426,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>q</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} q</unitPattern>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>kk</displayName>
@@ -11537,12 +11537,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>BTU</displayName>
 				<unitPattern count="one">{0}Btu</unitPattern>
 				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>US therm</displayName>
 				<unitPattern count="one">{0}US therm</unitPattern>
 				<unitPattern count="other">{0}US therm</unitPattern>
 			</unit>
@@ -11582,47 +11582,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="one">{0}px</unitPattern>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>MP</displayName>
 				<unitPattern count="one">{0}MP</unitPattern>
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">{0}ppi</unitPattern>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}dpcm</unitPattern>
 				<unitPattern count="other">{0}dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">{0}dpi</unitPattern>
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>piste</displayName>
 				<unitPattern count="one">{0}piste</unitPattern>
 				<unitPattern count="other">{0}pistettä</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">{0}R⊕</unitPattern>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
@@ -11727,7 +11727,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pnk</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="one">{0}pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
@@ -11742,12 +11742,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">{0}cd</unitPattern>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
@@ -11831,7 +11831,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>graanit</displayName>
 				<unitPattern count="one">{0}graani</unitPattern>
 				<unitPattern count="other">{0}graania</unitPattern>
 			</unit>
@@ -11891,12 +11891,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm</displayName>
 				<unitPattern count="one">{0}atm</unitPattern>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="one">{0}Pa</unitPattern>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
@@ -11906,12 +11906,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="one">{0}kPa</unitPattern>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="one">{0}MPa</unitPattern>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
@@ -11956,12 +11956,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="one">{0}lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Nm</displayName>
 				<unitPattern count="one">{0}Nm</unitPattern>
 				<unitPattern count="other">{0}Nm</unitPattern>
 			</unit>
@@ -12106,7 +12106,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>jrkl</displayName>
 				<unitPattern count="one">{0}jrkl</unitPattern>
 				<unitPattern count="other">{0}jrkl</unitPattern>
 			</unit>
@@ -12121,17 +12121,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}gtt</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>dramit</displayName>
 				<unitPattern count="one">{0}dram</unitPattern>
 				<unitPattern count="other">{0}dramia</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>jiggerit</displayName>
 				<unitPattern count="one">{0}jigger</unitPattern>
 				<unitPattern count="other">{0}jiggeriä</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ripaus</displayName>
 				<unitPattern count="one">{0}ripaus</unitPattern>
 				<unitPattern count="other">{0}ripausta</unitPattern>
 			</unit>
@@ -12172,22 +12172,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} tai {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} tai {1}</listPatternPart>
+			<listPatternPart type="2">{0} tai {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} tai {1}</listPatternPart>
+			<listPatternPart type="2">{0} tai {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ja {1}</listPatternPart>
+			<listPatternPart type="2">{0} ja {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -12414,10 +12414,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
@@ -12468,7 +12468,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname} {surname2} {given}, {title}</namePattern>
@@ -12483,10 +12483,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{surname} {given-initial} {given2-initial}</namePattern>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -823,7 +823,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Türkiye</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Türkiye</territory>
 			<territory type="TT">Trinidad &amp; Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1901,7 +1901,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1909,7 +1909,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2473,7 +2473,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2481,7 +2481,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4092,7 +4092,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} quarter ang nakalipas</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} quarter ang nakalipas</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
@@ -4592,7 +4592,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">sa {0} oras</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} oras ang nakalipas</relativeTimePattern>
 					<relativeTimePattern count="other">{0} oras ang nakalipas</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -4660,7 +4660,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">sa {0} seg.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} seg. ang nakalipas</relativeTimePattern>
 					<relativeTimePattern count="other">{0} seg. ang nakalipas</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -6914,7 +6914,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="latn">
 			<decimalFormatLength>
@@ -7765,7 +7765,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="NIO">
 				<displayName>Córdoba ng Nicaragua</displayName>
 				<displayName count="one">córdoba ng Nicaragua</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Córdoba ng Nicaragua</displayName>
 				<symbol>NIO</symbol>
 				<symbol alt="narrow">C$</symbol>
 			</currency>
@@ -8273,7 +8273,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">cubic {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-force</displayName>
@@ -8361,9 +8361,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} kada pulgada kwadrado</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karat</displayName>
@@ -8382,7 +8382,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>mga item</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">{0} na item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -8503,9 +8503,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>mga quarter</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qtr</unitPattern>
 				<unitPattern count="other">{0} qaurter</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>mga buwan</displayName>
@@ -8619,9 +8619,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} British thermal unit</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>pound of force</displayName>
@@ -8660,8 +8660,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipograpikang em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>mga pixel</displayName>
@@ -8958,9 +8958,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} na pulgada ng asoge</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>millibar</displayName>
@@ -9203,9 +9203,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>karampot</displayName>
@@ -9315,12 +9315,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -9413,7 +9413,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -9433,7 +9433,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -9453,12 +9453,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>permyriad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mole</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -9543,7 +9543,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-decade">
 				<displayName>dec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dec</unitPattern>
 				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -9661,32 +9661,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>electronvolt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>US therm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>pound-force</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -9711,27 +9711,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>mga pixel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapixel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -9751,7 +9751,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} na R⊕</unitPattern>
 				<unitPattern count="other">{0} na R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9861,7 +9861,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>solar radii</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9871,17 +9871,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>solar luminosity</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9945,17 +9945,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>Earth mass</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>solar mass</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -10010,7 +10010,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -10025,7 +10025,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -10085,12 +10085,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>lbf⋅ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>N⋅m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -10178,7 +10178,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>mga bushel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -10215,7 +10215,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -10230,17 +10230,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>bariles</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -10250,12 +10250,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -10265,7 +10265,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>Imp na kuwart</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -10338,44 +10338,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-force</displayName>
@@ -10383,63 +10383,63 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>metro/segundo²</displayName>
 				<unitPattern count="one">{0}m/s²</unitPattern>
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="other">{0} na rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>radians</displayName>
 				<unitPattern count="one">{0}rad</unitPattern>
 				<unitPattern count="other">{0}rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>degrees</displayName>
+				<unitPattern count="one">{0} deg</unitPattern>
+				<unitPattern count="other">{0} na deg</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcmins</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcsecs</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0}km²</unitPattern>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektarya</displayName>
 				<unitPattern count="one">{0}ha</unitPattern>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>metro²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kada m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
 				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
 				<unitPattern count="one">{0}mi²</unitPattern>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>ektarya</displayName>
@@ -10448,8 +10448,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ft²</displayName>
@@ -10458,39 +10458,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>in²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">{0}item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -10498,24 +10498,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mol</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>L/km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -10524,7 +10524,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpg</unitPattern>
 				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
@@ -10533,49 +10533,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PByte</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TByte</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tbit</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GByte</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gbit</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MByte</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mbit</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
@@ -10583,19 +10583,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>siglo</displayName>
+				<unitPattern count="one">{0} siglo</unitPattern>
+				<unitPattern count="other">{0} siglo</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="one">{0} dec</unitPattern>
+				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>taon</displayName>
@@ -10604,16 +10604,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/taon</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>qtr</displayName>
+				<unitPattern count="one">{0} qtr</unitPattern>
+				<unitPattern count="other">{0} qtrs</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>buwan</displayName>
 				<unitPattern count="one">{0}buwan</unitPattern>
 				<unitPattern count="other">{0} buwan</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/buwan</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>linggo</displayName>
@@ -10625,7 +10625,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>araw</displayName>
 				<unitPattern count="one">{0} araw</unitPattern>
 				<unitPattern count="other">{0} na araw</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/araw</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>oras</displayName>
@@ -10661,149 +10661,149 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milliamps</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohms</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volts</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilojoule</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joules</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW-hour</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>electronvolt</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapixel</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>tuldok</displayName>
 				<unitPattern count="one">{0}dot</unitPattern>
 				<unitPattern count="other">{0}dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} na R⊕</unitPattern>
+				<unitPattern count="other">{0} na R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -10859,7 +10859,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>talampakan</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 				<perUnitPattern>{0}/ft</perUnitPattern>
@@ -10911,29 +10911,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">solar radii</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>solar luminosity</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -10973,7 +10973,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>libra</displayName>
 				<unitPattern count="one">{0}#</unitPattern>
 				<unitPattern count="other">{0}#</unitPattern>
 				<perUnitPattern>{0}/lb</perUnitPattern>
@@ -10985,7 +10985,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz troy</displayName>
 				<unitPattern count="one">{0}oz t</unitPattern>
 				<unitPattern count="other">{0}oz t</unitPattern>
 			</unit>
@@ -10995,52 +10995,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dalton</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Earth mass</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>solar mass</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>butil</displayName>
+				<unitPattern count="one">{0} butil</unitPattern>
+				<unitPattern count="other">{0} butil</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>watts</displayName>
 				<unitPattern count="one">{0}W</unitPattern>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
@@ -11060,9 +11060,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -11070,14 +11070,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -11085,14 +11085,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>
@@ -11125,71 +11125,71 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>deg. F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>deg. K</displayName>
 				<unitPattern count="one">{0}K</unitPattern>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0}mi³</unitPattern>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>yd³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>ft³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>in³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litro</displayName>
@@ -11198,19 +11198,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>pt</displayName>
@@ -11218,51 +11218,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} na mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>bushel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} na gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="one">{0} gal Imp.</unitPattern>
+				<unitPattern count="other">{0} gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qts</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pints</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tasa</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>Imp fl oz</displayName>
@@ -11281,8 +11281,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>bbl</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>kutsaritang panghimagas</displayName>
@@ -11295,9 +11295,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>patak</displayName>
+				<unitPattern count="one">{0} patak</unitPattern>
+				<unitPattern count="other">{0} patak</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl.dr.</displayName>
@@ -11305,8 +11305,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">{0}jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -11316,7 +11316,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>qt Imp</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">{0}qt-Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -11351,26 +11351,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, o {1}</listPatternPart>
+			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, o {1}</listPatternPart>
+			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, at {1}</listPatternPart>
 			<listPatternPart type="2">{0} at {1}</listPatternPart>
 		</listPattern>

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -762,7 +762,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunesia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkaland</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkaland</territory>
 			<territory type="TT">Trinidad &amp; Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taivan</territory>
@@ -1744,9 +1744,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>ár</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">í fjør</relative>
+				<relative type="0">í ár</relative>
+				<relative type="1">næsta ár</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">um {0} ár</relativeTimePattern>
 					<relativeTimePattern count="other">um {0} ár</relativeTimePattern>
@@ -1758,9 +1758,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>ár</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">í fjør</relative>
+				<relative type="0">í ár</relative>
+				<relative type="1">næsta ár</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">um {0} ár</relativeTimePattern>
 					<relativeTimePattern count="other">um {0} ár</relativeTimePattern>
@@ -1920,9 +1920,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>da.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">í gjár</relative>
+				<relative type="0">í dag</relative>
+				<relative type="1">í morgin</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">um {0} da.</relativeTimePattern>
 					<relativeTimePattern count="other">um {0} da.</relativeTimePattern>
@@ -1934,9 +1934,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>d.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">í gjár</relative>
+				<relative type="0">í dag</relative>
+				<relative type="1">í morgin</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">um {0} d.</relativeTimePattern>
 					<relativeTimePattern count="other">um {0} d.</relativeTimePattern>
@@ -5889,7 +5889,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">kubikk{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G-kreftir</displayName>
@@ -5977,9 +5977,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} fyri hvønn fertumma</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karat</displayName>
@@ -6017,9 +6017,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} promyriad</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litrar fyri hvønn kilometrar</displayName>
@@ -6260,8 +6260,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>prent em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>skíggjadeplar</displayName>
@@ -6508,9 +6508,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} sólarmassar</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>gigawatt</displayName>
@@ -6558,9 +6558,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} tummar av kviksilvur</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>millibar</displayName>
@@ -6914,11 +6914,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7011,7 +7011,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -7051,7 +7051,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7076,7 +7076,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
@@ -7248,12 +7248,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronvolt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>bretskar hitaeindir</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -7263,12 +7263,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -7293,38 +7293,38 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>skíggjadeplar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megaskíggjadeplar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>punkt</displayName>
@@ -7333,7 +7333,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7443,7 +7443,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>sólarradii</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -7453,17 +7453,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>sólarljósmegi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -7527,22 +7527,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>jarðmassi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>sólarmassi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -7592,7 +7592,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -7607,7 +7607,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>Pa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -7617,12 +7617,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -7667,12 +7667,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -7860,102 +7860,102 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
 				<unitPrefixPattern>dam{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<unitPattern count="one" draft="contributed">{0}G</unitPattern>
@@ -8166,22 +8166,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} ella {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, ella {1}</listPatternPart>
+			<listPatternPart type="2">{0} ella {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, ella {1}</listPatternPart>
+			<listPatternPart type="2">{0} ella {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} og {1}</listPatternPart>
+			<listPatternPart type="2">{0} og {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -125,7 +125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">cheyenne</language>
 			<language type="ckb">sorani</language>
 			<language type="ckb" alt="menu">kurde sorani</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">sorani</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">corse</language>
 			<language type="cop">copte</language>
@@ -179,9 +179,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="en_AU">anglais australien</language>
 			<language type="en_CA">anglais canadien</language>
 			<language type="en_GB">anglais britannique</language>
-			<language type="en_GB" alt="short">↑↑↑</language>
+			<language type="en_GB" alt="short">anglais britannique</language>
 			<language type="en_US">anglais américain</language>
-			<language type="en_US" alt="short">↑↑↑</language>
+			<language type="en_US" alt="short">anglais américain</language>
 			<language type="enm">moyen anglais</language>
 			<language type="eo">espéranto</language>
 			<language type="es">espagnol</language>
@@ -1638,13 +1638,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dateTimeFormatLength>
 					<availableFormats>
 						<dateFormatItem id="d">d</dateFormatItem>
-						<dateFormatItem id="E" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd" draft="unconfirmed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="E" draft="unconfirmed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="unconfirmed">E d</dateFormatItem>
+						<dateFormatItem id="Gy" draft="unconfirmed">y G</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="unconfirmed">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="unconfirmed">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd" draft="unconfirmed">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd" draft="unconfirmed">E d MMM y G</dateFormatItem>
 						<dateFormatItem id="M">L</dateFormatItem>
 						<dateFormatItem id="Md">d/M</dateFormatItem>
 						<dateFormatItem id="MEd">E d/M</dateFormatItem>
@@ -2183,11 +2183,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
@@ -2418,13 +2418,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
-							<greatestDifference id="m" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2543,11 +2543,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
@@ -2603,7 +2603,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2611,7 +2611,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2911,7 +2911,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="wed">M</day>
 							<day type="thu">J</day>
 							<day type="fri">V</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">di</day>
@@ -3173,7 +3173,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -3181,7 +3181,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3522,11 +3522,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
@@ -3638,11 +3638,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
@@ -3783,7 +3783,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
@@ -3808,11 +3808,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
@@ -4612,11 +4612,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
@@ -4725,11 +4725,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
@@ -4754,11 +4754,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
@@ -5399,7 +5399,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>s</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">maintenant</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">dans {0} s</relativeTimePattern>
 					<relativeTimePattern count="other">dans {0} s</relativeTimePattern>
@@ -5411,7 +5411,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>s</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">maintenant</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">+{0} s</relativeTimePattern>
 					<relativeTimePattern count="other">+{0} s</relativeTimePattern>
@@ -10136,12 +10136,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1 count="one">{0} cube</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">{0} cube</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0} cubes</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">{0} cubes</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}-{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>feminine</gender>
@@ -10759,7 +10759,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} milles scandinaves</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt typog.</displayName>
 				<unitPattern count="one">{0} point typographique</unitPattern>
 				<unitPattern count="other">{0} points typographiques</unitPattern>
 			</unit>
@@ -11336,12 +11336,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -11454,7 +11454,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} items</unitPattern>
 				<unitPattern count="other">{0} items</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -11772,7 +11772,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -11892,12 +11892,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -11981,7 +11981,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grains</unitPattern>
 				<unitPattern count="other">{0} grains</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -12299,109 +12299,109 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}-{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} force g</unitPattern>
+				<unitPattern count="other">{0} force g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>m/s²</displayName>
@@ -12504,7 +12504,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>item</displayName>
 				<unitPattern count="one">{0}item</unitPattern>
 				<unitPattern count="other">{0}items</unitPattern>
 			</unit>
@@ -12534,7 +12534,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>l/km</displayName>
 				<unitPattern count="one">{0}l/km</unitPattern>
 				<unitPattern count="other">{0}l/km</unitPattern>
 			</unit>
@@ -12549,7 +12549,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mi/gal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/gal imp.</displayName>
 				<unitPattern count="one">{0}mi/gal imp.</unitPattern>
 				<unitPattern count="other">{0}mi/gal imp.</unitPattern>
 			</unit>
@@ -12757,7 +12757,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100 km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
@@ -12782,49 +12782,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="one">{0}px</unitPattern>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mpx</displayName>
 				<unitPattern count="one">{0}Mpx</unitPattern>
 				<unitPattern count="other">{0}Mpx</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>px/cm</displayName>
 				<unitPattern count="one">{0}px/cm</unitPattern>
 				<unitPattern count="other">{0}px/cm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>px/po</displayName>
 				<unitPattern count="one">{0}px/po</unitPattern>
 				<unitPattern count="other">{0}px/po</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt/cm</displayName>
 				<unitPattern count="one">{0}pt/cm</unitPattern>
 				<unitPattern count="other">{0}pt/cm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt/po</displayName>
 				<unitPattern count="one">{0}pt/po</unitPattern>
 				<unitPattern count="other">{0}pt/po</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="one">{0}pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -12840,8 +12840,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>dm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
@@ -12856,13 +12856,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>μm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>nm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>pm</displayName>
@@ -12893,13 +12893,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-parsec">
 				<displayName>pc</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>al</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} al</unitPattern>
+				<unitPattern count="other">{0} al</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>ua</displayName>
@@ -12913,23 +12913,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fm</unitPattern>
+				<unitPattern count="other">{0} fm</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>nmi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>smi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pt typog.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt typog.</unitPattern>
+				<unitPattern count="other">{0} pts typog.</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
@@ -12942,12 +12942,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">{0}cd</unitPattern>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
@@ -13031,9 +13031,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>grain</displayName>
 				<unitPattern count="one">{0} grain</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} grains</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>GW</displayName>
@@ -13076,12 +13076,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} lb/po²</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="one">{0}bar</unitPattern>
 				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
@@ -13096,7 +13096,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="one">{0}Pa</unitPattern>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
@@ -13260,7 +13260,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal imp.</displayName>
 				<unitPattern count="one">{0}gal imp.</unitPattern>
 				<unitPattern count="other">{0}gal imp.</unitPattern>
 				<perUnitPattern>{0}/gal imp.</perUnitPattern>
@@ -13316,7 +13316,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}CàD imp.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>gte</displayName>
 				<unitPattern count="one">{0}gte</unitPattern>
 				<unitPattern count="other">{0}gte</unitPattern>
 			</unit>
@@ -13326,17 +13326,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl dr</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jiggers</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pincée</displayName>
+				<unitPattern count="one">{0} pincée</unitPattern>
+				<unitPattern count="other">{0} pincées</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt imp.</displayName>
 				<unitPattern count="one">{0}qt imp.</unitPattern>
 				<unitPattern count="other">{0}qt imp.</unitPattern>
 			</unit>
@@ -13372,16 +13372,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ou {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ou {1}</listPatternPart>
+			<listPatternPart type="2">{0} ou {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ou {1}</listPatternPart>
+			<listPatternPart type="2">{0} ou {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -206,7 +206,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="FR" draft="unconfirmed">Frankrik</territory>
 			<territory type="GA" draft="unconfirmed">Gabuun</territory>
 			<territory type="GB" draft="unconfirmed">Ferianigt Köningrik</territory>
-			<territory type="GB" alt="short" draft="unconfirmed">↑↑↑</territory>
+			<territory type="GB" alt="short" draft="unconfirmed">Ferianigt Köningrik</territory>
 			<territory type="GD" draft="unconfirmed">Grenaada</territory>
 			<territory type="GE" draft="unconfirmed">Georgien</territory>
 			<territory type="GF" draft="unconfirmed">Fransöösk Guiana</territory>
@@ -680,18 +680,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">Jan</month>
+							<month type="2" draft="unconfirmed">Feb</month>
+							<month type="3" draft="unconfirmed">Mar</month>
+							<month type="4" draft="unconfirmed">Apr</month>
+							<month type="5" draft="unconfirmed">Mei</month>
+							<month type="6" draft="unconfirmed">Jün</month>
+							<month type="7" draft="unconfirmed">Jül</month>
+							<month type="8" draft="unconfirmed">Aug</month>
+							<month type="9" draft="unconfirmed">Sep</month>
+							<month type="10" draft="unconfirmed">Okt</month>
+							<month type="11" draft="unconfirmed">Nof</month>
+							<month type="12" draft="unconfirmed">Det</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="unconfirmed">J</month>
@@ -708,18 +708,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12" draft="unconfirmed">D</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">Janewoore</month>
+							<month type="2" draft="unconfirmed">Febrewoore</month>
+							<month type="3" draft="unconfirmed">Maarts</month>
+							<month type="4" draft="unconfirmed">April</month>
+							<month type="5" draft="unconfirmed">Mei</month>
+							<month type="6" draft="unconfirmed">Jüüne</month>
+							<month type="7" draft="unconfirmed">Jüüle</month>
+							<month type="8" draft="unconfirmed">August</month>
+							<month type="9" draft="unconfirmed">September</month>
+							<month type="10" draft="unconfirmed">Oktuuber</month>
+							<month type="11" draft="unconfirmed">Nofember</month>
+							<month type="12" draft="unconfirmed">Detsember</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -735,13 +735,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat" draft="unconfirmed">San</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">S</day>
+							<day type="mon" draft="unconfirmed">M</day>
+							<day type="tue" draft="unconfirmed">T</day>
+							<day type="wed" draft="unconfirmed">W</day>
+							<day type="thu" draft="unconfirmed">T</day>
+							<day type="fri" draft="unconfirmed">F</day>
+							<day type="sat" draft="unconfirmed">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun" draft="unconfirmed">Sö</day>
@@ -764,13 +764,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">Sön</day>
+							<day type="mon" draft="unconfirmed">Mun</day>
+							<day type="tue" draft="unconfirmed">Tei</day>
+							<day type="wed" draft="unconfirmed">Wed</day>
+							<day type="thu" draft="unconfirmed">Tür</day>
+							<day type="fri" draft="unconfirmed">Fre</day>
+							<day type="sat" draft="unconfirmed">San</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun" draft="unconfirmed">S</day>
@@ -782,32 +782,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat" draft="unconfirmed">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">Sö</day>
+							<day type="mon" draft="unconfirmed">Mu</day>
+							<day type="tue" draft="unconfirmed">Te</day>
+							<day type="wed" draft="unconfirmed">We</day>
+							<day type="thu" draft="unconfirmed">Tü</day>
+							<day type="fri" draft="unconfirmed">Fr</day>
+							<day type="sat" draft="unconfirmed">Sa</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">Söndai</day>
+							<day type="mon" draft="unconfirmed">Mundai</day>
+							<day type="tue" draft="unconfirmed">Teisdai</day>
+							<day type="wed" draft="unconfirmed">Weedensdai</day>
+							<day type="thu" draft="unconfirmed">Tüürsdai</day>
+							<day type="fri" draft="unconfirmed">Freidai</day>
+							<day type="sat" draft="unconfirmed">Saninj</day>
 						</dayWidth>
 					</dayContext>
 				</days>
 				<quarters>
 					<quarterContext type="format">
 						<quarterWidth type="abbreviated">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="1" draft="unconfirmed">iarst kwartaal</quarter>
+							<quarter type="2" draft="unconfirmed">naist kwartaal</quarter>
+							<quarter type="3" draft="unconfirmed">traad kwartaal</quarter>
+							<quarter type="4" draft="unconfirmed">fjuard kwartaal</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1" draft="unconfirmed">I</quarter>
@@ -824,10 +824,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="1" draft="unconfirmed">iarst kwartaal</quarter>
+							<quarter type="2" draft="unconfirmed">naist kwartaal</quarter>
+							<quarter type="3" draft="unconfirmed">traad kwartaal</quarter>
+							<quarter type="4" draft="unconfirmed">fjuard kwartaal</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1" draft="unconfirmed">I</quarter>
@@ -836,10 +836,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4" draft="unconfirmed">IV</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="1" draft="unconfirmed">iarst kwartaal</quarter>
+							<quarter type="2" draft="unconfirmed">naist kwartaal</quarter>
+							<quarter type="3" draft="unconfirmed">traad kwartaal</quarter>
+							<quarter type="4" draft="unconfirmed">fjuard kwartaal</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -884,7 +884,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="0" draft="unconfirmed">f.Kr.</era>
 						<era type="0" alt="variant" draft="unconfirmed">f.Kr.</era>
 						<era type="1" draft="unconfirmed">AD</era>
-						<era type="1" alt="variant" draft="unconfirmed">↑↑↑</era>
+						<era type="1" alt="variant" draft="unconfirmed">AD</era>
 					</eraAbbr>
 				</eras>
 				<dateFormats>
@@ -3510,8 +3510,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
@@ -4413,7 +4413,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="per">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
@@ -4443,7 +4443,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern draft="unconfirmed">{0}{1}</compoundUnitPattern>
@@ -4480,46 +4480,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0} of {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} of {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0} of {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} of {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0} of {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} an {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} an {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} an {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} an {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} an {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} an {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} an {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} an {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} an {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} an {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -87,7 +87,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">Seiricis</language>
 			<language type="chy">Siáinis</language>
 			<language type="ckb">Coirdis Lárnach</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">Coirdis Lárnach</language>
 			<language type="ckb" alt="variant">Coirdis, Sóráinis</language>
 			<language type="clc">Chilcotin</language>
 			<language type="co">Corsaicis</language>
@@ -715,7 +715,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="CG" alt="variant">an Congó (Poblacht)</territory>
 			<territory type="CH">an Eilvéis</territory>
 			<territory type="CI">an Cósta Eabhair</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
+			<territory type="CI" alt="variant">an Cósta Eabhair</territory>
 			<territory type="CK">Oileáin Cook</territory>
 			<territory type="CL">an tSile</territory>
 			<territory type="CM">Camarún</territory>
@@ -756,7 +756,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="FR">an Fhrainc</territory>
 			<territory type="GA">an Ghabúin</territory>
 			<territory type="GB">an Ríocht Aontaithe</territory>
-			<territory type="GB" alt="short">↑↑↑</territory>
+			<territory type="GB" alt="short">an Ríocht Aontaithe</territory>
 			<territory type="GD">Greanáda</territory>
 			<territory type="GE">an tSeoirsia</territory>
 			<territory type="GF">Guáin na Fraince</territory>
@@ -854,7 +854,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">Nárú</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">an Nua-Shéalainn</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">an Nua-Shéalainn</territory>
 			<territory type="OM">Óman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peiriú</territory>
@@ -909,12 +909,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TJ">an Táidsíceastáin</territory>
 			<territory type="TK">Tócalá</territory>
 			<territory type="TL">Tíomór Thoir</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">Tíomór Thoir</territory>
 			<territory type="TM">an Tuircméanastáin</territory>
 			<territory type="TN">an Túinéis</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">an Tuirc</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">an Tuirc</territory>
 			<territory type="TT">Oileán na Tríonóide agus Tobága</territory>
 			<territory type="TV">Túvalú</territory>
 			<territory type="TW">an Téaváin</territory>
@@ -1878,8 +1878,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="pm">i.n.</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">r.n.</dayPeriod>
+							<dayPeriod type="pm">i.n.</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">r.n.</dayPeriod>
@@ -1888,8 +1888,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">r.n.</dayPeriod>
+							<dayPeriod type="pm">i.n.</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="am">r.n.</dayPeriod>
@@ -2450,15 +2450,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="1">an tscht. seo chugainn</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">+{0} scht.</relativeTimePattern>
-					<relativeTimePattern count="two">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="two">i gceann {0} shcht.</relativeTimePattern>
+					<relativeTimePattern count="few">i gceann {0} shcht.</relativeTimePattern>
 					<relativeTimePattern count="many">+{0} scht.</relativeTimePattern>
 					<relativeTimePattern count="other">+{0} scht.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">-{0} scht.</relativeTimePattern>
-					<relativeTimePattern count="two">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="two">{0} shcht. ó shin</relativeTimePattern>
+					<relativeTimePattern count="few">{0} shcht. ó shin</relativeTimePattern>
 					<relativeTimePattern count="many">-{0} scht.</relativeTimePattern>
 					<relativeTimePattern count="other">-{0} scht.</relativeTimePattern>
 				</relativeTime>
@@ -2496,7 +2496,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>lá</displayName>
 				<relative type="-2">arú inné</relative>
 				<relative type="-1">inné</relative>
 				<relative type="0">inniu</relative>
@@ -2518,7 +2518,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>lá</displayName>
 				<relative type="-2">arú inné</relative>
 				<relative type="-1">inné</relative>
 				<relative type="0">inniu</relative>
@@ -2555,7 +2555,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>lá den tscht.</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>lá den tscht.</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>lá den tseachtain sa mhí</displayName>
@@ -2980,14 +2980,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relativeTime type="future">
 					<relativeTimePattern count="one">i gceann {0} uair an chloig</relativeTimePattern>
 					<relativeTimePattern count="two">i gceann {0} uair an chloig</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">i gceann {0} uair an chloig</relativeTimePattern>
 					<relativeTimePattern count="many">i gceann {0} n-uair an chloig</relativeTimePattern>
 					<relativeTimePattern count="other">i gceann {0} uair an chloig</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} uair an chloig ó shin</relativeTimePattern>
 					<relativeTimePattern count="two">{0} uair an chloig ó shin</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">{0} uair an chloig ó shin</relativeTimePattern>
 					<relativeTimePattern count="many">{0} n-uair an chloig ó shin</relativeTimePattern>
 					<relativeTimePattern count="other">{0} uair an chloig ó shin</relativeTimePattern>
 				</relativeTime>
@@ -6255,7 +6255,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="many">rúbal na Bealarúise</displayName>
 				<displayName count="other">rúbal na Bealarúise</displayName>
 				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<symbol alt="narrow">BYN</symbol>
 			</currency>
 			<currency type="BYR">
 				<displayName>Rúbal na Bealarúise (2000–2016)</displayName>
@@ -8473,16 +8473,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>mebi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
 				<unitPrefixPattern>tebi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
 				<unitPrefixPattern>zebi{0}</unitPrefixPattern>
@@ -8508,7 +8508,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0} ciúbach</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-fhórsa</displayName>
@@ -8676,12 +8676,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} milleamól sa lítear</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="two">{0} item</unitPattern>
+				<unitPattern count="few">{0} item</unitPattern>
+				<unitPattern count="many">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>codanna sa mhilliún</displayName>
@@ -8854,9 +8854,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-decade">
 				<displayName>deicheanna blianta</displayName>
 				<unitPattern count="one">{0} deich mbliana</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dec</unitPattern>
+				<unitPattern count="few">{0} dec</unitPattern>
+				<unitPattern count="many">{0} dec</unitPattern>
 				<unitPattern count="other">{0} deich mbliana</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -9055,7 +9055,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>teirmeacha SAM</displayName>
 				<unitPattern count="one">{0} teirm SAM</unitPattern>
 				<unitPattern count="two">{0} theirm SAM</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} theirm SAM</unitPattern>
 				<unitPattern count="many">{0} dteirm SAM</unitPattern>
 				<unitPattern count="other">{0} teirm SAM</unitPattern>
 			</unit>
@@ -9079,8 +9079,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>cileavatuair in aghaidh 100 ciliméadar</displayName>
 				<unitPattern count="one">cileavatuair in aghaidh 100 ciliméadar</unitPattern>
 				<unitPattern count="two">{0} cileavatuair in aghaidh 100 cilliméadar</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">{0} cileavatuair in aghaidh 100 ciliméadar</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -10099,18 +10099,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10283,10 +10283,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="two">{0} item</unitPattern>
+				<unitPattern count="few">{0} item</unitPattern>
+				<unitPattern count="many">{0} item</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -10459,10 +10459,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-decade">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dec</unitPattern>
+				<unitPattern count="two">{0} dec</unitPattern>
+				<unitPattern count="few">{0} dec</unitPattern>
+				<unitPattern count="many">{0} dec</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -10683,10 +10683,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -10731,51 +10731,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>picteilíní</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>meigiphicteilíní</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="many">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ponc</displayName>
@@ -10787,10 +10787,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10976,18 +10976,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -11190,7 +11190,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>orlaí Hg</displayName>
 				<unitPattern count="one">{0} or. Hg</unitPattern>
 				<unitPattern count="two">{0} or. Hg</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} or. Hg</unitPattern>
 				<unitPattern count="many">{0} n-or. Hg</unitPattern>
 				<unitPattern count="other">{0} or. Hg</unitPattern>
 			</unit>
@@ -11220,10 +11220,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -11683,16 +11683,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
 				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
 				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
@@ -11705,22 +11705,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-fhórsa</displayName>
@@ -11856,12 +11856,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/or²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunaim</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="two">{0} dhunam</unitPattern>
+				<unitPattern count="few">{0} dhunam</unitPattern>
+				<unitPattern count="many">{0} ndunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>kt</displayName>
@@ -11888,12 +11888,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="two">{0} item</unitPattern>
+				<unitPattern count="few">{0} item</unitPattern>
+				<unitPattern count="many">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>codanna/milliún</displayName>
@@ -11912,28 +11912,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>faoin míle</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="two">{0}‰</unitPattern>
+				<unitPattern count="few">{0}‰</unitPattern>
+				<unitPattern count="many">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>permeiriad</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mól</displayName>
+				<unitPattern count="one">{0} mhól</unitPattern>
+				<unitPattern count="two">{0} mhól</unitPattern>
+				<unitPattern count="few">{0} mhól</unitPattern>
+				<unitPattern count="many">{0} mól</unitPattern>
+				<unitPattern count="other">{0} mól</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>l/km</displayName>
@@ -11968,12 +11968,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}m/gRA</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PBheart</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="two">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="many">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TB</displayName>
@@ -12064,12 +12064,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="one">{0} dec</unitPattern>
+				<unitPattern count="two">{0} dec</unitPattern>
+				<unitPattern count="few">{0} dec</unitPattern>
+				<unitPattern count="many">{0} dec</unitPattern>
+				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>bl</displayName>
@@ -12248,52 +12248,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>leictravolta</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="two">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="two">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>teirmeacha SAM</displayName>
+				<unitPattern count="one">{0} teirm SAM</unitPattern>
+				<unitPattern count="two">{0} theirm SAM</unitPattern>
+				<unitPattern count="few">{0} theirm SAM</unitPattern>
+				<unitPattern count="many">{0} dteirm SAM</unitPattern>
+				<unitPattern count="other">{0} teirm SAM</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>punt-fhórsa</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>niútan</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>GHz</displayName>
@@ -12328,76 +12328,76 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eim</displayName>
+				<unitPattern count="one">{0} eim</unitPattern>
+				<unitPattern count="two">{0} eim</unitPattern>
+				<unitPattern count="few">{0} eim</unitPattern>
+				<unitPattern count="many">{0} n-eim</unitPattern>
+				<unitPattern count="other">{0} eim</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>picteilíní</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>meigiphicteilíní</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="many">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ponc</displayName>
+				<unitPattern count="one">{0} phonc</unitPattern>
+				<unitPattern count="two">{0} phonc</unitPattern>
+				<unitPattern count="few">{0} phonc</unitPattern>
+				<unitPattern count="many">{0} bponc</unitPattern>
+				<unitPattern count="other">{0} ponc</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -12565,12 +12565,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>raonta gréine</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="two">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lucsa</displayName>
@@ -12581,28 +12581,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lonrachtaí gréine</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -12697,36 +12697,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>daltúin</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>maiseanna an Domhain</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>maiseanna gréine</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gráinne</displayName>
+				<unitPattern count="one">{0} ghráinne</unitPattern>
+				<unitPattern count="two">{0} ghráinne</unitPattern>
+				<unitPattern count="few">{0} ghráinne</unitPattern>
+				<unitPattern count="many">{0} ngráinne</unitPattern>
+				<unitPattern count="other">{0} gráinne</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>GW</displayName>
@@ -12801,12 +12801,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>barra</displayName>
+				<unitPattern count="one">{0} bharra</unitPattern>
+				<unitPattern count="two">{0} bharra</unitPattern>
+				<unitPattern count="few">{0} bharra</unitPattern>
+				<unitPattern count="many">{0} mbarra</unitPattern>
+				<unitPattern count="other">{0} barra</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -12817,20 +12817,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="two">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="many">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -12841,20 +12841,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="two">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="two">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/u</displayName>
@@ -12921,20 +12921,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="two">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
+				<unitPattern count="many">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>km³</displayName>
@@ -13126,12 +13126,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} unsa l.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Unsa leachtach impiriúil</displayName>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="two">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="few">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="many">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>spbh</displayName>
@@ -13150,68 +13150,68 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bairille</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="two">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="many">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>spmhil</displayName>
+				<unitPattern count="one">{0} spmhil</unitPattern>
+				<unitPattern count="two">{0} spmhil</unitPattern>
+				<unitPattern count="few">{0} spmhil</unitPattern>
+				<unitPattern count="many">{0} spmhil</unitPattern>
+				<unitPattern count="other">{0} spmhil</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>spmhil imp</displayName>
+				<unitPattern count="one">{0} spmhil imp</unitPattern>
+				<unitPattern count="two">{0} spmhil imp</unitPattern>
+				<unitPattern count="few">{0} spmhil imp</unitPattern>
+				<unitPattern count="many">{0} spmhil imp</unitPattern>
+				<unitPattern count="other">{0} spmhil imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>braon</displayName>
+				<unitPattern count="one">{0} bhraon</unitPattern>
+				<unitPattern count="two">{0} bhraon</unitPattern>
+				<unitPattern count="few">{0} bhraon</unitPattern>
+				<unitPattern count="many">{0} mbraon</unitPattern>
+				<unitPattern count="other">{0} braon</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dr l.</displayName>
+				<unitPattern count="one">{0} dr l.</unitPattern>
+				<unitPattern count="two">{0} dr l.</unitPattern>
+				<unitPattern count="few">{0} dr l.</unitPattern>
+				<unitPattern count="many">{0} dr l.</unitPattern>
+				<unitPattern count="other">{0} dr l.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miosúr</displayName>
+				<unitPattern count="one">{0} mhiosúr</unitPattern>
+				<unitPattern count="two">{0} mhiosúr</unitPattern>
+				<unitPattern count="few">{0} mhiosúr</unitPattern>
+				<unitPattern count="many">{0} miosúr</unitPattern>
+				<unitPattern count="other">{0} miosúr</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinse</displayName>
+				<unitPattern count="one">{0} phinse</unitPattern>
+				<unitPattern count="two">{0} phinse</unitPattern>
+				<unitPattern count="few">{0} phinse</unitPattern>
+				<unitPattern count="many">{0} bpinse</unitPattern>
+				<unitPattern count="other">{0} pinse</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cárt impiriúil</displayName>
+				<unitPattern count="one">{0} chárt impiriúil</unitPattern>
+				<unitPattern count="two">{0} chárt impiriúla</unitPattern>
+				<unitPattern count="few">{0} chárt impiriúla</unitPattern>
+				<unitPattern count="many">{0} gcárt impiriúla</unitPattern>
+				<unitPattern count="other">{0} cárt impiriúil</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>treo</displayName>
@@ -13245,16 +13245,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} nó {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} nó {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} nó {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} nó {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} nó {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -13522,7 +13522,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>

--- a/common/main/gaa.xml
+++ b/common/main/gaa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -595,18 +595,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">Aha</month>
+							<month type="2" draft="unconfirmed">Ofl</month>
 							<month type="3" draft="unconfirmed">Ots</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="4" draft="unconfirmed">Abe</month>
+							<month type="5" draft="unconfirmed">Agb</month>
+							<month type="6" draft="unconfirmed">Otu</month>
+							<month type="7" draft="unconfirmed">Maa</month>
+							<month type="8" draft="unconfirmed">Man</month>
+							<month type="9" draft="unconfirmed">Gbo</month>
+							<month type="10" draft="unconfirmed">Ant</month>
+							<month type="11" draft="unconfirmed">Ale</month>
+							<month type="12" draft="unconfirmed">Afu</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="unconfirmed">A</month>
@@ -623,17 +623,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12" draft="unconfirmed">A</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">Aharabata</month>
 							<month type="2" draft="unconfirmed">Oflɔ</month>
 							<month type="3" draft="unconfirmed">Otsokrikri</month>
 							<month type="4" draft="unconfirmed">Abeibe</month>
 							<month type="5" draft="unconfirmed">Agbiɛnaa</month>
 							<month type="6" draft="unconfirmed">Otukwajan</month>
 							<month type="7" draft="unconfirmed">Maawɛ</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
+							<month type="8" draft="unconfirmed">Manyawale</month>
+							<month type="9" draft="unconfirmed">Gbo</month>
 							<month type="10" draft="unconfirmed">Antɔŋ</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
+							<month type="11" draft="unconfirmed">Alemle</month>
 							<month type="12" draft="unconfirmed">Afuabe</month>
 						</monthWidth>
 					</monthContext>
@@ -645,7 +645,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon" draft="unconfirmed">Ju</day>
 							<day type="tue" draft="unconfirmed">Juf</day>
 							<day type="wed" draft="unconfirmed">Shɔ</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
+							<day type="thu" draft="unconfirmed">Soo</day>
 							<day type="fri" draft="unconfirmed">Soh</day>
 							<day type="sat" draft="unconfirmed">Hɔɔ</day>
 						</dayWidth>
@@ -663,8 +663,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon" draft="unconfirmed">Ju</day>
 							<day type="tue" draft="unconfirmed">Juf</day>
 							<day type="wed" draft="unconfirmed">Shɔ</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
+							<day type="thu" draft="unconfirmed">Soo</day>
+							<day type="fri" draft="unconfirmed">Soh</day>
 							<day type="sat" draft="unconfirmed">Hɔɔ</day>
 						</dayWidth>
 						<dayWidth type="wide">
@@ -683,8 +683,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon" draft="unconfirmed">Ju</day>
 							<day type="tue" draft="unconfirmed">Juf</day>
 							<day type="wed" draft="unconfirmed">Shɔ</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
+							<day type="thu" draft="unconfirmed">Soo</day>
+							<day type="fri" draft="unconfirmed">Soh</day>
 							<day type="sat" draft="unconfirmed">Hɔɔ</day>
 						</dayWidth>
 						<dayWidth type="narrow">
@@ -701,8 +701,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon" draft="unconfirmed">Ju</day>
 							<day type="tue" draft="unconfirmed">Juf</day>
 							<day type="wed" draft="unconfirmed">Shɔ</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
+							<day type="thu" draft="unconfirmed">Soo</day>
+							<day type="fri" draft="unconfirmed">Soh</day>
 							<day type="sat" draft="unconfirmed">Hɔɔ</day>
 						</dayWidth>
 						<dayWidth type="wide">
@@ -710,8 +710,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon" draft="unconfirmed">Ju</day>
 							<day type="tue" draft="unconfirmed">Jufɔ</day>
 							<day type="wed" draft="unconfirmed">Shɔ</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
+							<day type="thu" draft="unconfirmed">Soo</day>
+							<day type="fri" draft="unconfirmed">Sohaa</day>
 							<day type="sat" draft="unconfirmed">Hɔɔ</day>
 						</dayWidth>
 					</dayContext>
@@ -728,7 +728,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="1" draft="unconfirmed">1</quarter>
 							<quarter type="2" draft="unconfirmed">2</quarter>
 							<quarter type="3" draft="unconfirmed">3</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="4" draft="unconfirmed">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1" draft="unconfirmed">nyɔji etɛ 1</quarter>
@@ -765,8 +765,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm" draft="unconfirmed">SN</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">LB</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">SN</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am" draft="unconfirmed">LEEBI</dayPeriod>
@@ -775,12 +775,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">LB</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">SN</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">LB</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">SN</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am" draft="unconfirmed">LEEBI</dayPeriod>
@@ -2557,7 +2557,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">Belarus Rubol</displayName>
 				<displayName count="other" draft="unconfirmed">Belarus rubolii</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="unconfirmed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="unconfirmed">BYN</symbol>
 			</currency>
 			<currency type="BZD">
 				<displayName draft="unconfirmed">Belize Dɔla</displayName>
@@ -3029,12 +3029,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<unit type="angle-degree">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">deg</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}°</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">%</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}%</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName draft="unconfirmed">afii ohai</displayName>
@@ -3223,8 +3223,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<unit type="concentr-percent">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">%</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}%</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName draft="unconfirmed">afi</displayName>
@@ -3264,10 +3264,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-meter">
 				<displayName draft="unconfirmed">m</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} m</unitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mm</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0}mm</unitPattern>
 			</unit>
 			<coordinateUnit>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -121,7 +121,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">Cherokee</language>
 			<language type="chy">Cheyenne</language>
 			<language type="ckb">Cùrdais Mheadhanach</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">Cùrdais Mheadhanach</language>
 			<language type="ckb" alt="variant">Cùrdais Sorani</language>
 			<language type="clc">Chilcotin</language>
 			<language type="co">Corsais</language>
@@ -10550,7 +10550,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">{0} ciùbach</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>forsa-g</displayName>
@@ -11085,10 +11085,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em chlò-ghrafach</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="two">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piogsail</displayName>
@@ -11958,16 +11958,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -12148,9 +12148,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>sna deich mìltean</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -12436,44 +12436,44 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>volt-eleactroin</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="two">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>aonad-teasa Breatannach</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="two">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>aonad-teasa nan SA</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>punnd-fhorsa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -12506,37 +12506,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="two">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piogsail</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>meaga-piogsail</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -12562,9 +12562,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -12714,9 +12714,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>rèideas-grèine</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="two">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -12728,23 +12728,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-candela">
 				<displayName>candela</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>lumen</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>boillsgeachd-ghrèine</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -12837,16 +12837,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>tomad-talmhainn</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>tomad-grèine</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -12942,9 +12942,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -12963,9 +12963,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="two">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -13033,9 +13033,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="two">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -13227,9 +13227,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>baraill</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="two">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -13294,61 +13294,61 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -13378,21 +13378,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>forsa-g</displayName>
@@ -13569,8 +13569,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
 				<unitPattern count="few">{0}‱</unitPattern>
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
@@ -13926,14 +13926,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="two">{0}em</unitPattern>
 				<unitPattern count="few">{0}em</unitPattern>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>piogsail</displayName>
 				<unitPattern count="one">{0}px</unitPattern>
 				<unitPattern count="two">{0}px</unitPattern>
 				<unitPattern count="few">{0}px</unitPattern>
@@ -13947,14 +13947,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="two">{0}ppcm</unitPattern>
 				<unitPattern count="few">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">{0}ppi</unitPattern>
 				<unitPattern count="two">{0}ppi</unitPattern>
 				<unitPattern count="few">{0}ppi</unitPattern>
@@ -13982,7 +13982,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">{0}R⊕</unitPattern>
 				<unitPattern count="two">{0}R⊕</unitPattern>
 				<unitPattern count="few">{0}R⊕</unitPattern>
@@ -14453,7 +14453,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>N⋅m</displayName>
 				<unitPattern count="one">{0}N⋅m</unitPattern>
 				<unitPattern count="two">{0}N⋅m</unitPattern>
 				<unitPattern count="few">{0}N⋅m</unitPattern>
@@ -14734,16 +14734,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} no {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} no {1}</listPatternPart>
+			<listPatternPart type="2">{0} no {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} no {1}</listPatternPart>
+			<listPatternPart type="2">{0} no {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -15071,23 +15071,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
-			<namePattern alt="1">↑↑↑</namePattern>
+			<namePattern alt="1">{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal} {given2}</namePattern>
-			<namePattern alt="1">↑↑↑</namePattern>
+			<namePattern alt="1">{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname-core}, {given} {given2-initial} {surname-prefix}</namePattern>
-			<namePattern alt="1">↑↑↑</namePattern>
+			<namePattern alt="1">{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal} {given2}</namePattern>
-			<namePattern alt="1">↑↑↑</namePattern>
+			<namePattern alt="1">{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
 			<namePattern>{surname-core}, {given-initial} {given2-initial} {surname-prefix}</namePattern>
-			<namePattern alt="1">↑↑↑</namePattern>
+			<namePattern alt="1">{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal} {given2}</namePattern>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -84,7 +84,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyenne</language>
 			<language type="ckb">kurdo central</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">kurdo central</language>
 			<language type="ckb" alt="variant">sorani</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">corso</language>
@@ -817,12 +817,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TJ">Taxiquistán</territory>
 			<territory type="TK">Tokelau</territory>
 			<territory type="TL">Timor Leste</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">Timor Leste</territory>
 			<territory type="TM">Turkmenistán</territory>
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turquía</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turquía</territory>
 			<territory type="TT">Trinidad e Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwán</territory>
@@ -1082,7 +1082,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1090,7 +1090,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1098,7 +1098,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1106,7 +1106,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1913,9 +1913,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>ano</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">o ano pasado</relative>
 				<relative type="0">este ano</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">o próximo ano</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">en {0} ano</relativeTimePattern>
 					<relativeTimePattern count="other">en {0} anos</relativeTimePattern>
@@ -1997,9 +1997,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>mes</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">o mes pasado</relative>
+				<relative type="0">este mes</relative>
+				<relative type="1">o próximo mes</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">en {0} mes</relativeTimePattern>
 					<relativeTimePattern count="other">en {0} meses</relativeTimePattern>
@@ -2056,7 +2056,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="week-narrow">
 				<displayName>sem.</displayName>
 				<relative type="-1">a sem. pas.</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">esta sem.</relative>
 				<relative type="1">a próx. sem.</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">en {0} sem.</relativeTimePattern>
@@ -2095,9 +2095,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>día</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">onte</relative>
+				<relative type="0">hoxe</relative>
+				<relative type="1">mañá</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">en {0} día</relativeTimePattern>
 					<relativeTimePattern count="other">en {0} días</relativeTimePattern>
@@ -2109,9 +2109,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>día</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">onte</relative>
+				<relative type="0">hoxe</relative>
+				<relative type="1">mañá</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">en {0} día</relativeTimePattern>
 					<relativeTimePattern count="other">en {0} días</relativeTimePattern>
@@ -6316,7 +6316,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0} cúbicos</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>forzas G</displayName>
@@ -7358,12 +7358,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7704,7 +7704,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -7719,12 +7719,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>libra forza</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -7754,12 +7754,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
@@ -7794,7 +7794,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7904,7 +7904,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>raios solares</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -7914,17 +7914,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>luminosidades solares</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -7940,7 +7940,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gramos</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
 				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
@@ -7961,7 +7961,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -7988,17 +7988,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>daltons</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>masas da Terra</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>masas solares</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8068,7 +8068,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8078,12 +8078,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -8221,7 +8221,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -8273,7 +8273,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>barril</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -8381,69 +8381,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>rad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>graos</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>min</displayName>
@@ -8452,63 +8452,63 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>s</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}′′</unitPattern>
+				<unitPattern count="other">{0}′′</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ha</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>ac</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} acre</unitPattern>
+				<unitPattern count="other">{0} acres</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunams</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>kt</displayName>
@@ -8516,12 +8516,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg/dl</displayName>
 				<unitPattern count="one">{0} mg/dl</unitPattern>
 				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mmol/l</displayName>
 				<unitPattern count="one">{0} mmol/l</unitPattern>
 				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
@@ -8531,7 +8531,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} udes.</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppm</displayName>
 				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
@@ -8541,17 +8541,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>‰</displayName>
 				<unitPattern count="one">{0} ‰</unitPattern>
 				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">{0} ‱</unitPattern>
 				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
@@ -8567,58 +8567,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg EUA</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpg EUA</unitPattern>
+				<unitPattern count="other">{0} mpg EUA</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg imp.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpg imp.</unitPattern>
+				<unitPattern count="other">{0} mpg imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
@@ -8627,18 +8627,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-bit">
 				<displayName>b</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} b</unitPattern>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>séc.</displayName>
+				<unitPattern count="one">{0} séc.</unitPattern>
+				<unitPattern count="other">{0} séc.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>déc.</displayName>
+				<unitPattern count="one">{0} déc.</unitPattern>
+				<unitPattern count="other">{0} déc.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>a.</displayName>
@@ -8662,7 +8662,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>sem.</displayName>
 				<unitPattern count="one">{0} sem.</unitPattern>
 				<unitPattern count="other">{0} sem.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sem.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>día</displayName>
@@ -8674,19 +8674,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>h</displayName>
 				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="other">{0} h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
 				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">{0} min</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -8694,79 +8694,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>Ω</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>V</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kJ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>J</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} BTU</unitPattern>
+				<unitPattern count="other">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thm U.S.</displayName>
+				<unitPattern count="one">{0} thm U.S.</unitPattern>
+				<unitPattern count="other">{0} thm U.S.</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
@@ -8784,92 +8784,92 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kWh/100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mpx</displayName>
+				<unitPattern count="one">{0} Mpx</unitPattern>
+				<unitPattern count="other">{0} Mpx</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px/cm</displayName>
+				<unitPattern count="one">{0} px/cm</unitPattern>
+				<unitPattern count="other">{0} px/cm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px/in</displayName>
+				<unitPattern count="one">{0} px/in</unitPattern>
+				<unitPattern count="other">{0} px/in</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppp</displayName>
+				<unitPattern count="one">{0} ppp</unitPattern>
+				<unitPattern count="other">{0} ppp</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ptos.</displayName>
+				<unitPattern count="one">{0} ptos.</unitPattern>
+				<unitPattern count="other">{0} ptos.</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -8877,94 +8877,94 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>yd</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>in</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>pc</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>a.l.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} a.l.</unitPattern>
+				<unitPattern count="other">{0} a.l.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ua</displayName>
+				<unitPattern count="one">{0} ua</unitPattern>
+				<unitPattern count="other">{0} ua</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>fur</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fth</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M</displayName>
+				<unitPattern count="one">{0} M</unitPattern>
+				<unitPattern count="other">{0} M</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi esc.</displayName>
+				<unitPattern count="one">{0} mi esc.</unitPattern>
+				<unitPattern count="other">{0} mi esc.</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lux</displayName>
 				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
@@ -8979,163 +8979,163 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn EUA</displayName>
+				<unitPattern count="one">{0} tn EUA</unitPattern>
+				<unitPattern count="other">{0} tn EUA</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>lb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>ct</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ct</unitPattern>
+				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Da</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gran</displayName>
+				<unitPattern count="one">{0} gran</unitPattern>
+				<unitPattern count="other">{0} grans</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>W</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="one">{0} hp</unitPattern>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -9143,24 +9143,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>mi/h</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi/h</unitPattern>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>nós</displayName>
 				<unitPattern count="one">{0} nó</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} nós</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9168,199 +9168,199 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf ft</displayName>
+				<unitPattern count="one">{0} lbf ft</unitPattern>
+				<unitPattern count="other">{0} lbf ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ptm</displayName>
+				<unitPattern count="one">{0} ptm</unitPattern>
+				<unitPattern count="other">{0} ptm</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>mc</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>ac ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal EUA</displayName>
+				<unitPattern count="one">{0} gal EUA</unitPattern>
+				<unitPattern count="other">{0} gal EUA</unitPattern>
+				<perUnitPattern>{0}/gal EUA</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal imp.</displayName>
+				<unitPattern count="one">{0} gal imp.</unitPattern>
+				<unitPattern count="other">{0} gal imp.</unitPattern>
+				<perUnitPattern>{0}/gal imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>c</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz imp.</displayName>
+				<unitPattern count="one">{0} fl oz imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cull.</displayName>
+				<unitPattern count="one">{0} cull.</unitPattern>
+				<unitPattern count="other">{0} cull.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cullñs.</displayName>
+				<unitPattern count="one">{0} cullña.</unitPattern>
+				<unitPattern count="other">{0} cullñs.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>bbl</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cull. sobr.</displayName>
+				<unitPattern count="one">{0} cull. sobr.</unitPattern>
+				<unitPattern count="other">{0} cull. sobr.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cull. sobr. imp.</displayName>
+				<unitPattern count="one">{0} cull. sobr. imp.</unitPattern>
+				<unitPattern count="other">{0} cull. sobr. imp.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gota</displayName>
+				<unitPattern count="one">{0} gota</unitPattern>
+				<unitPattern count="other">{0} gotas</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dracma</displayName>
+				<unitPattern count="one">{0} dracma</unitPattern>
+				<unitPattern count="other">{0} dracmas</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>medidor</displayName>
+				<unitPattern count="one">{0} medidor</unitPattern>
+				<unitPattern count="other">{0} medidores</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>chisco</displayName>
+				<unitPattern count="one">{0} chisco</unitPattern>
+				<unitPattern count="other">{0} chiscos</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>cto. imp.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cto. imp.</unitPattern>
+				<unitPattern count="other">{0} ctos. imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>punto</displayName>
@@ -9394,22 +9394,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ou {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ou {1}</listPatternPart>
+			<listPatternPart type="2">{0} ou {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ou {1}</listPatternPart>
+			<listPatternPart type="2">{0} ou {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} e {1}</listPatternPart>
+			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -9733,7 +9733,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
 			<namePattern>{surname-core} {surname2}, {given-informal} {surname-prefix}</namePattern>
-			<namePattern alt="1">↑↑↑</namePattern>
+			<namePattern alt="1">{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname-core} {surname2}, {given} {given2-initial} {surname-prefix}</namePattern>
@@ -9741,7 +9741,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname-core} {surname2}, {given-informal} {surname-prefix}</namePattern>
-			<namePattern alt="1">↑↑↑</namePattern>
+			<namePattern alt="1">{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
 			<namePattern>{surname-core} {surname2}, {given-initial} {given2-initial} {surname-prefix}</namePattern>
@@ -9749,7 +9749,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname-core} {surname2}, {given-informal} {surname-prefix}</namePattern>
-			<namePattern alt="1">↑↑↑</namePattern>
+			<namePattern alt="1">{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">Uxía</nameField>

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -106,8 +106,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">શેરોકી</language>
 			<language type="chy">શેયેન્ન</language>
 			<language type="ckb">સેન્ટ્રલ કુર્દિશ</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">સેન્ટ્રલ કુર્દિશ</language>
+			<language type="ckb" alt="variant">સેન્ટ્રલ કુર્દિશ</language>
 			<language type="clc">ચિલકોટિન</language>
 			<language type="co">કોર્સિકન</language>
 			<language type="cop">કોપ્ટિક</language>
@@ -1014,7 +1014,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ટ્યુનિશિયા</territory>
 			<territory type="TO">ટોંગા</territory>
 			<territory type="TR">તુર્કિયે</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">તુર્કિયે</territory>
 			<territory type="TT">ટ્રિનીદાદ અને ટોબેગો</territory>
 			<territory type="TV">તુવાલુ</territory>
 			<territory type="TW">તાઇવાન</territory>
@@ -2015,7 +2015,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraNames>
 					<eraAbbr>
 						<era type="0">ઈ.સ.પૂર્વે</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">ઈ.સ.પૂર્વે</era>
 						<era type="1">ઈ.સ.</era>
 						<era type="1" alt="variant">સા.યુ.</era>
 					</eraAbbr>
@@ -2508,7 +2508,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="6">ભાદો</month>
 							<month type="7">અશ્વિન</month>
 							<month type="8">કાર્તિક</month>
-							<month type="9">↑↑↑</month>
+							<month type="9">અગ્રહાયણ</month>
 							<month type="10">પોષ</month>
 							<month type="11">મહા</month>
 							<month type="12">ફાલ્ગુન</month>
@@ -2523,7 +2523,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<era type="0">શક</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">શક</era>
 					</eraNarrow>
 				</eras>
 				<dateTimeFormats>
@@ -5706,7 +5706,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -6464,8 +6464,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>લેસોથો લોતી</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">લેસોથો લોતી</displayName>
+				<displayName count="other">લેસોથો લોતી</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -7387,8 +7387,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-day-person">
 				<gender>masculine</gender>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} દિવસ</unitPattern>
+				<unitPattern count="other">{0} દિવસ</unitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<gender>masculine</gender>
@@ -7536,8 +7536,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="graphics-em">
 				<gender>masculine</gender>
 				<displayName>ટાઇપોગ્રાફિક એમ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
@@ -7546,9 +7546,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} પિક્સેલ</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>પિક્સેલ પ્રતિ સેન્ટિમીટર</displayName>
@@ -7572,13 +7572,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ડૉટ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} ડૉટ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>કિલોમીટર</displayName>
@@ -7751,9 +7751,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ટન</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>સ્ટોન્સ</displayName>
 				<unitPattern count="one">{0} સ્ટોન</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} સ્ટોન</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>પાઉન્ડ</displayName>
@@ -8211,12 +8211,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8349,7 +8349,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>પરમિરિયડ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -8557,12 +8557,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>ઇલેક્ટ્રોનવૉલ્ટ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -8572,17 +8572,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>પાઉન્ડ બળ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>ન્યૂટન</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -8607,47 +8607,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>પિક્સેલ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ડૉટ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} ડૉટ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -8732,12 +8732,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>ફર્લાંગ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>ફૅધમ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -8757,7 +8757,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>સૌર ત્રિજ્યા</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -8767,17 +8767,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>સૌર તેજસ્વિતા</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8841,17 +8841,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ડાલ્ટન</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>પૃથ્વી ઘનતા</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>સૌર ઘનતા</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8931,12 +8931,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>MPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -8981,12 +8981,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>lbf⋅ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>N⋅m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -9074,7 +9074,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>બુશલ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -9126,17 +9126,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>બેરલ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -9146,7 +9146,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>ડ્રામ ફ્લૂઇડ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
@@ -9161,7 +9161,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -9183,7 +9183,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>મિલી{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
 				<unitPrefixPattern>નેનો{0}</unitPrefixPattern>
@@ -9261,122 +9261,122 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>ગુ-બળ</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>મી/સે²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} મી/સે²</unitPattern>
+				<unitPattern count="other">{0} મી/સે²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>પરિભ્રમણ</displayName>
+				<unitPattern count="one">{0} પરિભ્રમણ</unitPattern>
+				<unitPattern count="other">{0} પરિભ્રમણ</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>સમત્રિજ્યાકોણ</displayName>
 				<unitPattern count="one">{0} સમત્રિ.</unitPattern>
 				<unitPattern count="other">{0} સમત્રિ.</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>અંશ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} અંશ</unitPattern>
+				<unitPattern count="other">{0} અંશ</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>ચાપમિનિટ</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ચાપસેકન્ડ</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ચોરસ કિમી</displayName>
 				<unitPattern count="one">{0}ચો.કિમી</unitPattern>
 				<unitPattern count="other">{0}ચો.કિમી</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} /ચોરસ કિમી</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>હેક્ટર</displayName>
+				<unitPattern count="one">{0} હેક્ટર</unitPattern>
+				<unitPattern count="other">{0} હેક્ટર</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ચોરસ મીટર</displayName>
 				<unitPattern count="one">{0}ચો.મીટર</unitPattern>
 				<unitPattern count="other">{0}ચો.મીટર</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} પ્રતિ ચો. મીટર</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ચોરસ સેમી</displayName>
 				<unitPattern count="one">{0}ચો.સેમી</unitPattern>
 				<unitPattern count="other">{0}ચો.સેમી</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} પ્રતિ ચો. સેમી</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ચોરસ માઇલ</displayName>
+				<unitPattern count="one">{0} ચોરસ માઇલ</unitPattern>
+				<unitPattern count="other">{0} ચોરસ માઇલ</unitPattern>
 				<perUnitPattern>{0} / ચોરસ માઇલ</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>એકર</displayName>
+				<unitPattern count="one">{0} એકર</unitPattern>
+				<unitPattern count="other">{0} એકર</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ચોરસ વાર</displayName>
+				<unitPattern count="one">{0} ચોરસ વાર</unitPattern>
+				<unitPattern count="other">{0} ચોરસ વાર</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ચોરસ ફૂટ</displayName>
+				<unitPattern count="one">{0} ચોરસ ફૂટ</unitPattern>
+				<unitPattern count="other">{0} ચોરસ ફૂટ</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ચોરસ ઇંચ</displayName>
+				<unitPattern count="one">{0} ચોરસ ઇંચ</unitPattern>
+				<unitPattern count="other">{0} ચોરસ ઇંચ</unitPattern>
+				<perUnitPattern>{0} પ્રતિ ચો. ઈંચ</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ડનમ</displayName>
+				<unitPattern count="one">{0} ડનમ</unitPattern>
+				<unitPattern count="other">{0} ડનમ</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>કૅરેટ</displayName>
+				<unitPattern count="one">{0} કૅરેટ</unitPattern>
+				<unitPattern count="other">{0} કૅરેટ</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/L</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>વસ્તુ</displayName>
@@ -9385,8 +9385,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9395,23 +9395,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>મોલ</displayName>
+				<unitPattern count="one">{0} મોલ</unitPattern>
+				<unitPattern count="other">{0} મોલ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>લીટર/કિમી</displayName>
+				<unitPattern count="one">{0} લીટર/કિમી</unitPattern>
+				<unitPattern count="other">{0} લીટર/કિમી</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>લિ/100 કિમી</displayName>
@@ -9419,85 +9419,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}લિ/100કિમી</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>માઇલ/ગૅલન</displayName>
+				<unitPattern count="one">{0} માઇલ/ગૅલન</unitPattern>
+				<unitPattern count="other">{0} માઇલ/ગૅલન</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>માઈલ/ઈમ્પે. ગેલન</displayName>
 				<unitPattern count="one">{0} માઈલ/ઈમ્પે. ગેલન</unitPattern>
 				<unitPattern count="other">{0} માઈલ/ઈમ્પે. ગેલન</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>PB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>બાઇટ</displayName>
+				<unitPattern count="one">{0} બાઇટ</unitPattern>
+				<unitPattern count="other">{0} બાઇટ</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>બિટ</displayName>
+				<unitPattern count="one">{0} બિટ</unitPattern>
+				<unitPattern count="other">{0} બિટ</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>સદી</displayName>
+				<unitPattern count="one">{0} સદી</unitPattern>
+				<unitPattern count="other">{0} સદી</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>દાયકા</displayName>
+				<unitPattern count="one">{0} દા</unitPattern>
+				<unitPattern count="other">{0} દા</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>વર્ષ</displayName>
 				<unitPattern count="one">{0} વ</unitPattern>
 				<unitPattern count="other">{0} વ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/વર્ષ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>ત્રિમાસ</displayName>
@@ -9509,13 +9509,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>મહિના</displayName>
 				<unitPattern count="one">{0} મ</unitPattern>
 				<unitPattern count="other">{0} મ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/માસ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>અઠવાડિયા</displayName>
 				<unitPattern count="one">{0} અઠ.</unitPattern>
 				<unitPattern count="other">{0} અઠ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} / અઠ.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>દિવસ</displayName>
@@ -9547,159 +9547,159 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} મિસે</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>ns</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ઓહ્મ</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>વૉલ્ટ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>જૂલ</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>યુએસ થર્મ</displayName>
+				<unitPattern count="one">{0} યુએસ થર્મ</unitPattern>
+				<unitPattern count="other">{0} યુએસ થર્મ</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>હર્ટ્ઝ</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>પિક્સેલ</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ડૉટ</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} ડૉટ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>કિમી</displayName>
@@ -9730,17 +9730,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} મિમી</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>માઇક્રોમીટર</displayName>
+				<unitPattern count="one">{0} μમી</unitPattern>
+				<unitPattern count="other">{0} μમી</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>નેનોમીટર</displayName>
+				<unitPattern count="one">{0} નેનોમીટર</unitPattern>
+				<unitPattern count="other">{0} નેનોમીટર</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>પિસૉમીટર</displayName>
 				<unitPattern count="one">{0}પિસૉ.મી</unitPattern>
 				<unitPattern count="other">{0}પિસૉ.મી</unitPattern>
 			</unit>
@@ -9755,10 +9755,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} વાર</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ફૂટ</displayName>
 				<unitPattern count="one">{0} '</unitPattern>
 				<unitPattern count="other">{0} '</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ફૂટ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>ઇંચ</displayName>
@@ -9767,34 +9767,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/ઈંચ</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>પરસેક</displayName>
+				<unitPattern count="one">{0} પરસેક</unitPattern>
+				<unitPattern count="other">{0} પરસેક</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>પ્રકાશ વર્ષ</displayName>
 				<unitPattern count="one">{0}પ્રકાશવર્ષ</unitPattern>
 				<unitPattern count="other">{0}પ્રકાશવર્ષ</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ખગોળીય યુનિટ</displayName>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ફર્લાંગ</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ફૅધમ</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>નૉટિકલ માઇલ</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>smi</displayName>
@@ -9803,38 +9803,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-point">
 				<displayName>પોઈન્ટ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} પોઈન્ટ</unitPattern>
+				<unitPattern count="other">{0} પોઈન્ટ</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>લક્સ</displayName>
+				<unitPattern count="one">{0} લક્સ</unitPattern>
+				<unitPattern count="other">{0} લક્સ</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>કિગ્રા</displayName>
@@ -9849,19 +9849,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/ગ્રામ</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>મિગ્રા</displayName>
+				<unitPattern count="one">{0} મિગ્રા</unitPattern>
+				<unitPattern count="other">{0} મિગ્રા</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μગ્રામ</displayName>
+				<unitPattern count="one">{0} μગ્રામ</unitPattern>
+				<unitPattern count="other">{0} μગ્રામ</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ટન</displayName>
+				<unitPattern count="one">{0} ટન</unitPattern>
+				<unitPattern count="other">{0} ટન</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>સ્ટોન</displayName>
@@ -9876,119 +9876,119 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>ઔંસ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ઔંસ</unitPattern>
+				<unitPattern count="other">{0} ઔંસ</unitPattern>
 				<perUnitPattern>{0}/ઔંસ</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ટ્રોય ઔંસ</displayName>
+				<unitPattern count="one">{0} ટ્રોય ઔંસ</unitPattern>
+				<unitPattern count="other">{0} ટ્રોય ઔંસ</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>કેરેટ</displayName>
+				<unitPattern count="one">{0} કેરેટ</unitPattern>
+				<unitPattern count="other">{0} કેરેટ</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Da</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ગ્રેન</displayName>
+				<unitPattern count="one">{0} ગ્રેન</unitPattern>
+				<unitPattern count="other">{0} ગ્રેન</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>વૉટ</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>બાર</displayName>
+				<unitPattern count="one">{0} બાર</unitPattern>
+				<unitPattern count="other">{0} બાર</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} મિલિબાર</unitPattern>
 				<unitPattern count="other">{0}મિલીબાર</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>કિમી/કલાક</displayName>
@@ -9997,23 +9997,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>મીટર/સેકન્ડ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} મીટર/સેકન્ડ</unitPattern>
+				<unitPattern count="other">{0} મીટર/સેકન્ડ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>માઇલ/કલાક</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} માઇલ/કલાક</unitPattern>
+				<unitPattern count="other">{0} માઇલ/કલાક</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>નોટ</displayName>
+				<unitPattern count="one">{0} નોટ</unitPattern>
+				<unitPattern count="other">{0} નોટ</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -10021,199 +10021,199 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ડિગ્રી ફેરનહીટ</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>કેલ્વિન</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ઘન કિમી</displayName>
+				<unitPattern count="one">{0} ઘન કિમી</unitPattern>
+				<unitPattern count="other">{0} ઘન કિમી</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ઘન મીટર</displayName>
+				<unitPattern count="one">{0} ઘન મીટર</unitPattern>
+				<unitPattern count="other">{0} ઘન મીટર</unitPattern>
+				<perUnitPattern>{0}/ઘન મી.</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ઘન સેમી</displayName>
+				<unitPattern count="one">{0} ઘન સેમી</unitPattern>
+				<unitPattern count="other">{0} ઘન સેમી</unitPattern>
+				<perUnitPattern>{0}/ ઘન સેમી</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ઘન માઇલ</displayName>
+				<unitPattern count="one">{0} ઘન માઇલ</unitPattern>
+				<unitPattern count="other">{0} ઘન માઇલ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ઘન વાર</displayName>
+				<unitPattern count="one">{0} ઘન વાર</unitPattern>
+				<unitPattern count="other">{0} ઘન વાર</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ઘન ફૂટ</displayName>
+				<unitPattern count="one">{0} ઘન ફૂટ</unitPattern>
+				<unitPattern count="other">{0} ઘન ફૂટ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ઘન ઇંચ</displayName>
+				<unitPattern count="one">{0} ઘન ઇંચ</unitPattern>
+				<unitPattern count="other">{0} ઘન ઇંચ</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>મેગાલીટર</displayName>
+				<unitPattern count="one">{0} મેગાલીટર</unitPattern>
+				<unitPattern count="other">{0} મેગાલીટર</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>હેક્ટોલીટર</displayName>
+				<unitPattern count="one">{0} હેક્ટોલીટર</unitPattern>
+				<unitPattern count="other">{0} હેક્ટોલીટર</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>લિટર</displayName>
 				<unitPattern count="one">{0} લિ</unitPattern>
 				<unitPattern count="other">{0} લિ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/લિ</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ડેસિલીટર</displayName>
+				<unitPattern count="one">{0} ડેસિલીટર</unitPattern>
+				<unitPattern count="other">{0} ડેસિલીટર</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>સેન્ટિલીટર</displayName>
+				<unitPattern count="one">{0} સેન્ટિલીટર</unitPattern>
+				<unitPattern count="other">{0} સેન્ટિલીટર</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>મિલિલીટર</displayName>
+				<unitPattern count="one">{0} મિલિલીટર</unitPattern>
+				<unitPattern count="other">{0} મિલિલીટર</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>મે.પિન્ટ</displayName>
+				<unitPattern count="one">{0} મે.પિન્ટ</unitPattern>
+				<unitPattern count="other">{0} મે.પિન્ટ</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>મે. કપ</displayName>
+				<unitPattern count="one">{0} મે. કપ</unitPattern>
+				<unitPattern count="other">{0} મે. કપ</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>એકર-ફૂટ</displayName>
+				<unitPattern count="one">{0} એકર-ફૂટ</unitPattern>
+				<unitPattern count="other">{0} એકર-ફૂટ</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>બુશલ</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ગૅલન</displayName>
+				<unitPattern count="one">{0} ગૅલન</unitPattern>
+				<unitPattern count="other">{0} ગૅલન</unitPattern>
+				<perUnitPattern>{0}/ગૅલન</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ઈમ્પિ. ગૅલન</displayName>
 				<unitPattern count="one">{0} ગૅ. ઈમ્પિ.</unitPattern>
 				<unitPattern count="other">{0} ગૅ. ઈમ્પિ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} /ગૅલન ઈમ્પિ.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ક્વાર્ટ</displayName>
+				<unitPattern count="one">{0} ક્વાર્ટ</unitPattern>
+				<unitPattern count="other">{0} ક્વાર્ટ</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>પિન્ટ</displayName>
+				<unitPattern count="one">{0} પિન્ટ</unitPattern>
+				<unitPattern count="other">{0} પિન્ટ</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>કપ</displayName>
+				<unitPattern count="one">{0} કપ</unitPattern>
+				<unitPattern count="other">{0} કપ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>પ્રવાહી ઔંસ</displayName>
 				<unitPattern count="one">{0} પ્ર. ઔંસ</unitPattern>
 				<unitPattern count="other">{0} પ્ર. ઔંસ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ઇમ્પીરિયલ પ્રવાહી ઔંસ</displayName>
 				<unitPattern count="one">{0} પ્રવાહી ઔંસ ઈમ્પી.</unitPattern>
 				<unitPattern count="other">{0} પ્રવાહી ઔંસ ઈમ્પી.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ટેબલસ્પૂન</displayName>
+				<unitPattern count="one">{0} ટેબલસ્પૂન</unitPattern>
+				<unitPattern count="other">{0} ટેબલસ્પૂન</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ટીસ્પૂન</displayName>
+				<unitPattern count="one">{0} ટીસ્પૂન</unitPattern>
+				<unitPattern count="other">{0} ટીસ્પૂન</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>બેરલ</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstspn Imp</displayName>
 				<unitPattern count="one">{0} dstspn-Imp</unitPattern>
 				<unitPattern count="other">{0} dstspn-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ડ્રોપ</displayName>
+				<unitPattern count="one">{0} ડ્રોપ</unitPattern>
+				<unitPattern count="other">{0} ડ્રોપ</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ડ્રામ ફ્લૂઇડ</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>જિગર</displayName>
+				<unitPattern count="one">{0} જિગર</unitPattern>
+				<unitPattern count="other">{0} જિગર</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ચપટી</displayName>
+				<unitPattern count="one">{0} ચપટી</unitPattern>
+				<unitPattern count="other">{0} ચપટી</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>દિશા</displayName>
@@ -10247,20 +10247,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} અથવા {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} અથવા {1}</listPatternPart>
+			<listPatternPart type="2">{0} અથવા {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} અથવા {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} અથવા {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -10509,7 +10509,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname-initial}</namePattern>
@@ -10584,19 +10584,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">કિરણ</nameField>

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -452,9 +452,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="zh">Harshen Sinanci</language>
 			<language type="zh" alt="menu">Harshen, Sinanci</language>
 			<language type="zh_Hans">Sauƙaƙaƙƙen Sinanci</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">Sauƙaƙaƙƙen Sinanci</language>
 			<language type="zh_Hant">Sinanci na gargajiya</language>
-			<language type="zh_Hant" alt="long">↑↑↑</language>
+			<language type="zh_Hant" alt="long">Sinanci na gargajiya</language>
 			<language type="zu">Harshen Zulu</language>
 			<language type="zun">Zuni</language>
 			<language type="zxx">Babu abun cikin yare</language>
@@ -615,7 +615,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CX">Tsibirin Kirsmati</territory>
 			<territory type="CY">Sifurus</territory>
 			<territory type="CZ">Jamhuriyar Cak</territory>
-			<territory type="CZ" alt="variant">↑↑↑</territory>
+			<territory type="CZ" alt="variant">Jamhuriyar Cak</territory>
 			<territory type="DE">Jamus</territory>
 			<territory type="DG">Tsibirn Diego Garcia</territory>
 			<territory type="DJ">Jibuti</territory>
@@ -636,13 +636,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="FI">Finlan</territory>
 			<territory type="FJ">Fiji</territory>
 			<territory type="FK">Tsibiran Falkilan</territory>
-			<territory type="FK" alt="variant">↑↑↑</territory>
+			<territory type="FK" alt="variant">Tsibiran Falkilan</territory>
 			<territory type="FM">Mikuronesiya</territory>
 			<territory type="FO">Tsibirai na Faroe</territory>
 			<territory type="FR">Faransa</territory>
 			<territory type="GA">Gabon</territory>
 			<territory type="GB">Biritaniya</territory>
-			<territory type="GB" alt="short">↑↑↑</territory>
+			<territory type="GB" alt="short">Biritaniya</territory>
 			<territory type="GD">Girnada</territory>
 			<territory type="GE">Jiwarjiya</territory>
 			<territory type="GF">Gini Ta Faransa</territory>
@@ -661,7 +661,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="GW">Gini Bisau</territory>
 			<territory type="GY">Guyana</territory>
 			<territory type="HK">Babban Yankin Mulkin Hong Kong na Ƙasar Sin</territory>
-			<territory type="HK" alt="short">↑↑↑</territory>
+			<territory type="HK" alt="short">Babban Yankin Mulkin Hong Kong na Ƙasar Sin</territory>
 			<territory type="HM">Tsibirin Heard da McDonald</territory>
 			<territory type="HN">Yankin Honduras</territory>
 			<territory type="HR">Kurowaishiya</territory>
@@ -716,7 +716,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MM">Burma, Miyamar</territory>
 			<territory type="MN">Mangoliya</territory>
 			<territory type="MO">Babban Yankin Mulkin Macao na Ƙasar Sin</territory>
-			<territory type="MO" alt="short">↑↑↑</territory>
+			<territory type="MO" alt="short">Babban Yankin Mulkin Macao na Ƙasar Sin</territory>
 			<territory type="MP">Tsibiran Mariyana Na Arewa</territory>
 			<territory type="MQ">Martinik</territory>
 			<territory type="MR">Moritaniya</territory>
@@ -795,12 +795,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TJ">Tajikistan</territory>
 			<territory type="TK">Takelau</territory>
 			<territory type="TL">Timor Ta Gabas</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">Timor Ta Gabas</territory>
 			<territory type="TM">Turkumenistan</territory>
 			<territory type="TN">Tunisiya</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkiyya</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkiyya</territory>
 			<territory type="TT">Tirinidad Da Tobago</territory>
 			<territory type="TV">Tubalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -810,7 +810,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UM">Rukunin Tsibirin U.S</territory>
 			<territory type="UN">Majalisar Ɗinkin Duniya</territory>
 			<territory type="US">Amurka</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">Amurka</territory>
 			<territory type="UY">Yurigwai</territory>
 			<territory type="UZ">Uzubekistan</territory>
 			<territory type="VA">Batikan</territory>
@@ -1021,7 +1021,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{0}, {1}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{0}, {1}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1029,7 +1029,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{0}, {1}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{0}, {1}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1414,8 +1414,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">YM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">SF</dayPeriod>
+							<dayPeriod type="pm">YM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">Safiya</dayPeriod>
@@ -1440,7 +1440,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<eras>
 					<eraNames>
 						<era type="0">Kafin haihuwar annab</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">K.H.Y</era>
 						<era type="1">Bayan haihuwar annab</era>
 						<era type="1" alt="variant">Sanannen Zamani</era>
 					</eraNames>
@@ -1525,7 +1525,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1533,7 +1533,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1572,7 +1572,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
 						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="one">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMW" count="one">'satin' W 'cikin' MMMM</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="other">'satin' W 'cikin' MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">y</dateFormatItem>
@@ -1753,18 +1753,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -1783,18 +1783,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Muh.</month>
+							<month type="2">Saf.</month>
+							<month type="3">Rab. I</month>
+							<month type="4">Rab. II</month>
+							<month type="5">Jum. I</month>
+							<month type="6">Jum. II</month>
+							<month type="7">Raj.</month>
+							<month type="8">Sha.</month>
+							<month type="9">Ram.</month>
+							<month type="10">Shaw.</month>
+							<month type="11">Dhuʻl-Q.</month>
+							<month type="12">Dhuʻl-H.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -1811,18 +1811,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Muharram</month>
+							<month type="2">Safar</month>
+							<month type="3">Rabiʻ I</month>
+							<month type="4">Rabiʻ II</month>
+							<month type="5">Jumada I</month>
+							<month type="6">Jumada II</month>
+							<month type="7">Rajab</month>
+							<month type="8">Shaʼaban</month>
+							<month type="9">Ramadan</month>
+							<month type="10">Shawwal</month>
+							<month type="11">Dhuʻl-Qiʻdah</month>
+							<month type="12">Dhuʻl-Hijjah</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1834,29 +1834,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, d MMMM, y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM, y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM, y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d/M/yy GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">d E</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
 						<dateFormatItem id="GyMd">GGGGG dd-MM-y</dateFormatItem>
@@ -1866,12 +1866,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="M">L</dateFormatItem>
 						<dateFormatItem id="Md">d/M</dateFormatItem>
 						<dateFormatItem id="MEd">E, d/M</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
 						<dateFormatItem id="MMMMEd">E d MMM</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
 						<dateFormatItem id="yM">yM</dateFormatItem>
 						<dateFormatItem id="yMEd">E, d M y</dateFormatItem>
 						<dateFormatItem id="yMMM">y MMM</dateFormatItem>
@@ -1898,10 +1898,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>zamani</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>zamani</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>zamani</displayName>
 			</field>
 			<field type="year">
 				<displayName>shekara</displayName>
@@ -1913,7 +1913,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">a shekaru {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">shekara da suka gabata {0}</relativeTimePattern>
 					<relativeTimePattern count="other">shekara da suka gabata {0}</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -1923,25 +1923,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">bana</relative>
 				<relative type="1">badi</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">a shekarar {0}</relativeTimePattern>
+					<relativeTimePattern count="other">a shekaru {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">shekara da suka gabata {0}</relativeTimePattern>
+					<relativeTimePattern count="other">shekara da suka gabata {0}</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>shekara</displayName>
 				<relative type="-1">bara</relative>
 				<relative type="0">bana</relative>
 				<relative type="1">badi</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">a shekarar {0}</relativeTimePattern>
+					<relativeTimePattern count="other">a shekaru {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">shekara da suka gabata {0}</relativeTimePattern>
 					<relativeTimePattern count="other">shekara da suka gabata {0}</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -1966,7 +1966,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">a cikin kwatas {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">kwata da suka gabata {0}</relativeTimePattern>
 					<relativeTimePattern count="other">kwatas da suka gabata {0}</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2051,7 +2051,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="one">mako da ya gabata {0}</relativeTimePattern>
 					<relativeTimePattern count="other">mako da ya gabata {0}</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>sati na {0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
 				<displayName>mako</displayName>
@@ -2093,26 +2093,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>kwana</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">jiya</relative>
+				<relative type="0">yau</relative>
+				<relative type="1">gobe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">a cikin rana {0}</relativeTimePattern>
 					<relativeTimePattern count="other">a cikin kwanaki {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">rana da ya gabata {0}</relativeTimePattern>
+					<relativeTimePattern count="other">kwanaki da suka gabata {0}</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
 				<displayName>kwana</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">jiya</relative>
+				<relative type="0">yau</relative>
+				<relative type="1">gobe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">a cikin rana {0}</relativeTimePattern>
+					<relativeTimePattern count="other">a cikin kwanaki {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">rana da ya gabata {0}</relativeTimePattern>
@@ -2132,10 +2132,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ranar mako</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ranar mako</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ranar mako</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>Ranar Aikin Wata</displayName>
@@ -2144,7 +2144,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Ranar Aikin Wata</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ranar Aikin Wata</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1">Lahadin da ya gabata</relative>
@@ -2155,7 +2155,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">cikin {0} Lahadi</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Lahadin da ta gabata</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Lahadin da ta gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2194,7 +2194,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">cikin {0} Litinin</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Litinin din da ta gabata</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Litinin din da ta gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2233,7 +2233,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">cikin {0} Talata</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Talatar da ta gabata</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Talatar da ta gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2246,8 +2246,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">cikin {0} Talata</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Talatar da ta gabata</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Talatar da ta gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
@@ -2272,14 +2272,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">cikin {0} Laraba</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Laraba da ta gabata</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Laraba da ta gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-short">
 				<relative type="-1">Laraba da ta gabata</relative>
 				<relative type="0">wannan Larabar</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">Laraba mai zuwa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">cikin {0} Laraba</relativeTimePattern>
 					<relativeTimePattern count="other">cikin {0} Laraba</relativeTimePattern>
@@ -2307,18 +2307,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">wannan Alhamis din</relative>
 				<relative type="1">Alhamis din mai zuwa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">cikin {0} Alhamis</relativeTimePattern>
 					<relativeTimePattern count="other">cikin {0} Alhamis</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Alhamis din da ya gabata</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Alhamis din da ya gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-short">
 				<relative type="-1">Alhamis din da ya Gabata</relative>
 				<relative type="0">wannan Alhamis din</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">Alhamis din mai zuwa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">cikin {0} Alhamis</relativeTimePattern>
 					<relativeTimePattern count="other">cikin {0} Alhamis</relativeTimePattern>
@@ -2331,7 +2331,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="thu-narrow">
 				<relative type="-1">Alhamis din da ya Gabata</relative>
 				<relative type="0">wannan Alhamis din</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">Alhamis din mai zuwa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">cikin {0} Alhamis</relativeTimePattern>
 					<relativeTimePattern count="other">cikin {0} Alhamis</relativeTimePattern>
@@ -2346,11 +2346,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">wannan Jumaʼar</relative>
 				<relative type="1">Jumaʼa mai zuwa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">cikin {0} Jumaʼa</relativeTimePattern>
 					<relativeTimePattern count="other">cikin {0} Jumaʼa</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Jumaʼa da ta wuce</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Jumaʼa da ta wuce</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2359,8 +2359,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">wannan Jumaʼar</relative>
 				<relative type="1">Jumaʼa mai zuwa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">cikin {0} Jumaʼa</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} Jumaʼa</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} Jumaʼa da ta wuce</relativeTimePattern>
@@ -2385,11 +2385,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">wannan Asabar din</relative>
 				<relative type="1">Asabar mai zuwa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">cikin {0} Asabar</relativeTimePattern>
 					<relativeTimePattern count="other">cikin {0} Asabar</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Asabar din da ya wuce</relativeTimePattern>
 					<relativeTimePattern count="other">{0} Asabar din da ya wuce</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2398,7 +2398,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">wannan Asabar din</relative>
 				<relative type="1">Asabar mai zuwa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">cikin {0} Asabar</relativeTimePattern>
 					<relativeTimePattern count="other">cikin {0} Asabar</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
@@ -2416,17 +2416,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} Asabar din da ya wuce</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Asabar din da ya wuce</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>SF/YM</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>SF/YM</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>SF/YM</displayName>
 			</field>
 			<field type="hour">
 				<displayName>awa</displayName>
@@ -2436,7 +2436,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">cikin {0} awa</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} awa da ya gabata</relativeTimePattern>
 					<relativeTimePattern count="other">{0} awa da ya gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2454,8 +2454,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="hour-narrow">
 				<displayName>awa</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">cikin {0} awa</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} awa</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} awa da ya gabata</relativeTimePattern>
@@ -2470,7 +2470,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">cikin {0} minti</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} minti da ya gabata</relativeTimePattern>
 					<relativeTimePattern count="other">{0} minti da ya gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2504,12 +2504,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">cikin {0} dakika</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dakika da ya gabata</relativeTimePattern>
 					<relativeTimePattern count="other">{0} dakika da ya gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>daƙiƙa</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">cikin {0} dakika</relativeTimePattern>
 					<relativeTimePattern count="other">cikin {0} dakika</relativeTimePattern>
@@ -2520,7 +2520,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>daƙiƙa</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">cikin {0} dakika</relativeTimePattern>
 					<relativeTimePattern count="other">cikin {0} dakika</relativeTimePattern>
@@ -2534,10 +2534,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Lokacin yanki</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Lokacin yanki</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Lokacin yanki</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -4833,13 +4833,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
+					<pattern type="1000" count="one">¤ 0D</pattern>
 					<pattern type="1000" count="other">¤ 0D</pattern>
 					<pattern type="10000" count="one">¤ 00D</pattern>
 					<pattern type="10000" count="other">¤ 00D</pattern>
@@ -4852,14 +4852,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000" count="one">¤ 000M</pattern>
 					<pattern type="100000000" count="other">¤ 000M</pattern>
 					<pattern type="1000000000" count="one">¤0B</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤0B</pattern>
 					<pattern type="1000000000" count="other">¤0B</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000" count="one">¤00B</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="10000000000" count="other">¤00B</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000" count="one">¤000B</pattern>
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="100000000000" count="other">¤000B</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
@@ -4878,14 +4878,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">
 				<displayName>Kuɗin Haɗaɗɗiyar Daular Larabawa</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Haɗaɗɗiyar Daular Larabawa</displayName>
+				<displayName count="other">Kuɗin Haɗaɗɗiyar Daular Larabawa</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AFN">
@@ -4911,26 +4911,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="ANG">
 				<displayName>Antillean Guilder na ƙasar Netherlands</displayName>
 				<displayName count="one">Antillean guilder na ƙasar Netherlands</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Antillean Guilder na ƙasar Netherlands</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AOA">
 				<displayName>Kuɗin Angola</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Angola</displayName>
+				<displayName count="other">Kuɗin Angola</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="ARS">
 				<displayName>Peso na ƙasar Argentina</displayName>
 				<displayName count="one">peso na ƙasar Argentina</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Peso na ƙasar Argentina</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="AUD">
 				<displayName>Dalar Ostareliya</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Dalolin Ostareliya</displayName>
 				<displayName count="other">Dalolin Ostareliya</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">$</symbol>
@@ -4938,7 +4938,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="AWG">
 				<displayName>Florin na yankin Aruba</displayName>
 				<displayName count="one">florin na yankin Aruba</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Florin na yankin Aruba</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AZN">
@@ -4957,8 +4957,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BBD">
 				<displayName>Dalar ƙasar Barbados</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Dalar ƙasar Barbados</displayName>
+				<displayName count="other">Dalar ƙasar Barbados</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -4977,26 +4977,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BHD">
 				<displayName>Kuɗin Baharan</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Baharan</displayName>
+				<displayName count="other">Kuɗin Baharan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="BIF">
 				<displayName>Kuɗin Burundi</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Burundi</displayName>
+				<displayName count="other">Kuɗin Burundi</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="BMD">
 				<displayName>Dalar ƙasar Bermuda</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Dalar ƙasar Bermuda</displayName>
+				<displayName count="other">Dalar ƙasar Bermuda</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BND">
 				<displayName>Dalar Brunei</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Dalolin Brunei</displayName>
 				<displayName count="other">Dalolin Brunei</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
@@ -5004,7 +5004,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="BOB">
 				<displayName>Boloviano na ƙasar Bolivia</displayName>
 				<displayName count="one">boliviano na ƙasar Bolivia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Boloviano na ƙasar Bolivia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5018,7 +5018,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="BSD">
 				<displayName>Dalar ƙasar Bahamas</displayName>
 				<displayName count="one">dalar ƙasar Bahamas</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalar ƙasar Bahamas</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5030,8 +5030,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BWP">
 				<displayName>Kuɗin Baswana</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Baswana</displayName>
+				<displayName count="other">Kuɗin Baswana</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5040,38 +5040,38 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="one">Kuɗin Belarus</displayName>
 				<displayName count="other">Kuɗin Belarus</displayName>
 				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<symbol alt="narrow">BYN</symbol>
 			</currency>
 			<currency type="BZD">
 				<displayName>Dalar ƙasar Belize</displayName>
 				<displayName count="one">Dalar ƙasar Belize</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalar ƙasar Belize</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CAD">
 				<displayName>Dalar Kanada</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Dalar Kanada</displayName>
+				<displayName count="other">Dalar Kanada</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CDF">
 				<displayName>Kuɗin Kongo</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Kongo</displayName>
+				<displayName count="other">Kuɗin Kongo</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CHF">
 				<displayName>Kuɗin Suwizalan</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Suwizalan</displayName>
+				<displayName count="other">Kuɗin Suwizalan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CLP">
 				<displayName>Peso na ƙasar Chile</displayName>
 				<displayName count="one">peso na ƙasar Chile</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Peso na ƙasar Chile</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5091,7 +5091,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="COP">
 				<displayName>Peso na ƙasar Columbia</displayName>
 				<displayName count="one">peso na ƙasar Columbia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Peso na ƙasar Columbia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5104,8 +5104,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CUC">
 				<displayName>Peso mai fuska biyu na ƙasar Kuba</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Peso mai fuska biyu na ƙasar Kuba</displayName>
+				<displayName count="other">Peso mai fuska biyu na ƙasar Kuba</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5118,8 +5118,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CVE">
 				<displayName>Kuɗin Tsibiran Kap Barde</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Tsibiran Kap Barde</displayName>
+				<displayName count="other">Kuɗin Tsibiran Kap Barde</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CZK">
@@ -5131,21 +5131,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="DJF">
 				<displayName>Kuɗin Jibuti</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Jibuti</displayName>
+				<displayName count="other">Kuɗin Jibuti</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="DKK">
 				<displayName>Krone na ƙasar Denmark</displayName>
 				<displayName count="one">krone na ƙasar Denmark</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Krone na ƙasar Denmark</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="DOP">
 				<displayName>Peso na jamhuriyar Dominica</displayName>
 				<displayName count="one">peso na jamhuriyar Dominica</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Peso na jamhuriyar Dominica</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5164,34 +5164,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="ERN">
 				<displayName>Kuɗin Eritireya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Eritireya</displayName>
+				<displayName count="other">Kuɗin Eritireya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="ETB">
 				<displayName>Kuɗin Habasha</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Habasha</displayName>
+				<displayName count="other">Kuɗin Habasha</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="EUR">
 				<displayName>Yuro</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Yuro</displayName>
+				<displayName count="other">Yuro</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="FJD">
 				<displayName>Dalar Fiji</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Dalolin Fiji</displayName>
 				<displayName count="other">Dalolin Fiji</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="FKP">
 				<displayName>Fam na ƙasar Tsibirai na Falkland</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Fam na ƙasar Tsibirai na Falkland</displayName>
+				<displayName count="other">Fam na ƙasar Tsibirai na Falkland</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5228,8 +5228,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="GMD">
 				<displayName>Kuɗin Gambiya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Gambiya</displayName>
+				<displayName count="other">Kuɗin Gambiya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="GNF">
@@ -5245,42 +5245,42 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="GTQ">
 				<displayName>Quetzal na ƙasar Guatemala</displayName>
 				<displayName count="one">quetzal na ƙasar Guatemala</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Quetzal na ƙasar Guatemala</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GYD">
 				<displayName>Dalar Guyana</displayName>
 				<displayName count="one">dalar Guyana</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalar Guyana</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HKD">
 				<displayName>Dalar Hong Kong</displayName>
 				<displayName count="one">dalar Hong Kong</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalar Hong Kong</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HNL">
 				<displayName>Lempira na ƙasar Honduras</displayName>
 				<displayName count="one">lempira na ƙasar Honduras</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Lempira na ƙasar Honduras</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HRK">
 				<displayName>Kuɗin Croatia</displayName>
 				<displayName count="one">Kuɗin Croatia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Kuɗin Croatia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HTG">
 				<displayName>Gourde na ƙasar Haiti</displayName>
 				<displayName count="one">gourde na ƙasar Haiti</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Gourde na ƙasar Haiti</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="HUF">
@@ -5293,7 +5293,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="IDR">
 				<displayName>Rupiah na ƙasar Indonesia</displayName>
 				<displayName count="one">rupiah na ƙasar Indonesia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rupiah na ƙasar Indonesia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5306,15 +5306,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="INR">
 				<displayName>Kuɗin Indiya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Indiya</displayName>
+				<displayName count="other">Kuɗin Indiya</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="IQD">
 				<displayName>Dinarin Iraqi</displayName>
 				<displayName count="one">dinarin Iraqi</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dinarin Iraqi</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="IRR">
@@ -5326,14 +5326,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="ISK">
 				<displayName>Króna na ƙasar Iceland</displayName>
 				<displayName count="one">króna na ƙasar Iceland</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Króna na ƙasar Iceland</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="JMD">
 				<displayName>Dalar Jamaica</displayName>
 				<displayName count="one">dalar Jamaica</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalar Jamaica</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5352,27 +5352,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="KES">
 				<displayName>Sulen Kenya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Sulen Kenya</displayName>
+				<displayName count="other">Sulen Kenya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="KGS">
 				<displayName>Som na ƙasar Kyrgystani</displayName>
 				<displayName count="one">som na ƙasar Kyrgystani</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Som na ƙasar Kyrgystani</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="KHR">
 				<displayName>Riel na ƙasar Cambodia</displayName>
 				<displayName count="one">riel na ƙasar Cambodia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Riel na ƙasar Cambodia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KMF">
 				<displayName>Kuɗin Kwamoras</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Kwamoras</displayName>
+				<displayName count="other">Kuɗin Kwamoras</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5393,20 +5393,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="KWD">
 				<displayName>Dinarin Kuwaiti</displayName>
 				<displayName count="one">dinarin Kuwaiti</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dinarin Kuwaiti</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="KYD">
 				<displayName>Dalar ƙasar Tsibirai na Cayman</displayName>
 				<displayName count="one">dalar ƙasar Tsibirai na Cayman</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalar ƙasar Tsibirai na Cayman</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KZT">
 				<displayName>Tenge na ƙasar Kazkhstan</displayName>
 				<displayName count="one">tenge na ƙasar Kazakhstan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Tenge na ƙasar Kazkhstan</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5433,14 +5433,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="LRD">
 				<displayName>Dalar Laberiya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Dalar Laberiya</displayName>
+				<displayName count="other">Dalar Laberiya</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="LSL">
 				<displayName>Kuɗin Lesoto</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Kuɗaɗen Lesoto</displayName>
 				<displayName count="other">Kuɗaɗen Lesoto</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5464,8 +5464,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MGA">
 				<displayName>Kuɗin Madagaskar</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Madagaskar</displayName>
+				<displayName count="other">Kuɗin Madagaskar</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5485,14 +5485,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="MNT">
 				<displayName>Tugrik na Mongolia</displayName>
 				<displayName count="one">tugrik na Mongoliya</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Tugrik na Mongolia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MOP">
 				<displayName>Pataca na ƙasar Macao</displayName>
 				<displayName count="one">pataca na ƙasar Macao</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Pataca na ƙasar Macao</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MRO">
@@ -5500,14 +5500,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MRU">
 				<displayName>Kuɗin Moritaniya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Moritaniya</displayName>
+				<displayName count="other">Kuɗin Moritaniya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MUR">
 				<displayName>Kuɗin Moritus</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Moritus</displayName>
+				<displayName count="other">Kuɗin Moritus</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5519,8 +5519,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MWK">
 				<displayName>Kuɗin Malawi</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Malawi</displayName>
+				<displayName count="other">Kuɗin Malawi</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MXN">
@@ -5543,13 +5543,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="MZN">
 				<displayName>Metical na ƙasar Mozambique</displayName>
 				<displayName count="one">metical na ƙasar Mozambique</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Metical na ƙasar Mozambique</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="NAD">
 				<displayName>Dalar Namibiya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Dalar Namibiya</displayName>
+				<displayName count="other">Dalar Namibiya</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5563,27 +5563,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="NIO">
 				<displayName>Córdoba na ƙasar Nicaragua</displayName>
 				<displayName count="one">córdoba na ƙasar Nicaragua</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Córdoba na ƙasar Nicaragua</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NOK">
 				<displayName>Krone na ƙasar Norway</displayName>
 				<displayName count="one">krone na ƙasar Norway</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Krone na ƙasar Norway</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NPR">
 				<displayName>Rupee na Nepal</displayName>
 				<displayName count="one">rupee na Nepal</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rupee na Nepal</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NZD">
 				<displayName>Dalar New Zealand</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Dalolin New Zealand</displayName>
 				<displayName count="other">Dalolin New Zealand</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
@@ -5597,19 +5597,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="PAB">
 				<displayName>Balboa na ƙasar Panama</displayName>
 				<displayName count="one">balboa na ƙasar Panama</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Balboa na ƙasar Panama</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PEN">
 				<displayName>Sol na ƙasar Peru</displayName>
 				<displayName count="one">sol na ƙasar Peru</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Sol na ƙasar Peru</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PGK">
 				<displayName>Kina na ƙasar Papua Sabon Guinea</displayName>
 				<displayName count="one">kina na ƙasar Papua Sabon Guinea</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Kina na ƙasar Papua Sabon Guinea</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PHP">
@@ -5636,7 +5636,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="PYG">
 				<displayName>Guarani na ƙasar Paraguay</displayName>
 				<displayName count="one">guarani na ƙasar Paraguay</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Guarani na ƙasar Paraguay</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5668,28 +5668,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="RWF">
 				<displayName>Kuɗin Ruwanda</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Ruwanda</displayName>
+				<displayName count="other">Kuɗin Ruwanda</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SAR">
 				<displayName>Riyal</displayName>
 				<displayName count="one">Riyal ɗin Saudiyya</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Riyal</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SBD">
 				<displayName>Dalar Tsibirai na Solomon</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Dalolin Tsibirai na Solomon</displayName>
 				<displayName count="other">Dalolin Tsibirai na Solomon</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SCR">
 				<displayName>Kuɗin Saishal</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Saishal</displayName>
+				<displayName count="other">Kuɗin Saishal</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SDG">
@@ -5701,13 +5701,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="SEK">
 				<displayName>Krona na ƙasar Sweden</displayName>
 				<displayName count="one">krona na ƙasar Sweden</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Krona na ƙasar Sweden</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SGD">
 				<displayName>Dalar Singapore</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Dalolin Singapore</displayName>
 				<displayName count="other">Dalolin Singapore</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
@@ -5727,21 +5727,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="SOS">
 				<displayName>Sulen Somaliya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Sulen Somaliya</displayName>
+				<displayName count="other">Sulen Somaliya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SRD">
 				<displayName>Dalar ƙasar Suriname</displayName>
 				<displayName count="one">dalar ƙasar Suriname</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalar ƙasar Suriname</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SSP">
 				<displayName>Fam na Kudancin Sudan</displayName>
 				<displayName count="one">fam na Kudancin Sudan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Fam na Kudancin Sudan</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5750,8 +5750,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="STN">
 				<displayName>Kuɗin Sawo Tome da Paransip</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Sawo Tome da Paransip</displayName>
+				<displayName count="other">Kuɗin Sawo Tome da Paransip</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5764,27 +5764,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="SZL">
 				<displayName>Kuɗin Lilangeni</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Lilangeni</displayName>
+				<displayName count="other">Kuɗin Lilangeni</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="THB">
 				<displayName>Baht na ƙasar Thailand</displayName>
 				<displayName count="one">baht na ƙasar Thailand</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Baht na ƙasar Thailand</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TJS">
 				<displayName>Somoni na ƙasar Tajikistan</displayName>
 				<displayName count="one">somoni na ƙasar Tajikistan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Somoni na ƙasar Tajikistan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="TMT">
 				<displayName>Manat na ƙasar Turkmenistan</displayName>
 				<displayName count="one">manat na ƙasar Turkmenistan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Manat na ƙasar Turkmenistan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="TND">
@@ -5796,13 +5796,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="TOP">
 				<displayName>Paʻanga na ƙasar Tonga</displayName>
 				<displayName count="one">paʻanga na ƙasar Tonga</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Paʻanga na ƙasar Tonga</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TRY">
 				<displayName>Kuɗin Turkiyya</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Turkiyya</displayName>
 				<displayName count="other">Kuɗin Turkiyya</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
@@ -5811,21 +5811,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="TTD">
 				<displayName>Dalar ƙasar Trinidad da Tobago</displayName>
 				<displayName count="one">dalar ƙasar Trinidad da Tobago</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalar ƙasar Trinidad da Tobago</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TWD">
 				<displayName>Sabuwar Dalar Taiwan</displayName>
 				<displayName count="one">Sabuwar dalar Taiwan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Sabuwar Dalar Taiwan</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TZS">
 				<displayName>Sulen Tanzaniya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Sulen Tanzaniya</displayName>
+				<displayName count="other">Sulen Tanzaniya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="UAH">
@@ -5837,7 +5837,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="UGX">
 				<displayName>Sule Yuganda</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Sulallan Yuganda</displayName>
 				<displayName count="other">Sulallan Yuganda</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
@@ -5851,20 +5851,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="UYU">
 				<displayName>Peso na ƙasar Uruguay</displayName>
 				<displayName count="one">peso na ƙasar Uruguay</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Peso na ƙasar Uruguay</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="UZS">
 				<displayName>Som na ƙasar Uzbekistan</displayName>
 				<displayName count="one">som na ƙasar Uzbekistan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Som na ƙasar Uzbekistan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="VES">
 				<displayName>Bolívar na ƙasar Venezuela</displayName>
 				<displayName count="one">bolívar na ƙasar Venezuela</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Bolívar na ƙasar Venezuela</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="VND">
@@ -5877,19 +5877,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="VUV">
 				<displayName>Vatu da ƙasar Vanuatu</displayName>
 				<displayName count="one">vatu na ƙasar Vanuatu</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Vatu da ƙasar Vanuatu</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="WST">
 				<displayName>Tala na ƙasar Samoa</displayName>
 				<displayName count="one">tala na ƙasar Samoa</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Tala na ƙasar Samoa</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="XAF">
 				<displayName>Kuɗin Sefa na Afirka Ta Tsakiya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Sefa na Afirka Ta Tsakiya</displayName>
+				<displayName count="other">Kuɗin Sefa na Afirka Ta Tsakiya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="XCD">
@@ -5901,8 +5901,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="XOF">
 				<displayName>Kuɗin Sefa na Afirka Ta Yamma</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Sefa na Afirka Ta Yamma</displayName>
+				<displayName count="other">Kuɗin Sefa na Afirka Ta Yamma</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="XPF">
@@ -5924,8 +5924,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="ZAR">
 				<displayName>Kuɗin Afirka Ta Kudu</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Afirka Ta Kudu</displayName>
+				<displayName count="other">Kuɗin Afirka Ta Kudu</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5934,8 +5934,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="ZMW">
 				<displayName>Kuɗin Zambiya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Kuɗin Zambiya</displayName>
+				<displayName count="other">Kuɗin Zambiya</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -6012,34 +6012,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>exa{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0} a {1}</compoundUnitPattern>
@@ -6053,10 +6053,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">kubic {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>g-force</displayName>
 				<unitPattern count="one">g-force {0}</unitPattern>
 				<unitPattern count="other">g-force {0}</unitPattern>
 			</unit>
@@ -6272,7 +6272,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-decade">
 				<displayName>shekaru goma-goma</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">sk gm {0}</unitPattern>
 				<unitPattern count="other">shk gm-gm {0}</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -6399,7 +6399,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">British thermal units {0}</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>US therm</displayName>
 				<unitPattern count="one">US therm {0}</unitPattern>
 				<unitPattern count="other">US therms {0}</unitPattern>
 			</unit>
@@ -6440,7 +6440,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>typographic em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">em {0}</unitPattern>
 				<unitPattern count="other">{0} ems</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -6474,7 +6474,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ayoyi a inci</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>aya</displayName>
 				<unitPattern count="one">aya {0}</unitPattern>
 				<unitPattern count="other">aya {0}</unitPattern>
 			</unit>
@@ -6609,7 +6609,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">lumen {0}</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>solar luminosities</displayName>
 				<unitPattern count="one">solar luminosity {0}</unitPattern>
 				<unitPattern count="other">solar luminosities {0}</unitPattern>
 			</unit>
@@ -6651,10 +6651,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">stones {0}</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>laba-laba</displayName>
 				<unitPattern count="one">Laba {0}</unitPattern>
 				<unitPattern count="other">laba-laba {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>oza-oza</displayName>
@@ -6793,7 +6793,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">knots {0}</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="one">Digirin yanayi {0}</unitPattern>
 				<unitPattern count="other">digiri-digiri {0}</unitPattern>
 			</unit>
@@ -6983,14 +6983,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">jigger {0}</unitPattern>
+				<unitPattern count="other">jigger {0}</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="one">pinch {0}</unitPattern>
+				<unitPattern count="other">pinch {0}</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>Imp. quart</displayName>
@@ -7095,12 +7095,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7223,7 +7223,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>kaso</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
@@ -7515,12 +7515,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">ppi {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">dpcm {0}</unitPattern>
 				<unitPattern count="other">dpcm {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">dpi {0}</unitPattern>
 				<unitPattern count="other">dpi {0}</unitPattern>
 			</unit>
@@ -7656,7 +7656,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -7892,7 +7892,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">mi³ {0}</unitPattern>
 				<unitPattern count="other">mi³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
@@ -8058,107 +8058,107 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
 				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>g-force</displayName>
 				<unitPattern count="one">G{0}</unitPattern>
 				<unitPattern count="other">Gs{0}</unitPattern>
 			</unit>
@@ -8168,7 +8168,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">m/s²{0}</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
+				<displayName>rev</displayName>
 				<unitPattern count="one">rev{0}</unitPattern>
 				<unitPattern count="other">rev{0}</unitPattern>
 			</unit>
@@ -8193,10 +8193,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">arcsecs{0}</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">km²{0}</unitPattern>
 				<unitPattern count="other">km²{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hekta</displayName>
@@ -8204,22 +8204,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">hk{0}</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mitoci²</displayName>
 				<unitPattern count="one">m²{0}</unitPattern>
 				<unitPattern count="other">m²{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm²</displayName>
 				<unitPattern count="one">cm²{0}</unitPattern>
 				<unitPattern count="other">cm²{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>sk mil-mil</displayName>
 				<unitPattern count="one">sq mi{0}</unitPattern>
 				<unitPattern count="other">sq mi{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>eka</displayName>
@@ -8232,15 +8232,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">yd²{0}</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>sk ƙafa</displayName>
 				<unitPattern count="one">sk ƙf {0}</unitPattern>
 				<unitPattern count="other">sk ƙf{0}</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>incina²</displayName>
 				<unitPattern count="one">in²{0}</unitPattern>
 				<unitPattern count="other">in²{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
@@ -8253,7 +8253,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">kt{0}</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg/dL</displayName>
 				<unitPattern count="one">mg/dL{0}</unitPattern>
 				<unitPattern count="other">mg/dL{0}</unitPattern>
 			</unit>
@@ -8263,7 +8263,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">mmol/L{0}</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>abu</displayName>
 				<unitPattern count="one">abu{0}</unitPattern>
 				<unitPattern count="other">Abw{0}</unitPattern>
 			</unit>
@@ -8273,19 +8273,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">ppm{0}</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
+				<displayName>kaso</displayName>
 				<unitPattern count="one">%{0}</unitPattern>
 				<unitPattern count="other">%{0}</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">‰{0}</unitPattern>
+				<unitPattern count="other">‰{0}</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">‱{0}</unitPattern>
+				<unitPattern count="other">‱{0}</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mol</displayName>
@@ -8303,7 +8303,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">L/100km{0}</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil-mil/gal</displayName>
 				<unitPattern count="one">mag{0}</unitPattern>
 				<unitPattern count="other">mag{0}</unitPattern>
 			</unit>
@@ -8363,28 +8363,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">B{0}</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>bit</displayName>
 				<unitPattern count="one">bit{0}</unitPattern>
 				<unitPattern count="other">bit{0}</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙ</displayName>
 				<unitPattern count="one">ƙ{0}</unitPattern>
 				<unitPattern count="other">ƙ{0}</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>shkr gm</displayName>
 				<unitPattern count="one">sk gm{0}</unitPattern>
 				<unitPattern count="other">sk gm{0}</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>shkr</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">shkr {0}</unitPattern>
 				<unitPattern count="other">s{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>kwt</displayName>
 				<unitPattern count="one">kwt{0}</unitPattern>
 				<unitPattern count="other">kwt{0}</unitPattern>
 				<perUnitPattern>k/{0}</perUnitPattern>
@@ -8393,37 +8393,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>wata</displayName>
 				<unitPattern count="one">w{0}</unitPattern>
 				<unitPattern count="other">w{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/w</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>mk</displayName>
 				<unitPattern count="one">m{0}</unitPattern>
 				<unitPattern count="other">m{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>rana</displayName>
 				<unitPattern count="one">r{0}</unitPattern>
 				<unitPattern count="other">r{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/r</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>saʼa</displayName>
 				<unitPattern count="one">s{0}</unitPattern>
 				<unitPattern count="other">s{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/saʼa</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>mnt</displayName>
 				<unitPattern count="one">minti{0}</unitPattern>
 				<unitPattern count="other">minti {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mnt</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>daƙ</displayName>
 				<unitPattern count="one">d {0}</unitPattern>
 				<unitPattern count="other">d {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>msek</displayName>
@@ -8431,17 +8431,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">ms {0}</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>μsecs</displayName>
 				<unitPattern count="one">μs{0}</unitPattern>
 				<unitPattern count="other">μs{0}</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>nanoseks</displayName>
 				<unitPattern count="one">ns{0}</unitPattern>
 				<unitPattern count="other">ns{0}</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>amp</displayName>
 				<unitPattern count="one">A{0}</unitPattern>
 				<unitPattern count="other">A{0}</unitPattern>
 			</unit>
@@ -8451,7 +8451,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">mA{0}</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>ohm</displayName>
 				<unitPattern count="one">Ω{0}</unitPattern>
 				<unitPattern count="other">Ω{0}</unitPattern>
 			</unit>
@@ -8461,17 +8461,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">V{0}</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">kcal{0}</unitPattern>
 				<unitPattern count="other">kcal{0}</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kal</displayName>
 				<unitPattern count="one">kal{0}</unitPattern>
 				<unitPattern count="other">kal{0}</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kal</displayName>
 				<unitPattern count="one">Kal{0}</unitPattern>
 				<unitPattern count="other">Kal{0}</unitPattern>
 			</unit>
@@ -8496,12 +8496,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">eV{0}</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>BTU</displayName>
 				<unitPattern count="one">Btu{0}</unitPattern>
 				<unitPattern count="other">Btu{0}</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>US therm</displayName>
 				<unitPattern count="one">US therm{0}</unitPattern>
 				<unitPattern count="other">US therm{0}</unitPattern>
 			</unit>
@@ -8516,139 +8516,139 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">N{0}</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">kWh/100km{0}</unitPattern>
 				<unitPattern count="other">kWh/100km{0}</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="one">GHz{0}</unitPattern>
 				<unitPattern count="other">GHz{0}</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="one">MHz{0}</unitPattern>
 				<unitPattern count="other">MHz{0}</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="one">kHz{0}</unitPattern>
 				<unitPattern count="other">kHz{0}</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="one">Hz{0}</unitPattern>
 				<unitPattern count="other">Hz{0}</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">em{0}</unitPattern>
 				<unitPattern count="other">em{0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>fikzels</displayName>
 				<unitPattern count="one">px{0}</unitPattern>
 				<unitPattern count="other">px{0}</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>megafikzels</displayName>
 				<unitPattern count="one">MP{0}</unitPattern>
 				<unitPattern count="other">MP{0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">ppcm{0}</unitPattern>
 				<unitPattern count="other">ppcm{0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">ppi{0}</unitPattern>
 				<unitPattern count="other">ppi{0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">dpcm{0}</unitPattern>
 				<unitPattern count="other">dpcm{0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">dpi{0}</unitPattern>
 				<unitPattern count="other">dpi{0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>aya</displayName>
 				<unitPattern count="one">aya{0}</unitPattern>
 				<unitPattern count="other">ayoyi{0}</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">R⊕{0}</unitPattern>
 				<unitPattern count="other">R⊕{0}</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km</displayName>
 				<unitPattern count="one">km{0}</unitPattern>
 				<unitPattern count="other">km{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">m{0}</unitPattern>
 				<unitPattern count="other">m{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dm</displayName>
 				<unitPattern count="one">dm{0}</unitPattern>
 				<unitPattern count="other">dm{0}</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm</displayName>
 				<unitPattern count="one">cm{0}</unitPattern>
 				<unitPattern count="other">cm{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mm</displayName>
 				<unitPattern count="one">mm{0}</unitPattern>
 				<unitPattern count="other">mm{0}</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>μmeters</displayName>
 				<unitPattern count="one">μm{0}</unitPattern>
 				<unitPattern count="other">μm{0}</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>nm</displayName>
 				<unitPattern count="one">nm{0}</unitPattern>
 				<unitPattern count="other">nm{0}</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">pm{0}</unitPattern>
 				<unitPattern count="other">pm{0}</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil-mil</displayName>
 				<unitPattern count="one">mi{0}</unitPattern>
 				<unitPattern count="other">mil-mil{0}</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yaduka</displayName>
 				<unitPattern count="one">yd{0}</unitPattern>
 				<unitPattern count="other">ydk{0}</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙafafu</displayName>
 				<unitPattern count="one">ƙf{0}</unitPattern>
 				<unitPattern count="other">ƙff{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ƙf</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>incina</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>fasek</displayName>
@@ -8661,7 +8661,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">sh{0}</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>au</displayName>
 				<unitPattern count="one">au{0}</unitPattern>
 				<unitPattern count="other">au{0}</unitPattern>
 			</unit>
@@ -8676,17 +8676,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">fth{0}</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>nmi</displayName>
 				<unitPattern count="one">nmi{0}</unitPattern>
 				<unitPattern count="other">nmi{0}</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
+				<displayName>smi</displayName>
 				<unitPattern count="one">smi{0}</unitPattern>
 				<unitPattern count="other">smi{0}</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>makuna</displayName>
 				<unitPattern count="one">mk{0}</unitPattern>
 				<unitPattern count="other">mk{0}</unitPattern>
 			</unit>
@@ -8696,17 +8696,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">R☉{0}</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lux</displayName>
 				<unitPattern count="one">lx{0}</unitPattern>
 				<unitPattern count="other">lx{0}</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">cd{0}</unitPattern>
 				<unitPattern count="other">cd{0}</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">lm{0}</unitPattern>
 				<unitPattern count="other">lm{0}</unitPattern>
 			</unit>
@@ -8716,29 +8716,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">L☉{0}</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>t</displayName>
 				<unitPattern count="one">t{0}</unitPattern>
 				<unitPattern count="other">t{0}</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
+				<displayName>kg</displayName>
 				<unitPattern count="one">kg{0}</unitPattern>
 				<unitPattern count="other">kg{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>giram</displayName>
 				<unitPattern count="one">g{0}</unitPattern>
 				<unitPattern count="other">g{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="one">mg{0}</unitPattern>
 				<unitPattern count="other">mg{0}</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>μg</displayName>
 				<unitPattern count="one">μg{0}</unitPattern>
 				<unitPattern count="other">μg{0}</unitPattern>
 			</unit>
@@ -8756,13 +8756,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>laba</displayName>
 				<unitPattern count="one">{0}#</unitPattern>
 				<unitPattern count="other">{0}#</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">oz{0}</unitPattern>
 				<unitPattern count="other">oz{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz t</displayName>
@@ -8790,22 +8790,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">M☉{0}</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙwaya</displayName>
 				<unitPattern count="one">ƙwaya{0}</unitPattern>
 				<unitPattern count="other">ƙwaya{0}</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="one">GW{0}</unitPattern>
 				<unitPattern count="other">GW{0}</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="one">MW{0}</unitPattern>
 				<unitPattern count="other">MW{0}</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">kW{0}</unitPattern>
 				<unitPattern count="other">kW{0}</unitPattern>
 			</unit>
@@ -8815,12 +8815,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">W{0}</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">mW{0}</unitPattern>
 				<unitPattern count="other">mW{0}</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙi</displayName>
 				<unitPattern count="one">ƙi{0}</unitPattern>
 				<unitPattern count="other">ƙi{0}</unitPattern>
 			</unit>
@@ -8830,7 +8830,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">mmHg{0}</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 				<unitPattern count="one">psi{0}</unitPattern>
 				<unitPattern count="other">psi{0}</unitPattern>
 			</unit>
@@ -8840,42 +8840,42 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">″ Hg{0}</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>sanda</displayName>
 				<unitPattern count="one">sanda{0}</unitPattern>
 				<unitPattern count="other">sanda{0}</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">mbar{0}</unitPattern>
 				<unitPattern count="other">mbar{0}</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>yny</displayName>
 				<unitPattern count="one">yny{0}</unitPattern>
 				<unitPattern count="other">yny{0}</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="one">Pa{0}</unitPattern>
 				<unitPattern count="other">Pa{0}</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">hPa{0}</unitPattern>
 				<unitPattern count="other">hPa{0}</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="one">kPa{0}</unitPattern>
 				<unitPattern count="other">kPa{0}</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="one">MPa{0}</unitPattern>
 				<unitPattern count="other">MPa{0}</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>km/saʼa</displayName>
 				<unitPattern count="one">km/s{0}</unitPattern>
 				<unitPattern count="other">km/s{0}</unitPattern>
 			</unit>
@@ -8885,19 +8885,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">m/d{0}</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil-mil/saʼa</displayName>
 				<unitPattern count="one">mas{0}</unitPattern>
 				<unitPattern count="other">mas{0}</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kn</displayName>
 				<unitPattern count="one">kn{0}</unitPattern>
 				<unitPattern count="other">kn{0}</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">°{0}</unitPattern>
+				<unitPattern count="other">°{0}</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°S</displayName>
@@ -8910,64 +8910,64 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">°{0}</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="one">K{0}</unitPattern>
 				<unitPattern count="other">K{0}</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="one">lbf⋅ft{0}</unitPattern>
 				<unitPattern count="other">lbf⋅ft{0}</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>N⋅m</displayName>
 				<unitPattern count="one">N⋅m{0}</unitPattern>
 				<unitPattern count="other">N⋅m{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">km³{0}</unitPattern>
 				<unitPattern count="other">km³{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">m³{0}</unitPattern>
 				<unitPattern count="other">m³{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">cm³{0}</unitPattern>
 				<unitPattern count="other">cm³{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">mi³{0}</unitPattern>
 				<unitPattern count="other">mi³{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yaduka³</displayName>
 				<unitPattern count="one">yd³{0}</unitPattern>
 				<unitPattern count="other">yd³{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙafafu³</displayName>
 				<unitPattern count="one">ƙf³{0}</unitPattern>
 				<unitPattern count="other">ƙf³{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>incina³</displayName>
 				<unitPattern count="one">in³{0}</unitPattern>
 				<unitPattern count="other">in³{0}</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ML</displayName>
 				<unitPattern count="one">ML{0}</unitPattern>
 				<unitPattern count="other">ML{0}</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>hL</displayName>
 				<unitPattern count="one">hL{0}</unitPattern>
 				<unitPattern count="other">hL{0}</unitPattern>
 			</unit>
@@ -8975,35 +8975,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>lita</displayName>
 				<unitPattern count="one">L{0}</unitPattern>
 				<unitPattern count="other">L{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dL</displayName>
 				<unitPattern count="one">dL{0}</unitPattern>
 				<unitPattern count="other">dL{0}</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cL</displayName>
 				<unitPattern count="one">sL{0}</unitPattern>
 				<unitPattern count="other">sL {0}</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mL</displayName>
 				<unitPattern count="one">mL{0}</unitPattern>
 				<unitPattern count="other">mL{0}</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpt</displayName>
 				<unitPattern count="one">mpt{0}</unitPattern>
 				<unitPattern count="other">mpt{0}</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>mcup</displayName>
 				<unitPattern count="one">mc{0}</unitPattern>
 				<unitPattern count="other">mc{0}</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>eka ƙf</displayName>
 				<unitPattern count="one">ek ƙf{0}</unitPattern>
 				<unitPattern count="other">ek ƙf{0}</unitPattern>
 			</unit>
@@ -9013,7 +9013,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">bu {0}</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">gal{0}</unitPattern>
 				<unitPattern count="other">gal{0}</unitPattern>
 				<perUnitPattern>{0}/gal</perUnitPattern>
@@ -9040,7 +9040,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">kfn{0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz</displayName>
 				<unitPattern count="one">fl oz{0}</unitPattern>
 				<unitPattern count="other">fl oz{0}</unitPattern>
 			</unit>
@@ -9050,17 +9050,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">fl oz Im{0}</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>bckl</displayName>
 				<unitPattern count="one">bckl{0}</unitPattern>
 				<unitPattern count="other">bckl{0}</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙmc</displayName>
 				<unitPattern count="one">ƙmc{0}</unitPattern>
 				<unitPattern count="other">ƙmc{0}</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bbl</displayName>
 				<unitPattern count="one">gang{0}</unitPattern>
 				<unitPattern count="other">gang{0}</unitPattern>
 			</unit>
@@ -9075,7 +9075,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">dsp-lmp{0}</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>ɗigo</displayName>
 				<unitPattern count="one">ɗigo{0}</unitPattern>
 				<unitPattern count="other">ɗigo{0}</unitPattern>
 			</unit>
@@ -9085,7 +9085,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">fl.dr.{0}</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>jigger</displayName>
 				<unitPattern count="one">jigger{0}</unitPattern>
 				<unitPattern count="other">jigger{0}</unitPattern>
 			</unit>
@@ -9095,12 +9095,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">pn{0}</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt Imp</displayName>
 				<unitPattern count="one">qt-Imp.{0}</unitPattern>
 				<unitPattern count="other">qt-Imp.{0}</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
+				<displayName>direction</displayName>
 				<coordinateUnitPattern type="east">G{0}</coordinateUnitPattern>
 				<coordinateUnitPattern type="north">A{0}</coordinateUnitPattern>
 				<coordinateUnitPattern type="south">K{0}</coordinateUnitPattern>
@@ -9131,44 +9131,44 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} ko {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} ko {1}</listPatternPart>
 			<listPatternPart type="2">{0} ko {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} ko {1}</listPatternPart>
 			<listPatternPart type="2">{0} ko {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, da {1}</listPatternPart>
+			<listPatternPart type="2">{0} da {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, da {1}</listPatternPart>
+			<listPatternPart type="2">{0} da {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -9189,7 +9189,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<characterLabelPattern type="miscellaneous">{0} — daban-daban</characterLabelPattern>
 		<characterLabelPattern type="other">{0} — wani dabam</characterLabelPattern>
 		<characterLabelPattern type="scripts">rubututtuka — {0}</characterLabelPattern>
-		<characterLabelPattern type="strokes" count="one">↑↑↑</characterLabelPattern>
+		<characterLabelPattern type="strokes" count="one">bugu-bugu {0}</characterLabelPattern>
 		<characterLabelPattern type="strokes" count="other">bugu-bugu {0}</characterLabelPattern>
 		<characterLabelPattern type="subscript">rubutu ƙasa {0}</characterLabelPattern>
 		<characterLabelPattern type="superscript">rubutu sama {0}</characterLabelPattern>
@@ -9372,10 +9372,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -9387,10 +9387,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
@@ -9471,16 +9471,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">Sule</nameField>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -108,8 +108,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">צ׳רוקי</language>
 			<language type="chy">שאיין</language>
 			<language type="ckb">כורדית סוראנית</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">כורדית סוראנית</language>
+			<language type="ckb" alt="variant">כורדית סוראנית</language>
 			<language type="clc">צ׳ילקוטין</language>
 			<language type="co">קורסיקנית</language>
 			<language type="cop">קופטית</language>
@@ -1065,7 +1065,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">תוניסיה</territory>
 			<territory type="TO">טונגה</territory>
 			<territory type="TR">טורקיה</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">טורקיה</territory>
 			<territory type="TT">טרינידד וטובגו</territory>
 			<territory type="TV">טובאלו</territory>
 			<territory type="TW">טייוואן</territory>
@@ -1465,200 +1465,200 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">EEEE, d בMMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">d בMMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">d בMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">d.M.y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="contributed">E ה-d</dateFormatItem>
+						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd" draft="contributed">d בMMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd" draft="contributed">E, d בMMM y G</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
+						<dateFormatItem id="Md" draft="contributed">d.M</dateFormatItem>
+						<dateFormatItem id="MEd" draft="contributed">E, d/M</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">d בMMM</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E, d בMMM</dateFormatItem>
+						<dateFormatItem id="MMMMd" draft="contributed">MMMM d</dateFormatItem>
+						<dateFormatItem id="y" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM" draft="contributed">M.y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd" draft="contributed">d.M.y G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd" draft="contributed">E, d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd" draft="contributed">d בMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd" draft="contributed">E, d בMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM" draft="contributed">G y MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ" draft="contributed">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ" draft="contributed">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d.M.y – d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d.M.y – d.M.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d.M.y GGGGG – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d בMMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d בMMM y G – d בMMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d בMMM – d בMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d בMMM y – d בMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d בMMM – E, d בMMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d בMMM y G – E, d בMMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d בMMM – E, d בMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d בMMM y – E, d בMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H–H</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">EEEE dd/MM – EEEE dd/MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">EEEE dd/MM – EEEE dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">EEEE d MMM – EEEE d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">EEEE d MMM – EEEE d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MM/y – MM/y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MM/y – MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd/MM/y – dd/MM/y</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd/MM/y – dd/MM/y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd/MM/y – dd/MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">EEEE dd/MM/y – EEEE dd/MM/y</greatestDifference>
+							<greatestDifference id="M" draft="contributed">EEEE dd/MM/y – EEEE dd/MM/y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">EEEE dd/MM/y – EEEE dd/MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d–d בMMM y G</greatestDifference>
@@ -1667,12 +1667,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
 							<greatestDifference id="d" draft="contributed">E, d בMMM – E, d בMMM y G</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">EEEE d MMM – EEEE d MMM y</greatestDifference>
 							<greatestDifference id="y" draft="contributed">E, d, בMMM, y – E, d בMMM, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMMM y–MMMM y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1798,218 +1798,218 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">EEEE, d בMMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">d בMMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">d בMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">d.M.y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="contributed">E ה-d</dateFormatItem>
+						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd" draft="contributed">d בMMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd" draft="contributed">E, d בMMM y G</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
+						<dateFormatItem id="Md" draft="contributed">d.M</dateFormatItem>
+						<dateFormatItem id="MEd" draft="contributed">E, d/M</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">d בMMM</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E, d בMMM</dateFormatItem>
+						<dateFormatItem id="MMMMd" draft="contributed">MMMM d</dateFormatItem>
+						<dateFormatItem id="y" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM" draft="contributed">M.y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd" draft="contributed">d.M.y G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd" draft="contributed">E, d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMM" draft="contributed">MM/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd" draft="contributed">d בMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd" draft="contributed">E, d בMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM" draft="contributed">G y MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ" draft="contributed">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ" draft="contributed">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d.M.y – d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d.M.y – d.M.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d.M.y GGGGG – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d בMMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d בMMM y G – d בMMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d בMMM – d בMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d בMMM y – d בMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d בMMM – E, d בMMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d בMMM y G – E, d בMMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d בMMM – E, d בMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d בMMM y – E, d בMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H–H</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">EEEE dd/MM – EEEE dd/MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">EEEE dd/MM – EEEE dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">EEEE d MMM – EEEE d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">EEEE d MMM – EEEE d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">LLLL–LLLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MM/y – MM/y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MM/y – MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd/MM/y – dd/MM/y</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd/MM/y – dd/MM/y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd/MM/y – dd/MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">EEEE dd/MM/y – EEEE dd/MM/y</greatestDifference>
+							<greatestDifference id="M" draft="contributed">EEEE dd/MM/y – EEEE dd/MM/y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">EEEE dd/MM/y – EEEE dd/MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">EEEE d MMM – EEEE d MMM y</greatestDifference>
+							<greatestDifference id="M" draft="contributed">EEEE d MMM – EEEE d MMM y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">EEEE d MMM y – EEEE d MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMMM y–MMMM y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2129,13 +2129,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="ethiopic-amete-alem">
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">ERA0</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="contributed">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">ERA0</era>
 					</eraNarrow>
 				</eras>
 			</calendar>
@@ -2188,7 +2188,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2196,7 +2196,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2689,9 +2689,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0" draft="contributed">לפני</era>
-						<era type="0" alt="variant" draft="contributed">↑↑↑</era>
+						<era type="0" alt="variant" draft="contributed">BCE</era>
 						<era type="1" draft="contributed">אחריי</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">CE</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -2768,7 +2768,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2776,7 +2776,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3128,30 +3128,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d בMMMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, d בMMMM y G</dateFormatItem>
@@ -3165,7 +3165,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="MMMMEd">E, d בMMMM</dateFormatItem>
 						<dateFormatItem id="mmss" draft="provisional">mm:ss</dateFormatItem>
 						<dateFormatItem id="y" draft="contributed">y</dateFormatItem>
-						<dateFormatItem id="yyyy" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyy" draft="contributed">y G</dateFormatItem>
 						<dateFormatItem id="yyyyM" draft="contributed">MMMM y</dateFormatItem>
 						<dateFormatItem id="yyyyMd" draft="contributed">d בMMMM y</dateFormatItem>
 						<dateFormatItem id="yyyyMEd" draft="contributed">E, d בMMMM y</dateFormatItem>
@@ -3183,61 +3183,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="h" draft="contributed">h–h בB</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
 							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d.M.y – d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d.M.y – d.M.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d.M.y GGGGG – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d.M.y – E, d.M.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d בMMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d בMMM y G – d בMMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d בMMM – d בMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d בMMM y – d בMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d בMMM – E, d בMMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d בMMM y G – E, d בMMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d בMMM – E, d בMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d בMMM y – E, d בMMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H–H</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
 							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a</greatestDifference>
 							<greatestDifference id="m" draft="contributed">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
@@ -3250,15 +3250,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">h:mm – h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H:mm–H:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">H:mm–H:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h – h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">H–H v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">MMM – MMM</greatestDifference>
@@ -3283,7 +3283,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M" draft="contributed">E d בMMM – E d בMMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M" draft="contributed">MMM y – MMM y</greatestDifference>
@@ -3300,8 +3300,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y" draft="contributed">E d בMMM y – E d בMMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d" draft="contributed">d–d בMMM y</greatestDifference>
@@ -3554,7 +3554,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E ה-d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d בMMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, d בMMM y G</dateFormatItem>
@@ -3997,7 +3997,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="-1">אתמול</relative>
 				<relative type="0">היום</relative>
 				<relative type="1">מחר</relative>
-				<relative type="2" draft="contributed">↑↑↑</relative>
+				<relative type="2" draft="contributed">מחרתיים</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">מחר</relativeTimePattern>
 					<relativeTimePattern count="two">בעוד יומיים</relativeTimePattern>
@@ -4422,7 +4422,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>שעה</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">בשעה זו</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">בעוד שעה</relativeTimePattern>
 					<relativeTimePattern count="two">בעוד שעתיים</relativeTimePattern>
@@ -4438,7 +4438,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>שע׳</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">בשעה זו</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">בעוד שעה</relativeTimePattern>
 					<relativeTimePattern count="two">בעוד שעתיים</relativeTimePattern>
@@ -4518,7 +4518,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>שנ׳</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">עכשיו</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">בעוד שנ׳</relativeTimePattern>
 					<relativeTimePattern count="two">בעוד שתי שנ׳</relativeTimePattern>
@@ -4534,7 +4534,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>שנ׳</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">עכשיו</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">בעוד שנ׳</relativeTimePattern>
 					<relativeTimePattern count="two">בעוד שתי שנ׳</relativeTimePattern>
@@ -6829,7 +6829,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
 			<infinity draft="contributed">∞</infinity>
@@ -6986,7 +6986,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -7437,7 +7437,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">פסו קובני להמרה</displayName>
 				<displayName count="two">פסו קובני להמרה</displayName>
 				<displayName count="many">פסו קובני להמרה</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">פסו קובני להמרה</displayName>
 				<symbol>CUC</symbol>
 				<symbol alt="narrow">$</symbol>
 			</currency>
@@ -7908,10 +7908,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>לוטי לסותי</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="two">↑↑↑</displayName>
-				<displayName count="many">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">לוטי לסותי</displayName>
+				<displayName count="two">לוטי לסותי</displayName>
+				<displayName count="many">לוטי לסותי</displayName>
+				<displayName count="other">לוטי לסותי</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -8559,18 +8559,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="USN">
 				<displayName>דולר אמריקאי (היום הבא)</displayName>
-				<displayName count="one" draft="contributed">↑↑↑</displayName>
-				<displayName count="two" draft="contributed">↑↑↑</displayName>
-				<displayName count="many" draft="contributed">↑↑↑</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="one" draft="contributed">דולר אמריקאי (היום הבא)</displayName>
+				<displayName count="two" draft="contributed">דולר אמריקאי (היום הבא)</displayName>
+				<displayName count="many" draft="contributed">דולר אמריקאי (היום הבא)</displayName>
+				<displayName count="other" draft="contributed">דולר אמריקאי (היום הבא)</displayName>
 				<symbol draft="contributed">USN</symbol>
 			</currency>
 			<currency type="USS">
 				<displayName>דולר אמריקאי (היום הזה)</displayName>
-				<displayName count="one" draft="contributed">↑↑↑</displayName>
-				<displayName count="two" draft="contributed">↑↑↑</displayName>
-				<displayName count="many" draft="contributed">↑↑↑</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="one" draft="contributed">דולר אמריקאי (היום הזה)</displayName>
+				<displayName count="two" draft="contributed">דולר אמריקאי (היום הזה)</displayName>
+				<displayName count="many" draft="contributed">דולר אמריקאי (היום הזה)</displayName>
+				<displayName count="other" draft="contributed">דולר אמריקאי (היום הזה)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="UYU">
@@ -8851,26 +8851,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="one">{0} בריבוע</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">{0} בריבוע</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two">{0} בריבוע</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two" gender="feminine">{0} בריבוע</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">{0} בריבוע</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine">{0} בריבוע</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0} בריבוע</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">{0} בריבוע</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1 count="one">{0} מעוקב</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">{0} מעוקב</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two">{0} מעוקב</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two" gender="feminine">{0} מעוקב</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">{0} מעוקב</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine">{0} מעוקב</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0} מעוקב</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">{0} מעוקב</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>masculine</gender>
@@ -9002,7 +9002,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>דונם</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} דונם</unitPattern>
 				<unitPattern count="two">{0} דונם</unitPattern>
 				<unitPattern count="many">{0} דונם</unitPattern>
 				<unitPattern count="other">{0} דונם</unitPattern>
@@ -9207,7 +9207,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-decade">
 				<gender>masculine</gender>
 				<displayName>עשורים</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">עשור {0}</unitPattern>
 				<unitPattern count="two">{0} עשורים</unitPattern>
 				<unitPattern count="many">{0} עשורים</unitPattern>
 				<unitPattern count="other">{0} עשורים</unitPattern>
@@ -9228,7 +9228,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} רבעונים</unitPattern>
 				<unitPattern count="many">{0} רבעונים</unitPattern>
 				<unitPattern count="other">{0} רבעונים</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<gender>masculine</gender>
@@ -9405,10 +9405,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>יחידה תרמית בארה״ב</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="many">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>ליברת-כוח</displayName>
@@ -9476,26 +9476,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
 				<displayName>פיקסלים</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">‎{0} px ‎</unitPattern>
 				<unitPattern count="two">‎{0} px ‎</unitPattern>
 				<unitPattern count="many">‎{0} px ‎</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">‎{0} px ‎</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>masculine</gender>
 				<displayName>מגה-פיקסל</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">‎{0} MP ‎</unitPattern>
 				<unitPattern count="two">‎{0} MP ‎</unitPattern>
 				<unitPattern count="many">‎{0} MP ‎</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">‎{0} MP ‎</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>masculine</gender>
 				<displayName>פיקסלים לסנטימטר</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">‎{0} ppcm‎</unitPattern>
 				<unitPattern count="two">‎{0} ppcm‎</unitPattern>
 				<unitPattern count="many">‎{0} ppcm‎</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">‎{0} ppcm‎</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>פיקסלים לאינץ׳</displayName>
@@ -9719,10 +9719,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>אנרגיה סולארית ביחידת זמן</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<gender>masculine</gender>
@@ -9823,7 +9823,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} מסת כדור הארץ</unitPattern>
 				<unitPattern count="two">{0} מסות כדור הארץ</unitPattern>
 				<unitPattern count="many">{0} מסות כדור הארץ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>מסת השמש</displayName>
@@ -10391,16 +10391,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10581,16 +10581,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="two">{0} mol</unitPattern>
+				<unitPattern count="many">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -10722,9 +10722,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>רבעונים</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} q</unitPattern>
+				<unitPattern count="two">{0} q</unitPattern>
+				<unitPattern count="many">{0} q</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -10869,37 +10869,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="two">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="two">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="many">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -10973,14 +10973,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">‎{0} ppi‎</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">‎{0} dpcm</unitPattern>
 				<unitPattern count="two">‎{0} dpcm</unitPattern>
 				<unitPattern count="many">‎{0} dpcm</unitPattern>
 				<unitPattern count="other">‎{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">‎{0} dpi‎</unitPattern>
 				<unitPattern count="two">‎{0} dpi‎</unitPattern>
 				<unitPattern count="many">‎{0} dpi‎</unitPattern>
@@ -10995,9 +10995,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -11010,8 +11010,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-meter">
 				<displayName>מטרים</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} מ׳</unitPattern>
+				<unitPattern count="two">{0} מ׳</unitPattern>
 				<unitPattern count="many">{0} מ׳</unitPattern>
 				<unitPattern count="other">{0} מ׳</unitPattern>
 				<perUnitPattern>{0}/מ׳</perUnitPattern>
@@ -11025,7 +11025,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>ס״מ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ס״מ</unitPattern>
 				<unitPattern count="two">{0} ס״מ</unitPattern>
 				<unitPattern count="many">{0} ס״מ</unitPattern>
 				<unitPattern count="other">{0} ס״מ</unitPattern>
@@ -11061,7 +11061,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-mile">
 				<displayName>מייל</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} מייל</unitPattern>
 				<unitPattern count="two">{0} מייל</unitPattern>
 				<unitPattern count="many">{0} מייל</unitPattern>
 				<unitPattern count="other">{0} מייל</unitPattern>
@@ -11112,16 +11112,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="two">{0} fur</unitPattern>
+				<unitPattern count="many">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="two">{0} fth</unitPattern>
+				<unitPattern count="many">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -11161,23 +11161,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -11263,23 +11263,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -11375,9 +11375,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -11389,16 +11389,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="two">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="two">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -11459,16 +11459,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="two">{0} N⋅m</unitPattern>
+				<unitPattern count="many">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -11588,9 +11588,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="two">{0} bu</unitPattern>
+				<unitPattern count="many">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -11667,16 +11667,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="two">{0} dstspn</unitPattern>
+				<unitPattern count="many">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="two">{0} dstspn Imp</unitPattern>
+				<unitPattern count="many">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -11688,16 +11688,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="two">{0} dram fl</unitPattern>
+				<unitPattern count="many">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="two">{0} jigger</unitPattern>
+				<unitPattern count="many">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -11709,9 +11709,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="two">{0} qt Imp.</unitPattern>
+				<unitPattern count="many">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -11733,7 +11733,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>מילי{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
 				<unitPrefixPattern>ננו{0}</unitPrefixPattern>
@@ -11784,48 +11784,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>יוטא{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>כוח ג׳י</displayName>
@@ -11842,135 +11842,135 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ס׳</displayName>
+				<unitPattern count="one">{0} ס׳</unitPattern>
+				<unitPattern count="two">{0} ס׳</unitPattern>
+				<unitPattern count="many">{0} ס׳</unitPattern>
+				<unitPattern count="other">{0} ס׳</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>רדיאנים</displayName>
+				<unitPattern count="one">{0} π</unitPattern>
+				<unitPattern count="two">{0} π</unitPattern>
+				<unitPattern count="many">{0} π</unitPattern>
+				<unitPattern count="other">{0} π</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>מעלות</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="two">{0}°</unitPattern>
 				<unitPattern count="many">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>דק׳ קשת</displayName>
 				<unitPattern count="one">דקה {0}</unitPattern>
 				<unitPattern count="two">{0} דקות</unitPattern>
 				<unitPattern count="many">{0} דקות</unitPattern>
 				<unitPattern count="other">{0} דקות</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>שנ׳ קשת</displayName>
 				<unitPattern count="one">שנ׳ {0}</unitPattern>
 				<unitPattern count="two">{0} שנ׳</unitPattern>
 				<unitPattern count="many">{0} שנ׳</unitPattern>
 				<unitPattern count="other">{0} שנ׳</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>קמ״ר</displayName>
 				<unitPattern count="one">קמ״ר {0}</unitPattern>
 				<unitPattern count="two">{0} קמ״ר</unitPattern>
 				<unitPattern count="many">{0} קמ״ר</unitPattern>
 				<unitPattern count="other">{0} קמ״ר</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/קמ״ר</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>הקטאר</displayName>
 				<unitPattern count="one">הקטאר {0}</unitPattern>
 				<unitPattern count="two">{0} הקטאר</unitPattern>
 				<unitPattern count="many">{0} הקטאר</unitPattern>
 				<unitPattern count="other">{0} הקטאר</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>מ״ר</displayName>
 				<unitPattern count="one">מ״ר {0}</unitPattern>
 				<unitPattern count="two">{0} מ״ר</unitPattern>
 				<unitPattern count="many">{0} מ״ר</unitPattern>
 				<unitPattern count="other">{0} מ״ר</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/מ״ר</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>סמ״ר</displayName>
+				<unitPattern count="one">{0} סמ״ר</unitPattern>
+				<unitPattern count="two">{0} סמ״ר</unitPattern>
+				<unitPattern count="many">{0} סמ״ר</unitPattern>
+				<unitPattern count="other">{0} סמ״ר</unitPattern>
+				<perUnitPattern>{0}/סמ״ר</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>מייל רבוע</displayName>
 				<unitPattern count="one">מייל רבוע {0}</unitPattern>
 				<unitPattern count="two">{0} מייל רבוע</unitPattern>
 				<unitPattern count="many">{0} מייל רבוע</unitPattern>
 				<unitPattern count="other">{0} מייל רבוע</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>‎{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>אקר</displayName>
 				<unitPattern count="one">אקר {0}</unitPattern>
 				<unitPattern count="two">{0} אקר</unitPattern>
 				<unitPattern count="many">{0} אקר</unitPattern>
 				<unitPattern count="other">{0} אקר</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yards²</displayName>
+				<unitPattern count="one">‎{0} yd²</unitPattern>
+				<unitPattern count="two">‎{0} yd²</unitPattern>
+				<unitPattern count="many">‎{0} yd²</unitPattern>
+				<unitPattern count="other">‎{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">רגל רבועה {0}</unitPattern>
 				<unitPattern count="two">{0} רגל רבועה</unitPattern>
 				<unitPattern count="many">{0} רגל רבועה</unitPattern>
 				<unitPattern count="other">{0} רגל רבועה</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">‎{0} in²</unitPattern>
+				<unitPattern count="two">‎{0} in²</unitPattern>
+				<unitPattern count="many">‎{0} in²</unitPattern>
+				<unitPattern count="other">‎{0} in²</unitPattern>
+				<perUnitPattern>‎{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>דונם</displayName>
+				<unitPattern count="one">{0} דונם</unitPattern>
+				<unitPattern count="two">{0} דונם</unitPattern>
+				<unitPattern count="many">{0} דונם</unitPattern>
+				<unitPattern count="other">{0} דונם</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="two">{0} kt</unitPattern>
+				<unitPattern count="many">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="two">{0} mg/dL</unitPattern>
+				<unitPattern count="many">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="two">{0} mmol/L</unitPattern>
+				<unitPattern count="many">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>פריט</displayName>
@@ -11980,11 +11980,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} פר'</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="two">{0} ppm</unitPattern>
+				<unitPattern count="many">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -11994,32 +11994,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="two">{0}‰</unitPattern>
+				<unitPattern count="many">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="two">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="two">{0} mol</unitPattern>
+				<unitPattern count="many">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ליטרים/ק״מ</displayName>
+				<unitPattern count="one">{0} ל׳/ק״מ</unitPattern>
+				<unitPattern count="two">{0} ל׳/ק״מ</unitPattern>
+				<unitPattern count="many">{0} ל׳/ק״מ</unitPattern>
+				<unitPattern count="other">{0} ל׳/ק״מ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ל׳/100ק״מ</displayName>
@@ -12030,38 +12030,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>מייל/גלון</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="two">{0} mpg</unitPattern>
+				<unitPattern count="many">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miles/gal Imp.</displayName>
+				<unitPattern count="one">{0} mpg Imp.</unitPattern>
+				<unitPattern count="two">{0} mpg Imp.</unitPattern>
+				<unitPattern count="many">{0} mpg Imp.</unitPattern>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="two">{0} PB</unitPattern>
+				<unitPattern count="many">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="two">{0} TB</unitPattern>
+				<unitPattern count="many">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="two">{0} Tb</unitPattern>
+				<unitPattern count="many">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>ג״ב</displayName>
@@ -12071,25 +12071,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ג״ב</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gbit</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="two">{0} Gb</unitPattern>
+				<unitPattern count="many">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="one">{0} מ״ב</unitPattern>
 				<unitPattern count="two">{0} מ״ב</unitPattern>
 				<unitPattern count="many">{0} מ״ב</unitPattern>
 				<unitPattern count="other">{0} מ״ב</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mbit</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="two">{0} Mb</unitPattern>
+				<unitPattern count="many">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>ק״ב</displayName>
@@ -12099,21 +12099,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ק״ב</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="two">{0} kb</unitPattern>
+				<unitPattern count="many">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>בייט</displayName>
+				<unitPattern count="one">{0} בייט</unitPattern>
+				<unitPattern count="two">{0} בייט</unitPattern>
+				<unitPattern count="many">{0} בייט</unitPattern>
+				<unitPattern count="other">{0} בייט</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ביט</displayName>
 				<unitPattern count="one">{0} ביט</unitPattern>
 				<unitPattern count="two">{0} ביט</unitPattern>
 				<unitPattern count="many">{0} ביט</unitPattern>
@@ -12127,11 +12127,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} מאות</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>עשור</displayName>
+				<unitPattern count="one">עשור {0}</unitPattern>
+				<unitPattern count="two">{0} עשורים</unitPattern>
+				<unitPattern count="many">{0} עשורים</unitPattern>
+				<unitPattern count="other">{0} עשורים</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ש׳</displayName>
@@ -12143,11 +12143,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>רבעונים</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} q</unitPattern>
+				<unitPattern count="two">{0} q</unitPattern>
+				<unitPattern count="many">{0} q</unitPattern>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>ח׳</displayName>
@@ -12212,200 +12212,200 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ננו שניות</displayName>
 				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="two">{0} ns</unitPattern>
 				<unitPattern count="many">{0} ns</unitPattern>
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amps</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="two">{0} A</unitPattern>
+				<unitPattern count="many">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="two">{0} mA</unitPattern>
+				<unitPattern count="many">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">ohms</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="two">{0} Ω</unitPattern>
+				<unitPattern count="many">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>וולט</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="two">{0} V</unitPattern>
+				<unitPattern count="many">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="two">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="two">{0} cal</unitPattern>
+				<unitPattern count="many">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="two">{0} Cal</unitPattern>
+				<unitPattern count="many">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>קילו ג׳אול</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="two">{0} kJ</unitPattern>
+				<unitPattern count="many">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ג׳אול</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="two">{0} J</unitPattern>
+				<unitPattern count="many">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>קוט״ש</displayName>
+				<unitPattern count="one">{0} קוט״ש</unitPattern>
+				<unitPattern count="two">{0} קוט״ש</unitPattern>
+				<unitPattern count="many">{0} קוט״ש</unitPattern>
+				<unitPattern count="other">{0} קוט״ש</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="two">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="two">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="many">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0} kWh/100km</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} קוט&quot;ש/100 ק&quot;מ</unitPattern>
 				<unitPattern count="many">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="two">{0} GHz</unitPattern>
+				<unitPattern count="many">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="two">{0} MHz</unitPattern>
+				<unitPattern count="many">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="two">{0} kHz</unitPattern>
+				<unitPattern count="many">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="two">{0} Hz</unitPattern>
+				<unitPattern count="many">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">‎{0} em ‎</unitPattern>
+				<unitPattern count="two">‎{0} em ‎</unitPattern>
+				<unitPattern count="many">‎{0} em ‎</unitPattern>
+				<unitPattern count="other">‎{0} em ‎</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">‎{0} px ‎</unitPattern>
+				<unitPattern count="two">‎{0} px ‎</unitPattern>
+				<unitPattern count="many">‎{0} px ‎</unitPattern>
+				<unitPattern count="other">‎{0} px ‎</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">‎{0} MP ‎</unitPattern>
+				<unitPattern count="two">‎{0} MP ‎</unitPattern>
+				<unitPattern count="many">‎{0} MP ‎</unitPattern>
+				<unitPattern count="other">‎{0} MP ‎</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">‎{0} ppcm‎</unitPattern>
+				<unitPattern count="two">‎{0} ppcm‎</unitPattern>
+				<unitPattern count="many">‎{0} ppcm‎</unitPattern>
+				<unitPattern count="other">‎{0} ppcm‎</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">‎{0} ppi‎</unitPattern>
+				<unitPattern count="two">‎{0} ppi‎</unitPattern>
+				<unitPattern count="many">‎{0} ppi‎</unitPattern>
+				<unitPattern count="other">‎{0} ppi‎</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">‎{0} dpcm</unitPattern>
+				<unitPattern count="two">‎{0} dpcm</unitPattern>
+				<unitPattern count="many">‎{0} dpcm</unitPattern>
+				<unitPattern count="other">‎{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">‎{0} dpi‎</unitPattern>
+				<unitPattern count="two">‎{0} dpi‎</unitPattern>
+				<unitPattern count="many">‎{0} dpi‎</unitPattern>
+				<unitPattern count="other">‎{0} dpi‎</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>נק׳ קטנה</displayName>
@@ -12415,11 +12415,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} נק' ק'</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ק״מ</displayName>
@@ -12431,7 +12431,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-meter">
 				<displayName>מטר</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} מ׳</unitPattern>
 				<unitPattern count="two">{0} מ′</unitPattern>
 				<unitPattern count="many">{0} מ׳</unitPattern>
 				<unitPattern count="other">{0} מ׳</unitPattern>
@@ -12532,18 +12532,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="two">{0} fur</unitPattern>
+				<unitPattern count="many">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="two">{0} fth</unitPattern>
+				<unitPattern count="many">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>מ״י</displayName>
@@ -12567,39 +12567,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} נק'</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">‎{0} R☉‎</unitPattern>
+				<unitPattern count="two">‎{0} R☉‎</unitPattern>
+				<unitPattern count="many">‎{0} R☉‎</unitPattern>
+				<unitPattern count="other">‎{0} R☉‎</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="two">{0} lx</unitPattern>
+				<unitPattern count="many">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -12646,26 +12646,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ט׳</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>סטון</displayName>
+				<unitPattern count="one">סטון {0}</unitPattern>
+				<unitPattern count="two">{0} סטון</unitPattern>
+				<unitPattern count="many">{0} סטון</unitPattern>
+				<unitPattern count="other">{0} סטון</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>פאונד</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
+				<unitPattern count="two">{0} lbs</unitPattern>
+				<unitPattern count="many">{0} lbs</unitPattern>
+				<unitPattern count="other">{0} lbs</unitPattern>
 				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>oz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="two">{0} oz</unitPattern>
+				<unitPattern count="many">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
 				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
@@ -12683,70 +12683,70 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>גרעין</displayName>
+				<unitPattern count="one">גרעין {0}</unitPattern>
+				<unitPattern count="two">{0} גרעינים</unitPattern>
+				<unitPattern count="many">{0} גרעינים</unitPattern>
+				<unitPattern count="other">{0} גרעינים</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="two">{0} GW</unitPattern>
+				<unitPattern count="many">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="two">{0} MW</unitPattern>
+				<unitPattern count="many">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="two">{0} kW</unitPattern>
 				<unitPattern count="many">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ואט</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="two">{0} W</unitPattern>
 				<unitPattern count="many">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="two">{0} mW</unitPattern>
+				<unitPattern count="many">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>כ״ס</displayName>
 				<unitPattern count="one">כ״ס {0}</unitPattern>
 				<unitPattern count="two">{0} כ״ס</unitPattern>
 				<unitPattern count="many">{0} כ״ס</unitPattern>
@@ -12774,11 +12774,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>בר</displayName>
+				<unitPattern count="one">{0} בר</unitPattern>
+				<unitPattern count="two">{0} בר</unitPattern>
+				<unitPattern count="many">{0} בר</unitPattern>
+				<unitPattern count="other">{0} בר</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>מ״ב</displayName>
@@ -12788,18 +12788,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} מיליבר</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="two">{0} atm</unitPattern>
+				<unitPattern count="many">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -12809,18 +12809,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="two">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="two">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>קמ״ש</displayName>
@@ -12879,83 +12879,83 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="two">{0} N⋅m</unitPattern>
+				<unitPattern count="many">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>קמ״ק</displayName>
 				<unitPattern count="one">{0} קמ״ק</unitPattern>
 				<unitPattern count="two">{0} קמ״ק</unitPattern>
 				<unitPattern count="many">{0} קמ״ק</unitPattern>
 				<unitPattern count="other">{0} קמ״ק</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">‎{0} m³</unitPattern>
+				<unitPattern count="two">‎{0} m³</unitPattern>
+				<unitPattern count="many">‎{0} m³</unitPattern>
+				<unitPattern count="other">‎{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>סמ״ק</displayName>
+				<unitPattern count="one">{0} סמ״ק</unitPattern>
+				<unitPattern count="two">{0} סמ״ק</unitPattern>
+				<unitPattern count="many">{0} סמ״ק</unitPattern>
+				<unitPattern count="other">{0} סמ״ק</unitPattern>
+				<perUnitPattern>{0}/סמ״ק</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="two">{0} mi³</unitPattern>
 				<unitPattern count="many">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">‎{0} yd³</unitPattern>
+				<unitPattern count="two">‎{0} yd³</unitPattern>
+				<unitPattern count="many">‎{0} yd³</unitPattern>
+				<unitPattern count="other">‎{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>feet³</displayName>
+				<unitPattern count="one">‎{0} ft³</unitPattern>
+				<unitPattern count="two">‎{0} ft³</unitPattern>
+				<unitPattern count="many">‎{0} ft³</unitPattern>
+				<unitPattern count="other">‎{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">‎{0} in³</unitPattern>
+				<unitPattern count="two">‎{0} in³</unitPattern>
+				<unitPattern count="many">‎{0} in³</unitPattern>
+				<unitPattern count="other">‎{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">‎{0} ML</unitPattern>
+				<unitPattern count="two">‎{0} ML</unitPattern>
+				<unitPattern count="many">‎{0} ML</unitPattern>
+				<unitPattern count="other">‎{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">‎{0} hL</unitPattern>
+				<unitPattern count="two">‎{0} hL</unitPattern>
+				<unitPattern count="many">‎{0} hL</unitPattern>
+				<unitPattern count="other">‎{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ליטר</displayName>
@@ -12963,67 +12963,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} ל׳</unitPattern>
 				<unitPattern count="many">{0} ל׳</unitPattern>
 				<unitPattern count="other">{0} ל׳</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ל׳</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>דצ״ל</displayName>
+				<unitPattern count="one">{0} דצ״ל</unitPattern>
+				<unitPattern count="two">{0} דצ״ל</unitPattern>
+				<unitPattern count="many">{0} דצ״ל</unitPattern>
+				<unitPattern count="other">{0} דצ״ל</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">‎{0} cL</unitPattern>
+				<unitPattern count="two">‎{0} cL</unitPattern>
+				<unitPattern count="many">‎{0} cL</unitPattern>
+				<unitPattern count="other">‎{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>מ״ל</displayName>
+				<unitPattern count="one">מ״ל {0}</unitPattern>
+				<unitPattern count="two">{0} מ״ל</unitPattern>
+				<unitPattern count="many">{0} מ״ל</unitPattern>
+				<unitPattern count="other">{0} מ״ל</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">‎{0} mpt</unitPattern>
+				<unitPattern count="two">‎{0} mpt</unitPattern>
+				<unitPattern count="many">‎{0} mpt</unitPattern>
+				<unitPattern count="other">‎{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">‎{0} mc</unitPattern>
+				<unitPattern count="two">‎{0} mc</unitPattern>
+				<unitPattern count="many">‎{0} mc</unitPattern>
+				<unitPattern count="other">‎{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">‎{0} ac ft</unitPattern>
+				<unitPattern count="two">‎{0} ac ft</unitPattern>
+				<unitPattern count="many">‎{0} ac ft</unitPattern>
+				<unitPattern count="other">‎{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="two">{0} bu</unitPattern>
+				<unitPattern count="many">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>גלון</displayName>
+				<unitPattern count="one">{0} גל׳</unitPattern>
+				<unitPattern count="two">{0} גל׳</unitPattern>
+				<unitPattern count="many">{0} גל׳</unitPattern>
+				<unitPattern count="other">{0} גל׳</unitPattern>
+				<perUnitPattern>{0}/גל׳</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>גלון בריטי</displayName>
 				<unitPattern count="one">{0}/galIm</unitPattern>
 				<unitPattern count="two">{0}/galIm</unitPattern>
 				<unitPattern count="many">{0}/galIm</unitPattern>
@@ -13031,109 +13031,109 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/galIm</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qts</displayName>
+				<unitPattern count="one">‎{0} qt</unitPattern>
+				<unitPattern count="two">‎{0} qt</unitPattern>
+				<unitPattern count="many">‎{0} qt</unitPattern>
+				<unitPattern count="other">‎{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>פינט</displayName>
+				<unitPattern count="one">‎{0} pt</unitPattern>
+				<unitPattern count="two">‎{0} pt</unitPattern>
+				<unitPattern count="many">‎{0} pt</unitPattern>
+				<unitPattern count="other">‎{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>כוסות</displayName>
+				<unitPattern count="one">כ׳ {0}</unitPattern>
+				<unitPattern count="two">{0} כ׳</unitPattern>
+				<unitPattern count="many">{0} כ׳</unitPattern>
+				<unitPattern count="other">{0} כ׳</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">‎{0} fl oz</unitPattern>
+				<unitPattern count="two">‎{0} fl oz</unitPattern>
+				<unitPattern count="many">‎{0} fl oz</unitPattern>
+				<unitPattern count="other">‎{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="one">‎{0} fl oz Imp.‎</unitPattern>
+				<unitPattern count="two">‎{0} fl oz Imp.‎</unitPattern>
+				<unitPattern count="many">‎{0} fl oz Imp.‎</unitPattern>
+				<unitPattern count="other">‎{0} fl oz Imp.‎</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>כפות</displayName>
+				<unitPattern count="one">{0} כפ׳</unitPattern>
+				<unitPattern count="two">{0} כפ׳</unitPattern>
+				<unitPattern count="many">{0} כפ׳</unitPattern>
+				<unitPattern count="other">{0} כפ׳</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>כפית</displayName>
+				<unitPattern count="one">{0} כפי׳</unitPattern>
+				<unitPattern count="two">{0} כפי׳</unitPattern>
+				<unitPattern count="many">{0} כפי׳</unitPattern>
+				<unitPattern count="other">{0} כפי׳</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">‎{0} bbl</unitPattern>
+				<unitPattern count="two">‎{0} bbl</unitPattern>
+				<unitPattern count="many">‎{0} bbl</unitPattern>
+				<unitPattern count="other">‎{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="two">{0} dstspn</unitPattern>
+				<unitPattern count="many">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstspn Imp</displayName>
 				<unitPattern count="one">{0}dsp-Imp</unitPattern>
 				<unitPattern count="two">{0}dsp-Imp</unitPattern>
 				<unitPattern count="many">{0} dstspn</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>טיפה</displayName>
+				<unitPattern count="one">טיפה</unitPattern>
+				<unitPattern count="two">{0} טיפות</unitPattern>
+				<unitPattern count="many">{0} טיפות</unitPattern>
+				<unitPattern count="other">{0} טיפות</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram fluid</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="two">{0} dram fl</unitPattern>
+				<unitPattern count="many">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="two">{0} jigger</unitPattern>
+				<unitPattern count="many">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>פינץ׳</displayName>
+				<unitPattern count="one">{0} פינץ'</unitPattern>
+				<unitPattern count="two">{0} פינץ'</unitPattern>
+				<unitPattern count="many">{0} פינץ'</unitPattern>
+				<unitPattern count="other">{0} פינץ'</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="two">{0} qt Imp.</unitPattern>
+				<unitPattern count="many">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>כיוון</displayName>
@@ -13167,22 +13167,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} או {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} או {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} או {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} או {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} או {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ו{1}</listPatternPart>
+			<listPatternPart type="2">{0} ו{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -13412,10 +13412,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern alt="1">{given-monogram-allCaps}{given2-monogram-allCaps}״{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}״{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -13427,10 +13427,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}״{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}״{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{title} {given-initial} {surname}</namePattern>
@@ -13445,16 +13445,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}״{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}״{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
 			<namePattern>{title} {surname}</namePattern>
@@ -13466,7 +13466,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2-initial} {credentials}</namePattern>
@@ -13508,7 +13508,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname-core}, {given} {given2-initial} {surname-prefix}</namePattern>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -102,7 +102,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">शेयेन्न</language>
 			<language type="ckb">सोरानी कुर्दिश</language>
 			<language type="ckb" alt="menu">कुर्दी, सोरानी</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">सोरानी कुर्दिश</language>
 			<language type="clc">चिलकोटिन</language>
 			<language type="co">कोर्सीकन</language>
 			<language type="cop">कॉप्टिक</language>
@@ -1016,7 +1016,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ट्यूनीशिया</territory>
 			<territory type="TO">टोंगा</territory>
 			<territory type="TR">तुर्किये</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">तुर्किये</territory>
 			<territory type="TT">त्रिनिदाद और टोबैगो</territory>
 			<territory type="TV">तुवालू</territory>
 			<territory type="TW">ताइवान</territory>
@@ -1273,83 +1273,83 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">G EEEE, d MMMM y</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">G d MMMM y</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">G d MMM y</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">G d/M/y</pattern>
+							<datetimeSkeleton draft="contributed">GyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="contributed">d E</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
 						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd" draft="contributed">E, d MMM y G</dateFormatItem>
-						<dateFormatItem id="M" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMdd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">M</dateFormatItem>
+						<dateFormatItem id="Md" draft="contributed">d/M</dateFormatItem>
+						<dateFormatItem id="MEd" draft="contributed">E, d/M</dateFormatItem>
+						<dateFormatItem id="MMdd" draft="contributed">dd-MM</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">MMM</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E, d MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd" draft="contributed">d MMMM</dateFormatItem>
 						<dateFormatItem id="y" draft="contributed">y G</dateFormatItem>
 						<dateFormatItem id="yyyy" draft="contributed">y G</dateFormatItem>
 						<dateFormatItem id="yyyyM" draft="contributed">M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMd" draft="contributed">d/M`/y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMEd" draft="contributed">E, d/M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyMMdd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyMMdd" draft="contributed">dd-MM-y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM" draft="contributed">G MMM y</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd" draft="contributed">G d MMM y</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd" draft="contributed">E, d MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM" draft="contributed">MMMM y G</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ" draft="contributed">QQQ G y</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ" draft="contributed">QQQQ G y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
 							<greatestDifference id="G" draft="contributed">G y – G y</greatestDifference>
@@ -1390,93 +1390,93 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M – d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M – d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M – E, d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M – E, d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M/y – d/M/y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M/y – d/M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d/M/y – d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1551,7 +1551,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1559,7 +1559,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2111,7 +2111,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2119,7 +2119,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2417,13 +2417,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">शक</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">शक</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">शक</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -2455,60 +2455,60 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="contributed">d E</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
 						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd" draft="contributed">E, d MMM y G</dateFormatItem>
-						<dateFormatItem id="M" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMdd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">M</dateFormatItem>
+						<dateFormatItem id="Md" draft="contributed">d/M</dateFormatItem>
+						<dateFormatItem id="MEd" draft="contributed">E, d/M</dateFormatItem>
+						<dateFormatItem id="MMdd" draft="contributed">dd-MM</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">MMM</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E, d MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd" draft="contributed">d MMMM</dateFormatItem>
 						<dateFormatItem id="y" draft="contributed">y G</dateFormatItem>
 						<dateFormatItem id="yyyy" draft="contributed">y G</dateFormatItem>
 						<dateFormatItem id="yyyyM" draft="contributed">M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMEd" draft="contributed">E, d/M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyMMdd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyMMdd" draft="contributed">dd-MM-y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMM" draft="contributed">MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMd" draft="contributed">d MMM y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd" draft="contributed">G E, d MMM y</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM" draft="contributed">G y MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ" draft="contributed">QQQ G y</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ" draft="contributed">QQQQ G y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">G y – G y</greatestDifference>
+							<greatestDifference id="y" draft="contributed">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
 							<greatestDifference id="G" draft="contributed">GGGGG M/y – GGGGG M/y</greatestDifference>
@@ -2831,9 +2831,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>वर्ष</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">पिछला वर्ष</relative>
+				<relative type="0">इस वर्ष</relative>
+				<relative type="1">अगला वर्ष</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} वर्ष में</relativeTimePattern>
 					<relativeTimePattern count="other">{0} वर्ष में</relativeTimePattern>
@@ -2915,9 +2915,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>माह</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">पिछला माह</relative>
+				<relative type="0">इस माह</relative>
+				<relative type="1">अगला माह</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} माह में</relativeTimePattern>
 					<relativeTimePattern count="other">{0} माह में</relativeTimePattern>
@@ -2929,9 +2929,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>माह</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">पिछला माह</relative>
+				<relative type="0">इस माह</relative>
+				<relative type="1">अगला माह</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} माह में</relativeTimePattern>
 					<relativeTimePattern count="other">{0} माह में</relativeTimePattern>
@@ -2958,9 +2958,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>सप्ताह</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">पिछला सप्ताह</relative>
+				<relative type="0">इस सप्ताह</relative>
+				<relative type="1">अगला सप्ताह</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} सप्ताह में</relativeTimePattern>
 					<relativeTimePattern count="other">{0} सप्ताह में</relativeTimePattern>
@@ -2973,9 +2973,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>सप्ताह</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">पिछला सप्ताह</relative>
+				<relative type="0">इस सप्ताह</relative>
+				<relative type="1">अगला सप्ताह</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} सप्ताह में</relativeTimePattern>
 					<relativeTimePattern count="other">{0} सप्ताह में</relativeTimePattern>
@@ -3014,7 +3014,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-short">
 				<displayName>दिन</displayName>
 				<relative type="-1">बीता कल</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">आज</relative>
 				<relative type="1">आने वाला कल</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} दिन में</relativeTimePattern>
@@ -3028,7 +3028,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-narrow">
 				<displayName>दिन</displayName>
 				<relative type="-1">बीता कल</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">आज</relative>
 				<relative type="1">आने वाला कल</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} दिन में</relativeTimePattern>
@@ -5696,19 +5696,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
@@ -5741,304 +5741,304 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
 			<decimal>.</decimal>
 			<group>,</group>
-			<list>↑↑↑</list>
+			<list>;</list>
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -6056,349 +6056,349 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator>↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="deva">
 			<decimalFormatLength>
@@ -6538,8 +6538,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 00 लाख</pattern>
 					<pattern type="1000000" count="other">¤00 लाख</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 00 लाख</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="one">¤0 क॰</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤0 क॰</pattern>
 					<pattern type="10000000" count="other">¤0 क॰</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0 क॰</pattern>
 					<pattern type="100000000" count="one">¤00 क॰</pattern>
@@ -7163,8 +7163,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>लेसोथो लोटी</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">लेसोथो लोटी</displayName>
+				<displayName count="other">लेसोथो लोटी</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -7692,7 +7692,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XEU">
 				<displayName draft="contributed">यूरोपीय मुद्रा इकाई</displayName>
 				<displayName count="one" draft="contributed">यूरोपीय मुद्रा इकाई</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">यूरोपीय मुद्रा इकाई</displayName>
 			</currency>
 			<currency type="XOF">
 				<displayName>पश्चिमी अफ़्रीकी CFA फ़्रैंक</displayName>
@@ -7847,27 +7847,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>वर्ग {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">वर्ग {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="oblique">वर्ग {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">वर्ग {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">वर्ग {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">वर्ग {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="oblique">वर्ग {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">वर्ग {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">वर्ग {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>घन {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">घन {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="oblique">घन {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">घन {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">घन {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">घन {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="oblique">घन {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">घन {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">घन {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>masculine</gender>
@@ -7889,7 +7889,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>घूर्णन</displayName>
 				<unitPattern count="one">{0} घूर्णन</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} घूर्णन</unitPattern>
 				<unitPattern count="other">{0} घूर्णन</unitPattern>
 				<unitPattern count="other" case="oblique">{0} घूर्णनों</unitPattern>
 			</unit>
@@ -7897,15 +7897,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>रेडियन</displayName>
 				<unitPattern count="one">{0} रेडियन</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} रेडियन</unitPattern>
 				<unitPattern count="other">{0} रेडियन</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} रेडियन</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>masculine</gender>
 				<displayName>अंश</displayName>
 				<unitPattern count="one">{0} अंश</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} अंश</unitPattern>
 				<unitPattern count="other">{0} अंश</unitPattern>
 				<unitPattern count="other" case="oblique">{0} अंशों</unitPattern>
 			</unit>
@@ -7913,17 +7913,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>आर्क मिनट</displayName>
 				<unitPattern count="one">{0} आर्क मिनट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} आर्क मिनट</unitPattern>
 				<unitPattern count="other">{0} आर्क मिनट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} आर्क मिनट</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>masculine</gender>
 				<displayName>आर्क सेकंड</displayName>
 				<unitPattern count="one">{0} आर्क सेकंड</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} आर्क सेकंड</unitPattern>
 				<unitPattern count="other">{0} आर्क सेकंड</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} आर्क सेकंड</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>masculine</gender>
@@ -7946,9 +7946,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>वर्ग मीटर</displayName>
 				<unitPattern count="one">{0} वर्ग मीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} वर्ग मीटर</unitPattern>
 				<unitPattern count="other">{0} वर्ग मीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} वर्ग मीटर</unitPattern>
 				<perUnitPattern>{0}/वर्ग मीटर</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
@@ -8005,9 +8005,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>कैरट</displayName>
 				<unitPattern count="one">{0} कैरट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} कैरट</unitPattern>
 				<unitPattern count="other">{0} कैरट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} कैरट</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>मिलिग्राम प्रति डेसीलीटर</displayName>
@@ -8018,25 +8018,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>मिलीमोल प्रति लीटर</displayName>
 				<unitPattern count="one">{0} मिलीमोल प्रति लीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मिलीमोल प्रति लीटर</unitPattern>
 				<unitPattern count="other">{0} मिलीमोल प्रति लीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मिलीमोल प्रति लीटर</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>masculine</gender>
 				<displayName>items</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="one" case="oblique">{0} आइटम</unitPattern>
 				<unitPattern count="other">{0} items</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} items</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>masculine</gender>
 				<displayName>हिस्सा प्रति दस लाख</displayName>
 				<unitPattern count="one">{0} हिस्सा प्रति दस लाख</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} हिस्सा प्रति दस लाख</unitPattern>
 				<unitPattern count="other">{0} हिस्सा प्रति दस लाख</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} हिस्सा प्रति दस लाख</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>masculine</gender>
@@ -8050,41 +8050,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>प्रति हज़ार</displayName>
 				<unitPattern count="one">{0} प्रति हज़ार</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} प्रति हज़ार</unitPattern>
 				<unitPattern count="other">{0} प्रति हज़ार</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} प्रति हज़ार</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>masculine</gender>
 				<displayName>प्रति दस हज़ार</displayName>
 				<unitPattern count="one">{0} प्रति दस हज़ार</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} प्रति दस हज़ार</unitPattern>
 				<unitPattern count="other">{0} प्रति दस हज़ार</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} प्रति दस हज़ार</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>masculine</gender>
 				<displayName>मोल</displayName>
 				<unitPattern count="one">{0} मोल</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मोल</unitPattern>
 				<unitPattern count="other">{0} मोल</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मोल</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>masculine</gender>
 				<displayName>लीटर प्रति किलोमीटर</displayName>
 				<unitPattern count="one">{0} लीटर प्रति किलोमीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} लीटर प्रति किलोमीटर</unitPattern>
 				<unitPattern count="other">{0} लीटर प्रति किलोमीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} लीटर प्रति किलोमीटर</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>masculine</gender>
 				<displayName>लीटर प्रति 100 किलोमीटर</displayName>
 				<unitPattern count="one">{0} लीटर प्रति 100 किलोमीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} लीटर प्रति 100 किलोमीटर</unitPattern>
 				<unitPattern count="other">{0} लीटर प्रति 100 किलोमीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} लीटर प्रति 100 किलोमीटर</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<gender>masculine</gender>
@@ -8106,95 +8106,95 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>पेटाबाइट</displayName>
 				<unitPattern count="one">{0} पेटाबाइट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} पेटाबाइट</unitPattern>
 				<unitPattern count="other">{0} पेटाबाइट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} पेटाबाइट</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>masculine</gender>
 				<displayName>टेराबाइट</displayName>
 				<unitPattern count="one">{0} टेराबाइट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} टेराबाइट</unitPattern>
 				<unitPattern count="other">{0} टेराबाइट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} टेराबाइट</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>masculine</gender>
 				<displayName>टेराबिट</displayName>
 				<unitPattern count="one">{0} टेराबिट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} टेराबिट</unitPattern>
 				<unitPattern count="other">{0} टेराबिट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} टेराबिट</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>masculine</gender>
 				<displayName>गीगाबाइट</displayName>
 				<unitPattern count="one">{0} गीगाबाइट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} गीगाबाइट</unitPattern>
 				<unitPattern count="other">{0} गीगाबाइट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} गीगाबाइट</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>masculine</gender>
 				<displayName>गीगाबिट</displayName>
 				<unitPattern count="one">{0} गीगाबिट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} गीगाबिट</unitPattern>
 				<unitPattern count="other">{0} गीगाबिट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} गीगाबिट</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>masculine</gender>
 				<displayName>मेगाबाइट</displayName>
 				<unitPattern count="one">{0} मेगाबाइट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेगाबाइट</unitPattern>
 				<unitPattern count="other">{0} मेगाबाइट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेगाबाइट</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>masculine</gender>
 				<displayName>मेगाबिट</displayName>
 				<unitPattern count="one">{0} मेगाबिट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेगाबिट</unitPattern>
 				<unitPattern count="other">{0} मेगाबिट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेगाबिट</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>masculine</gender>
 				<displayName>किलोबाइट</displayName>
 				<unitPattern count="one">{0} किलोबाइट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} किलोबाइट</unitPattern>
 				<unitPattern count="other">{0} किलोबाइट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} किलोबाइट</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>masculine</gender>
 				<displayName>किलोबिट</displayName>
 				<unitPattern count="one">{0} किलोबिट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} किलोबिट</unitPattern>
 				<unitPattern count="other">{0} किलोबिट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} किलोबिट</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>masculine</gender>
 				<displayName>बाइट</displayName>
 				<unitPattern count="one">{0} बाइट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} बाइट</unitPattern>
 				<unitPattern count="other">{0} बाइट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} बाइट</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>masculine</gender>
 				<displayName>बिट</displayName>
 				<unitPattern count="one">{0} बिट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} बिट</unitPattern>
 				<unitPattern count="other">{0} बिट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} बिट</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>feminine</gender>
 				<displayName>शताब्दियाँ</displayName>
 				<unitPattern count="one">{0} शताब्दी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} शताब्दी</unitPattern>
 				<unitPattern count="other">{0} शताब्दियाँ</unitPattern>
 				<unitPattern count="other" case="oblique">{0} शताब्दियों</unitPattern>
 			</unit>
@@ -8202,17 +8202,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>दशकों</displayName>
 				<unitPattern count="one">{0} दशक</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} दशक</unitPattern>
 				<unitPattern count="other">{0} दशकों</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} दशकों</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>masculine</gender>
 				<displayName>वर्ष</displayName>
 				<unitPattern count="one">{0} वर्ष</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} वर्ष</unitPattern>
 				<unitPattern count="other">{0} वर्ष</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} वर्ष</unitPattern>
 				<perUnitPattern>{0} प्रति वर्ष</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -8246,7 +8246,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>दिन</displayName>
 				<unitPattern count="one">{0} दिन</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} दिन</unitPattern>
 				<unitPattern count="other">{0} दिन</unitPattern>
 				<unitPattern count="other" case="oblique">{0} दिनों</unitPattern>
 				<perUnitPattern>{0} प्रति दिन</perUnitPattern>
@@ -8282,57 +8282,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>मिलीसेकंड</displayName>
 				<unitPattern count="one">{0} मिलीसेकंड</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मिलीसेकंड</unitPattern>
 				<unitPattern count="other">{0} मिलीसेकंड</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मिलीसेकंड</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>masculine</gender>
 				<displayName>माइक्रोसेकंड</displayName>
 				<unitPattern count="one">{0} माइक्रोसेकंड</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} माइक्रोसेकंड</unitPattern>
 				<unitPattern count="other">{0} माइक्रोसेकंड</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} माइक्रोसेकंड</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>masculine</gender>
 				<displayName>नैनो सेकंड</displayName>
 				<unitPattern count="one">{0} नैनो सेकंड</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} नैनो सेकंड</unitPattern>
 				<unitPattern count="other">{0} नैनो सेकंड</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} नैनो सेकंड</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>masculine</gender>
 				<displayName>एम्पीयर</displayName>
 				<unitPattern count="one">{0} एम्पीयर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} एम्पीयर</unitPattern>
 				<unitPattern count="other">{0} एम्पीयर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} एम्पीयर</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>masculine</gender>
 				<displayName>मिली एम्‍पीयर</displayName>
 				<unitPattern count="one">{0} मिली एम्‍पीयर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मिली एम्‍पीयर</unitPattern>
 				<unitPattern count="other">{0} मिली एम्‍पीयर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मिली एम्‍पीयर</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>masculine</gender>
 				<displayName>ओम</displayName>
 				<unitPattern count="one">{0} ओम</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ओम</unitPattern>
 				<unitPattern count="other">{0} ओम</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ओम</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>feminine</gender>
 				<displayName>वोल्ट</displayName>
 				<unitPattern count="one">{0} वोल्ट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} वोल्ट</unitPattern>
 				<unitPattern count="other">{0} वोल्ट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} वोल्ट</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<gender>feminine</gender>
@@ -8346,9 +8346,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>कैलोरी</displayName>
 				<unitPattern count="one">{0} कैलोरी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} कैलोरी</unitPattern>
 				<unitPattern count="other">{0} कैलोरी</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} कैलोरी</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<gender>feminine</gender>
@@ -8362,25 +8362,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>किलो जूल</displayName>
 				<unitPattern count="one">{0} किलो जूल</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} किलो जूल</unitPattern>
 				<unitPattern count="other">{0} किलो जूल</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} किलो जूल</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>masculine</gender>
 				<displayName>जूल</displayName>
 				<unitPattern count="one">{0} जूल</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} जूल</unitPattern>
 				<unitPattern count="other">{0} जूल</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} जूल</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>masculine</gender>
 				<displayName>किलोवॉट घंटे</displayName>
 				<unitPattern count="one">{0} किलोवॉट घंटा</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} किलोवॉट घंटा</unitPattern>
 				<unitPattern count="other">{0} किलोवॉट घंटे</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} किलोवॉट घंटे</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>इलेक्ट्रॉनवोल्ट</displayName>
@@ -8406,81 +8406,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>न्यूटन</displayName>
 				<unitPattern count="one">{0} न्यूटन</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} न्यूटन</unitPattern>
 				<unitPattern count="other">{0} न्यूटन</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} न्यूटन</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="oblique">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="oblique">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>masculine</gender>
 				<displayName>गीगाहर्ट्ज़</displayName>
 				<unitPattern count="one">{0} गीगाहर्ट्ज़</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} गीगाहर्ट्ज़</unitPattern>
 				<unitPattern count="other">{0} गीगाहर्ट्ज़</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} गीगाहर्ट्ज़</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>masculine</gender>
 				<displayName>मेगाहर्ट्ज़</displayName>
 				<unitPattern count="one">{0} मेगाहर्ट्ज़</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेगाहर्ट्ज़</unitPattern>
 				<unitPattern count="other">{0} मेगाहर्ट्ज़</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेगाहर्ट्ज़</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>masculine</gender>
 				<displayName>किलोहर्ट्ज़</displayName>
 				<unitPattern count="one">{0} किलोहर्ट्ज़</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} किलोहर्ट्ज़</unitPattern>
 				<unitPattern count="other">{0} किलोहर्ट्ज़</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} किलोहर्ट्ज़</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>masculine</gender>
 				<displayName>हर्ट्ज़</displayName>
 				<unitPattern count="one">{0} हर्ट्ज़</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} हर्ट्ज़</unitPattern>
 				<unitPattern count="other">{0} हर्ट्ज़</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} हर्ट्ज़</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>masculine</gender>
 				<displayName>टाइपोग्राफ़िक एम</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="oblique">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="oblique">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
 				<displayName>पिक्सेल</displayName>
 				<unitPattern count="one">{0} पिक्सेल</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} पिक्सेल</unitPattern>
 				<unitPattern count="other">{0} पिक्सेल</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} पिक्सेल</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>masculine</gender>
 				<displayName>मेगापिक्सेल</displayName>
 				<unitPattern count="one">{0} मेगापिक्सेल</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेगापिक्सेल</unitPattern>
 				<unitPattern count="other">{0} मेगापिक्सेल</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेगापिक्सेल</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>masculine</gender>
 				<displayName>पिक्सेल प्रति सेंटीमीटर</displayName>
 				<unitPattern count="one">{0} पिक्सेल प्रति सेंटीमीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} पिक्सेल प्रति सेंटीमीटर</unitPattern>
 				<unitPattern count="other">{0} पिक्सेल प्रति सेंटीमीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} पिक्सेल प्रति सेंटीमीटर</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>पिक्सेल प्रति इंच</displayName>
@@ -8499,8 +8499,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>बिंदु</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} बिंदु</unitPattern>
+				<unitPattern count="other">{0} बिंदु</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>पृथ्वी की त्रिज्या</displayName>
@@ -8529,9 +8529,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>डेसीमीटर</displayName>
 				<unitPattern count="one">{0} डेसीमीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} डेसीमीटर</unitPattern>
 				<unitPattern count="other">{0} डेसीमीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} डेसीमीटर</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>masculine</gender>
@@ -8554,17 +8554,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>माइक्रोमीटर</displayName>
 				<unitPattern count="one">{0} माइक्रोमीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} माइक्रोमीटर</unitPattern>
 				<unitPattern count="other">{0} माइक्रोमीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} माइक्रोमीटर</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>masculine</gender>
 				<displayName>नैनोमीटर</displayName>
 				<unitPattern count="one">{0} नैनोमीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} नैनोमीटर</unitPattern>
 				<unitPattern count="other">{0} नैनोमीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} नैनोमीटर</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>masculine</gender>
@@ -8586,9 +8586,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>यार्ड</displayName>
 				<unitPattern count="one">{0} यार्ड</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} यार्ड</unitPattern>
 				<unitPattern count="other">{0} यार्ड</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} यार्ड</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<gender>masculine</gender>
@@ -8612,9 +8612,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>पार्सेक</displayName>
 				<unitPattern count="one">{0} पार्सेक</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} पार्सेक</unitPattern>
 				<unitPattern count="other">{0} पार्सेक</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} पार्सेक</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>प्रकाश वर्ष</displayName>
@@ -8645,9 +8645,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>मील-स्कैण्डिनेवियन</displayName>
 				<unitPattern count="one">{0} मील-स्कैण्डिनेवियन</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मील-स्कैण्डिनेवियन</unitPattern>
 				<unitPattern count="other">{0} मील-स्कैण्डिनेवियन</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मील-स्कैण्डिनेवियन</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pt</displayName>
@@ -8666,25 +8666,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>लक्स</displayName>
 				<unitPattern count="one">{0} लक्स</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} लक्स</unitPattern>
 				<unitPattern count="other">{0} लक्स</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} लक्स</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
 				<displayName>कैन्डेला</displayName>
 				<unitPattern count="one">{0} कैन्डेला</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} कैन्डेला</unitPattern>
 				<unitPattern count="other">{0} कैन्डेला</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} कैन्डेला</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>masculine</gender>
 				<displayName>लुमेन</displayName>
 				<unitPattern count="one">{0} लुमेन</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} लुमेन</unitPattern>
 				<unitPattern count="other">{0} लुमेन</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} लुमेन</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<gender>masculine</gender>
@@ -8698,9 +8698,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>मीट्रिक टन</displayName>
 				<unitPattern count="one">{0} मीट्रिक टन</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मीट्रिक टन</unitPattern>
 				<unitPattern count="other">{0} मीट्रिक टन</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मीट्रिक टन</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>masculine</gender>
@@ -8732,9 +8732,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>माइक्रोग्राम</displayName>
 				<unitPattern count="one">{0} माइक्रोग्राम</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} माइक्रोग्राम</unitPattern>
 				<unitPattern count="other">{0} माइक्रोग्राम</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} माइक्रोग्राम</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>टन</displayName>
@@ -8750,18 +8750,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>पौंड</displayName>
 				<unitPattern count="one">{0} पौंड</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} पौंड</unitPattern>
 				<unitPattern count="other">{0} पौंड</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} पौंड</unitPattern>
 				<perUnitPattern>{0}/पौंड</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<gender>masculine</gender>
 				<displayName>औंस</displayName>
 				<unitPattern count="one">{0} औंस</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} औंस</unitPattern>
 				<unitPattern count="other">{0} औंस</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} औंस</unitPattern>
 				<perUnitPattern>{0}/औंस</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
@@ -8773,17 +8773,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>कैरेट</displayName>
 				<unitPattern count="one">{0} कैरेट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} कैरेट</unitPattern>
 				<unitPattern count="other">{0} कैरेट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} कैरेट</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<gender>masculine</gender>
 				<displayName>डाल्टन</displayName>
 				<unitPattern count="one">{0} डाल्टन</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} डाल्टन</unitPattern>
 				<unitPattern count="other">{0} डाल्टन</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} डाल्टन</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<gender>masculine</gender>
@@ -8813,41 +8813,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>गिगावॉट</displayName>
 				<unitPattern count="one">{0} गिगावॉट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} गिगावॉट</unitPattern>
 				<unitPattern count="other">{0} गिगावॉट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} गिगावॉट</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>masculine</gender>
 				<displayName>मेगावॉट</displayName>
 				<unitPattern count="one">{0} मेगावॉट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेगावॉट</unitPattern>
 				<unitPattern count="other">{0} मेगावॉट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेगावॉट</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>masculine</gender>
 				<displayName>किलोवॉट</displayName>
 				<unitPattern count="one">{0} किलोवॉट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} किलोवॉट</unitPattern>
 				<unitPattern count="other">{0} किलोवॉट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} किलोवॉट</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>masculine</gender>
 				<displayName>वॉट</displayName>
 				<unitPattern count="one">{0} वॉट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} वॉट</unitPattern>
 				<unitPattern count="other">{0} वॉट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} वॉट</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>masculine</gender>
 				<displayName>मिलीवॉट</displayName>
 				<unitPattern count="one">{0} मिलीवॉट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मिलीवॉट</unitPattern>
 				<unitPattern count="other">{0} मिलीवॉट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मिलीवॉट</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>अश्वशक्ति</displayName>
@@ -8873,39 +8873,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>बार</displayName>
 				<unitPattern count="one">{0} बार</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} बार</unitPattern>
 				<unitPattern count="other">{0} बार</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} बार</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>masculine</gender>
 				<displayName>मिलीबार</displayName>
 				<unitPattern count="one">{0} मिलीबार</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मिलीबार</unitPattern>
 				<unitPattern count="other">{0} मिलीबार</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मिलीबार</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>masculine</gender>
 				<displayName>वायुमण्डलीय दबाव</displayName>
 				<unitPattern count="one">{0} वायुमंडलीय दबाव</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} वायुमंडलीय दबाव</unitPattern>
 				<unitPattern count="other">{0} वायुमंडलीय दबाव</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} वायुमंडलीय दबाव</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>masculine</gender>
 				<displayName>पास्कल</displayName>
 				<unitPattern count="one">{0} पास्कल</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} पास्कल</unitPattern>
 				<unitPattern count="other">{0} पास्कल</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} पास्कल</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>masculine</gender>
 				<displayName>हेक्टोपास्कल</displayName>
 				<unitPattern count="one">{0} हेक्टोपास्कल</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} हेक्टोपास्कल</unitPattern>
 				<unitPattern count="other">{0} हेक्टोपास्कल</unitPattern>
 				<unitPattern count="other" case="oblique">{0} हेक्टोपास्कल</unitPattern>
 			</unit>
@@ -8921,9 +8921,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>मेगापास्कल</displayName>
 				<unitPattern count="one">{0} मेगापास्कल</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेगापास्कल</unitPattern>
 				<unitPattern count="other">{0} मेगापास्कल</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेगापास्कल</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>masculine</gender>
@@ -8995,25 +8995,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>न्यूटन-मीटर</displayName>
 				<unitPattern count="one">{0} न्यूटन-मीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} न्यूटन-मीटर</unitPattern>
 				<unitPattern count="other">{0} न्यूटन-मीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} न्यूटन-मीटर</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>masculine</gender>
 				<displayName>घन किलोमीटर</displayName>
 				<unitPattern count="one">{0} घन किलोमीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} घन किलोमीटर</unitPattern>
 				<unitPattern count="other">{0} घन किलोमीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} घन किलोमीटर</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>masculine</gender>
 				<displayName>घन मीटर</displayName>
 				<unitPattern count="one">{0} घन मीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} घन मीटर</unitPattern>
 				<unitPattern count="other">{0} घन मीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} घन मीटर</unitPattern>
 				<perUnitPattern>{0}/घन मीटर</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
@@ -9022,7 +9022,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} घन सेंटीमीटर</unitPattern>
 				<unitPattern count="one" case="oblique">{0} घन सेंटीमीटर</unitPattern>
 				<unitPattern count="other">{0} घन सेंटीमीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} घन सेंटीमीटर</unitPattern>
 				<perUnitPattern>{0}/घन सेंटीमीटर</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -9055,9 +9055,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>मेगालीटर</displayName>
 				<unitPattern count="one">{0} मेगालीटर</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेगालीटर</unitPattern>
 				<unitPattern count="other">{0} मेगालीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेगालीटर</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>masculine</gender>
@@ -9065,7 +9065,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} हेक्टोलीटर</unitPattern>
 				<unitPattern count="one" case="oblique">{0} हेक्टोलीटर</unitPattern>
 				<unitPattern count="other">{0} हेक्टोलीटर</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} हेक्टोलीटर</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>masculine</gender>
@@ -9104,17 +9104,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>मीट्रिक पिंट</displayName>
 				<unitPattern count="one">{0} मीट्रिक पिंट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मीट्रिक पिंट</unitPattern>
 				<unitPattern count="other">{0} मीट्रिक पिंट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मीट्रिक पिंट</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>masculine</gender>
 				<displayName>मीट्रिक कप</displayName>
 				<unitPattern count="one">{0} मीट्रिक कप</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मीट्रिक कप</unitPattern>
 				<unitPattern count="other">{0} मीट्रिक कप</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मीट्रिक कप</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>एकड़ फ़ीट</displayName>
@@ -9130,9 +9130,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>गैलन</displayName>
 				<unitPattern count="one">{0} गैलन</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} गैलन</unitPattern>
 				<unitPattern count="other">{0} गैलन</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} गैलन</unitPattern>
 				<perUnitPattern>{0}/गैलन</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
@@ -9148,14 +9148,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>क्वार्ट</displayName>
 				<unitPattern count="one">{0} क्वार्ट</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} क्वार्ट</unitPattern>
 				<unitPattern count="other">{0} क्वार्ट</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} क्वार्ट</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>पाइंट</displayName>
+				<unitPattern count="one">{0} पाइंट</unitPattern>
 				<unitPattern count="one" case="oblique">{0} पाइंट</unitPattern>
 				<unitPattern count="other">{0} पाइंट</unitPattern>
 				<unitPattern count="other" case="oblique">{0} पाइंट</unitPattern>
@@ -9164,17 +9164,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>कप</displayName>
 				<unitPattern count="one">{0} कप</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} कप</unitPattern>
 				<unitPattern count="other">{0} कप</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} कप</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<gender>masculine</gender>
 				<displayName>फ़्लूइड आउंस</displayName>
 				<unitPattern count="one">{0} फ़्लूइड आउंस</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} फ़्लूइड आउंस</unitPattern>
 				<unitPattern count="other">{0} फ़्लूइड आउंस</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} फ़्लूइड आउंस</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<gender>masculine</gender>
@@ -9188,17 +9188,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>टेबलस्पून</displayName>
 				<unitPattern count="one">{0} टेबलस्पून</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} टेबलस्पून</unitPattern>
 				<unitPattern count="other">{0} टेबलस्पून</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} टेबलस्पून</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
 				<gender>masculine</gender>
 				<displayName>टी स्पून</displayName>
 				<unitPattern count="one">{0} टी स्पून</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} टी स्पून</unitPattern>
 				<unitPattern count="other">{0} टी स्पून</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} टी स्पून</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>बैरल</displayName>
@@ -9477,7 +9477,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -9497,7 +9497,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -9705,12 +9705,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -9720,7 +9720,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
@@ -9755,38 +9755,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>पिक्सेल</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>मेगापिक्सेल</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>बिंदु</displayName>
@@ -9795,7 +9795,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9905,7 +9905,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9915,17 +9915,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9994,12 +9994,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -10129,7 +10129,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -10259,7 +10259,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -10331,7 +10331,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>मि {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
 				<unitPrefixPattern>नै {0}</unitPrefixPattern>
@@ -10419,7 +10419,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>गु–बल</displayName>
@@ -10427,9 +10427,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} गु</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मीटर/से²</displayName>
+				<unitPattern count="one">{0} मी॰/व॰से॰</unitPattern>
+				<unitPattern count="other">{0} मी॰/व॰से॰</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>r</displayName>
@@ -10442,35 +10442,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>अंश</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>आर्क मिनट</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>आर्क सेकंड</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>वर्ग किमी</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} वर्ग कि॰मी॰</unitPattern>
+				<unitPattern count="other">{0} वर्ग कि॰मी॰</unitPattern>
 				<perUnitPattern>{0}/वर्ग किमी</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>हे</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} हे॰</unitPattern>
+				<unitPattern count="other">{0} हे॰</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>वर्ग मी</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} वर्ग मी॰</unitPattern>
+				<unitPattern count="other">{0} वर्ग मी॰</unitPattern>
 				<perUnitPattern>{0}/वर्ग मी</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
@@ -10480,15 +10480,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/वर्ग सेंमी</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>वर्ग मील</displayName>
+				<unitPattern count="one">{0} वर्ग मील</unitPattern>
 				<unitPattern count="other">{0} व मी</unitPattern>
 				<perUnitPattern>{0}/वर्ग मील</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>एकड़</displayName>
+				<unitPattern count="one">{0} एकड़</unitPattern>
+				<unitPattern count="other">{0} एकड़</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>वर्ग गज़</displayName>
@@ -10504,37 +10504,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>वर्ग इंच</displayName>
 				<unitPattern count="one">{0} व इं</unitPattern>
 				<unitPattern count="other">{0} व इं</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/वर्ग इंच</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>डोनम</displayName>
+				<unitPattern count="one">{0} डोनम</unitPattern>
+				<unitPattern count="other">{0} डोनम</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>कैरट</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मि॰ग्रा॰/डे॰ली॰</displayName>
+				<unitPattern count="one">{0} मि॰ग्रा॰/डे॰ली॰</unitPattern>
+				<unitPattern count="other">{0} मि॰ग्रा॰/डे॰ली॰</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मिलीमोल/लीटर</displayName>
+				<unitPattern count="one">{0} मिलीमोल/ली॰</unitPattern>
+				<unitPattern count="other">{0} मिलीमोल/ली॰</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -10542,24 +10542,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>प्रति हज़ार</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मोल</displayName>
+				<unitPattern count="one">{0} मोल</unitPattern>
+				<unitPattern count="other">{0} मोल</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>लीटर/किमी</displayName>
+				<unitPattern count="one">{0} ली/किमी</unitPattern>
+				<unitPattern count="other">{0} ली/किमी</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ली॰/100 कि॰मी॰</displayName>
@@ -10567,69 +10567,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ली/100 किमी</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मील/गैलन</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg इंपीरियल</displayName>
+				<unitPattern count="one">{0} mpg इंपीरियल</unitPattern>
+				<unitPattern count="other">{0} mpg इंपीरियल</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>PB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बाइट</displayName>
+				<unitPattern count="one">{0} बाइट</unitPattern>
+				<unitPattern count="other">{0} बाइट</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बिट</displayName>
+				<unitPattern count="one">{0} बिट</unitPattern>
+				<unitPattern count="other">{0} बिट</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>श</displayName>
@@ -10637,9 +10637,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} श</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>दश.</displayName>
+				<unitPattern count="one">{0} दश.</unitPattern>
+				<unitPattern count="other">{0} दश.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>वर्ष</displayName>
@@ -10648,16 +10648,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/व</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>तिमा</displayName>
+				<unitPattern count="one">{0} तिमा</unitPattern>
+				<unitPattern count="other">{0} तिमा</unitPattern>
 				<perUnitPattern>{0}/ति</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>माह</displayName>
 				<unitPattern count="one">{0}माह</unitPattern>
 				<unitPattern count="other">{0}माह</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/माह</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>सप्ताह</displayName>
@@ -10696,8 +10696,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>μsec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>ns</displayName>
@@ -10705,32 +10705,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} नैनो से</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>एम्पी॰</displayName>
+				<unitPattern count="one">{0} ए॰</unitPattern>
+				<unitPattern count="other">{0} ए॰</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मि॰ ए॰</displayName>
+				<unitPattern count="one">{0} मि॰ ए॰</unitPattern>
+				<unitPattern count="other">{0} मि॰ ए॰</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ओम</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>वोल्ट</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="one">{0} कै</unitPattern>
 				<unitPattern count="other">{0} कै</unitPattern>
 			</unit>
@@ -10740,94 +10740,94 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} कै</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>किलो जूल</displayName>
 				<unitPattern count="one">{0} किजू</unitPattern>
 				<unitPattern count="other">{0} किजू</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>जूल</displayName>
 				<unitPattern count="one">{0} जू</unitPattern>
 				<unitPattern count="other">{0} जू</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>यूएस थेर्म</displayName>
+				<unitPattern count="one">{0} यूएस थेर्म</unitPattern>
+				<unitPattern count="other">{0} यूएस थेर्म</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>न्यू॰</displayName>
+				<unitPattern count="one">{0} न्यू॰</unitPattern>
+				<unitPattern count="other">{0} न्यू॰</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
@@ -10840,14 +10840,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>बिंदु</displayName>
 				<unitPattern count="one">{0}बिंदु</unitPattern>
 				<unitPattern count="other">{0}बिंदु</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>कि॰मी॰</displayName>
@@ -10857,9 +10857,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-meter">
 				<displayName>मीटर</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} मी</unitPattern>
+				<unitPattern count="other">{0} मी</unitPattern>
+				<perUnitPattern>{0}/मी</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>डेमी</displayName>
@@ -10868,8 +10868,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>सें॰मी॰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} सें॰मी॰</unitPattern>
+				<unitPattern count="other">{0} सें॰मी॰</unitPattern>
 				<perUnitPattern>{0}/सेंमी</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
@@ -10893,29 +10893,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}पि॰मी॰</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मील</displayName>
+				<unitPattern count="one">{0} मील</unitPattern>
+				<unitPattern count="other">{0} मील</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>यार्ड</displayName>
+				<unitPattern count="one">{0} यार्ड</unitPattern>
+				<unitPattern count="other">{0} यार्ड</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>फ़ीट</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/फ़ीट</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>इंच</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/इंच</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>पार्सेक</displayName>
 				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
@@ -10925,17 +10925,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} प्रव</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>खगो॰ इका॰</displayName>
+				<unitPattern count="one">{0} खगो॰ इका॰</unitPattern>
+				<unitPattern count="other">{0} खगो॰ इका॰</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>फ़र्लांग</displayName>
+				<unitPattern count="one">{0} फ़र्लांग</unitPattern>
+				<unitPattern count="other">{0} फ़र्लांग</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>फ़ैदम</displayName>
 				<unitPattern count="one">{0} फ़ै</unitPattern>
 				<unitPattern count="other">{0} फ़ै</unitPattern>
 			</unit>
@@ -10945,42 +10945,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>लक्स</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>मीट्रिक टन</displayName>
 				<unitPattern count="one">{0} ट</unitPattern>
 				<unitPattern count="other">{0} ट</unitPattern>
 			</unit>
@@ -10988,155 +10988,155 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>कि॰ग्रा॰</displayName>
 				<unitPattern count="one">{0} किग्रा</unitPattern>
 				<unitPattern count="other">{0} किग्रा</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/कि॰ग्रा॰</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>ग्राम</displayName>
 				<unitPattern count="one">{0} ग्रा॰</unitPattern>
 				<unitPattern count="other">{0} ग्रा॰</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ग्रा॰</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>मि॰ग्रा॰</displayName>
 				<unitPattern count="one">{0} मिग्रा</unitPattern>
 				<unitPattern count="other">{0} मिग्रा</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मा॰ग्रा॰</displayName>
+				<unitPattern count="one">{0} मा॰ग्रा॰</unitPattern>
+				<unitPattern count="other">{0} मा॰ग्रा॰</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>टन</displayName>
+				<unitPattern count="one">{0} टन</unitPattern>
+				<unitPattern count="other">{0} टन</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>14 पौ. का बट्टा</displayName>
 				<unitPattern count="one">{0} ला</unitPattern>
 				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>पौंड</displayName>
 				<unitPattern count="one">{0}#</unitPattern>
 				<unitPattern count="other">{0}#</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/पौंड</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>औंस</displayName>
 				<unitPattern count="one">{0} औं॰</unitPattern>
 				<unitPattern count="other">{0} औं॰</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/औंस</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ट्राई औंस</displayName>
+				<unitPattern count="one">{0} ट्राई औंस</unitPattern>
+				<unitPattern count="other">{0} ट्राई औंस</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>कै॰</displayName>
+				<unitPattern count="one">{0} कै॰</unitPattern>
+				<unitPattern count="other">{0} कै॰</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>डाल्टन</displayName>
+				<unitPattern count="one">{0} डाल्टन</unitPattern>
+				<unitPattern count="other">{0} डाल्टन</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>डे. रत्ती</displayName>
+				<unitPattern count="one">{0} डे. रत्ती</unitPattern>
+				<unitPattern count="other">{0} डेढ़ रत्ती</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} किवॉ</unitPattern>
 				<unitPattern count="other">{0} किवॉ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>वॉट</displayName>
 				<unitPattern count="one">{0} वॉ</unitPattern>
 				<unitPattern count="other">{0} वॉ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">{0} मिवॉ</unitPattern>
 				<unitPattern count="other">{0} मिवॉ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0} एचपी</unitPattern>
 				<unitPattern count="other">{0} एचपी</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="one">{0} mm Hg</unitPattern>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0}&quot; Hg</unitPattern>
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बार</displayName>
+				<unitPattern count="one">{0} बार</unitPattern>
+				<unitPattern count="other">{0} बार</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0}mb</unitPattern>
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>पा॰</displayName>
+				<unitPattern count="one">{0} पा॰</unitPattern>
+				<unitPattern count="other">{0} पा॰</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0}hPa</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>किपा॰</displayName>
+				<unitPattern count="one">{0} किपा॰</unitPattern>
+				<unitPattern count="other">{0} किपा॰</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मेपा॰</displayName>
+				<unitPattern count="one">{0} मेपा॰</unitPattern>
+				<unitPattern count="other">{0} मेपा॰</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>कि॰मी॰/घं॰</displayName>
@@ -11144,24 +11144,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} किमी/घं</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>मीटर/से॰</displayName>
 				<unitPattern count="one">{0} मी/से</unitPattern>
 				<unitPattern count="other">{0}मी॰/से॰</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>मील/घंटा</displayName>
 				<unitPattern count="one">{0} मीप्रघं</unitPattern>
 				<unitPattern count="other">{0} मीप्रघं</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>नॉट</displayName>
+				<unitPattern count="one">{0} नॉट</unitPattern>
+				<unitPattern count="other">{0} नॉट</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°से॰</displayName>
@@ -11169,27 +11169,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°से॰</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>डिग्री फ़ेरनहाइट</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>न्यू॰मी॰</displayName>
+				<unitPattern count="one">{0} न्यू॰मी॰</unitPattern>
+				<unitPattern count="other">{0} न्यू॰मी॰</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>घन कि॰मी॰</displayName>
 				<unitPattern count="one">{0} घन किमी</unitPattern>
 				<unitPattern count="other">{0} घन किमी</unitPattern>
 			</unit>
@@ -11206,24 +11206,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/घन सेंमी</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>घन मील</displayName>
+				<unitPattern count="one">{0} घन मील</unitPattern>
+				<unitPattern count="other">{0} घन मील</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>घन या॰</displayName>
+				<unitPattern count="one">{0} घन या॰</unitPattern>
+				<unitPattern count="other">{0} घन या॰</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>घन फ़ीट</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} घ॰ फ़ी॰</unitPattern>
+				<unitPattern count="other">{0} घ॰ फ़ी॰</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>घन इंच</displayName>
+				<unitPattern count="one">{0} घन इंच</unitPattern>
+				<unitPattern count="other">{0} घन इंच</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>मेली</displayName>
@@ -11231,7 +11231,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} मेली</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>है॰ली॰</displayName>
 				<unitPattern count="one">{0} हेली</unitPattern>
 				<unitPattern count="other">{0} हेली</unitPattern>
 			</unit>
@@ -11257,17 +11257,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} मिली</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मीट्रिक पिंट</displayName>
+				<unitPattern count="one">{0} मीट्रिक पिंट</unitPattern>
+				<unitPattern count="other">{0} मीट्रिक पिंट</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मीट्रिक कप</displayName>
+				<unitPattern count="one">{0} मीट्रिक कप</unitPattern>
+				<unitPattern count="other">{0} मीट्रिक कप</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>एकड़ फ़ीट</displayName>
 				<unitPattern count="one">{0} एकड़ फ़ीट</unitPattern>
 				<unitPattern count="other">{0} एकड़ फ़ीट</unitPattern>
 			</unit>
@@ -11289,9 +11289,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/इम्पी गैलन</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>क्वार्ट</displayName>
+				<unitPattern count="one">{0} क्वार्ट</unitPattern>
+				<unitPattern count="other">{0} क्वार्ट</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>पा</displayName>
@@ -11299,9 +11299,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} पा</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>कप</displayName>
+				<unitPattern count="one">{0} कप</unitPattern>
+				<unitPattern count="other">{0} कप</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<displayName>fl oz</displayName>
@@ -11324,9 +11324,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बैरल</displayName>
+				<unitPattern count="one">{0} बैरल</unitPattern>
+				<unitPattern count="other">{0} बैरल</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dsp</displayName>
@@ -11339,9 +11339,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बूंद</displayName>
+				<unitPattern count="one">{0} बूंद</unitPattern>
+				<unitPattern count="other">{0} बूंद</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl.dr.</displayName>
@@ -11349,14 +11349,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>जिगर</displayName>
+				<unitPattern count="one">{0} जिगर</unitPattern>
+				<unitPattern count="other">{0} जिगर</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>चुटकी</displayName>
+				<unitPattern count="one">{0} चुटकी</unitPattern>
+				<unitPattern count="other">{0} चुटकी</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>qt Imp</displayName>
@@ -11395,22 +11395,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} या {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} या {1}</listPatternPart>
+			<listPatternPart type="2">{0} या {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} या {1}</listPatternPart>
+			<listPatternPart type="2">{0} या {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} और {1}</listPatternPart>
+			<listPatternPart type="2">{0} और {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/hnj.xml
+++ b/common/main/hnj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -27,7 +27,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="hmn">𞄀𞄄𞄰𞄩</language>
 			<language type="hnj">𞄀𞄄𞄰𞄩𞄍𞄜𞄰</language>
 			<language type="zh">𞄋𞄄</language>
-			<language type="zh" alt="menu">↑↑↑</language>
+			<language type="zh" alt="menu">𞄋𞄄</language>
 			<language type="zh_Hans">↑↑↑</language>
 			<language type="zh_Hans" alt="long">↑↑↑</language>
 			<language type="zh_Hant">↑↑↑</language>
@@ -39,7 +39,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</scripts>
 		<territories>
 			<territory type="US">𞄒𞄫𞄱𞄔𞄩𞄴</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">𞄒𞄫𞄱𞄔𞄩𞄴</territory>
 		</territories>
 	</localeDisplayNames>
 	<layout>
@@ -62,32 +62,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">𞄆𞄬</month>
+							<month type="2">𞄛𞄨𞄱𞄄𞄤𞄲𞄨</month>
+							<month type="3">𞄒𞄫𞄰𞄒𞄪𞄱</month>
+							<month type="4">𞄤𞄨𞄱</month>
+							<month type="5">𞄀𞄪𞄴</month>
+							<month type="6">𞄛𞄤𞄱𞄞𞄤𞄦</month>
+							<month type="7">𞄔𞄩𞄴𞄆𞄨𞄰</month>
+							<month type="8">𞄕𞄩𞄲𞄔𞄄𞄰𞄤</month>
+							<month type="9">𞄛𞄤𞄱𞄒𞄤𞄰</month>
+							<month type="10">𞄪𞄱𞄀𞄤𞄴</month>
+							<month type="11">𞄚𞄦𞄲𞄤𞄚𞄄𞄰𞄫</month>
+							<month type="12">𞄒𞄩𞄱𞄔𞄬𞄴</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">𞄆𞄬</month>
@@ -106,32 +106,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">𞄆𞄬</month>
+							<month type="2">𞄛𞄨𞄱𞄄𞄤𞄲𞄨</month>
+							<month type="3">𞄒𞄫𞄰𞄒𞄪𞄱</month>
+							<month type="4">𞄤𞄨𞄱</month>
+							<month type="5">𞄀𞄪𞄴</month>
+							<month type="6">𞄛𞄤𞄱𞄞𞄤𞄦</month>
+							<month type="7">𞄔𞄩𞄴𞄆𞄨𞄰</month>
+							<month type="8">𞄕𞄩𞄲𞄔𞄄𞄰𞄤</month>
+							<month type="9">𞄛𞄤𞄱𞄒𞄤𞄰</month>
+							<month type="10">𞄪𞄱𞄀𞄤𞄴</month>
+							<month type="11">𞄚𞄦𞄲𞄤𞄚𞄄𞄰𞄫</month>
+							<month type="12">𞄒𞄩𞄱𞄔𞄬𞄴</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">𞄆𞄬</month>
+							<month type="2">𞄛𞄨𞄱𞄄𞄤𞄲𞄨</month>
+							<month type="3">𞄒𞄫𞄰𞄒𞄪𞄱</month>
+							<month type="4">𞄤𞄨𞄱</month>
+							<month type="5">𞄀𞄪𞄴</month>
+							<month type="6">𞄛𞄤𞄱𞄞𞄤𞄦</month>
+							<month type="7">𞄔𞄩𞄴𞄆𞄨𞄰</month>
+							<month type="8">𞄕𞄩𞄲𞄔𞄄𞄰𞄤</month>
+							<month type="9">𞄛𞄤𞄱𞄒𞄤𞄰</month>
+							<month type="10">𞄪𞄱𞄀𞄤𞄴</month>
+							<month type="11">𞄚𞄦𞄲𞄤𞄚𞄄𞄰𞄫</month>
+							<month type="12">𞄒𞄩𞄱𞄔𞄬𞄴</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -152,9 +152,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<quarterContext type="format">
 						<quarterWidth type="narrow">
 							<quarter type="1">𞅁</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="2">𞅂</quarter>
+							<quarter type="3">𞅃</quarter>
+							<quarter type="4">𞅄</quarter>
 						</quarterWidth>
 					</quarterContext>
 					<quarterContext type="stand-alone">
@@ -168,7 +168,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</quarters>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">𞄜𞄆𞄪</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">𞄜𞄆𞄪</era>
@@ -181,10 +181,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>𞄛𞄩</displayName>
 			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𞄛𞄩</displayName>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𞄛𞄩</displayName>
 			</field>
 		</fields>
 	</dates>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -988,7 +988,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">Novi Zeland</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Novi Zeland</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -1048,7 +1048,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunis</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turska</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turska</territory>
 			<territory type="TT">Trinidad i Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tajvan</territory>
@@ -1535,7 +1535,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1543,7 +1543,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2104,7 +2104,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2112,7 +2112,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -8513,163 +8513,163 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>četvorni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">četvorni {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">četvorni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">četvornog {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="instrumental">četvornim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine">četvorna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">četvornu {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">četvorne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">četvornom {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate">četvorni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">četvorni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">četvornog {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">četvornim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">četvorna {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">četvorna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">četvorna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="instrumental">četvorna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine">četvorne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">četvorne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">četvorne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">četvorne {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate">četvorna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">četvorna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">četvorna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">četvorna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">četvornih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">četvornih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">četvornih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">četvornih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">četvornih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">četvornih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">četvornih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">četvornih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate">četvornih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">četvornih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">četvornih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">četvornih {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>kubni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kubni {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">kubni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">kubnog {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="instrumental">kubnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine">kubna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">kubnu {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">kubne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">kubnom {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">kubni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">kubnog {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">kubnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">kubna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="accusative">kubna {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="instrumental">kubna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine">kubne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">kubne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">kubne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">kubne {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate">kubna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">kubna {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">kubna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kubnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">kubnih {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>inanimate</gender>
 				<displayName>G</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} G</unitPattern>
+				<unitPattern count="one" case="genitive">{0} G</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} G</unitPattern>
 				<unitPattern count="few">{0} G</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} G</unitPattern>
+				<unitPattern count="few" case="genitive">{0} G</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} G</unitPattern>
+				<unitPattern count="other" case="genitive">{0} G</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>inanimate</gender>
 				<displayName>metri u sekundi na kvadrat</displayName>
 				<unitPattern count="one">{0} metar u sekundi na kvadrat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} metar u sekundi na kvadrat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra u sekundi na kvadrat</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom u sekundi na kvadrat</unitPattern>
 				<unitPattern count="few">{0} metra u sekundi na kvadrat</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metra u sekundi na kvadrat</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metra u sekundi na kvadrat</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metra u sekundi na kvadrat</unitPattern>
 				<unitPattern count="other">{0} metara u sekundi na kvadrat</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metara u sekundi na kvadrat</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metara u sekundi na kvadrat</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metara u sekundi na kvadrat</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>inanimate</gender>
 				<displayName>okretaj</displayName>
 				<unitPattern count="one">{0} okretaj</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} okretaj</unitPattern>
 				<unitPattern count="one" case="genitive">{0} okretaja</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} okretajem</unitPattern>
 				<unitPattern count="few">{0} okretaja</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} okretaja</unitPattern>
+				<unitPattern count="few" case="genitive">{0} okretaja</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} okretaja</unitPattern>
 				<unitPattern count="other">{0} okretaja</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} okretaja</unitPattern>
+				<unitPattern count="other" case="genitive">{0} okretaja</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} okretaja</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>inanimate</gender>
 				<displayName>radijani</displayName>
 				<unitPattern count="one">{0} radijan</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} radijan</unitPattern>
 				<unitPattern count="one" case="genitive">{0} radijana</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} radijanom</unitPattern>
 				<unitPattern count="few">{0} radijana</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} radijana</unitPattern>
+				<unitPattern count="few" case="genitive">{0} radijana</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} radijana</unitPattern>
 				<unitPattern count="other">{0} radijana</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} radijana</unitPattern>
+				<unitPattern count="other" case="genitive">{0} radijana</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} radijana</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>inanimate</gender>
 				<displayName>stupnjevi</displayName>
 				<unitPattern count="one">{0} stupanj</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} stupanj</unitPattern>
 				<unitPattern count="one" case="genitive">{0} stupnja</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stupnjem</unitPattern>
 				<unitPattern count="few">{0} stupnja</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stupnja</unitPattern>
+				<unitPattern count="few" case="genitive">{0} stupnja</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} stupnja</unitPattern>
 				<unitPattern count="other">{0} stupnjeva</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stupnjeva</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stupnjeva</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stupnjeva</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>feminine</gender>
@@ -8707,67 +8707,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kvadratni kilometri</displayName>
 				<unitPattern count="one">{0} kvadratni kilometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kvadratni kilometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kvadratnog kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kvadratnim kilometrom</unitPattern>
 				<unitPattern count="few">{0} kvadratna kilometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kvadratna kilometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kvadratna kilometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kvadratna kilometra</unitPattern>
 				<unitPattern count="other">{0} kvadratnih kilometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratnih kilometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kvadratnih kilometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kvadratnih kilometara</unitPattern>
 				<perUnitPattern>{0} po kvadratnom kilometru</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<gender>inanimate</gender>
 				<displayName>hektari</displayName>
 				<unitPattern count="one">{0} hektar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektrom</unitPattern>
 				<unitPattern count="few">{0} hektra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hektra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} hektra</unitPattern>
 				<unitPattern count="other">{0} hektara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektara</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>inanimate</gender>
 				<displayName>kvadratni metri</displayName>
 				<unitPattern count="one">{0} kvadratni metar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kvadratni metar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kvadratnog metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kvadratnim metrom</unitPattern>
 				<unitPattern count="few">{0} kvadratna metra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kvadratna metra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kvadratna metra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kvadratna metra</unitPattern>
 				<unitPattern count="other">{0} kvadratnih metara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratnih metara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kvadratnih metara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kvadratnih metara</unitPattern>
 				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<gender>inanimate</gender>
 				<displayName>kvadratni centimetri</displayName>
 				<unitPattern count="one">{0} kvadratni centimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kvadratni centimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kvadratnog centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kvadratnim centimetrom</unitPattern>
 				<unitPattern count="few">{0} kvadratna centimetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kvadratna centimetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kvadratna centimetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kvadratna centimetra</unitPattern>
 				<unitPattern count="other">{0} kvadratnih centimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratnih centimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kvadratnih centimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kvadratnih centimetara</unitPattern>
 				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -8804,7 +8804,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunami</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="few">{0} dunama</unitPattern>
 				<unitPattern count="other">{0} dunama</unitPattern>
 			</unit>
@@ -8812,17 +8812,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>karati</displayName>
 				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} karatom</unitPattern>
 				<unitPattern count="few">{0} karata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} karata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} karata</unitPattern>
 				<unitPattern count="other">{0} karata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karata</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} karata</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>miligrami po decilitru</displayName>
@@ -8834,17 +8834,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>milimoli po litri</displayName>
 				<unitPattern count="one">{0} milimol po litri</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milimol po litri</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milimola po litri</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milimolom po litri</unitPattern>
 				<unitPattern count="few">{0} milimola po litri</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milimola po litri</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milimola po litri</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milimola po litri</unitPattern>
 				<unitPattern count="other">{0} milimola po litri</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimola po litri</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimola po litri</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milimola po litri</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>feminine</gender>
@@ -8854,93 +8854,93 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} stavke</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stavkom</unitPattern>
 				<unitPattern count="few">{0} stavke</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stavke</unitPattern>
+				<unitPattern count="few" case="genitive">{0} stavke</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} stavke</unitPattern>
 				<unitPattern count="other">{0} stavki</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stavki</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stavki</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stavki</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>inanimate</gender>
 				<displayName>dijelovi na milijun</displayName>
 				<unitPattern count="one">{0} dio na milijun</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} dio na milijun</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dijela na milijun</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} dijelom na milijun</unitPattern>
 				<unitPattern count="few">{0} dijela na milijun</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} dijela na milijun</unitPattern>
+				<unitPattern count="few" case="genitive">{0} dijela na milijun</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} dijela na milijun</unitPattern>
 				<unitPattern count="other">{0} dijelova na milijun</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dijelova na milijun</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dijelova na milijun</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} dijelova na milijun</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>inanimate</gender>
 				<displayName>postotak</displayName>
 				<unitPattern count="one">{0} posto</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} posto</unitPattern>
+				<unitPattern count="one" case="genitive">{0} posto</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} posto</unitPattern>
 				<unitPattern count="few">{0} posto</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} posto</unitPattern>
+				<unitPattern count="few" case="genitive">{0} posto</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} posto</unitPattern>
 				<unitPattern count="other">{0} posto</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} posto</unitPattern>
+				<unitPattern count="other" case="genitive">{0} posto</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} posto</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>inanimate</gender>
 				<displayName>promil</displayName>
 				<unitPattern count="one">{0} promil</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} promil</unitPattern>
 				<unitPattern count="one" case="genitive">{0} promila</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} promilom</unitPattern>
 				<unitPattern count="few">{0} promila</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} promila</unitPattern>
+				<unitPattern count="few" case="genitive">{0} promila</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} promila</unitPattern>
 				<unitPattern count="other">{0} promila</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} promila</unitPattern>
+				<unitPattern count="other" case="genitive">{0} promila</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} promila</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>inanimate</gender>
 				<displayName>permyriad</displayName>
 				<unitPattern count="one">{0} permyriad</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} permyriad</unitPattern>
 				<unitPattern count="one" case="genitive">{0} permyriada</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} permyriadom</unitPattern>
 				<unitPattern count="few">{0} permyriada</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} permyriada</unitPattern>
+				<unitPattern count="few" case="genitive">{0} permyriada</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} permyriada</unitPattern>
 				<unitPattern count="other">{0} permyriada</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} permyriada</unitPattern>
+				<unitPattern count="other" case="genitive">{0} permyriada</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} permyriada</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>inanimate</gender>
 				<displayName>moli</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mola</unitPattern>
 				<unitPattern count="one" case="accusative">{0} mol</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mola</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} molom</unitPattern>
 				<unitPattern count="few">{0} mola</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mola</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mola</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mola</unitPattern>
 				<unitPattern count="other">{0} mola</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mola</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mola</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mola</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>feminine</gender>
@@ -8950,29 +8950,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} litre po kilometru</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom po kilometru</unitPattern>
 				<unitPattern count="few">{0} litre po kilometru</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litre po kilometru</unitPattern>
+				<unitPattern count="few" case="genitive">{0} litre po kilometru</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} litre po kilometru</unitPattern>
 				<unitPattern count="other">{0} litara po kilometru</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litara po kilometru</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litara po kilometru</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litara po kilometru</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>feminine</gender>
 				<displayName>litre na 100 kilometara</displayName>
 				<unitPattern count="one">{0} litra na 100 kilometara</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} litra na 100 kilometara</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litre na 100 kilometara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom na 100 kilometara</unitPattern>
 				<unitPattern count="few">{0} litre na 100 kilometara</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litre na 100 kilometara</unitPattern>
+				<unitPattern count="few" case="genitive">{0} litre na 100 kilometara</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} litre na 100 kilometara</unitPattern>
 				<unitPattern count="other">{0} litara na 100 kilometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litara na 100 kilometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litara na 100 kilometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litara na 100 kilometara</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>milje po galonu</displayName>
@@ -8990,209 +8990,209 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>petabajti</displayName>
 				<unitPattern count="one">{0} petabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} petabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} petabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} petabajtom</unitPattern>
 				<unitPattern count="few">{0} petabajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} petabajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} petabajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} petabajta</unitPattern>
 				<unitPattern count="other">{0} petabajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} petabajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} petabajta</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} petabajta</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>inanimate</gender>
 				<displayName>terabajti</displayName>
 				<unitPattern count="one">{0} terabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} terabajtom</unitPattern>
 				<unitPattern count="few">{0} terabajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} terabajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} terabajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} terabajta</unitPattern>
 				<unitPattern count="other">{0} terabajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabajta</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} terabajta</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>inanimate</gender>
 				<displayName>terabiti</displayName>
 				<unitPattern count="one">{0} terabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} terabitom</unitPattern>
 				<unitPattern count="few">{0} terabita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} terabita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} terabita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} terabita</unitPattern>
 				<unitPattern count="other">{0} terabita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabita</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} terabita</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>inanimate</gender>
 				<displayName>gigabajti</displayName>
 				<unitPattern count="one">{0} gigabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigabajtom</unitPattern>
 				<unitPattern count="few">{0} gigabajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigabajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigabajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigabajta</unitPattern>
 				<unitPattern count="other">{0} gigabajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabajta</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigabajta</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>inanimate</gender>
 				<displayName>gigabiti</displayName>
 				<unitPattern count="one">{0} gigabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigabitom</unitPattern>
 				<unitPattern count="few">{0} gigabita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigabita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigabita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigabita</unitPattern>
 				<unitPattern count="other">{0} gigabita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabita</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigabita</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>inanimate</gender>
 				<displayName>megabajti</displayName>
 				<unitPattern count="one">{0} megabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megabajtom</unitPattern>
 				<unitPattern count="few">{0} megabajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megabajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megabajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megabajta</unitPattern>
 				<unitPattern count="other">{0} megabajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabajta</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megabajta</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>inanimate</gender>
 				<displayName>megabiti</displayName>
 				<unitPattern count="one">{0} megabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megabitom</unitPattern>
 				<unitPattern count="few">{0} megabita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megabita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megabita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megabita</unitPattern>
 				<unitPattern count="other">{0} megabita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabita</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megabita</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>inanimate</gender>
 				<displayName>kilobajti</displayName>
 				<unitPattern count="one">{0} kilobajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilobajtom</unitPattern>
 				<unitPattern count="few">{0} kilobajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilobajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilobajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilobajta</unitPattern>
 				<unitPattern count="other">{0} kilobajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobajta</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilobajta</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>inanimate</gender>
 				<displayName>kilobiti</displayName>
 				<unitPattern count="one">{0} kilobit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilobitom</unitPattern>
 				<unitPattern count="few">{0} kilobita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilobita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilobita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilobita</unitPattern>
 				<unitPattern count="other">{0} kilobita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobita</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilobita</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>inanimate</gender>
 				<displayName>bajtovi</displayName>
 				<unitPattern count="one">{0} bajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} bajtom</unitPattern>
 				<unitPattern count="few">{0} bajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} bajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} bajta</unitPattern>
 				<unitPattern count="other">{0} bajtova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bajtova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bajtova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} bajtova</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>inanimate</gender>
 				<displayName>bitovi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} bitom</unitPattern>
 				<unitPattern count="few">{0} bita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} bita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} bita</unitPattern>
 				<unitPattern count="other">{0} bitova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bitova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bitova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} bitova</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>neuter</gender>
 				<displayName>stoljeća</displayName>
 				<unitPattern count="one">{0} stoljeće</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} stoljeće</unitPattern>
 				<unitPattern count="one" case="genitive">{0} stoljeća</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stoljećem</unitPattern>
 				<unitPattern count="few">{0} stoljeća</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stoljeća</unitPattern>
+				<unitPattern count="few" case="genitive">{0} stoljeća</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} stoljeća</unitPattern>
 				<unitPattern count="other">{0} stoljeća</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stoljeća</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stoljeća</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stoljeća</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>neuter</gender>
 				<displayName>desetljeća</displayName>
 				<unitPattern count="one">{0} desetljeće</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} desetljeće</unitPattern>
 				<unitPattern count="one" case="genitive">{0} desetljeća</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} desetljećem</unitPattern>
 				<unitPattern count="few">{0} desetljeća</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} desetljeća</unitPattern>
+				<unitPattern count="few" case="genitive">{0} desetljeća</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} desetljeća</unitPattern>
 				<unitPattern count="other">{0} desetljeća</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} desetljeća</unitPattern>
+				<unitPattern count="other" case="genitive">{0} desetljeća</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} desetljeća</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>feminine</gender>
@@ -9202,13 +9202,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} godine</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} godinom</unitPattern>
 				<unitPattern count="few">{0} godine</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} godine</unitPattern>
+				<unitPattern count="few" case="genitive">{0} godine</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} godine</unitPattern>
 				<unitPattern count="other">{0} godina</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} godina</unitPattern>
+				<unitPattern count="other" case="genitive">{0} godina</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} godina</unitPattern>
 				<perUnitPattern>{0} godišnje</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -9221,7 +9221,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} četvrtine</unitPattern>
 				<unitPattern count="few" case="accusative">{0} četvrtine</unitPattern>
 				<unitPattern count="few" case="genitive">{0} četvrtine</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} četvrtine</unitPattern>
 				<unitPattern count="other">{0} četvrtina</unitPattern>
 				<unitPattern count="other" case="accusative">{0} četvrtina</unitPattern>
 				<unitPattern count="other" case="genitive">{0} četvrtina</unitPattern>
@@ -9232,83 +9232,83 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>mjeseci</displayName>
 				<unitPattern count="one">{0} mjesec</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mjesec</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mjeseca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mjesecom</unitPattern>
 				<unitPattern count="few">{0} mjeseca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mjeseca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mjeseca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mjeseca</unitPattern>
 				<unitPattern count="other">{0} mjeseci</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mjeseci</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mjeseci</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mjeseci</unitPattern>
 				<perUnitPattern>{0} mjesečno</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<gender>inanimate</gender>
 				<displayName>tjedni</displayName>
 				<unitPattern count="one">{0} tjedan</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} tjedan</unitPattern>
 				<unitPattern count="one" case="genitive">{0} tjedna</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} tjednom</unitPattern>
 				<unitPattern count="few">{0} tjedna</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} tjedna</unitPattern>
+				<unitPattern count="few" case="genitive">{0} tjedna</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} tjedna</unitPattern>
 				<unitPattern count="other">{0} tjedana</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} tjedana</unitPattern>
+				<unitPattern count="other" case="genitive">{0} tjedana</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} tjedana</unitPattern>
 				<perUnitPattern>{0} tjedno</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<gender>inanimate</gender>
 				<displayName>dani</displayName>
 				<unitPattern count="one">{0} dan</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} dan</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dana</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} danom</unitPattern>
 				<unitPattern count="few">{0} dana</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} dana</unitPattern>
+				<unitPattern count="few" case="genitive">{0} dana</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} dana</unitPattern>
 				<unitPattern count="other">{0} dana</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dana</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dana</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} dana</unitPattern>
 				<perUnitPattern>{0} dnevno</perUnitPattern>
 			</unit>
 			<unit type="duration-day-person">
 				<gender>inanimate</gender>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dan</unitPattern>
+				<unitPattern count="one" case="accusative">{0} dan</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dana</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} danom</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} dana</unitPattern>
+				<unitPattern count="few" case="accusative">{0} dana</unitPattern>
+				<unitPattern count="few" case="genitive">{0} dana</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} dana</unitPattern>
+				<unitPattern count="other">{0} dana</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dana</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dana</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} dana</unitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<gender>inanimate</gender>
 				<displayName>sati</displayName>
 				<unitPattern count="one">{0} sat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} sat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} sata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} satom</unitPattern>
 				<unitPattern count="few">{0} sata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} sata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} sata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} sata</unitPattern>
 				<unitPattern count="other">{0} sati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} sati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} sati</unitPattern>
 				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -9319,13 +9319,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} minute</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} minutom</unitPattern>
 				<unitPattern count="few">{0} minute</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} minute</unitPattern>
+				<unitPattern count="few" case="genitive">{0} minute</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} minute</unitPattern>
 				<unitPattern count="other">{0} minuta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} minuta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} minuta</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} minuta</unitPattern>
 				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -9336,13 +9336,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} sekunde</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} sekundom</unitPattern>
 				<unitPattern count="few">{0} sekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} sekunde</unitPattern>
+				<unitPattern count="few" case="genitive">{0} sekunde</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} sekunde</unitPattern>
 				<unitPattern count="other">{0} sekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} sekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} sekundi</unitPattern>
 				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
@@ -9353,29 +9353,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} milisekunde</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milisekundom</unitPattern>
 				<unitPattern count="few">{0} milisekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milisekunde</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milisekunde</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milisekunde</unitPattern>
 				<unitPattern count="other">{0} milisekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milisekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milisekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milisekundi</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>feminine</gender>
 				<displayName>mikrosekunde</displayName>
 				<unitPattern count="one">{0} mikrosekunda</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrosekunda</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrosekunde</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mikrosekundom</unitPattern>
 				<unitPattern count="few">{0} mikrosekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrosekunde</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mikrosekunde</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mikrosekunde</unitPattern>
 				<unitPattern count="other">{0} mikrosekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrosekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrosekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mikrosekundi</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>feminine</gender>
@@ -9385,75 +9385,75 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} nanosekunde</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} nanosekundom</unitPattern>
 				<unitPattern count="few">{0} nanosekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} nanosekunde</unitPattern>
+				<unitPattern count="few" case="genitive">{0} nanosekunde</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} nanosekunde</unitPattern>
 				<unitPattern count="other">{0} nanosekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanosekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nanosekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} nanosekundi</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>inanimate</gender>
 				<displayName>amperi</displayName>
 				<unitPattern count="one">{0} amper</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} amper</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ampera</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} amperom</unitPattern>
 				<unitPattern count="few">{0} ampera</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ampera</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ampera</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} ampera</unitPattern>
 				<unitPattern count="other">{0} ampera</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ampera</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ampera</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ampera</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>inanimate</gender>
 				<displayName>miliamperi</displayName>
 				<unitPattern count="one">{0} miliamper</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miliamper</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miliampera</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} miliamperom</unitPattern>
 				<unitPattern count="few">{0} miliampera</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} miliampera</unitPattern>
+				<unitPattern count="few" case="genitive">{0} miliampera</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} miliampera</unitPattern>
 				<unitPattern count="other">{0} miliampera</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miliampera</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miliampera</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} miliampera</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>inanimate</gender>
 				<displayName>omi</displayName>
 				<unitPattern count="one">{0} om</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} om</unitPattern>
 				<unitPattern count="one" case="genitive">{0} oma</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} omom</unitPattern>
 				<unitPattern count="few">{0} oma</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} oma</unitPattern>
+				<unitPattern count="few" case="genitive">{0} oma</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} oma</unitPattern>
 				<unitPattern count="other">{0} oma</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} oma</unitPattern>
+				<unitPattern count="other" case="genitive">{0} oma</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} oma</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>inanimate</gender>
 				<displayName>volti</displayName>
 				<unitPattern count="one">{0} volt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} volt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} volta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} voltom</unitPattern>
 				<unitPattern count="few">{0} volta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} volta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} volta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} volta</unitPattern>
 				<unitPattern count="other">{0} volti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} volti</unitPattern>
 				<unitPattern count="other" case="genitive">{0} volta</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} volta</unitPattern>
 			</unit>
@@ -9471,13 +9471,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} kalorije</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kalorijom</unitPattern>
 				<unitPattern count="few">{0} kalorije</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kalorije</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kalorije</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kalorije</unitPattern>
 				<unitPattern count="other">{0} kalorija</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kalorija</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kalorija</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kalorija</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>kilokalorije</displayName>
@@ -9489,49 +9489,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilodžuli</displayName>
 				<unitPattern count="one">{0} kilodžul</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilodžul</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilodžula</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilodžulom</unitPattern>
 				<unitPattern count="few">{0} kilodžula</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilodžula</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilodžula</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilodžula</unitPattern>
 				<unitPattern count="other">{0} kilodžula</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilodžula</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilodžula</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilodžula</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>inanimate</gender>
 				<displayName>džuli</displayName>
 				<unitPattern count="one">{0} džul</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} džul</unitPattern>
 				<unitPattern count="one" case="genitive">{0} džula</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} džulom</unitPattern>
 				<unitPattern count="few">{0} džula</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} džula</unitPattern>
+				<unitPattern count="few" case="genitive">{0} džula</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} džula</unitPattern>
 				<unitPattern count="other">{0} džula</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} džula</unitPattern>
+				<unitPattern count="other" case="genitive">{0} džula</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} džula</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>inanimate</gender>
 				<displayName>kilovatsati</displayName>
 				<unitPattern count="one">{0} kilovatsat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilovatsat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilovatsata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilovatsatom</unitPattern>
 				<unitPattern count="few">{0} kilovatsata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilovatsata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilovatsata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilovatsata</unitPattern>
 				<unitPattern count="other">{0} kilovatsati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovatsati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilovatsati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilovatsati</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronvolti</displayName>
@@ -9561,161 +9561,161 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>njutni</displayName>
 				<unitPattern count="one">{0} njutn</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} njutn</unitPattern>
 				<unitPattern count="one" case="genitive">{0} njutna</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} njutnom</unitPattern>
 				<unitPattern count="few">{0} njutna</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} njutna</unitPattern>
+				<unitPattern count="few" case="genitive">{0} njutna</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} njutna</unitPattern>
 				<unitPattern count="other">{0} njutna</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} njutna</unitPattern>
+				<unitPattern count="other" case="genitive">{0} njutna</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} njutna</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>inanimate</gender>
 				<displayName>kilovatsat na 100 kilometara</displayName>
 				<unitPattern count="one">{0} kilovatsat na 100 kilometara</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilovatsat na 100 kilometara</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilovatsata na 100 kilometara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilovatsatom na 100 kilometara</unitPattern>
 				<unitPattern count="few">{0} kilovatsata na 100 kilometara</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilovatsata na 100 kilometara</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilovatsata na 100 kilometara</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilovatsata na 100 kilometara</unitPattern>
 				<unitPattern count="other">{0} kilovatsati na 100 kilometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovatsati na 100 kilometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilovatsati na 100 kilometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilovatsati na 100 kilometara</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>inanimate</gender>
 				<displayName>gigaherci</displayName>
 				<unitPattern count="one">{0} gigaherc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigaherc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigaherca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigahercom</unitPattern>
 				<unitPattern count="few">{0} gigaherca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigaherca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigaherca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigaherca</unitPattern>
 				<unitPattern count="other">{0} gigaherca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigaherca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigaherca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigaherca</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>inanimate</gender>
 				<displayName>megaherci</displayName>
 				<unitPattern count="one">{0} megaherc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megaherc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megaherca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megahercom</unitPattern>
 				<unitPattern count="few">{0} megaherca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megaherca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megaherca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megaherca</unitPattern>
 				<unitPattern count="other">{0} megaherca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megaherca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megaherca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megaherca</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>inanimate</gender>
 				<displayName>kiloherci</displayName>
 				<unitPattern count="one">{0} kiloherc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kiloherc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kiloherca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilohercom</unitPattern>
 				<unitPattern count="few">{0} kiloherca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kiloherca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kiloherca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kiloherca</unitPattern>
 				<unitPattern count="other">{0} kiloherca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kiloherca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kiloherca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kiloherca</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>inanimate</gender>
 				<displayName>herci</displayName>
 				<unitPattern count="one">{0} herc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} herc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} herca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hercom</unitPattern>
 				<unitPattern count="few">{0} herca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} herca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} herca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} herca</unitPattern>
 				<unitPattern count="other">{0} herca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} herca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} herca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} herca</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>inanimate</gender>
 				<displayName>tipografski em</displayName>
 				<unitPattern count="one">{0} tipografski em</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} tipografski em</unitPattern>
 				<unitPattern count="one" case="genitive">{0} tipografskog ema</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} tipografskim emom</unitPattern>
 				<unitPattern count="few">{0} tipografska ema</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} tipografska ema</unitPattern>
+				<unitPattern count="few" case="genitive">{0} tipografska ema</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} tipografska ema</unitPattern>
 				<unitPattern count="other">{0} tipografskih ema</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} tipografskih ema</unitPattern>
+				<unitPattern count="other" case="genitive">{0} tipografskih ema</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} tipografskih ema</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>inanimate</gender>
 				<displayName>pikseli</displayName>
 				<unitPattern count="one">{0} piksel</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} piksel</unitPattern>
 				<unitPattern count="one" case="genitive">{0} piksela</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} pikselom</unitPattern>
 				<unitPattern count="few">{0} piksela</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} piksela</unitPattern>
+				<unitPattern count="few" case="genitive">{0} piksela</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} piksela</unitPattern>
 				<unitPattern count="other">{0} piksela</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} piksela</unitPattern>
+				<unitPattern count="other" case="genitive">{0} piksela</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} piksela</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>inanimate</gender>
 				<displayName>megapikseli</displayName>
 				<unitPattern count="one">{0} megapiksel</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapiksel</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megapiksela</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megapikselom</unitPattern>
 				<unitPattern count="few">{0} megapiksela</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megapiksela</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megapiksela</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megapiksela</unitPattern>
 				<unitPattern count="other">{0} megapiksela</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapiksela</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapiksela</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megapiksela</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>inanimate</gender>
 				<displayName>pikseli po centimetru</displayName>
 				<unitPattern count="one">{0} piksel po centimetru</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} piksel po centimetru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} piksela po centimetru</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} pikselom po centimetru</unitPattern>
 				<unitPattern count="few">{0} piksela po centimetru</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} piksela po centimetru</unitPattern>
+				<unitPattern count="few" case="genitive">{0} piksela po centimetru</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} piksela po centimetru</unitPattern>
 				<unitPattern count="other">{0} piksela po centimetru</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} piksela po centimetru</unitPattern>
+				<unitPattern count="other" case="genitive">{0} piksela po centimetru</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} piksela po centimetru</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>pikseli po inču</displayName>
@@ -9751,132 +9751,132 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilometri</displayName>
 				<unitPattern count="one">{0} kilometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilometrom</unitPattern>
 				<unitPattern count="few">{0} kilometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilometra</unitPattern>
 				<unitPattern count="other">{0} kilometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilometara</unitPattern>
 				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<gender>inanimate</gender>
 				<displayName>metri</displayName>
 				<unitPattern count="one">{0} metar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} metar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom</unitPattern>
 				<unitPattern count="few">{0} metra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metra</unitPattern>
 				<unitPattern count="other">{0} metara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metara</unitPattern>
 				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<gender>inanimate</gender>
 				<displayName>decimetri</displayName>
 				<unitPattern count="one">{0} decimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} decimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} decimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} decimetrom</unitPattern>
 				<unitPattern count="few">{0} decimetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} decimetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} decimetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} decimetra</unitPattern>
 				<unitPattern count="other">{0} decimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} decimetara</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>inanimate</gender>
 				<displayName>centimetri</displayName>
 				<unitPattern count="one">{0} centimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} centimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} centimetrom</unitPattern>
 				<unitPattern count="few">{0} centimetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} centimetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} centimetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} centimetra</unitPattern>
 				<unitPattern count="other">{0} centimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centimetara</unitPattern>
 				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<gender>inanimate</gender>
 				<displayName>milimetri</displayName>
 				<unitPattern count="one">{0} milimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milimetrom</unitPattern>
 				<unitPattern count="few">{0} milimetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milimetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milimetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milimetra</unitPattern>
 				<unitPattern count="other">{0} milimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milimetara</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>inanimate</gender>
 				<displayName>mikrometri</displayName>
 				<unitPattern count="one">{0} mikrometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mikrometrom</unitPattern>
 				<unitPattern count="few">{0} mikrometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mikrometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mikrometra</unitPattern>
 				<unitPattern count="other">{0} mikrometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mikrometara</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>inanimate</gender>
 				<displayName>nanometri</displayName>
 				<unitPattern count="one">{0} nanometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} nanometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} nanometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} nanometrom</unitPattern>
 				<unitPattern count="few">{0} nanometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} nanometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} nanometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} nanometra</unitPattern>
 				<unitPattern count="other">{0} nanometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nanometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} nanometara</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>inanimate</gender>
 				<displayName>pikometri</displayName>
 				<unitPattern count="one">{0} pikometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} pikometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} pikometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} pikometrom</unitPattern>
 				<unitPattern count="few">{0} pikometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} pikometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} pikometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} pikometra</unitPattern>
 				<unitPattern count="other">{0} pikometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pikometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pikometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} pikometara</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>milje</displayName>
@@ -9948,13 +9948,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} skandinavske milje</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} skandinavskom miljom</unitPattern>
 				<unitPattern count="few">{0} skandinavske milje</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} skandinavske milje</unitPattern>
+				<unitPattern count="few" case="genitive">{0} skandinavske milje</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} skandinavske milje</unitPattern>
 				<unitPattern count="other">{0} skandinavskih milja</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} skandinavskih milja</unitPattern>
+				<unitPattern count="other" case="genitive">{0} skandinavskih milja</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} skandinavskih milja</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>točke</displayName>
@@ -9972,17 +9972,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>luksi</displayName>
 				<unitPattern count="one">{0} luks</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} luks</unitPattern>
 				<unitPattern count="one" case="genitive">{0} luksa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} luksom</unitPattern>
 				<unitPattern count="few">{0} luksa</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} luksa</unitPattern>
+				<unitPattern count="few" case="genitive">{0} luksa</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} luksa</unitPattern>
 				<unitPattern count="other">{0} luksa</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} luksa</unitPattern>
+				<unitPattern count="other" case="genitive">{0} luksa</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} luksa</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
@@ -9992,13 +9992,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} kandele</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kandelom</unitPattern>
 				<unitPattern count="few">{0} kandele</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kandele</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kandele</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kandele</unitPattern>
 				<unitPattern count="other">{0} kandela</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kandela</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kandela</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kandela</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>inanimate</gender>
@@ -10008,13 +10008,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} lumena</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} lumenom</unitPattern>
 				<unitPattern count="few">{0} lumena</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} lumena</unitPattern>
+				<unitPattern count="few" case="genitive">{0} lumena</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} lumena</unitPattern>
 				<unitPattern count="other">{0} lumena</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} lumena</unitPattern>
+				<unitPattern count="other" case="genitive">{0} lumena</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} lumena</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>sjaja Sunca</displayName>
@@ -10030,79 +10030,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} tone</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} tonom</unitPattern>
 				<unitPattern count="few">{0} tone</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} tone</unitPattern>
+				<unitPattern count="few" case="genitive">{0} tone</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} tone</unitPattern>
 				<unitPattern count="other">{0} tona</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} tona</unitPattern>
+				<unitPattern count="other" case="genitive">{0} tona</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} tona</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>inanimate</gender>
 				<displayName>kilogrami</displayName>
 				<unitPattern count="one">{0} kilogram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilogram</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilograma</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilogramom</unitPattern>
 				<unitPattern count="few">{0} kilograma</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilograma</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilograma</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilograma</unitPattern>
 				<unitPattern count="other">{0} kilograma</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilograma</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilograma</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilograma</unitPattern>
 				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<gender>inanimate</gender>
 				<displayName>grami</displayName>
 				<unitPattern count="one">{0} gram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gram</unitPattern>
 				<unitPattern count="one" case="genitive">{0} grama</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gramom</unitPattern>
 				<unitPattern count="few">{0} grama</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} grama</unitPattern>
+				<unitPattern count="few" case="genitive">{0} grama</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} grama</unitPattern>
 				<unitPattern count="other">{0} grama</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} grama</unitPattern>
+				<unitPattern count="other" case="genitive">{0} grama</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} grama</unitPattern>
 				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<gender>inanimate</gender>
 				<displayName>miligrami</displayName>
 				<unitPattern count="one">{0} miligram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miligram</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miligrama</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} miligramom</unitPattern>
 				<unitPattern count="few">{0} miligrama</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} miligrama</unitPattern>
+				<unitPattern count="few" case="genitive">{0} miligrama</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} miligrama</unitPattern>
 				<unitPattern count="other">{0} miligrama</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miligrama</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miligrama</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} miligrama</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>inanimate</gender>
 				<displayName>mikrogrami</displayName>
 				<unitPattern count="one">{0} mikrogram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrogram</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrograma</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mikrogramom</unitPattern>
 				<unitPattern count="few">{0} mikrograma</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrograma</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mikrograma</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mikrograma</unitPattern>
 				<unitPattern count="other">{0} mikrograma</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrograma</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrograma</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mikrograma</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>kratke tone</displayName>
@@ -10140,17 +10140,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>karati</displayName>
 				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} karatom</unitPattern>
 				<unitPattern count="few">{0} karata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} karata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} karata</unitPattern>
 				<unitPattern count="other">{0} karata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karata</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} karata</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>daltoni</displayName>
@@ -10180,81 +10180,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>gigavati</displayName>
 				<unitPattern count="one">{0} gigavat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigavat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigavata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigavatom</unitPattern>
 				<unitPattern count="few">{0} gigavata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigavata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigavata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigavata</unitPattern>
 				<unitPattern count="other">{0} gigavata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigavata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigavata</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigavata</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>inanimate</gender>
 				<displayName>megavati</displayName>
 				<unitPattern count="one">{0} megavat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megavat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megavata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megavatom</unitPattern>
 				<unitPattern count="few">{0} megavata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megavata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megavata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megavata</unitPattern>
 				<unitPattern count="other">{0} megavata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megavata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megavata</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megavata</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>inanimate</gender>
 				<displayName>kilovati</displayName>
 				<unitPattern count="one">{0} kilovat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilovat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilovata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilovatom</unitPattern>
 				<unitPattern count="few">{0} kilovata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilovata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilovata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilovata</unitPattern>
 				<unitPattern count="other">{0} kilovata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilovata</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilovata</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>inanimate</gender>
 				<displayName>vati</displayName>
 				<unitPattern count="one">{0} vat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} vat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} vata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} vatom</unitPattern>
 				<unitPattern count="few">{0} vata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} vata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} vata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} vata</unitPattern>
 				<unitPattern count="other">{0} vati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} vati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} vati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} vati</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>inanimate</gender>
 				<displayName>milivati</displayName>
 				<unitPattern count="one">{0} milivat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milivat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milivata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milivatom</unitPattern>
 				<unitPattern count="few">{0} milivata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milivata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milivata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milivata</unitPattern>
 				<unitPattern count="other">{0} milivata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milivata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milivata</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milivata</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>konjske snage</displayName>
@@ -10284,33 +10284,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>bari</displayName>
 				<unitPattern count="one">{0} bar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} barom</unitPattern>
 				<unitPattern count="few">{0} bara</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bara</unitPattern>
+				<unitPattern count="few" case="genitive">{0} bara</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} bara</unitPattern>
 				<unitPattern count="other">{0} bara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} bara</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>inanimate</gender>
 				<displayName>milibari</displayName>
 				<unitPattern count="one">{0} milibar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milibar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milibara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milibarom</unitPattern>
 				<unitPattern count="few">{0} milibara</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milibara</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milibara</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milibara</unitPattern>
 				<unitPattern count="other">{0} milibara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milibara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milibara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milibara</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>feminine</gender>
@@ -10320,109 +10320,109 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} atmosfere</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} atmosferom</unitPattern>
 				<unitPattern count="few">{0} atmosfere</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} atmosfere</unitPattern>
+				<unitPattern count="few" case="genitive">{0} atmosfere</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} atmosfere</unitPattern>
 				<unitPattern count="other">{0} atmosfera</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} atmosfera</unitPattern>
+				<unitPattern count="other" case="genitive">{0} atmosfera</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} atmosfera</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>inanimate</gender>
 				<displayName>paskali</displayName>
 				<unitPattern count="one">{0} paskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} paskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} paskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} paskalom</unitPattern>
 				<unitPattern count="few">{0} paskala</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} paskala</unitPattern>
+				<unitPattern count="few" case="genitive">{0} paskala</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} paskala</unitPattern>
 				<unitPattern count="other">{0} paskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} paskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} paskala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} paskala</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>inanimate</gender>
 				<displayName>hektopaskali</displayName>
 				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektopaskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektopaskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektopaskalom</unitPattern>
 				<unitPattern count="few">{0} hektopaskala</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektopaskala</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hektopaskala</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} hektopaskala</unitPattern>
 				<unitPattern count="other">{0} hektopaskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektopaskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektopaskala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>inanimate</gender>
 				<displayName>kilopaskali</displayName>
 				<unitPattern count="one">{0} kilopaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilopaskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilopaskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilopaskalom</unitPattern>
 				<unitPattern count="few">{0} kilopaskala</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilopaskala</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilopaskala</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilopaskala</unitPattern>
 				<unitPattern count="other">{0} kilopaskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilopaskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilopaskala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>inanimate</gender>
 				<displayName>megapaskali</displayName>
 				<unitPattern count="one">{0} megapaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapaskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megapaskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megapaskalom</unitPattern>
 				<unitPattern count="few">{0} megapaskala</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megapaskala</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megapaskala</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megapaskala</unitPattern>
 				<unitPattern count="other">{0} megapaskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapaskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapaskala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megapaskala</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>inanimate</gender>
 				<displayName>kilometri na sat</displayName>
 				<unitPattern count="one">{0} kilometar na sat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilometar na sat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilometra na sat</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilometrom na sat</unitPattern>
 				<unitPattern count="few">{0} kilometra na sat</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilometra na sat</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilometra na sat</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilometra na sat</unitPattern>
 				<unitPattern count="other">{0} kilometara na sat</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometara na sat</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometara na sat</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilometara na sat</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>inanimate</gender>
 				<displayName>metri u sekundi</displayName>
 				<unitPattern count="one">{0} metar u sekundi</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} metar u sekundi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra u sekundi</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metara u sekundi</unitPattern>
 				<unitPattern count="few">{0} metra u sekundi</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metra u sekundi</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metra u sekundi</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metra u sekundi</unitPattern>
 				<unitPattern count="other">{0} metara u sekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metara u sekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metara u sekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metara u sekundi</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>milje na sat</displayName>
@@ -10440,33 +10440,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>stupnjevi</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0}°</unitPattern>
+				<unitPattern count="one" case="genitive">{0}°</unitPattern>
+				<unitPattern count="one" case="instrumental">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0}°</unitPattern>
+				<unitPattern count="few" case="genitive">{0}°</unitPattern>
+				<unitPattern count="few" case="instrumental">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0}°</unitPattern>
+				<unitPattern count="other" case="genitive">{0}°</unitPattern>
+				<unitPattern count="other" case="instrumental">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<gender>inanimate</gender>
 				<displayName>Celzijevi stupnjevi</displayName>
 				<unitPattern count="one">{0} Celzijev stupanj</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Celzijev stupanj</unitPattern>
 				<unitPattern count="one" case="genitive">{0} Celzijevog stupnja</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} Celzijevim stupnjem</unitPattern>
 				<unitPattern count="few">{0} Celzijeva stupnja</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} Celzijeva stupnja</unitPattern>
+				<unitPattern count="few" case="genitive">{0} Celzijeva stupnja</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} Celzijeva stupnja</unitPattern>
 				<unitPattern count="other">{0} Celzijevih stupnjeva</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Celzijevih stupnjeva</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Celzijevih stupnjeva</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} Celzijevih stupnjeva</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>Fahrenheitovi stupnjevi</displayName>
@@ -10478,17 +10478,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kelvini</displayName>
 				<unitPattern count="one">{0} kelvin</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kelvin</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kelvina</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kelvinom</unitPattern>
 				<unitPattern count="few">{0} kelvina</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kelvina</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kelvina</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kelvina</unitPattern>
 				<unitPattern count="other">{0} kelvina</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kelvina</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kelvina</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kelvina</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>funte sile po stopi</displayName>
@@ -10500,66 +10500,66 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>njutnmetri</displayName>
 				<unitPattern count="one">{0} njutnmetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} njutnmetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} njutnmetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} njutnmetrom</unitPattern>
 				<unitPattern count="few">{0} njutnmetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} njutnmetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} njutnmetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} njutnmetra</unitPattern>
 				<unitPattern count="other">{0} njutnmetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} njutnmetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} njutnmetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} njutnmetara</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>inanimate</gender>
 				<displayName>kubni kilometri</displayName>
 				<unitPattern count="one">{0} kubni kilometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubni kilometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubnog kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubnim kilometrom</unitPattern>
 				<unitPattern count="few">{0} kubna kilometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kubna kilometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kubna kilometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kubna kilometra</unitPattern>
 				<unitPattern count="other">{0} kubnih kilometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubnih kilometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubnih kilometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kubnih kilometara</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>inanimate</gender>
 				<displayName>kubni metri</displayName>
 				<unitPattern count="one">{0} kubni metar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubni metar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubnog metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubnim metrom</unitPattern>
 				<unitPattern count="few">{0} kubna metra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kubna metra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kubna metra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kubna metra</unitPattern>
 				<unitPattern count="other">{0} kubnih metara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubnih metara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubnih metara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kubnih metara</unitPattern>
 				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<gender>inanimate</gender>
 				<displayName>kubni centimetri</displayName>
 				<unitPattern count="one">{0} kubni centimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubni centimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubnog centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubnim centimetrom</unitPattern>
 				<unitPattern count="few">{0} kubna centimetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kubna centimetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kubna centimetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kubna centimetra</unitPattern>
 				<unitPattern count="other">{0} kubnih centimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubnih centimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubnih centimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kubnih centimetara</unitPattern>
 				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -10590,33 +10590,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>megalitri</displayName>
 				<unitPattern count="one">{0} megalitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megalitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megalitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megalitrom</unitPattern>
 				<unitPattern count="few">{0} megalitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megalitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megalitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megalitra</unitPattern>
 				<unitPattern count="other">{0} megalitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megalitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megalitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megalitara</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>inanimate</gender>
 				<displayName>hektolitri</displayName>
 				<unitPattern count="one">{0} hektolitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektolitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektolitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektolitrom</unitPattern>
 				<unitPattern count="few">{0} hektolitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektolitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hektolitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} hektolitra</unitPattern>
 				<unitPattern count="other">{0} hektolitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektolitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektolitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektolitara</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>feminine</gender>
@@ -10626,62 +10626,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} litre</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom</unitPattern>
 				<unitPattern count="few">{0} litre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litre</unitPattern>
+				<unitPattern count="few" case="genitive">{0} litre</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} litre</unitPattern>
 				<unitPattern count="other">{0} litara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litara</unitPattern>
 				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<gender>inanimate</gender>
 				<displayName>decilitri</displayName>
 				<unitPattern count="one">{0} decilitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} decilitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} decilitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} decilitrom</unitPattern>
 				<unitPattern count="few">{0} decilitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} decilitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} decilitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} decilitra</unitPattern>
 				<unitPattern count="other">{0} decilitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decilitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decilitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} decilitara</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>inanimate</gender>
 				<displayName>centilitri</displayName>
 				<unitPattern count="one">{0} centilitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} centilitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} centilitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} centilitrom</unitPattern>
 				<unitPattern count="few">{0} centilitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} centilitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} centilitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} centilitra</unitPattern>
 				<unitPattern count="other">{0} centilitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centilitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centilitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centilitara</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>inanimate</gender>
 				<displayName>mililitri</displayName>
 				<unitPattern count="one">{0} mililitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mililitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mililitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mililitrom</unitPattern>
 				<unitPattern count="few">{0} mililitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mililitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mililitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mililitra</unitPattern>
 				<unitPattern count="other">{0} mililitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mililitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mililitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mililitara</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>feminine</gender>
@@ -10691,13 +10691,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} metričke pinte</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metričkom pintom</unitPattern>
 				<unitPattern count="few">{0} metričke pinte</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metričke pinte</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metričke pinte</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metričke pinte</unitPattern>
 				<unitPattern count="other">{0} metričkih pinti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metričkih pinti</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metričkih pinti</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metričkih pinti</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>feminine</gender>
@@ -10707,13 +10707,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} metričke šalice</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metričkom šalicom</unitPattern>
 				<unitPattern count="few">{0} metričke šalice</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metričke šalice</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metričke šalice</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metričke šalice</unitPattern>
 				<unitPattern count="other">{0} metričkih šalica</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metričkih šalica</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metričkih šalica</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metričkih šalica</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>aker-stope</displayName>
@@ -10805,7 +10805,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kap</displayName>
 				<unitPattern count="one">{0} kap</unitPattern>
 				<unitPattern count="few">{0} kapi</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} kapi</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>dram tekućine</displayName>
@@ -10814,8 +10814,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} drama tekućine</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jiggera</unitPattern>
 				<unitPattern count="few">{0} jiggera</unitPattern>
 				<unitPattern count="other">{0} jiggera</unitPattern>
 			</unit>
@@ -10929,14 +10929,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -11099,7 +11099,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mola</unitPattern>
 				<unitPattern count="few">{0} mola</unitPattern>
 				<unitPattern count="other">{0} mola</unitPattern>
 			</unit>
@@ -11341,8 +11341,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -11359,14 +11359,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -11580,8 +11580,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -11592,20 +11592,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -11680,20 +11680,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>daltoni</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -11788,14 +11788,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -11848,8 +11848,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -12021,8 +12021,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -12051,7 +12051,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jiggera</unitPattern>
 				<unitPattern count="few">{0} jiggera</unitPattern>
 				<unitPattern count="other">{0} jiggera</unitPattern>
 			</unit>
@@ -12063,8 +12063,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="few">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -12077,133 +12077,133 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>G</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="few">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s²</displayName>
 				<unitPattern count="one">{0} m/s²</unitPattern>
 				<unitPattern count="few">{0} m/s²</unitPattern>
 				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>okr.</displayName>
+				<unitPattern count="one">{0} okr.</unitPattern>
+				<unitPattern count="few">{0} okr.</unitPattern>
+				<unitPattern count="other">{0} okr.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>rad</displayName>
 				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="few">{0} rad</unitPattern>
 				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
@@ -12215,87 +12215,87 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>s</displayName>
+				<unitPattern count="one">{0} s</unitPattern>
+				<unitPattern count="few">{0} s</unitPattern>
+				<unitPattern count="other">{0} s</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ha</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="few">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm²</displayName>
 				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="few">{0} cm²</unitPattern>
 				<unitPattern count="other">{0} cm²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="few">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>kj</displayName>
 				<unitPattern count="one">{0} kj</unitPattern>
 				<unitPattern count="few">{0} kj</unitPattern>
 				<unitPattern count="other">{0} kj</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd²</displayName>
 				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="few">{0} yd²</unitPattern>
 				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="few">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in²</displayName>
 				<unitPattern count="one">{0} in²</unitPattern>
 				<unitPattern count="few">{0} in²</unitPattern>
 				<unitPattern count="other">{0} in²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
 				<unitPattern count="one">{0} dunam</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} dunama</unitPattern>
+				<unitPattern count="other">{0} dunama</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>kt</displayName>
 				<unitPattern count="one">{0} kt</unitPattern>
 				<unitPattern count="few">{0} kt</unitPattern>
 				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="few">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/l</displayName>
@@ -12310,10 +12310,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} stavki</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -12322,25 +12322,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="few">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="few">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0} mol</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} mola</unitPattern>
+				<unitPattern count="other">{0} mola</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>l/km</displayName>
 				<unitPattern count="one">{0} l/km</unitPattern>
 				<unitPattern count="few">{0} l/km</unitPattern>
 				<unitPattern count="other">{0} l/km</unitPattern>
@@ -12352,101 +12352,101 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpg</displayName>
 				<unitPattern count="one">{0} mpg</unitPattern>
 				<unitPattern count="few">{0} mpg</unitPattern>
 				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milje/imp. gal.</displayName>
+				<unitPattern count="one">{0} mpg imp.</unitPattern>
+				<unitPattern count="few">{0} mpg imp.</unitPattern>
+				<unitPattern count="other">{0} mpg imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>TB</displayName>
 				<unitPattern count="one">{0} TB</unitPattern>
 				<unitPattern count="few">{0} TB</unitPattern>
 				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Tb</displayName>
 				<unitPattern count="one">{0} Tb</unitPattern>
 				<unitPattern count="few">{0} Tb</unitPattern>
 				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>GB</displayName>
 				<unitPattern count="one">{0} GB</unitPattern>
 				<unitPattern count="few">{0} GB</unitPattern>
 				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gb</displayName>
 				<unitPattern count="one">{0} Gb</unitPattern>
 				<unitPattern count="few">{0} Gb</unitPattern>
 				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="one">{0} MB</unitPattern>
 				<unitPattern count="few">{0} MB</unitPattern>
 				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mb</displayName>
 				<unitPattern count="one">{0} Mb</unitPattern>
 				<unitPattern count="few">{0} Mb</unitPattern>
 				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>kB</displayName>
 				<unitPattern count="one">{0} kB</unitPattern>
 				<unitPattern count="few">{0} kB</unitPattern>
 				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>kb</displayName>
 				<unitPattern count="one">{0} kb</unitPattern>
 				<unitPattern count="few">{0} kb</unitPattern>
 				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>bajt</displayName>
 				<unitPattern count="one">{0} bajt</unitPattern>
 				<unitPattern count="few">{0} bajta</unitPattern>
 				<unitPattern count="other">{0} bajtova</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
 				<unitPattern count="few">{0} bita</unitPattern>
 				<unitPattern count="other">{0} bitova</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st.</displayName>
+				<unitPattern count="one">{0} st.</unitPattern>
+				<unitPattern count="few">{0} st.</unitPattern>
+				<unitPattern count="other">{0} st.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>des.</displayName>
+				<unitPattern count="one">{0} des.</unitPattern>
+				<unitPattern count="few">{0} des.</unitPattern>
+				<unitPattern count="other">{0} des.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>g.</displayName>
 				<unitPattern count="one">{0} g.</unitPattern>
 				<unitPattern count="few">{0} g.</unitPattern>
 				<unitPattern count="other">{0} g.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>čet.</displayName>
@@ -12460,42 +12460,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} mj.</unitPattern>
 				<unitPattern count="few">{0} mj.</unitPattern>
 				<unitPattern count="other">{0} mj.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mj.</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>tj.</displayName>
 				<unitPattern count="one">{0} tj.</unitPattern>
 				<unitPattern count="few">{0} tj.</unitPattern>
 				<unitPattern count="other">{0} tj.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/tj.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>d.</displayName>
 				<unitPattern count="one">{0} d.</unitPattern>
 				<unitPattern count="few">{0} d.</unitPattern>
 				<unitPattern count="other">{0} d.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d.</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>h</displayName>
 				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="few">{0} h</unitPattern>
 				<unitPattern count="other">{0} h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="few">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -12504,49 +12504,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>μs</displayName>
 				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="few">{0} μs</unitPattern>
 				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ns</displayName>
 				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="few">{0} ns</unitPattern>
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>A</displayName>
 				<unitPattern count="one">{0} A</unitPattern>
 				<unitPattern count="few">{0} A</unitPattern>
 				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>mA</displayName>
 				<unitPattern count="one">{0} mA</unitPattern>
 				<unitPattern count="few">{0} mA</unitPattern>
 				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ω</displayName>
 				<unitPattern count="one">{0} Ω</unitPattern>
 				<unitPattern count="few">{0} Ω</unitPattern>
 				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>V</displayName>
 				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="few">{0} V</unitPattern>
 				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="few">{0} kcal</unitPattern>
 				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="one">{0} cal</unitPattern>
 				<unitPattern count="few">{0} cal</unitPattern>
 				<unitPattern count="other">{0} cal</unitPattern>
@@ -12558,52 +12558,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kJ</displayName>
 				<unitPattern count="one">{0} kJ</unitPattern>
 				<unitPattern count="few">{0} kJ</unitPattern>
 				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>J</displayName>
 				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="few">{0} J</unitPattern>
 				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh</displayName>
 				<unitPattern count="one">{0} kWh</unitPattern>
 				<unitPattern count="few">{0} kWh</unitPattern>
 				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} BTU</unitPattern>
+				<unitPattern count="few">{0} BTU</unitPattern>
+				<unitPattern count="other">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>SAD therm</displayName>
+				<unitPattern count="one">{0} SAD therm</unitPattern>
+				<unitPattern count="few">{0} SAD therma</unitPattern>
+				<unitPattern count="other">{0} SAD therma</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100km</displayName>
@@ -12612,40 +12612,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kWh/100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="one">{0} GHz</unitPattern>
 				<unitPattern count="few">{0} GHz</unitPattern>
 				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="one">{0} MHz</unitPattern>
 				<unitPattern count="few">{0} MHz</unitPattern>
 				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="few">{0} kHz</unitPattern>
 				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="few">{0} Hz</unitPattern>
 				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} ema</unitPattern>
+				<unitPattern count="other">{0} emova</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>Mp</displayName>
@@ -12654,57 +12654,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Mp</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="few">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="few">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pikseli</displayName>
+				<unitPattern count="one">{0} p</unitPattern>
+				<unitPattern count="few">{0} p</unitPattern>
+				<unitPattern count="other">{0} p</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="few">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dm</displayName>
 				<unitPattern count="one">{0} dm</unitPattern>
 				<unitPattern count="few">{0} dm</unitPattern>
 				<unitPattern count="other">{0} dm</unitPattern>
@@ -12714,7 +12714,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="few">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -12723,25 +12723,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>μm</displayName>
 				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="few">{0} μm</unitPattern>
 				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>nm</displayName>
 				<unitPattern count="one">{0} nm</unitPattern>
 				<unitPattern count="few">{0} nm</unitPattern>
 				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="few">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi</displayName>
 				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="few">{0} mi</unitPattern>
 				<unitPattern count="other">{0} mi</unitPattern>
@@ -12757,17 +12757,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>in</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>pc</displayName>
 				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="few">{0} pc</unitPattern>
 				<unitPattern count="other">{0} pc</unitPattern>
@@ -12779,7 +12779,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>au</displayName>
 				<unitPattern count="one">{0} au</unitPattern>
 				<unitPattern count="few">{0} au</unitPattern>
 				<unitPattern count="other">{0} au</unitPattern>
@@ -12797,55 +12797,55 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hv</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>nmi</displayName>
 				<unitPattern count="one">{0} nmi</unitPattern>
 				<unitPattern count="few">{0} nmi</unitPattern>
 				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lx</displayName>
 				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="few">{0} lx</unitPattern>
 				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>t</displayName>
 				<unitPattern count="one">{0} t</unitPattern>
 				<unitPattern count="few">{0} t</unitPattern>
 				<unitPattern count="other">{0} t</unitPattern>
@@ -12855,29 +12855,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="few">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="one">{0} mg</unitPattern>
 				<unitPattern count="few">{0} mg</unitPattern>
 				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>μg</displayName>
 				<unitPattern count="one">{0} μg</unitPattern>
 				<unitPattern count="few">{0} μg</unitPattern>
 				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>tn</displayName>
 				<unitPattern count="one">{0} tn</unitPattern>
 				<unitPattern count="few">{0} tn</unitPattern>
 				<unitPattern count="other">{0} tn</unitPattern>
@@ -12889,150 +12889,150 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="few">{0} lb</unitPattern>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="few">{0} oz</unitPattern>
 				<unitPattern count="other">{0} oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz t</displayName>
 				<unitPattern count="one">{0} oz t</unitPattern>
 				<unitPattern count="few">{0} oz t</unitPattern>
 				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>ct</displayName>
 				<unitPattern count="one">{0} ct</unitPattern>
 				<unitPattern count="few">{0} ct</unitPattern>
 				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Da</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gr</displayName>
+				<unitPattern count="one">{0} gr</unitPattern>
+				<unitPattern count="few">{0} gr</unitPattern>
+				<unitPattern count="other">{0} gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="one">{0} GW</unitPattern>
 				<unitPattern count="few">{0} GW</unitPattern>
 				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="few">{0} MW</unitPattern>
 				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="few">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="few">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="few">{0} mW</unitPattern>
 				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>KS</displayName>
 				<unitPattern count="one">{0} KS</unitPattern>
 				<unitPattern count="few">{0} KS</unitPattern>
 				<unitPattern count="other">{0} KS</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0} mm Hg</unitPattern>
 				<unitPattern count="few">{0} mm Hg</unitPattern>
 				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 				<unitPattern count="one">{0} psi</unitPattern>
 				<unitPattern count="few">{0} psi</unitPattern>
 				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="few">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bara</unitPattern>
+				<unitPattern count="other">{0} bara</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="few">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="few">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -13041,28 +13041,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="few">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/h</displayName>
 				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="few">{0} mi/h</unitPattern>
 				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>čv</displayName>
+				<unitPattern count="one">{0} čv</unitPattern>
+				<unitPattern count="few">{0} čv</unitPattern>
+				<unitPattern count="other">{0} čv</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -13071,81 +13071,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="one">{0} °F</unitPattern>
+				<unitPattern count="few">{0} °F</unitPattern>
+				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="one">{0} K</unitPattern>
 				<unitPattern count="few">{0} K</unitPattern>
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nm</displayName>
+				<unitPattern count="one">{0} Nm</unitPattern>
+				<unitPattern count="few">{0} Nm</unitPattern>
+				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="few">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="few">{0} m³</unitPattern>
 				<unitPattern count="other">{0} m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="few">{0} cm³</unitPattern>
 				<unitPattern count="other">{0} cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd³</displayName>
 				<unitPattern count="one">{0} yd³</unitPattern>
 				<unitPattern count="few">{0} yd³</unitPattern>
 				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft³</displayName>
 				<unitPattern count="one">{0} ft³</unitPattern>
 				<unitPattern count="few">{0} ft³</unitPattern>
 				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in³</displayName>
 				<unitPattern count="one">{0} in³</unitPattern>
 				<unitPattern count="few">{0} in³</unitPattern>
 				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ml</displayName>
 				<unitPattern count="one">{0} Ml</unitPattern>
 				<unitPattern count="few">{0} Ml</unitPattern>
 				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>hl</displayName>
 				<unitPattern count="one">{0} hl</unitPattern>
 				<unitPattern count="few">{0} hl</unitPattern>
 				<unitPattern count="other">{0} hl</unitPattern>
@@ -13155,40 +13155,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0} dl</unitPattern>
 				<unitPattern count="few">{0} dl</unitPattern>
 				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cl</displayName>
 				<unitPattern count="one">{0} cl</unitPattern>
 				<unitPattern count="few">{0} cl</unitPattern>
 				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ml</displayName>
 				<unitPattern count="one">{0} ml</unitPattern>
 				<unitPattern count="few">{0} ml</unitPattern>
 				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m. šalica</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="few">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ac ft</displayName>
 				<unitPattern count="one">{0} ac ft</unitPattern>
 				<unitPattern count="few">{0} ac ft</unitPattern>
 				<unitPattern count="other">{0} ac ft</unitPattern>
@@ -13200,108 +13200,108 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">{0} gal</unitPattern>
 				<unitPattern count="few">{0} gal</unitPattern>
 				<unitPattern count="other">{0} gal</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>imp. gal.</displayName>
 				<unitPattern count="one">{0} i. gal.</unitPattern>
 				<unitPattern count="few">{0} i. gal.</unitPattern>
 				<unitPattern count="other">{0} i. gal.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/imp. gal.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt</displayName>
 				<unitPattern count="one">{0} qt</unitPattern>
 				<unitPattern count="few">{0} qt</unitPattern>
 				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="few">{0} pt</unitPattern>
 				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>šalice</displayName>
 				<unitPattern count="one">{0} c</unitPattern>
 				<unitPattern count="few">{0} c</unitPattern>
 				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz</displayName>
 				<unitPattern count="one">{0} fl oz</unitPattern>
 				<unitPattern count="few">{0} fl oz</unitPattern>
 				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>imp. fl oz</displayName>
 				<unitPattern count="one">{0} i. fl oz</unitPattern>
 				<unitPattern count="few">{0} i. fl oz</unitPattern>
 				<unitPattern count="other">{0} i. fl oz</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>tbsp</displayName>
 				<unitPattern count="one">{0} tbsp</unitPattern>
 				<unitPattern count="few">{0} tbsp</unitPattern>
 				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>tsp</displayName>
 				<unitPattern count="one">{0} tsp</unitPattern>
 				<unitPattern count="few">{0} tsp</unitPattern>
 				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>žličica</displayName>
 				<unitPattern count="one">{0} žličica</unitPattern>
 				<unitPattern count="few">{0} žličice</unitPattern>
 				<unitPattern count="other">{0} žličica</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>imp. žličica</displayName>
 				<unitPattern count="one">{0} i. žličica</unitPattern>
 				<unitPattern count="few">{0} i. žličice</unitPattern>
 				<unitPattern count="other">{0} i. žličica</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kap</displayName>
+				<unitPattern count="one">{0} kap</unitPattern>
+				<unitPattern count="few">{0} kapi</unitPattern>
+				<unitPattern count="other">{0} kapi</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl dr</displayName>
+				<unitPattern count="one">{0} fl dr</unitPattern>
+				<unitPattern count="few">{0} fl dr</unitPattern>
+				<unitPattern count="other">{0} fl dr</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>jigger</displayName>
 				<unitPattern count="one">{0} jigger</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} jiggera</unitPattern>
+				<unitPattern count="other">{0} jiggera</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>prstohvat</displayName>
+				<unitPattern count="one">{0} prstohvat</unitPattern>
+				<unitPattern count="few">{0} prstohvata</unitPattern>
+				<unitPattern count="other">{0} prstohvata</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="few">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>smjer</displayName>
@@ -13335,22 +13335,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ili {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ili {1}</listPatternPart>
+			<listPatternPart type="2">{0} ili {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ili {1}</listPatternPart>
+			<listPatternPart type="2">{0} ili {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} i {1}</listPatternPart>
+			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -13373,8 +13373,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<listPattern type="unit-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} i {1}</listPatternPart>
+			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -46,7 +46,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="awa">awandhišćina</language>
 			<language type="ay">aymaršćina</language>
 			<language type="az">azerbajdźanšćina</language>
-			<language type="az" alt="short">↑↑↑</language>
+			<language type="az" alt="short">azerbajdźanšćina</language>
 			<language type="ba">baškiršćina</language>
 			<language type="ban">balinezišćina</language>
 			<language type="bas">basaa</language>
@@ -80,7 +80,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyennešćina</language>
 			<language type="ckb">sorani</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">sorani</language>
 			<language type="ckb" alt="variant">centralna kurdišćina</language>
 			<language type="clc">chilcotinšćina</language>
 			<language type="co">korsišćina</language>
@@ -630,7 +630,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CX">Hodowna kupa</territory>
 			<territory type="CY">Cypern</territory>
 			<territory type="CZ">Čěska republika</territory>
-			<territory type="CZ" alt="variant">↑↑↑</territory>
+			<territory type="CZ" alt="variant">Čěska republika</territory>
 			<territory type="DE">Němska</territory>
 			<territory type="DG">Diego Garcia</territory>
 			<territory type="DJ">Dźibuti</territory>
@@ -800,7 +800,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="SX">Sint Maarten</territory>
 			<territory type="SY">Syriska</territory>
 			<territory type="SZ">Swaziska</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
+			<territory type="SZ" alt="variant">Swaziska</territory>
 			<territory type="TA">Tristan da Cunha</territory>
 			<territory type="TC">kupy Turks a Caicos</territory>
 			<territory type="TD">Čad</territory>
@@ -815,7 +815,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tuneziska</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkowska</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkowska</territory>
 			<territory type="TT">Trinidad a Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1035,7 +1035,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1043,7 +1043,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1531,7 +1531,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1539,7 +1539,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1750,10 +1750,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>doba</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>doba</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>doba</displayName>
 			</field>
 			<field type="year">
 				<displayName>lěto</displayName>
@@ -2044,7 +2044,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>dźeń tydźenja</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>dźeń tydźenja</displayName>
 			</field>
 			<field type="weekday-narrow">
 				<displayName>dź. tydźenja</displayName>
@@ -2416,7 +2416,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>połojca dnja</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>połojca dnja</displayName>
@@ -2566,7 +2566,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>časowe pasmo</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>časowe pasmo</displayName>
 			</field>
 			<field type="zone-narrow">
 				<displayName>čas. pasmo</displayName>
@@ -8196,7 +8196,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="area-dunam">
 				<displayName>dun.</displayName>
 				<unitPattern count="one">{0} dun.</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dun.</unitPattern>
 				<unitPattern count="few">{0} dun.</unitPattern>
 				<unitPattern count="other">{0} dun.</unitPattern>
 			</unit>
@@ -9253,7 +9253,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="volume-gallon-imperial">
 				<displayName>brit. gal.</displayName>
 				<unitPattern count="one">{0} brit. gal.</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} brit. gal.</unitPattern>
 				<unitPattern count="few">{0} brit. gal.</unitPattern>
 				<unitPattern count="other">{0} brit. gal.</unitPattern>
 				<perUnitPattern>{0}/brit. gal.</perUnitPattern>
@@ -9460,227 +9460,227 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>G</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="two">{0} G</unitPattern>
 				<unitPattern count="few">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="two">{0} m/s²</unitPattern>
+				<unitPattern count="few">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>wobr.</displayName>
+				<unitPattern count="one">{0} wobr.</unitPattern>
+				<unitPattern count="two">{0} wobr.</unitPattern>
+				<unitPattern count="few">{0} wobr.</unitPattern>
+				<unitPattern count="other">{0} wobr.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="two">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="two">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>′</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="two">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>″</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="two">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="two">{0} km²</unitPattern>
 				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ha</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="two">{0} ha</unitPattern>
 				<unitPattern count="few">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="two">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="two">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="two">{0} mi²</unitPattern>
 				<unitPattern count="few">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ac</displayName>
 				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="two">{0} ac</unitPattern>
 				<unitPattern count="few">{0} ac</unitPattern>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="two">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="two">{0} ft²</unitPattern>
 				<unitPattern count="few">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="two">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dun.</displayName>
+				<unitPattern count="one">{0} dun.</unitPattern>
+				<unitPattern count="two">{0} dun.</unitPattern>
+				<unitPattern count="few">{0} dun.</unitPattern>
+				<unitPattern count="other">{0} dun.</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="two">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="two">{0} mg/dl</unitPattern>
+				<unitPattern count="few">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/l</displayName>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="two">{0} mmol/l</unitPattern>
+				<unitPattern count="few">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kus</displayName>
+				<unitPattern count="one">{0} kus</unitPattern>
+				<unitPattern count="two">{0} kusaj</unitPattern>
+				<unitPattern count="few">{0} kusy</unitPattern>
+				<unitPattern count="other">{0} kusow</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="two">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="one">{0} %</unitPattern>
+				<unitPattern count="two">{0} %</unitPattern>
+				<unitPattern count="few">{0} %</unitPattern>
+				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="two">{0} ‰</unitPattern>
+				<unitPattern count="few">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="two">{0} ‱</unitPattern>
+				<unitPattern count="few">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="two">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="two">{0} l/km</unitPattern>
+				<unitPattern count="few">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/100km</displayName>
+				<unitPattern count="one">{0} l/100km</unitPattern>
+				<unitPattern count="two">{0} l/100km</unitPattern>
+				<unitPattern count="few">{0} l/100km</unitPattern>
+				<unitPattern count="other">{0} l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="two">{0} mpg</unitPattern>
+				<unitPattern count="few">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg br.</displayName>
@@ -9690,18 +9690,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} mpg br.</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lětst.</displayName>
+				<unitPattern count="one">{0} lětst.</unitPattern>
+				<unitPattern count="two">{0} lětst.</unitPattern>
+				<unitPattern count="few">{0} lětst.</unitPattern>
+				<unitPattern count="other">{0} lětst.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lětdź.</displayName>
+				<unitPattern count="one">{0} lětdź.</unitPattern>
+				<unitPattern count="two">{0} lětdź.</unitPattern>
+				<unitPattern count="few">{0} lětdź.</unitPattern>
+				<unitPattern count="other">{0} lětdź.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>l.</displayName>
@@ -9709,7 +9709,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} l.</unitPattern>
 				<unitPattern count="few">{0} l.</unitPattern>
 				<unitPattern count="other">{0} l.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>kw.</displayName>
@@ -9725,7 +9725,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} měs.</unitPattern>
 				<unitPattern count="few">{0} měs.</unitPattern>
 				<unitPattern count="other">{0} měs.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/měs.</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>t.</displayName>
@@ -9733,7 +9733,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} t.</unitPattern>
 				<unitPattern count="few">{0} t.</unitPattern>
 				<unitPattern count="other">{0} t.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/tydź.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>d</displayName>
@@ -9741,7 +9741,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} d</unitPattern>
 				<unitPattern count="few">{0} d</unitPattern>
 				<unitPattern count="other">{0} d</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/dź.</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>h</displayName>
@@ -9749,7 +9749,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} h</unitPattern>
 				<unitPattern count="few">{0} h</unitPattern>
 				<unitPattern count="other">{0} h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
@@ -9757,7 +9757,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} min</unitPattern>
 				<unitPattern count="few">{0} min</unitPattern>
 				<unitPattern count="other">{0} min</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min.</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
@@ -9765,7 +9765,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} s</unitPattern>
 				<unitPattern count="few">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -9775,81 +9775,81 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="two">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="two">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="two">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -9857,7 +9857,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} km</unitPattern>
 				<unitPattern count="few">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
@@ -9865,14 +9865,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="two">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
@@ -9880,7 +9880,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} cm</unitPattern>
 				<unitPattern count="few">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -9890,153 +9890,153 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="two">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="two">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="two">{0} pm</unitPattern>
 				<unitPattern count="few">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi</displayName>
 				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="two">{0} mi</unitPattern>
 				<unitPattern count="few">{0} mi</unitPattern>
 				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd</displayName>
 				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="two">{0} yd</unitPattern>
 				<unitPattern count="few">{0} yd</unitPattern>
 				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft</displayName>
 				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="two">{0} ft</unitPattern>
 				<unitPattern count="few">{0} ft</unitPattern>
 				<unitPattern count="other">{0} ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in</displayName>
 				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="two">{0} in</unitPattern>
 				<unitPattern count="few">{0} in</unitPattern>
 				<unitPattern count="other">{0} in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cól</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="two">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>ly</displayName>
 				<unitPattern count="one">{0} ly</unitPattern>
 				<unitPattern count="two">{0} ly</unitPattern>
 				<unitPattern count="few">{0} ly</unitPattern>
 				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="two">{0} au</unitPattern>
+				<unitPattern count="few">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="two">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fth</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="two">{0} fth</unitPattern>
+				<unitPattern count="few">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="two">{0} nmi</unitPattern>
+				<unitPattern count="few">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="two">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="two">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="two">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="two">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="two">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
@@ -10044,7 +10044,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} kg</unitPattern>
 				<unitPattern count="few">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
@@ -10052,93 +10052,93 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} g</unitPattern>
 				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="two">{0} mg</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="two">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>am.tony</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="two">{0} tn</unitPattern>
+				<unitPattern count="few">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="two">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="two">{0} lb</unitPattern>
 				<unitPattern count="few">{0} lb</unitPattern>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="two">{0} oz</unitPattern>
 				<unitPattern count="few">{0} oz</unitPattern>
 				<unitPattern count="other">{0} oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz. tr.</displayName>
+				<unitPattern count="one">{0} oz. tr.</unitPattern>
+				<unitPattern count="two">{0} oz. tr.</unitPattern>
+				<unitPattern count="few">{0} oz. tr.</unitPattern>
+				<unitPattern count="other">{0} oz. tr.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kt</displayName>
+				<unitPattern count="one">{0} Kt</unitPattern>
+				<unitPattern count="two">{0} Kt</unitPattern>
+				<unitPattern count="few">{0} Kt</unitPattern>
+				<unitPattern count="other">{0} Kt</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="two">{0} grainaj</unitPattern>
+				<unitPattern count="few">{0} grainy</unitPattern>
+				<unitPattern count="other">{0} grainow</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<unitPattern count="one">{0} kW</unitPattern>
@@ -10184,25 +10184,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="two">{0} m/s</unitPattern>
 				<unitPattern count="few">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mph</displayName>
 				<unitPattern count="one">{0} mph</unitPattern>
 				<unitPattern count="two">{0} mph</unitPattern>
 				<unitPattern count="few">{0} mph</unitPattern>
 				<unitPattern count="other">{0} mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sk</displayName>
+				<unitPattern count="one">{0} sk</unitPattern>
+				<unitPattern count="two">{0} sk</unitPattern>
+				<unitPattern count="few">{0} sk</unitPattern>
+				<unitPattern count="other">{0} sk</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -10218,83 +10218,83 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nm</displayName>
+				<unitPattern count="one">{0} Nm</unitPattern>
+				<unitPattern count="two">{0} Nm</unitPattern>
+				<unitPattern count="few">{0} Nm</unitPattern>
+				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="two">{0} km³</unitPattern>
 				<unitPattern count="few">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="two">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="two">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="two">{0} mi³</unitPattern>
 				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="two">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="two">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="two">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="two">{0} Ml</unitPattern>
+				<unitPattern count="few">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="two">{0} hl</unitPattern>
+				<unitPattern count="few">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
@@ -10302,64 +10302,64 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="two">{0} l</unitPattern>
 				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="two">{0} dl</unitPattern>
+				<unitPattern count="few">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="two">{0} cl</unitPattern>
+				<unitPattern count="few">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="two">{0} ml</unitPattern>
+				<unitPattern count="few">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="two">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mc</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="two">{0} mc</unitPattern>
+				<unitPattern count="few">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="two">{0} ac ft</unitPattern>
+				<unitPattern count="few">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="two">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="two">{0} gal</unitPattern>
+				<unitPattern count="few">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>br. gal.</displayName>
@@ -10370,32 +10370,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/br. gal.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="two">{0} qt</unitPattern>
+				<unitPattern count="few">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="two">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>š.</displayName>
+				<unitPattern count="one">{0} š.</unitPattern>
+				<unitPattern count="two">{0} š.</unitPattern>
+				<unitPattern count="few">{0} š.</unitPattern>
+				<unitPattern count="other">{0} š.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl. oz.</displayName>
+				<unitPattern count="one">{0} fl. oz.</unitPattern>
+				<unitPattern count="two">{0} fl. oz.</unitPattern>
+				<unitPattern count="few">{0} fl. oz.</unitPattern>
+				<unitPattern count="other">{0} fl. oz.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>br. fl oz</displayName>
@@ -10405,32 +10405,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} br. fl oz</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>łž.</displayName>
+				<unitPattern count="one">{0} łž.</unitPattern>
+				<unitPattern count="two">{0} łž.</unitPattern>
+				<unitPattern count="few">{0} łž.</unitPattern>
+				<unitPattern count="other">{0} łž.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>łžk.</displayName>
+				<unitPattern count="one">{0} łžk.</unitPattern>
+				<unitPattern count="two">{0} łžk.</unitPattern>
+				<unitPattern count="few">{0} łžk.</unitPattern>
+				<unitPattern count="other">{0} łžk.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="two">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dess. łžk.</displayName>
+				<unitPattern count="one">{0} dess. łžk.</unitPattern>
+				<unitPattern count="two">{0} dess. łžk.</unitPattern>
+				<unitPattern count="few">{0} dess. łžk.</unitPattern>
+				<unitPattern count="other">{0} dess. łžk.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>im. łk.</displayName>
@@ -10440,18 +10440,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} im. łk.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kpk.</displayName>
+				<unitPattern count="one">{0} kpk.</unitPattern>
+				<unitPattern count="two">{0} kpk.</unitPattern>
+				<unitPattern count="few">{0} kpk.</unitPattern>
+				<unitPattern count="other">{0} kpk.</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dr</displayName>
+				<unitPattern count="one">{0} dr</unitPattern>
+				<unitPattern count="two">{0} dr</unitPattern>
+				<unitPattern count="few">{0} dr</unitPattern>
+				<unitPattern count="other">{0} dr</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>jigg.</displayName>
@@ -10468,18 +10468,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} šć</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="two">{0} qt Imp.</unitPattern>
+				<unitPattern count="few">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>směr</displayName>
+				<coordinateUnitPattern type="east">{0} w</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} s</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0} j</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0} z</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -10506,28 +10506,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} abo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} abo {1}</listPatternPart>
+			<listPatternPart type="2">{0} abo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} abo {1}</listPatternPart>
+			<listPatternPart type="2">{0} abo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} a {1}</listPatternPart>
+			<listPatternPart type="2">{0} a {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} a {1}</listPatternPart>
+			<listPatternPart type="2">{0} a {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -108,7 +108,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cseroki</language>
 			<language type="chy">csejen</language>
 			<language type="ckb">közép-ázsiai kurd</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">közép-ázsiai kurd</language>
 			<language type="ckb" alt="variant">kurd, szoráni</language>
 			<language type="clc">csilkotin</language>
 			<language type="co">korzikai</language>
@@ -823,7 +823,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="CG" alt="variant">Kongó (Köztársaság)</territory>
 			<territory type="CH">Svájc</territory>
 			<territory type="CI">Elefántcsontpart</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
+			<territory type="CI" alt="variant">Elefántcsontpart</territory>
 			<territory type="CK">Cook-szigetek</territory>
 			<territory type="CL">Chile</territory>
 			<territory type="CM">Kamerun</territory>
@@ -1022,7 +1022,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunézia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Törökország</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Törökország</territory>
 			<territory type="TT">Trinidad és Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tajvan</territory>
@@ -1614,7 +1614,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1622,7 +1622,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1630,7 +1630,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1638,7 +1638,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2194,7 +2194,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2202,7 +2202,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2210,7 +2210,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2218,7 +2218,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2435,9 +2435,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="8" draft="contributed">Niszán</month>
 							<month type="9" draft="contributed">Ijár</month>
 							<month type="10" draft="contributed">Sziván</month>
-							<month type="11" draft="contributed">↑↑↑</month>
+							<month type="11" draft="contributed">Tamuz</month>
 							<month type="12" draft="contributed">Áv</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Tisri</month>
@@ -2469,9 +2469,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="8" draft="contributed">Niszán</month>
 							<month type="9" draft="contributed">Ijár</month>
 							<month type="10" draft="contributed">Sziván</month>
-							<month type="11" draft="contributed">↑↑↑</month>
+							<month type="11" draft="contributed">Tamuz</month>
 							<month type="12" draft="contributed">Áv</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1" draft="contributed">Tisri</month>
@@ -2485,9 +2485,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="8" draft="contributed">Niszán</month>
 							<month type="9" draft="contributed">Ijár</month>
 							<month type="10" draft="contributed">Sziván</month>
-							<month type="11" draft="contributed">↑↑↑</month>
+							<month type="11" draft="contributed">Tamuz</month>
 							<month type="12" draft="contributed">Áv</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -3326,7 +3326,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>óra</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">ebben az órában</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} óra múlva</relativeTimePattern>
 					<relativeTimePattern count="other">{0} óra múlva</relativeTimePattern>
@@ -3338,7 +3338,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>ó</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">ebben az órában</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} óra múlva</relativeTimePattern>
 					<relativeTimePattern count="other">{0} óra múlva</relativeTimePattern>
@@ -3362,7 +3362,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>perc</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">ebben a percben</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} perc múlva</relativeTimePattern>
 					<relativeTimePattern count="other">{0} perc múlva</relativeTimePattern>
@@ -3374,7 +3374,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>p</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">ebben a percben</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} perc múlva</relativeTimePattern>
 					<relativeTimePattern count="other">{0} perc múlva</relativeTimePattern>
@@ -3398,7 +3398,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>másodperc</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">most</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} másodperc múlva</relativeTimePattern>
 					<relativeTimePattern count="other">{0} másodperc múlva</relativeTimePattern>
@@ -3410,7 +3410,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>mp</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">most</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} másodperc múlva</relativeTimePattern>
 					<relativeTimePattern count="other">{0} másodperc múlva</relativeTimePattern>
@@ -5730,31 +5730,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
@@ -5772,13 +5772,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="contributed">↑↑↑</decimal>
+			<decimal draft="contributed">,</decimal>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="latn">
 			<decimalFormatLength>
@@ -6389,8 +6389,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="ESB">
 				<displayName>spanyol peseta (konvertibilis kontó)</displayName>
-				<displayName count="one" draft="contributed">↑↑↑</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="one" draft="contributed">spanyol peseta (konvertibilis kontó)</displayName>
+				<displayName count="other" draft="contributed">spanyol peseta (konvertibilis kontó)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ESP">
@@ -6731,8 +6731,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LUC">
 				<displayName>luxemburgi konvertibilis frank</displayName>
-				<displayName count="one" draft="contributed">↑↑↑</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="one" draft="contributed">luxemburgi konvertibilis frank</displayName>
+				<displayName count="other" draft="contributed">luxemburgi konvertibilis frank</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LUF">
@@ -6740,8 +6740,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LUL">
 				<displayName>luxemburgi pénzügyi frank</displayName>
-				<displayName count="one" draft="contributed">↑↑↑</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="one" draft="contributed">luxemburgi pénzügyi frank</displayName>
+				<displayName count="other" draft="contributed">luxemburgi pénzügyi frank</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LVL">
@@ -6971,8 +6971,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="PEI">
 				<displayName>perui inti</displayName>
-				<displayName count="one" draft="contributed">↑↑↑</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="one" draft="contributed">perui inti</displayName>
+				<displayName count="other" draft="contributed">perui inti</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PEN">
@@ -6983,8 +6983,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="PES">
 				<displayName>perui sol (1863–1965)</displayName>
-				<displayName count="one" draft="contributed">↑↑↑</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="one" draft="contributed">perui sol (1863–1965)</displayName>
+				<displayName count="other" draft="contributed">perui sol (1863–1965)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PGK">
@@ -7075,7 +7075,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">orosz rubel (1991–1998)</displayName>
 				<displayName count="other">orosz rubel (1991–1998)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">RUR</symbol>
 			</currency>
 			<currency type="RWF">
 				<displayName>ruandai frank</displayName>
@@ -7684,7 +7684,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">köb{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g gyorsulás</displayName>
@@ -7860,9 +7860,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/négyzethüvelyk</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karát</displayName>
@@ -7896,13 +7896,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="translative">{0} millimól/literré</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="one" case="accusative">{0} itemet</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} itemmel</unitPattern>
 				<unitPattern count="one" case="terminative">{0} itemig</unitPattern>
 				<unitPattern count="one" case="translative">{0} itemmé</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 				<unitPattern count="other" case="accusative">{0} itemet</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} itemmel</unitPattern>
 				<unitPattern count="other" case="terminative">{0} itemig</unitPattern>
@@ -8249,12 +8249,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/nap</perUnitPattern>
 			</unit>
 			<unit type="duration-day-person">
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nap</unitPattern>
 				<unitPattern count="one" case="accusative">{0} napot</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} nappal</unitPattern>
 				<unitPattern count="one" case="terminative">{0} napig</unitPattern>
 				<unitPattern count="one" case="translative">{0} nappá</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} nap</unitPattern>
 				<unitPattern count="other" case="accusative">{0} napot</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} nappal</unitPattern>
 				<unitPattern count="other" case="terminative">{0} napig</unitPattern>
@@ -9069,13 +9069,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} higanyhüvelyk</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="one" case="accusative">{0} bart</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} barral</unitPattern>
 				<unitPattern count="one" case="terminative">{0} barig</unitPattern>
 				<unitPattern count="one" case="translative">{0} barrá</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 				<unitPattern count="other" case="accusative">{0} bart</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} barral</unitPattern>
 				<unitPattern count="other" case="terminative">{0} barig</unitPattern>
@@ -9716,7 +9716,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -9736,7 +9736,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -9756,12 +9756,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -9964,12 +9964,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -9979,12 +9979,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -10019,33 +10019,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>képpont</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapixel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
 				<unitPattern count="one">{0} dpcm</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>képpont</displayName>
@@ -10054,7 +10054,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10164,7 +10164,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>Nap-sugár</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -10174,17 +10174,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -10221,7 +10221,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -10248,17 +10248,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -10313,7 +10313,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -10338,12 +10338,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -10388,12 +10388,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>Nm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Nm</unitPattern>
 				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -10581,64 +10581,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -10668,132 +10668,132 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>g gyorsulás</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ford.</displayName>
+				<unitPattern count="one">{0} ford.</unitPattern>
+				<unitPattern count="other">{0} ford.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>fok</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>ívperc</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ívmásodperc</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ha</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>kh</displayName>
 				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/l</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -10802,23 +10802,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -10826,69 +10826,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mérföld/bir. gallon</displayName>
+				<unitPattern count="one">{0} mpg bir.</unitPattern>
+				<unitPattern count="other">{0} mpg bir.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>bájt</displayName>
 				<unitPattern count="one">{0} B</unitPattern>
 				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>sz.</displayName>
@@ -10896,15 +10896,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} sz.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dek</displayName>
+				<unitPattern count="one">{0} dek</unitPattern>
+				<unitPattern count="other">{0} dek</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>év</displayName>
 				<unitPattern count="one">{0} év</unitPattern>
 				<unitPattern count="other">{0} év</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/év</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>n.év</displayName>
@@ -10916,13 +10916,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>hónap</displayName>
 				<unitPattern count="one">{0} h.</unitPattern>
 				<unitPattern count="other">{0} h.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/hó</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>hét</displayName>
 				<unitPattern count="one">{0} hét</unitPattern>
 				<unitPattern count="other">{0} hét</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/hét</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>nap</displayName>
@@ -10933,14 +10933,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-hour">
 				<displayName>ó</displayName>
 				<unitPattern count="one">{0} ó</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} ó</unitPattern>
+				<perUnitPattern>{0}/ó</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>p</displayName>
 				<unitPattern count="one">{0} p</unitPattern>
 				<unitPattern count="other">{0} p</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/p</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>mp</displayName>
@@ -10954,89 +10954,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>USA therm</displayName>
+				<unitPattern count="one">{0} USA therm</unitPattern>
+				<unitPattern count="other">{0} USA therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100 km</displayName>
@@ -11044,69 +11044,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kWh/100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>képpont</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapixel</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>képpont</displayName>
+				<unitPattern count="one">{0} képpont</unitPattern>
+				<unitPattern count="other">{0} képpont</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -11137,17 +11137,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
@@ -11174,34 +11174,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>fényév</displayName>
 				<unitPattern count="one">{0} fényév</unitPattern>
 				<unitPattern count="other">{0} fényév</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>CsE</displayName>
+				<unitPattern count="one">{0} CsE</unitPattern>
+				<unitPattern count="other">{0} CsE</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>furlong</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>öl</displayName>
+				<unitPattern count="one">{0} öl</unitPattern>
+				<unitPattern count="other">{0} öl</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>mil</displayName>
@@ -11210,38 +11210,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-point">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nap-sugár</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
@@ -11256,19 +11256,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>st</displayName>
@@ -11277,73 +11277,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-pound">
 				<displayName>lb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">{0} font</unitPattern>
 				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>oz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">{0} uncia</unitPattern>
 				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kt</displayName>
+				<unitPattern count="one">{0} Kt</unitPattern>
+				<unitPattern count="other">{0} Kt</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>LE</displayName>
 				<unitPattern count="one">{0} LE</unitPattern>
 				<unitPattern count="other">{0} LE</unitPattern>
 			</unit>
@@ -11363,24 +11363,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -11388,14 +11388,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -11413,9 +11413,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
@@ -11438,189 +11438,189 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nm</displayName>
+				<unitPattern count="one">{0} Nm</unitPattern>
+				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bg</displayName>
+				<unitPattern count="one">{0} bg</unitPattern>
+				<unitPattern count="other">{0} bg</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>véka</displayName>
+				<unitPattern count="one">{0} véka</unitPattern>
+				<unitPattern count="other">{0} véka</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>bir. gal</displayName>
+				<unitPattern count="one">{0} bir. gal</unitPattern>
+				<unitPattern count="other">{0} bir. gal</unitPattern>
+				<perUnitPattern>{0}/bir. gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cs.</displayName>
+				<unitPattern count="one">{0} cs.</unitPattern>
+				<unitPattern count="other">{0} cs.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bir. f. uncia</displayName>
+				<unitPattern count="one">{0} bir. f. uncia</unitPattern>
+				<unitPattern count="other">{0} bir. f. uncia</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ek.</displayName>
+				<unitPattern count="one">{0} ek.</unitPattern>
+				<unitPattern count="other">{0} ek.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kk.</displayName>
+				<unitPattern count="one">{0} kk.</unitPattern>
+				<unitPattern count="other">{0} kk.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hordó</displayName>
+				<unitPattern count="one">{0} hordó</unitPattern>
+				<unitPattern count="other">{0} hordó</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>desszertkanál</displayName>
+				<unitPattern count="one">{0} desszertkanál</unitPattern>
+				<unitPattern count="other">{0} desszertkanál</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bir. desszertkanál</displayName>
+				<unitPattern count="one">{0} bir. desszertkanál</unitPattern>
+				<unitPattern count="other">{0} bir. desszertkanál</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>csepp</displayName>
+				<unitPattern count="one">{0} csepp</unitPattern>
+				<unitPattern count="other">{0} csepp</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fluid dram</displayName>
+				<unitPattern count="one">{0} fl dram</unitPattern>
+				<unitPattern count="other">{0} fl dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>adagolópohár</displayName>
+				<unitPattern count="one">{0} adagolópohár</unitPattern>
+				<unitPattern count="other">{0} adagolópohár</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>csipet</displayName>
+				<unitPattern count="one">{0} csipet</unitPattern>
+				<unitPattern count="other">{0} csipet</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bir. qt</displayName>
+				<unitPattern count="one">{0} bir. qt</unitPattern>
+				<unitPattern count="other">{0} bir. qt</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>irány</displayName>
@@ -11654,26 +11654,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} vagy {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} vagy {1}</listPatternPart>
+			<listPatternPart type="2">{0} vagy {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} vagy {1}</listPatternPart>
+			<listPatternPart type="2">{0} vagy {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} és {1}</listPatternPart>
+			<listPatternPart type="2">{0} és {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} és {1}</listPatternPart>
 			<listPatternPart type="2">{0} és {1}</listPatternPart>
 		</listPattern>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -135,9 +135,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="en_AU">ավստրալիական անգլերեն</language>
 			<language type="en_CA">կանադական անգլերեն</language>
 			<language type="en_GB">բրիտանական անգլերեն</language>
-			<language type="en_GB" alt="short">↑↑↑</language>
+			<language type="en_GB" alt="short">բրիտանական անգլերեն</language>
 			<language type="en_US">ամերիկյան անգլերեն</language>
-			<language type="en_US" alt="short">↑↑↑</language>
+			<language type="en_US" alt="short">ամերիկյան անգլերեն</language>
 			<language type="eo">էսպերանտո</language>
 			<language type="es">իսպաներեն</language>
 			<language type="es_419">լատինամերիկյան իսպաներեն</language>
@@ -886,7 +886,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Թունիս</territory>
 			<territory type="TO">Տոնգա</territory>
 			<territory type="TR">Թուրքիա</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Թուրքիա</territory>
 			<territory type="TT">Տրինիդադ և Տոբագո</territory>
 			<territory type="TV">Տուվալու</territory>
 			<territory type="TW">Թայվան</territory>
@@ -1100,7 +1100,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1108,7 +1108,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1116,7 +1116,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1124,7 +1124,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1664,7 +1664,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1672,7 +1672,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1680,7 +1680,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1688,7 +1688,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1916,9 +1916,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>տ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">նախորդ տարի</relative>
+				<relative type="0">այս տարի</relative>
+				<relative type="1">հաջորդ տարի</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} տարուց</relativeTimePattern>
 					<relativeTimePattern count="other">{0} տարուց</relativeTimePattern>
@@ -1930,9 +1930,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>տ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">նախորդ տարի</relative>
+				<relative type="0">այս տարի</relative>
+				<relative type="1">հաջորդ տարի</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} տարուց</relativeTimePattern>
 					<relativeTimePattern count="other">{0} տարուց</relativeTimePattern>
@@ -1994,7 +1994,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>ամս</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">նախորդ ամիս</relative>
 				<relative type="0">այս ամիս</relative>
 				<relative type="1">հաջորդ ամիս</relative>
 				<relativeTime type="future">
@@ -2037,9 +2037,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>շաբ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">նախորդ շաբաթ</relative>
+				<relative type="0">այս շաբաթ</relative>
+				<relative type="1">հաջորդ շաբաթ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} շաբ-ից</relativeTimePattern>
 					<relativeTimePattern count="other">{0} շաբ-ից</relativeTimePattern>
@@ -2052,9 +2052,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>շաբ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">նախորդ շաբաթ</relative>
+				<relative type="0">այս շաբաթ</relative>
+				<relative type="1">հաջորդ շաբաթ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} շաբ անց</relativeTimePattern>
 					<relativeTimePattern count="other">{0} շաբ անց</relativeTimePattern>
@@ -6083,20 +6083,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">խորանարդ {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ազատ անկման արագացում</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
-				<unitPattern count="one" case="ablative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="ablative">{0} g</unitPattern>
+				<unitPattern count="one" case="dative">{0} g</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} g</unitPattern>
+				<unitPattern count="one" case="locative">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<unitPattern count="other" case="ablative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="ablative">{0} g</unitPattern>
+				<unitPattern count="other" case="dative">{0} g</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} g</unitPattern>
+				<unitPattern count="other" case="locative">{0} g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>մետրեր/վայրկյան քառակուսի</displayName>
@@ -6942,16 +6942,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>տպագրական em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="ablative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="ablative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="ablative">{0} em</unitPattern>
+				<unitPattern count="one" case="dative">{0} em</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="one" case="locative">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="ablative">{0} em</unitPattern>
+				<unitPattern count="other" case="dative">{0} em</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="other" case="locative">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>փիքսելներ</displayName>
@@ -8401,7 +8401,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -8571,7 +8571,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8640,12 +8640,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8817,7 +8817,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>մատ³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} մատ³</unitPattern>
 				<unitPattern count="other">{0} մատ³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
@@ -9055,40 +9055,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>g</displayName>
 				<unitPattern count="one">{0}G</unitPattern>
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մ/վ²</displayName>
+				<unitPattern count="one">{0} մ/վ²</unitPattern>
+				<unitPattern count="other">{0} մ/վ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>պտ</displayName>
+				<unitPattern count="one">{0} պտ</unitPattern>
+				<unitPattern count="other">{0} պտ</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ռադ</displayName>
+				<unitPattern count="one">{0} ռադ</unitPattern>
+				<unitPattern count="other">{0} ռադ</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>աստիճան</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
@@ -9098,84 +9098,84 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>վայրկյաններ</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>կմ²</displayName>
 				<unitPattern count="one">{0} կմ²</unitPattern>
 				<unitPattern count="other">{0} կմ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/կմ²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>հա</displayName>
+				<unitPattern count="one">{0} հա</unitPattern>
+				<unitPattern count="other">{0} հա</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>մ²</displayName>
 				<unitPattern count="one">{0} մ²</unitPattern>
 				<unitPattern count="other">{0} մ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/մ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>սմ²</displayName>
+				<unitPattern count="one">{0} սմ²</unitPattern>
+				<unitPattern count="other">{0} սմ²</unitPattern>
+				<perUnitPattern>{0}/սմ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>մղ²</displayName>
 				<unitPattern count="one">{0}մղ²</unitPattern>
 				<unitPattern count="other">{0}մղ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/մղ²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ակր</displayName>
 				<unitPattern count="one">{0}ակր</unitPattern>
 				<unitPattern count="other">{0}ակր</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>յրդ²</displayName>
+				<unitPattern count="one">{0} յրդ²</unitPattern>
+				<unitPattern count="other">{0} յրդ²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ֆտ²</displayName>
 				<unitPattern count="one">{0}ֆտ²</unitPattern>
 				<unitPattern count="other">{0}ֆտ²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>մատ²</displayName>
+				<unitPattern count="one">{0} մատ²</unitPattern>
+				<unitPattern count="other">{0} մատ²</unitPattern>
+				<perUnitPattern>{0}/մատ²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>դունամ</displayName>
+				<unitPattern count="one">{0} դունամ</unitPattern>
+				<unitPattern count="other">{0} դունամ</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կար</displayName>
+				<unitPattern count="one">{0} կար</unitPattern>
+				<unitPattern count="other">{0} կար</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մգ/դլ</displayName>
+				<unitPattern count="one">{0} մգ/դլ</unitPattern>
+				<unitPattern count="other">{0} մգ/դլ</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>մմոլ/լ</displayName>
 				<unitPattern count="one">{0}մմոլ/լ</unitPattern>
 				<unitPattern count="other">{0}մմոլ/լ</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>միույթ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} միույթ</unitPattern>
+				<unitPattern count="other">{0} միույթ</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>մմվ</displayName>
@@ -9198,12 +9198,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>մոլ</displayName>
 				<unitPattern count="one">{0}մոլ</unitPattern>
 				<unitPattern count="other">{0}մոլ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>լ/կմ</displayName>
 				<unitPattern count="one">{0}լ/կմ</unitPattern>
 				<unitPattern count="other">{0}լ/կմ</unitPattern>
 			</unit>
@@ -9213,85 +9213,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Լ/100 կմ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մղ/գալ</displayName>
+				<unitPattern count="one">{0} մղ/գալ</unitPattern>
+				<unitPattern count="other">{0} մղ/գալ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մղ/անգլ․ գալ</displayName>
+				<unitPattern count="one">{0} մղ/անգլ․ գալ</unitPattern>
+				<unitPattern count="other">{0} մղ/անգլ․ գալ</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ՊԲայթ</displayName>
+				<unitPattern count="one">{0} ՊԲ</unitPattern>
+				<unitPattern count="other">{0} ՊԲ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ՏԲայթ</displayName>
+				<unitPattern count="one">{0} ՏԲ</unitPattern>
+				<unitPattern count="other">{0} ՏԲ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Տբիթ</displayName>
+				<unitPattern count="one">{0} Տբիթ</unitPattern>
+				<unitPattern count="other">{0} Տբիթ</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>ԳԲ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ԳԲ</unitPattern>
+				<unitPattern count="other">{0} ԳԲ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Գբիթ</displayName>
+				<unitPattern count="one">{0} Գբիթ</unitPattern>
+				<unitPattern count="other">{0} Գբիթ</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>ՄԲ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ՄԲ</unitPattern>
+				<unitPattern count="other">{0} ՄԲ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Մբիթ</displayName>
+				<unitPattern count="one">{0} Մբիթ</unitPattern>
+				<unitPattern count="other">{0} Մբիթ</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>կԲ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} կԲ</unitPattern>
+				<unitPattern count="other">{0} կԲ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կբիթ</displayName>
+				<unitPattern count="one">{0} կբիթ</unitPattern>
+				<unitPattern count="other">{0} կբիթ</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>Բ</displayName>
 				<unitPattern count="one">{0} Բ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} Բ</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>բիթ</displayName>
+				<unitPattern count="one">{0} բիթ</unitPattern>
+				<unitPattern count="other">{0} բիթ</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>դ․</displayName>
+				<unitPattern count="one">{0} դ․</unitPattern>
+				<unitPattern count="other">{0} դ․</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>10-ամյակ</displayName>
+				<unitPattern count="one">{0} 10-ամյակ</unitPattern>
+				<unitPattern count="other">{0} 10-ամյակ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>տ</displayName>
 				<unitPattern count="one">{0} տ</unitPattern>
 				<unitPattern count="other">{0} տ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/տ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>եռմս</displayName>
@@ -9303,31 +9303,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ա</displayName>
 				<unitPattern count="one">{0} ա</unitPattern>
 				<unitPattern count="other">{0} ա</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ամս</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>շ</displayName>
 				<unitPattern count="one">{0} շ</unitPattern>
 				<unitPattern count="other">{0} շ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/շաբ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>օ</displayName>
 				<unitPattern count="one">{0} օ</unitPattern>
 				<unitPattern count="other">{0} օ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/օր</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ժ</displayName>
 				<unitPattern count="one">{0} ժ</unitPattern>
 				<unitPattern count="other">{0} ժ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ժ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>ր</displayName>
 				<unitPattern count="one">{0} ր</unitPattern>
 				<unitPattern count="other">{0} ր</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ր</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>վ</displayName>
@@ -9341,89 +9341,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} մվ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մկվ</displayName>
+				<unitPattern count="one">{0} մկվ</unitPattern>
+				<unitPattern count="other">{0} մկվ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>նվ</displayName>
+				<unitPattern count="one">{0} նվ</unitPattern>
+				<unitPattern count="other">{0} նվ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ա</displayName>
+				<unitPattern count="one">{0} Ա</unitPattern>
+				<unitPattern count="other">{0} Ա</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մԱ</displayName>
+				<unitPattern count="one">{0} մԱ</unitPattern>
+				<unitPattern count="other">{0} մԱ</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>օհմեր</displayName>
+				<unitPattern count="one">{0} Օհմ</unitPattern>
+				<unitPattern count="other">{0} Օհմ</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Վ</displayName>
+				<unitPattern count="one">{0} Վ</unitPattern>
+				<unitPattern count="other">{0} Վ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կկալ</displayName>
+				<unitPattern count="one">{0} կկալ</unitPattern>
+				<unitPattern count="other">{0} կկալ</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կալ</displayName>
+				<unitPattern count="one">{0} կալ</unitPattern>
+				<unitPattern count="other">{0} կալ</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կալ</displayName>
+				<unitPattern count="one">{0} կալ</unitPattern>
+				<unitPattern count="other">{0} կալ</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կՋ</displayName>
+				<unitPattern count="one">{0} կՋ</unitPattern>
+				<unitPattern count="other">{0} կՋ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ջ</displayName>
+				<unitPattern count="one">{0} Ջ</unitPattern>
+				<unitPattern count="other">{0} Ջ</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կՎտ·ժ</displayName>
+				<unitPattern count="one">{0} կՎտ·ժ</unitPattern>
+				<unitPattern count="other">{0} կՎտ·ժ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>էՎ</displayName>
+				<unitPattern count="one">{0} էՎ</unitPattern>
+				<unitPattern count="other">{0} էՎ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ԲՋՄ</displayName>
+				<unitPattern count="one">{0} Բջմ</unitPattern>
+				<unitPattern count="other">{0} Բջմ</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ԱՄՆ ջերմ</displayName>
+				<unitPattern count="one">{0} ԱՄՆ ջերմ</unitPattern>
+				<unitPattern count="other">{0} ԱՄՆ ջերմ</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ֆնտ․ ու․</displayName>
+				<unitPattern count="one">{0} ֆնտ․ ու․</unitPattern>
+				<unitPattern count="other">{0} ֆնտ․ ու․</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ն</displayName>
+				<unitPattern count="one">{0} Ն</unitPattern>
+				<unitPattern count="other">{0} Ն</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>կՎտ⋅ժ/100 կմ</displayName>
@@ -9431,39 +9431,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} կՎտժ/100 կմ</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ԳՀց</displayName>
+				<unitPattern count="one">{0} ԳՀց</unitPattern>
+				<unitPattern count="other">{0} ԳՀց</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ՄՀց</displayName>
+				<unitPattern count="one">{0} ՄՀց</unitPattern>
+				<unitPattern count="other">{0} ՄՀց</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կՀց</displayName>
+				<unitPattern count="one">{0} կՀց</unitPattern>
+				<unitPattern count="other">{0} կՀց</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Հց</displayName>
+				<unitPattern count="one">{0} Հց</unitPattern>
+				<unitPattern count="other">{0} Հց</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>կտ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} փքս</unitPattern>
+				<unitPattern count="other">{0} փքս</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մեգափիքսելներ</displayName>
+				<unitPattern count="one">{0} ՄՓ</unitPattern>
+				<unitPattern count="other">{0} ՄՓ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>կսմվ</displayName>
@@ -9471,52 +9471,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}կսմվ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>փմչ</displayName>
+				<unitPattern count="one">{0} փմչ</unitPattern>
+				<unitPattern count="other">{0} փմչ</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կսմ</displayName>
+				<unitPattern count="one">{0} կսմ</unitPattern>
+				<unitPattern count="other">{0} կսմ</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կմչ</displayName>
+				<unitPattern count="one">{0} կմչ</unitPattern>
+				<unitPattern count="other">{0} կմչ</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կետ</displayName>
+				<unitPattern count="one">{0} կետ</unitPattern>
+				<unitPattern count="other">{0} կետ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>կմ</displayName>
 				<unitPattern count="one">{0} կմ</unitPattern>
 				<unitPattern count="other">{0} կմ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/կմ</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>մ</displayName>
 				<unitPattern count="one">{0} մ</unitPattern>
 				<unitPattern count="other">{0} մ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/մ</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>դմ</displayName>
+				<unitPattern count="one">{0} դմ</unitPattern>
+				<unitPattern count="other">{0} դմ</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>սմ</displayName>
 				<unitPattern count="one">{0} սմ</unitPattern>
 				<unitPattern count="other">{0} սմ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/սմ</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>մմ</displayName>
@@ -9524,265 +9524,265 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} մմ</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մկմ</displayName>
+				<unitPattern count="one">{0} մկմ</unitPattern>
+				<unitPattern count="other">{0} մկմ</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>նմ</displayName>
+				<unitPattern count="one">{0} նմ</unitPattern>
+				<unitPattern count="other">{0} նմ</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>պմ</displayName>
 				<unitPattern count="one">{0} պմ</unitPattern>
 				<unitPattern count="other">{0} պմ</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>մղ</displayName>
 				<unitPattern count="one">{0} մղ</unitPattern>
 				<unitPattern count="other">{0} մղ</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>յրդ</displayName>
 				<unitPattern count="one">{0} յդ.</unitPattern>
 				<unitPattern count="other">{0} յդ.</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ֆտ</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ֆտ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>մատ</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/մատ</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>պկ</displayName>
+				<unitPattern count="one">{0} պկ</unitPattern>
+				<unitPattern count="other">{0} պկ</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>լ․տ․</displayName>
 				<unitPattern count="one">{0} լ. տ.</unitPattern>
 				<unitPattern count="other">{0} լ. տ.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ա.մ.</displayName>
+				<unitPattern count="one">{0} ա.մ.</unitPattern>
+				<unitPattern count="other">{0} ա.մ.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ֆուրլոնգ</displayName>
+				<unitPattern count="one">{0} ֆուրլ․</unitPattern>
+				<unitPattern count="other">{0} ֆուրլ․</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>ֆատոմ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ֆատոմ</unitPattern>
+				<unitPattern count="other">{0} ֆատոմ</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ծով․ մղ</displayName>
+				<unitPattern count="one">{0} ծով․ մղ</unitPattern>
+				<unitPattern count="other">{0} ծով․ մղ</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>սկանդ․ մղ</displayName>
+				<unitPattern count="one">{0} սկանդ․ մղ</unitPattern>
+				<unitPattern count="other">{0} սկանդ․ մղ</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>լք</displayName>
+				<unitPattern count="one">{0} լք</unitPattern>
+				<unitPattern count="other">{0} լք</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կդ</displayName>
+				<unitPattern count="one">{0} կդ</unitPattern>
+				<unitPattern count="other">{0} կդ</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>լմ</displayName>
+				<unitPattern count="one">{0} լմ</unitPattern>
+				<unitPattern count="other">{0} լմ</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>տ</displayName>
+				<unitPattern count="one">{0} տ</unitPattern>
+				<unitPattern count="other">{0} տ</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>կգ</displayName>
 				<unitPattern count="one">{0} կգ</unitPattern>
 				<unitPattern count="other">{0} կգ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/կգ</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>գ</displayName>
 				<unitPattern count="one">{0} գ</unitPattern>
 				<unitPattern count="other">{0} գ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/գ</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մգ</displayName>
+				<unitPattern count="one">{0} մգ</unitPattern>
+				<unitPattern count="other">{0} մգ</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մկգ</displayName>
+				<unitPattern count="one">{0} մկգ</unitPattern>
+				<unitPattern count="other">{0} մկգ</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ամեր․ տ</displayName>
+				<unitPattern count="one">{0} ամեր․ տ</unitPattern>
+				<unitPattern count="other">{0} ամեր․ տ</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>սթոուն</displayName>
+				<unitPattern count="one">{0} սթոուն</unitPattern>
+				<unitPattern count="other">{0} սթոուն</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>ֆունտ</displayName>
 				<unitPattern count="one">{0}#</unitPattern>
 				<unitPattern count="other">{0}#</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ֆունտ</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>ունկ.</displayName>
 				<unitPattern count="one">{0} ունց</unitPattern>
 				<unitPattern count="other">{0} ունց</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ունկ.</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>տրոյ․ ունկ.</displayName>
+				<unitPattern count="one">{0} տրոյ․ ունկ.</unitPattern>
+				<unitPattern count="other">{0} տրոյ․ ունկ.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կար</displayName>
+				<unitPattern count="one">{0} կար</unitPattern>
+				<unitPattern count="other">{0} կար</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>դա</displayName>
+				<unitPattern count="one">{0} դա</unitPattern>
+				<unitPattern count="other">{0} դա</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>գրան</displayName>
+				<unitPattern count="one">{0} գրան</unitPattern>
+				<unitPattern count="other">{0} գրան</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ԳՎտ</displayName>
+				<unitPattern count="one">{0} ԳՎտ</unitPattern>
+				<unitPattern count="other">{0} ԳՎտ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ՄՎտ</displayName>
+				<unitPattern count="one">{0} ՄՎտ</unitPattern>
+				<unitPattern count="other">{0} ՄՎտ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>կՎտ</displayName>
 				<unitPattern count="one">{0}կՎ</unitPattern>
 				<unitPattern count="other">{0}կՎ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>Վտ</displayName>
 				<unitPattern count="one">{0}Վ</unitPattern>
 				<unitPattern count="other">{0}Վ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մՎտ</displayName>
+				<unitPattern count="one">{0} մՎտ</unitPattern>
+				<unitPattern count="other">{0} մՎտ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>ձ․ու․</displayName>
 				<unitPattern count="one">{0}ձ/ու</unitPattern>
 				<unitPattern count="other">{0}ձ/ու</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մմ ս.ս.</displayName>
+				<unitPattern count="one">{0} մմ ս.ս.</unitPattern>
+				<unitPattern count="other">{0} մմ ս.ս.</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ֆ․/քառ․ դյմ</displayName>
+				<unitPattern count="one">{0} ֆ./քառ․ դյմ</unitPattern>
+				<unitPattern count="other">{0} ֆ./քառ․ դյմ</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>դյույմ ս.ս.</displayName>
 				<unitPattern count="one">{0}&quot; ս.ս.</unitPattern>
 				<unitPattern count="other">{0}&quot; ս. ս.</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>բար</displayName>
+				<unitPattern count="one">{0} բար</unitPattern>
+				<unitPattern count="other">{0} բար</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>մբար</displayName>
 				<unitPattern count="one">{0} մբ</unitPattern>
 				<unitPattern count="other">{0} մբ</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մթն</displayName>
+				<unitPattern count="one">{0} մթն</unitPattern>
+				<unitPattern count="other">{0} մթն</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Պա</displayName>
+				<unitPattern count="one">{0} Պա</unitPattern>
+				<unitPattern count="other">{0} Պա</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>հՊա</displayName>
 				<unitPattern count="one">{0} հՊա</unitPattern>
 				<unitPattern count="other">{0} հՊա</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կՊա</displayName>
+				<unitPattern count="one">{0} կՊա</unitPattern>
+				<unitPattern count="other">{0} կՊա</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ՄՊա</displayName>
+				<unitPattern count="one">{0} ՄՊա</unitPattern>
+				<unitPattern count="other">{0} ՄՊա</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>կմ/ժ</displayName>
@@ -9790,24 +9790,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} կմ/ժ</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>մ/վ</displayName>
 				<unitPattern count="one">{0}մ/վ</unitPattern>
 				<unitPattern count="other">{0}մ/վ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>մղ/ժ</displayName>
 				<unitPattern count="one">{0}մղ/ժ</unitPattern>
 				<unitPattern count="other">{0}մղ/ժ</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>հնգ</displayName>
+				<unitPattern count="one">{0} հնգ</unitPattern>
+				<unitPattern count="other">{0} հնգ</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9815,199 +9815,199 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Կ</displayName>
+				<unitPattern count="one">{0} Կ</unitPattern>
+				<unitPattern count="other">{0} Կ</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ֆնտ-ֆտ</displayName>
+				<unitPattern count="one">{0} ֆնտ-ֆտ</unitPattern>
+				<unitPattern count="other">{0} ֆնտ-ֆտ</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ն·մ</displayName>
+				<unitPattern count="one">{0} Ն·մ</unitPattern>
+				<unitPattern count="other">{0} Ն·մ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>կմ³</displayName>
 				<unitPattern count="one">{0}կմ³</unitPattern>
 				<unitPattern count="other">{0}կմ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>մ³</displayName>
+				<unitPattern count="one">{0} մ³</unitPattern>
+				<unitPattern count="other">{0} մ³</unitPattern>
+				<perUnitPattern>{0}/մ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>սմ³</displayName>
 				<unitPattern count="one">{0} սմ³</unitPattern>
 				<unitPattern count="other">{0} սմ³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/սմ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>մղ³</displayName>
 				<unitPattern count="one">{0}մղ³</unitPattern>
 				<unitPattern count="other">{0}մղ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>յրդ³</displayName>
+				<unitPattern count="one">{0} յրդ³</unitPattern>
+				<unitPattern count="other">{0} յրդ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ֆտ³</displayName>
+				<unitPattern count="one">{0} ֆտ³</unitPattern>
+				<unitPattern count="other">{0} ֆտ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մատ³</displayName>
+				<unitPattern count="one">{0} մատ³</unitPattern>
+				<unitPattern count="other">{0} մատ³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Մլ</displayName>
+				<unitPattern count="one">{0} Մլ</unitPattern>
+				<unitPattern count="other">{0} Մլ</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>հլ</displayName>
+				<unitPattern count="one">{0} հլ</unitPattern>
+				<unitPattern count="other">{0} հլ</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>լ</displayName>
 				<unitPattern count="one">{0} լ</unitPattern>
 				<unitPattern count="other">{0} լ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/լ</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>դլ</displayName>
+				<unitPattern count="one">{0} դլ</unitPattern>
+				<unitPattern count="other">{0} դլ</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>սլ</displayName>
+				<unitPattern count="one">{0} սլ</unitPattern>
+				<unitPattern count="other">{0} սլ</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մլ</displayName>
+				<unitPattern count="one">{0} մլ</unitPattern>
+				<unitPattern count="other">{0} մլ</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>մետր․ փինթեր</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} մետր․ փինթ</unitPattern>
+				<unitPattern count="other">{0} մետր․ փինթ</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>մ․ բաժ․</displayName>
+				<unitPattern count="one">{0} մ․ բաժ․</unitPattern>
+				<unitPattern count="other">{0} մ․ բաժ․</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ակր ֆտ</displayName>
+				<unitPattern count="one">{0} ակր ֆտ</unitPattern>
+				<unitPattern count="other">{0} ակր ֆտ</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>գալ</displayName>
+				<unitPattern count="one">{0} գալ</unitPattern>
+				<unitPattern count="other">{0} գալ</unitPattern>
+				<perUnitPattern>{0}/գալ</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>անգլ․ գալ</displayName>
+				<unitPattern count="one">{0} անգլ․ գալ</unitPattern>
+				<unitPattern count="other">{0} անգլ․ գալ</unitPattern>
+				<perUnitPattern>{0}/անգլ․ գալ</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>քվարտ</displayName>
+				<unitPattern count="one">{0} քվարտ</unitPattern>
+				<unitPattern count="other">{0} քվարտ</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>փինթեր</displayName>
+				<unitPattern count="one">{0} փինթ</unitPattern>
+				<unitPattern count="other">{0} փինթ</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>բաժակներ</displayName>
+				<unitPattern count="one">{0} բաժ․</unitPattern>
+				<unitPattern count="other">{0} բաժ․</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>հղ․ ունկ․</displayName>
+				<unitPattern count="one">{0} հղ. ունկ․</unitPattern>
+				<unitPattern count="other">{0} հղ. ունկ․</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ա․ հ․ ու․</displayName>
+				<unitPattern count="one">{0} ա․ հ․ ու․</unitPattern>
+				<unitPattern count="other">{0} ա․ հ․ ու․</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ճգ.</displayName>
+				<unitPattern count="one">{0} ճգ.</unitPattern>
+				<unitPattern count="other">{0} ճգ.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>թգ.</displayName>
+				<unitPattern count="one">{0} թգ.</unitPattern>
+				<unitPattern count="other">{0} թգ.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>տակառ</displayName>
+				<unitPattern count="one">{0} տկռ</unitPattern>
+				<unitPattern count="other">{0} տկռ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ագ․</displayName>
+				<unitPattern count="one">{0} ագ․</unitPattern>
+				<unitPattern count="other">{0} ագ․</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>անգլ․ ագ․</displayName>
+				<unitPattern count="one">{0} անգլ․ ագ․</unitPattern>
+				<unitPattern count="other">{0} անգլ․ ագ․</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>կաթիլ</displayName>
+				<unitPattern count="one">{0} կաթիլ</unitPattern>
+				<unitPattern count="other">{0} կաթիլ</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>հեղուկ դրամ</displayName>
+				<unitPattern count="one">{0} հեղուկ դրամ</unitPattern>
+				<unitPattern count="other">{0} հեղուկ դրամ</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ջիգեր</displayName>
+				<unitPattern count="one">{0} ջիգեր</unitPattern>
+				<unitPattern count="other">{0} ջիգեր</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>պտղունց</displayName>
+				<unitPattern count="one">{0} պտղունց</unitPattern>
+				<unitPattern count="other">{0} պտղունց</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>անգլիական քվարտ</displayName>
+				<unitPattern count="one">{0} անգլիական քվարտ</unitPattern>
+				<unitPattern count="other">{0} անգլիական քվարտ</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ուղղ․</displayName>
@@ -10041,20 +10041,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} կամ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} կամ {1}</listPatternPart>
+			<listPatternPart type="2">{0} կամ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} կամ {1}</listPatternPart>
+			<listPatternPart type="2">{0} կամ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -10381,10 +10381,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core} {given}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core} {given}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
 			<namePattern>{surname-core} {given-initial}</namePattern>

--- a/common/main/ia.xml
+++ b/common/main/ia.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -79,7 +79,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyenne</language>
 			<language type="ckb">kurdo central</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">kurdo central</language>
 			<language type="ckb" alt="variant">kurdo sorani</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">corso</language>
@@ -789,12 +789,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TJ">Tadzhikistan</territory>
 			<territory type="TK">Tokelau</territory>
 			<territory type="TL">Timor del Est</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">Timor del Est</territory>
 			<territory type="TM">Turkmenistan</territory>
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turchia</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turchia</territory>
 			<territory type="TT">Trinidad e Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1014,7 +1014,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1022,7 +1022,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1502,7 +1502,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd">d 'de' MMMM</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="one">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMW" count="one">'septimana' W 'de' MMMM</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="other">'septimana' W 'de' MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">y</dateFormatItem>
@@ -1515,7 +1515,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
 						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
 						<dateFormatItem id="yQQQQ">QQQQ 'de' y</dateFormatItem>
-						<dateFormatItem id="yw" count="one">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yw" count="one">'septimana' w 'de' Y</dateFormatItem>
 						<dateFormatItem id="yw" count="other">'septimana' w 'de' Y</dateFormatItem>
 					</availableFormats>
 					<appendItems>
@@ -1659,16 +1659,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>a.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">an. pass.</relative>
+				<relative type="0">iste an.</relative>
+				<relative type="1">an. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} an.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} an.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} an. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} an. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -1699,12 +1699,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="quarter-narrow">
 				<displayName>t.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} trim.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} trim.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} trim. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} trim. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -1737,16 +1737,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>m.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mns. pass.</relative>
+				<relative type="0">iste mns.</relative>
+				<relative type="1">mns. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} mns.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} mns.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} mns. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} mns. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -1781,18 +1781,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>s.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">sept. pass.</relative>
+				<relative type="0">iste sept.</relative>
+				<relative type="1">sept. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} sept.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} sept.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} sept. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} sept. retro</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>le sept. de {0}</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName>septimana del mense</displayName>
@@ -1819,30 +1819,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>die</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">heri</relative>
+				<relative type="0">hodie</relative>
+				<relative type="1">deman</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} die</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} dies</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} die retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dies retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
 				<displayName>d.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">heri</relative>
+				<relative type="0">hodie</relative>
+				<relative type="1">deman</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} die</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} dies</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} die retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dies retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
@@ -1899,16 +1899,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">dom. pass.</relative>
+				<relative type="0">iste dom.</relative>
+				<relative type="1">dom. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} dom.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} dom.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dom. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dom. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -1938,16 +1938,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">lun. pass.</relative>
+				<relative type="0">iste lun.</relative>
+				<relative type="1">lun. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} lun.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} lun.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} lun. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} lun. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -1977,16 +1977,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mar. pass.</relative>
+				<relative type="0">iste mar.</relative>
+				<relative type="1">mar. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} mar.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} mar.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} mar. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} mar. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -2016,16 +2016,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mer. pass.</relative>
+				<relative type="0">iste mer.</relative>
+				<relative type="1">mer. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} mer.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} mer.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} mer. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} mer. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -2055,16 +2055,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">jov. pass.</relative>
+				<relative type="0">iste jov.</relative>
+				<relative type="1">jov. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} jov.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} jov.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} jov. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} jov. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -2094,16 +2094,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ven. pass.</relative>
+				<relative type="0">iste ven.</relative>
+				<relative type="1">ven. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} ven.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} ven.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ven. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} ven. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -2133,16 +2133,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">sab. pass.</relative>
+				<relative type="0">iste sab.</relative>
+				<relative type="1">sab. prox.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} sab.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} sab.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} sab. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} sab. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
@@ -2180,12 +2180,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="hour-narrow">
 				<displayName>h.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} hr.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} hr.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} hr. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} hr. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
@@ -2214,12 +2214,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="minute-narrow">
 				<displayName>m.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} min.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} min.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} min. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} min. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -2248,12 +2248,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="second-narrow">
 				<displayName>s.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">in {0} sec.</relativeTimePattern>
+					<relativeTimePattern count="other">in {0} sec.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} sec. retro</relativeTimePattern>
+					<relativeTimePattern count="other">{0} sec. retro</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
@@ -4801,9 +4801,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} drachmas liquide</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>pinciatas</displayName>
@@ -4859,11 +4859,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
@@ -4873,187 +4873,187 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>m/s²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>rev</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rev</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>rad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>°</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>′</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>″</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>km²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ha</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>m²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>cm²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>ac</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ft²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>in²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>kt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/L</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L/km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mi/gal</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi/gal</unitPattern>
 				<unitPattern count="other">{0} mi/gal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mi/gal imp.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi/gal imp.</unitPattern>
 				<unitPattern count="other">{0} mi/gal imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>PB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>Tb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>GB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} byte</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>b</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} b</unitPattern>
 				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -5063,7 +5063,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-decade">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dec</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -5110,157 +5110,157 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>millisec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>μs</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>ns</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>A</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>mA</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>Ω</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>V</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>kcal</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>cal</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>kcal</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kJ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>J</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kWh</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>GHz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>MHz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>kHz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>Hz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>dm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>μm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>nm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>pm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>yd</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>in</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>pc</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
@@ -5270,7 +5270,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>ua</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ua</unitPattern>
 				<unitPattern count="other">{0} ua</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -5280,101 +5280,101 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>smi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>mg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>μg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>tn</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>lb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>oz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz t</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>ct</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ct</unitPattern>
 				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>GW</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>MW</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>kW</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>W</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>mW</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>cv</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cv</unitPattern>
 				<unitPattern count="other">{0} cv</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -5384,7 +5384,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} psi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
@@ -5394,57 +5394,57 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>atm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>m/s</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>mi/h</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>kn</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°C</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>°F</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>K</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -5496,23 +5496,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litros</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>dl</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dl</unitPattern>
 				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>cl</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cl</unitPattern>
 				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>ml</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ml</unitPattern>
 				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
@@ -5532,7 +5532,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>bushels</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -5584,7 +5584,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>barril</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -5609,7 +5609,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -5622,293 +5622,293 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fortia g</displayName>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>′</displayName>
+				<unitPattern count="one">{0}′</unitPattern>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>″</displayName>
+				<unitPattern count="one">{0}″</unitPattern>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ha</displayName>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac</displayName>
+				<unitPattern count="one">{0} ac</unitPattern>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="one">{0}%</unitPattern>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/100km</displayName>
+				<unitPattern count="one">{0} L/100km</unitPattern>
+				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/gal</displayName>
+				<unitPattern count="one">{0} mi/gal</unitPattern>
+				<unitPattern count="other">{0} mi/gal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/gal imp.</displayName>
+				<unitPattern count="one">{0} mi/gal imp.</unitPattern>
+				<unitPattern count="other">{0} mi/gal imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="one">{0} byte</unitPattern>
+				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>b</displayName>
+				<unitPattern count="one">{0} b</unitPattern>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>scl</displayName>
+				<unitPattern count="one">{0} scl</unitPattern>
+				<unitPattern count="other">{0} scl</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="one">{0} dec</unitPattern>
+				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>an</displayName>
 				<unitPattern count="one">{0}an</unitPattern>
 				<unitPattern count="other">{0}an</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/an</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>mense</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>sept.</displayName>
 				<unitPattern count="one">{0}sept</unitPattern>
 				<unitPattern count="other">{0}sept</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sept</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>die</displayName>
 				<unitPattern count="one">{0}d</unitPattern>
 				<unitPattern count="other">{0}d</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>hora</displayName>
 				<unitPattern count="one">{0}h</unitPattern>
 				<unitPattern count="other">{0}h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
 				<unitPattern count="one">{0}s</unitPattern>
 				<unitPattern count="other">{0}s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>millisec</displayName>
@@ -5916,107 +5916,107 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">{0}μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0}km</unitPattern>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0}cm</unitPattern>
 				<unitPattern count="other">{0}cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -6024,265 +6024,265 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi</displayName>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd</displayName>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in</displayName>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>al</displayName>
+				<unitPattern count="one">{0} al</unitPattern>
+				<unitPattern count="other">{0} al</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ua</displayName>
+				<unitPattern count="one">{0} ua</unitPattern>
+				<unitPattern count="other">{0} ua</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>lb</displayName>
+				<unitPattern count="one">{0} lb</unitPattern>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ct</displayName>
+				<unitPattern count="one">{0} ct</unitPattern>
+				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>W</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cv</displayName>
+				<unitPattern count="one">{0} cv</unitPattern>
+				<unitPattern count="other">{0} cv</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="one">{0} mm Hg</unitPattern>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 				<unitPattern count="one">{0} psi</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="one">{0} km/h</unitPattern>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/h</displayName>
+				<unitPattern count="one">{0} mi/h</unitPattern>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°C</unitPattern>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="one">{0}°F</unitPattern>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">{0}m³</unitPattern>
 				<unitPattern count="other">{0}m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0}cm³</unitPattern>
 				<unitPattern count="other">{0}cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0}mi³</unitPattern>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd³</displayName>
 				<unitPattern count="one">{0}yd³</unitPattern>
 				<unitPattern count="other">{0}yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>pd³</displayName>
 				<unitPattern count="one">{0}pd³</unitPattern>
 				<unitPattern count="other">{0}pd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in³</displayName>
 				<unitPattern count="one">{0}in³</unitPattern>
 				<unitPattern count="other">{0}in³</unitPattern>
 			</unit>
@@ -6297,23 +6297,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>litros</displayName>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="other">{0} l</unitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0}dl</unitPattern>
 				<unitPattern count="other">{0}dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cl</displayName>
 				<unitPattern count="one">{0}cl</unitPattern>
 				<unitPattern count="other">{0}cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ml</displayName>
 				<unitPattern count="one">{0}ml</unitPattern>
 				<unitPattern count="other">{0}ml</unitPattern>
 			</unit>
@@ -6323,7 +6323,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>tasm</displayName>
 				<unitPattern count="one">{0}tm</unitPattern>
 				<unitPattern count="other">{0}tm</unitPattern>
 			</unit>
@@ -6338,34 +6338,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">{0}gal</unitPattern>
 				<unitPattern count="other">{0}gal</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal imp</displayName>
 				<unitPattern count="one">{0}galim</unitPattern>
 				<unitPattern count="other">{0}galim</unitPattern>
 				<perUnitPattern>{0}/galim</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt</displayName>
 				<unitPattern count="one">{0}qt</unitPattern>
 				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>pintas</displayName>
 				<unitPattern count="one">{0}pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>tas</displayName>
 				<unitPattern count="one">{0}t</unitPattern>
 				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz liq</displayName>
 				<unitPattern count="one">{0}ozliq</unitPattern>
 				<unitPattern count="other">{0}ozliq</unitPattern>
 			</unit>
@@ -6410,7 +6410,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}drliq</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>jigger</displayName>
 				<unitPattern count="one">{0}jigger</unitPattern>
 				<unitPattern count="other">{0}jigger</unitPattern>
 			</unit>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -118,7 +118,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">Cheyenne</language>
 			<language type="ckb">Kurdi Sorani</language>
 			<language type="ckb" alt="menu">Kurdi Sorani</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">Kurdi Sorani</language>
 			<language type="clc">Chilcotin</language>
 			<language type="co">Korsika</language>
 			<language type="cop">Koptik</language>
@@ -1093,7 +1093,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="SX">Sint Maarten</territory>
 			<territory type="SY">Suriah</territory>
 			<territory type="SZ">eSwatini</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
+			<territory type="SZ" alt="variant">eSwatini</territory>
 			<territory type="TA">Tristan da Cunha</territory>
 			<territory type="TC">Kepulauan Turks dan Caicos</territory>
 			<territory type="TD">Chad</territory>
@@ -1108,7 +1108,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turki</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turki</territory>
 			<territory type="TT">Trinidad dan Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1514,23 +1514,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">E, d</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd" draft="contributed">E, d MMM y G</dateFormatItem>
-						<dateFormatItem id="M" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
 						<dateFormatItem id="Md">d/M</dateFormatItem>
 						<dateFormatItem id="MEd">E, d/M</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
 						<dateFormatItem id="MMMMEd">E, d MMMM</dateFormatItem>
-						<dateFormatItem id="y" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="y" draft="contributed">y G</dateFormatItem>
 						<dateFormatItem id="yyyy" draft="contributed">y G</dateFormatItem>
 						<dateFormatItem id="yyyyM" draft="contributed">M/y G</dateFormatItem>
 						<dateFormatItem id="yyyyMd" draft="contributed">d/M/y G</dateFormatItem>
@@ -1543,59 +1543,59 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ" draft="contributed">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h.mm B – h.mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h.mm – h.mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h.mm – h.mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d – d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d/M/y GGGGG – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
@@ -1620,7 +1620,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">HH.mm – HH.mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h – h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
@@ -1767,218 +1767,218 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">zi</cyclicName>
+								<cyclicName type="2" draft="contributed">chou</cyclicName>
+								<cyclicName type="3" draft="contributed">yin</cyclicName>
+								<cyclicName type="4" draft="contributed">mao</cyclicName>
+								<cyclicName type="5" draft="contributed">chen</cyclicName>
+								<cyclicName type="6" draft="contributed">si</cyclicName>
+								<cyclicName type="7" draft="contributed">wu</cyclicName>
+								<cyclicName type="8" draft="contributed">wei</cyclicName>
+								<cyclicName type="9" draft="contributed">shen</cyclicName>
+								<cyclicName type="10" draft="contributed">you</cyclicName>
+								<cyclicName type="11" draft="contributed">xu</cyclicName>
+								<cyclicName type="12" draft="contributed">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">zi</cyclicName>
+								<cyclicName type="2" draft="contributed">chou</cyclicName>
+								<cyclicName type="3" draft="contributed">yin</cyclicName>
+								<cyclicName type="4" draft="contributed">mao</cyclicName>
+								<cyclicName type="5" draft="contributed">chen</cyclicName>
+								<cyclicName type="6" draft="contributed">si</cyclicName>
+								<cyclicName type="7" draft="contributed">wu</cyclicName>
+								<cyclicName type="8" draft="contributed">wei</cyclicName>
+								<cyclicName type="9" draft="contributed">shen</cyclicName>
+								<cyclicName type="10" draft="contributed">you</cyclicName>
+								<cyclicName type="11" draft="contributed">xu</cyclicName>
+								<cyclicName type="12" draft="contributed">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="14" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="15" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="16" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="17" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="18" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="19" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="20" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="21" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="22" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="23" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="24" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="25" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="26" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="27" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="28" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="29" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="30" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="31" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="32" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="33" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="34" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="35" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="36" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="37" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="38" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="39" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="40" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="41" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="42" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="43" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="44" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="45" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="46" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="47" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="48" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="49" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="50" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="51" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="52" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="53" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="54" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="55" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="56" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="57" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="58" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="59" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="60" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">jia-zi</cyclicName>
+								<cyclicName type="2" draft="contributed">yi-chou</cyclicName>
+								<cyclicName type="3" draft="contributed">bing-yin</cyclicName>
+								<cyclicName type="4" draft="contributed">ding-mao</cyclicName>
+								<cyclicName type="5" draft="contributed">wu-chen</cyclicName>
+								<cyclicName type="6" draft="contributed">ji-si</cyclicName>
+								<cyclicName type="7" draft="contributed">geng-wu</cyclicName>
+								<cyclicName type="8" draft="contributed">xin-wei</cyclicName>
+								<cyclicName type="9" draft="contributed">ren-shen</cyclicName>
+								<cyclicName type="10" draft="contributed">gui-you</cyclicName>
+								<cyclicName type="11" draft="contributed">jia-xu</cyclicName>
+								<cyclicName type="12" draft="contributed">yi-hai</cyclicName>
+								<cyclicName type="13" draft="contributed">bing-zi</cyclicName>
+								<cyclicName type="14" draft="contributed">ding-chou</cyclicName>
+								<cyclicName type="15" draft="contributed">wu-yin</cyclicName>
+								<cyclicName type="16" draft="contributed">ji-mao</cyclicName>
+								<cyclicName type="17" draft="contributed">geng-chen</cyclicName>
+								<cyclicName type="18" draft="contributed">xin-si</cyclicName>
+								<cyclicName type="19" draft="contributed">ren-wu</cyclicName>
+								<cyclicName type="20" draft="contributed">gui-wei</cyclicName>
+								<cyclicName type="21" draft="contributed">jia-shen</cyclicName>
+								<cyclicName type="22" draft="contributed">yi-you</cyclicName>
+								<cyclicName type="23" draft="contributed">bing-xu</cyclicName>
+								<cyclicName type="24" draft="contributed">ding-hai</cyclicName>
+								<cyclicName type="25" draft="contributed">wu-zi</cyclicName>
+								<cyclicName type="26" draft="contributed">ji-chou</cyclicName>
+								<cyclicName type="27" draft="contributed">geng-yin</cyclicName>
+								<cyclicName type="28" draft="contributed">xin-mao</cyclicName>
+								<cyclicName type="29" draft="contributed">ren-chen</cyclicName>
+								<cyclicName type="30" draft="contributed">gui-si</cyclicName>
+								<cyclicName type="31" draft="contributed">jia-wu</cyclicName>
+								<cyclicName type="32" draft="contributed">yi-wei</cyclicName>
+								<cyclicName type="33" draft="contributed">bing-shen</cyclicName>
+								<cyclicName type="34" draft="contributed">ding-you</cyclicName>
+								<cyclicName type="35" draft="contributed">wu-xu</cyclicName>
+								<cyclicName type="36" draft="contributed">ji-hai</cyclicName>
+								<cyclicName type="37" draft="contributed">geng-zi</cyclicName>
+								<cyclicName type="38" draft="contributed">xin-chou</cyclicName>
+								<cyclicName type="39" draft="contributed">ren-yin</cyclicName>
+								<cyclicName type="40" draft="contributed">gui-mao</cyclicName>
+								<cyclicName type="41" draft="contributed">jia-chen</cyclicName>
+								<cyclicName type="42" draft="contributed">yi-si</cyclicName>
+								<cyclicName type="43" draft="contributed">bing-wu</cyclicName>
+								<cyclicName type="44" draft="contributed">ding-wei</cyclicName>
+								<cyclicName type="45" draft="contributed">wu-shen</cyclicName>
+								<cyclicName type="46" draft="contributed">ji-you</cyclicName>
+								<cyclicName type="47" draft="contributed">geng-xu</cyclicName>
+								<cyclicName type="48" draft="contributed">xin-hai</cyclicName>
+								<cyclicName type="49" draft="contributed">ren-zi</cyclicName>
+								<cyclicName type="50" draft="contributed">gui-chou</cyclicName>
+								<cyclicName type="51" draft="contributed">jia-yin</cyclicName>
+								<cyclicName type="52" draft="contributed">yi-mao</cyclicName>
+								<cyclicName type="53" draft="contributed">bing-chen</cyclicName>
+								<cyclicName type="54" draft="contributed">ding-si</cyclicName>
+								<cyclicName type="55" draft="contributed">wu-wu</cyclicName>
+								<cyclicName type="56" draft="contributed">ji-wei</cyclicName>
+								<cyclicName type="57" draft="contributed">geng-shen</cyclicName>
+								<cyclicName type="58" draft="contributed">xin-you</cyclicName>
+								<cyclicName type="59" draft="contributed">ren-xu</cyclicName>
+								<cyclicName type="60" draft="contributed">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="14" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="15" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="16" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="17" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="18" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="19" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="20" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="21" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="22" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="23" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="24" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="25" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="26" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="27" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="28" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="29" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="30" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="31" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="32" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="33" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="34" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="35" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="36" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="37" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="38" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="39" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="40" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="41" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="42" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="43" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="44" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="45" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="46" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="47" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="48" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="49" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="50" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="51" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="52" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="53" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="54" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="55" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="56" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="57" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="58" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="59" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="60" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">jia-zi</cyclicName>
+								<cyclicName type="2" draft="contributed">yi-chou</cyclicName>
+								<cyclicName type="3" draft="contributed">bing-yin</cyclicName>
+								<cyclicName type="4" draft="contributed">ding-mao</cyclicName>
+								<cyclicName type="5" draft="contributed">wu-chen</cyclicName>
+								<cyclicName type="6" draft="contributed">ji-si</cyclicName>
+								<cyclicName type="7" draft="contributed">geng-wu</cyclicName>
+								<cyclicName type="8" draft="contributed">xin-wei</cyclicName>
+								<cyclicName type="9" draft="contributed">ren-shen</cyclicName>
+								<cyclicName type="10" draft="contributed">gui-you</cyclicName>
+								<cyclicName type="11" draft="contributed">jia-xu</cyclicName>
+								<cyclicName type="12" draft="contributed">yi-hai</cyclicName>
+								<cyclicName type="13" draft="contributed">bing-zi</cyclicName>
+								<cyclicName type="14" draft="contributed">ding-chou</cyclicName>
+								<cyclicName type="15" draft="contributed">wu-yin</cyclicName>
+								<cyclicName type="16" draft="contributed">ji-mao</cyclicName>
+								<cyclicName type="17" draft="contributed">geng-chen</cyclicName>
+								<cyclicName type="18" draft="contributed">xin-si</cyclicName>
+								<cyclicName type="19" draft="contributed">ren-wu</cyclicName>
+								<cyclicName type="20" draft="contributed">gui-wei</cyclicName>
+								<cyclicName type="21" draft="contributed">jia-shen</cyclicName>
+								<cyclicName type="22" draft="contributed">yi-you</cyclicName>
+								<cyclicName type="23" draft="contributed">bing-xu</cyclicName>
+								<cyclicName type="24" draft="contributed">ding-hai</cyclicName>
+								<cyclicName type="25" draft="contributed">wu-zi</cyclicName>
+								<cyclicName type="26" draft="contributed">ji-chou</cyclicName>
+								<cyclicName type="27" draft="contributed">geng-yin</cyclicName>
+								<cyclicName type="28" draft="contributed">xin-mao</cyclicName>
+								<cyclicName type="29" draft="contributed">ren-chen</cyclicName>
+								<cyclicName type="30" draft="contributed">gui-si</cyclicName>
+								<cyclicName type="31" draft="contributed">jia-wu</cyclicName>
+								<cyclicName type="32" draft="contributed">yi-wei</cyclicName>
+								<cyclicName type="33" draft="contributed">bing-shen</cyclicName>
+								<cyclicName type="34" draft="contributed">ding-you</cyclicName>
+								<cyclicName type="35" draft="contributed">wu-xu</cyclicName>
+								<cyclicName type="36" draft="contributed">ji-hai</cyclicName>
+								<cyclicName type="37" draft="contributed">geng-zi</cyclicName>
+								<cyclicName type="38" draft="contributed">xin-chou</cyclicName>
+								<cyclicName type="39" draft="contributed">ren-yin</cyclicName>
+								<cyclicName type="40" draft="contributed">gui-mao</cyclicName>
+								<cyclicName type="41" draft="contributed">jia-chen</cyclicName>
+								<cyclicName type="42" draft="contributed">yi-si</cyclicName>
+								<cyclicName type="43" draft="contributed">bing-wu</cyclicName>
+								<cyclicName type="44" draft="contributed">ding-wei</cyclicName>
+								<cyclicName type="45" draft="contributed">wu-shen</cyclicName>
+								<cyclicName type="46" draft="contributed">ji-you</cyclicName>
+								<cyclicName type="47" draft="contributed">geng-xu</cyclicName>
+								<cyclicName type="48" draft="contributed">xin-hai</cyclicName>
+								<cyclicName type="49" draft="contributed">ren-zi</cyclicName>
+								<cyclicName type="50" draft="contributed">gui-chou</cyclicName>
+								<cyclicName type="51" draft="contributed">jia-yin</cyclicName>
+								<cyclicName type="52" draft="contributed">yi-mao</cyclicName>
+								<cyclicName type="53" draft="contributed">bing-chen</cyclicName>
+								<cyclicName type="54" draft="contributed">ding-si</cyclicName>
+								<cyclicName type="55" draft="contributed">wu-wu</cyclicName>
+								<cyclicName type="56" draft="contributed">ji-wei</cyclicName>
+								<cyclicName type="57" draft="contributed">geng-shen</cyclicName>
+								<cyclicName type="58" draft="contributed">xin-you</cyclicName>
+								<cyclicName type="59" draft="contributed">ren-xu</cyclicName>
+								<cyclicName type="60" draft="contributed">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="14" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="15" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="16" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="17" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="18" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="19" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="20" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="21" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="22" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="23" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="24" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="25" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="26" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="27" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="28" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="29" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="30" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="31" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="32" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="33" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="34" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="35" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="36" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="37" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="38" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="39" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="40" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="41" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="42" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="43" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="44" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="45" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="46" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="47" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="48" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="49" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="50" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="51" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="52" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="53" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="54" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="55" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="56" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">jia-zi</cyclicName>
+								<cyclicName type="2" draft="contributed">yi-chou</cyclicName>
+								<cyclicName type="3" draft="contributed">bing-yin</cyclicName>
+								<cyclicName type="4" draft="contributed">ding-mao</cyclicName>
+								<cyclicName type="5" draft="contributed">wu-chen</cyclicName>
+								<cyclicName type="6" draft="contributed">ji-si</cyclicName>
+								<cyclicName type="7" draft="contributed">geng-wu</cyclicName>
+								<cyclicName type="8" draft="contributed">xin-wei</cyclicName>
+								<cyclicName type="9" draft="contributed">ren-shen</cyclicName>
+								<cyclicName type="10" draft="contributed">gui-you</cyclicName>
+								<cyclicName type="11" draft="contributed">jia-xu</cyclicName>
+								<cyclicName type="12" draft="contributed">yi-hai</cyclicName>
+								<cyclicName type="13" draft="contributed">bing-zi</cyclicName>
+								<cyclicName type="14" draft="contributed">ding-chou</cyclicName>
+								<cyclicName type="15" draft="contributed">wu-yin</cyclicName>
+								<cyclicName type="16" draft="contributed">ji-mao</cyclicName>
+								<cyclicName type="17" draft="contributed">geng-chen</cyclicName>
+								<cyclicName type="18" draft="contributed">xin-si</cyclicName>
+								<cyclicName type="19" draft="contributed">ren-wu</cyclicName>
+								<cyclicName type="20" draft="contributed">gui-wei</cyclicName>
+								<cyclicName type="21" draft="contributed">jia-shen</cyclicName>
+								<cyclicName type="22" draft="contributed">yi-you</cyclicName>
+								<cyclicName type="23" draft="contributed">bing-xu</cyclicName>
+								<cyclicName type="24" draft="contributed">ding-hai</cyclicName>
+								<cyclicName type="25" draft="contributed">wu-zi</cyclicName>
+								<cyclicName type="26" draft="contributed">ji-chou</cyclicName>
+								<cyclicName type="27" draft="contributed">geng-yin</cyclicName>
+								<cyclicName type="28" draft="contributed">xin-mao</cyclicName>
+								<cyclicName type="29" draft="contributed">ren-chen</cyclicName>
+								<cyclicName type="30" draft="contributed">gui-si</cyclicName>
+								<cyclicName type="31" draft="contributed">jia-wu</cyclicName>
+								<cyclicName type="32" draft="contributed">yi-wei</cyclicName>
+								<cyclicName type="33" draft="contributed">bing-shen</cyclicName>
+								<cyclicName type="34" draft="contributed">ding-you</cyclicName>
+								<cyclicName type="35" draft="contributed">wu-xu</cyclicName>
+								<cyclicName type="36" draft="contributed">ji-hai</cyclicName>
+								<cyclicName type="37" draft="contributed">geng-zi</cyclicName>
+								<cyclicName type="38" draft="contributed">xin-chou</cyclicName>
+								<cyclicName type="39" draft="contributed">ren-yin</cyclicName>
+								<cyclicName type="40" draft="contributed">gui-mao</cyclicName>
+								<cyclicName type="41" draft="contributed">jia-chen</cyclicName>
+								<cyclicName type="42" draft="contributed">yi-si</cyclicName>
+								<cyclicName type="43" draft="contributed">bing-wu</cyclicName>
+								<cyclicName type="44" draft="contributed">ding-wei</cyclicName>
+								<cyclicName type="45" draft="contributed">wu-shen</cyclicName>
+								<cyclicName type="46" draft="contributed">ji-you</cyclicName>
+								<cyclicName type="47" draft="contributed">geng-xu</cyclicName>
+								<cyclicName type="48" draft="contributed">xin-hai</cyclicName>
+								<cyclicName type="49" draft="contributed">ren-zi</cyclicName>
+								<cyclicName type="50" draft="contributed">gui-chou</cyclicName>
+								<cyclicName type="51" draft="contributed">jia-yin</cyclicName>
+								<cyclicName type="52" draft="contributed">yi-mao</cyclicName>
+								<cyclicName type="53" draft="contributed">bing-chen</cyclicName>
+								<cyclicName type="54" draft="contributed">ding-si</cyclicName>
+								<cyclicName type="55" draft="contributed">wu-wu</cyclicName>
+								<cyclicName type="56" draft="contributed">ji-wei</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2117,7 +2117,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2125,7 +2125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2609,9 +2609,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">SM</era>
-						<era type="0" alt="variant" draft="contributed">↑↑↑</era>
+						<era type="0" alt="variant" draft="contributed">SEU</era>
 						<era type="1">M</era>
-						<era type="1" alt="variant" draft="contributed">↑↑↑</era>
+						<era type="1" alt="variant" draft="contributed">EU</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -2900,20 +2900,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="7" yeartype="leap">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -2967,18 +2967,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">Zulhi.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Muharam</month>
@@ -2997,15 +2997,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">Muh.</month>
+							<month type="2">Saf.</month>
 							<month type="3">Rab. Awal</month>
 							<month type="4">Rab. Akhir</month>
 							<month type="5">Jum. Awal</month>
 							<month type="6">Jum. Akhir</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">Raj.</month>
 							<month type="8">Sya.</month>
-							<month type="9">↑↑↑</month>
+							<month type="9">Ram.</month>
 							<month type="10">Syaw.</month>
 							<month type="11">Zulka.</month>
 							<month type="12">Zulhi.</month>
@@ -3026,12 +3026,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Muharam</month>
-							<month type="2">↑↑↑</month>
+							<month type="2">Safar</month>
 							<month type="3">Rabiulawal</month>
 							<month type="4">Rabiulakhir</month>
 							<month type="5">Jumadilawal</month>
 							<month type="6">Jumadilakhir</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">Rajab</month>
 							<month type="8">Syakban</month>
 							<month type="9">Ramadan</month>
 							<month type="10">Syawal</month>
@@ -3044,12 +3044,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<dayContext type="format">
 						<dayWidth type="wide">
 							<day type="sun">Ahad</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="mon">Senin</day>
+							<day type="tue">Selasa</day>
+							<day type="wed">Rabu</day>
+							<day type="thu">Kamis</day>
+							<day type="fri">Jumat</day>
+							<day type="sat">Sabtu</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -3108,18 +3108,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E, d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, d MMM y G</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
 						<dateFormatItem id="Md">d/M</dateFormatItem>
 						<dateFormatItem id="MEd">E, d/M</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
 						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
@@ -3441,9 +3441,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-narrow">
 				<displayName>krtl.</displayName>
-				<relative type="-1" draft="contributed">↑↑↑</relative>
-				<relative type="0" draft="contributed">↑↑↑</relative>
-				<relative type="1" draft="contributed">↑↑↑</relative>
+				<relative type="-1" draft="contributed">krtl lalu</relative>
+				<relative type="0" draft="contributed">krtl ini</relative>
+				<relative type="1" draft="contributed">krtl berikutnya</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">dlm {0} krtl.</relativeTimePattern>
 				</relativeTime>
@@ -3552,9 +3552,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-short">
 				<displayName>hr</displayName>
 				<relative type="-2" draft="contributed">selumbari</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">kemarin</relative>
+				<relative type="0">hari ini</relative>
+				<relative type="1">besok</relative>
 				<relative type="2" draft="contributed">lusa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">dalam {0} h</relativeTimePattern>
@@ -3565,10 +3565,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>h</displayName>
-				<relative type="-2" draft="contributed">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-2" draft="contributed">selumbari</relative>
+				<relative type="-1">kemarin</relative>
+				<relative type="0">hari ini</relative>
+				<relative type="1">besok</relative>
 				<relative type="2" draft="contributed">lusa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">dalam {0} h</relativeTimePattern>
@@ -3856,7 +3856,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>jam</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">jam ini</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">dalam {0} jam</relativeTimePattern>
 				</relativeTime>
@@ -3866,7 +3866,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>j</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">jam ini</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">dalam {0} jam</relativeTimePattern>
 				</relativeTime>
@@ -3916,7 +3916,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>dtk.</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">sekarang</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">dlm {0} dtk</relativeTimePattern>
 				</relativeTime>
@@ -3926,7 +3926,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>d</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">sekarang</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">dlm {0} dtk</relativeTimePattern>
 				</relativeTime>
@@ -7096,7 +7096,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>Loti Lesotho</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Loti Lesotho</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -7886,7 +7886,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0} kubik</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-force</displayName>
@@ -7958,8 +7958,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} per inci persegi</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karat</displayName>
@@ -7974,8 +7974,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} millimol per liter</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>bagian per juta</displayName>
@@ -7994,8 +7994,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} permyriad</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>liter per kilometer</displayName>
@@ -8199,7 +8199,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em tipografis</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piksel</displayName>
@@ -8439,8 +8439,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inci raksa</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>milibar</displayName>
@@ -9092,8 +9092,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>piksel</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
@@ -9523,64 +9523,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -9610,108 +9610,108 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>g-force</displayName>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>m/d²</displayName>
 				<unitPattern count="other">{0} m/d²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>rad</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>derajat</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>mnt busur</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>dtk busur</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hektare</displayName>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>meter²</displayName>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
 				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ekar</displayName>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ft²</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>in²</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/L</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9719,27 +9719,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>L/km</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100 km</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} L/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg UK</displayName>
@@ -9747,55 +9747,55 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>PB</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TB</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>Tb</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>GB</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gb</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MB</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mb</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kB</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kb</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
 				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>abad</displayName>
 				<unitPattern count="other">{0} abad</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dek</displayName>
+				<unitPattern count="other">{0} dek</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>thn</displayName>
@@ -9850,104 +9850,104 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ndtk</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>mA</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kkal</displayName>
+				<unitPattern count="other">{0} kkal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kal</displayName>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kal</displayName>
+				<unitPattern count="other">{0} Kal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kJ</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joule</displayName>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kWh</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>therm AS</displayName>
+				<unitPattern count="other">{0} therm AS</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
@@ -9962,61 +9962,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>meter</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dm</displayName>
 				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>μmeter</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mi</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>yd</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>ft</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>in</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>parsec</displayName>
@@ -10028,7 +10028,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>sa</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} sa</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>furlong</displayName>
@@ -10039,164 +10039,164 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dp</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>p</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} p</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gram</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>ton</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} tn AS</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>stone</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>lb</displayName>
 				<unitPattern count="other">{0}#</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz t</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>karat</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Da</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>gr</displayName>
 				<unitPattern count="other">{0} gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>watt</displayName>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>mmHg</displayName>
 				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>″ Hg</displayName>
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/jam</displayName>
@@ -10204,77 +10204,77 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>m/dtk</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} m/dtk</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>mi/j</displayName>
 				<unitPattern count="other">{0} mpj</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>yd³</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>in³</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>liter</displayName>
@@ -10282,74 +10282,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>pt</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gantang</displayName>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal Imp.</displayName>
 				<unitPattern count="other">{0} galIm</unitPattern>
 				<perUnitPattern>{0}/galIm</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pt</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cup</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sdm</displayName>
+				<unitPattern count="other">{0} sdm</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sdt</displayName>
+				<unitPattern count="other">{0} sdt</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>bbl</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dsp</displayName>
@@ -10360,24 +10360,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tetes</displayName>
+				<unitPattern count="other">{0} tetes</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl.dr.</displayName>
 				<unitPattern count="other">{0} fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sloki</displayName>
+				<unitPattern count="other">{0} sloki</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>jumput</displayName>
 				<unitPattern count="other">{0} jumput</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>qt Imp</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>arah</displayName>
@@ -10411,20 +10411,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} atau {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, atau {1}</listPatternPart>
+			<listPatternPart type="2">{0} atau {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, atau {1}</listPatternPart>
+			<listPatternPart type="2">{0} atau {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -78,7 +78,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">Cheroke</language>
 			<language type="chy">Cheyene</language>
 			<language type="ckb">Kurdish ọsote</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">Kurdish ọsote</language>
 			<language type="ckb" alt="variant">Kurdish ọzọ</language>
 			<language type="clc">Chilcotinị</language>
 			<language type="co">Kọsịan</language>
@@ -447,11 +447,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="yue" alt="menu">Chinese,Cantonese</language>
 			<language type="zgh">Standard Moroccan Tamazait</language>
 			<language type="zh">Chainisi</language>
-			<language type="zh" alt="menu">↑↑↑</language>
+			<language type="zh" alt="menu">Chainisi</language>
 			<language type="zh_Hans">Asụsụ Chinese dị mfe</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">Asụsụ Chinese dị mfe</language>
 			<language type="zh_Hant">Asụsụ Chinese Izugbe</language>
-			<language type="zh_Hant" alt="long">↑↑↑</language>
+			<language type="zh_Hant" alt="long">Asụsụ Chinese Izugbe</language>
 			<language type="zu">Zulu</language>
 			<language type="zun">Zuni</language>
 			<language type="zxx">Ndị ọzọ abụghị asụsụ</language>
@@ -658,7 +658,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="GW">Guinea-Bissau</territory>
 			<territory type="GY">Guyana</territory>
 			<territory type="HK">Hong Kong SAR China</territory>
-			<territory type="HK" alt="short">↑↑↑</territory>
+			<territory type="HK" alt="short">Hong Kong SAR China</territory>
 			<territory type="HM">Agwaetiti Heard na Agwaetiti McDonald</territory>
 			<territory type="HN">Honduras</territory>
 			<territory type="HR">Croatia</territory>
@@ -737,7 +737,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">New Zealand</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">New Zealand</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -750,7 +750,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="PN">Agwaetiti Pitcairn</territory>
 			<territory type="PR">Puerto Rico</territory>
 			<territory type="PS">Palestinian Territories</territory>
-			<territory type="PS" alt="short">↑↑↑</territory>
+			<territory type="PS" alt="short">Palestinian Territories</territory>
 			<territory type="PT">Portugal</territory>
 			<territory type="PW">Palau</territory>
 			<territory type="PY">Paraguay</territory>
@@ -797,7 +797,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkey</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkey</territory>
 			<territory type="TT">Trinidad na Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -807,7 +807,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UM">Obere Agwaetiti Dị Na Mpụga U.S</territory>
 			<territory type="UN">Mba Ụwa Jikọrọ Ọnụ</territory>
 			<territory type="US">United States</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">United States</territory>
 			<territory type="UY">Uruguay</territory>
 			<territory type="UZ">Uzbekistan</territory>
 			<territory type="VA">Vatican City</territory>
@@ -1295,13 +1295,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">Sat</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">S</day>
+							<day type="mon">M</day>
+							<day type="tue">T</day>
+							<day type="wed">W</day>
+							<day type="thu">T</day>
+							<day type="fri">F</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">Sọn</day>
@@ -1741,10 +1741,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Agba</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Agba</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Agba</displayName>
 			</field>
 			<field type="year">
 				<displayName>Afọ</displayName>
@@ -1759,27 +1759,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Afọ</displayName>
 				<relative type="-1">Afọ gara aga</relative>
 				<relative type="0">Afọ a</relative>
 				<relative type="1">Afọ ọzọ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} y</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} y</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Afọ</displayName>
 				<relative type="-1">Afọ gara aga</relative>
 				<relative type="0">Afọ a</relative>
 				<relative type="1">Afọ ọzọ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} y</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} y</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -1797,19 +1797,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="quarter-short">
 				<displayName>Ọnwa atọ n’afọ</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Q</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Q</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
 				<displayName>Ọnwa atọ n’afọ</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Q</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Q</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -1825,27 +1825,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ọnwa</displayName>
 				<relative type="-1">Ọnwa gara aga</relative>
 				<relative type="0">Ọnwa a</relative>
 				<relative type="1">Ọnwa ọzọ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} m</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} m</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ọnwa</displayName>
 				<relative type="-1">Ọnwa gara aga</relative>
 				<relative type="0">Ọnwa a</relative>
 				<relative type="1">Ọnwa ọzọ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} m</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} m</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -1862,28 +1862,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativePeriod>Izu nke{0}</relativePeriod>
 			</field>
 			<field type="week-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Izu</displayName>
 				<relative type="-1">Izu gara aga</relative>
 				<relative type="0">Izu a</relative>
 				<relative type="1">Izu na-esote</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>Izu nke{0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Izu</displayName>
 				<relative type="-1">Izu gara aga</relative>
 				<relative type="0">Izu a</relative>
 				<relative type="1">Izu na-esote</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>Izu nke{0}</relativePeriod>
 			</field>
@@ -1909,27 +1909,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ụbọchị</displayName>
 				<relative type="-1">Ụnyaahụ</relative>
 				<relative type="0">Taata</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">Echi</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} d</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} d</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ụbọchị</displayName>
 				<relative type="-1">Ụnyaahụ</relative>
 				<relative type="0">Taata</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">Echi</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} d</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} d</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
@@ -1939,7 +1939,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Ụbọchị na afọ</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ụbọchị na afọ</displayName>
 			</field>
 			<field type="weekday">
 				<displayName>Ụbọchị izu</displayName>
@@ -1975,10 +1975,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ubochị ụka a</relative>
 				<relative type="1">ụbọchị ụka na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Sundays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Sundays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
@@ -1986,10 +1986,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị ụka a</relative>
 				<relative type="1">ụbọchị ụka na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Sundays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Sundays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2008,10 +2008,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Mọnde a</relative>
 				<relative type="1">ụbọchị Mọnde na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Mondays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Mondays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
@@ -2019,10 +2019,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Monde a</relative>
 				<relative type="1">ụbọchị Monde na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Mondays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Mondays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -2041,10 +2041,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Tuesde a</relative>
 				<relative type="1">ụbọchị Tuesde na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
@@ -2052,10 +2052,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Tuesde a</relative>
 				<relative type="1">ụbọchị Tuesde na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -2074,10 +2074,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Wednesde a</relative>
 				<relative type="1">ụbọchị Wednesde na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
@@ -2085,10 +2085,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Wednesde a</relative>
 				<relative type="1">ụbọchị Wednesde a</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -2107,10 +2107,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Tọsdee a</relative>
 				<relative type="1">ụbọchị Tọsdee na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
@@ -2118,10 +2118,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Tọsdee a</relative>
 				<relative type="1">ụbọchị Tọsdee na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -2140,10 +2140,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Faraịde a</relative>
 				<relative type="1">ụbọchị na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Fridays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Fridays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
@@ -2151,10 +2151,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Faraịde a</relative>
 				<relative type="1">ụọchị Faraịde na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Fridays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Fridays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -2173,10 +2173,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Satụde a</relative>
 				<relative type="1">ụbọchị Satụde na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
@@ -2184,10 +2184,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">ụbọchị Satụde a</relative>
 				<relative type="1">ụbọchị Satụde na abịa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
@@ -2210,21 +2210,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Elekere</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} h</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} h</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Elekere</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} h</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} h</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
@@ -2238,21 +2238,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="minute-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Nkeji</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} min</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} min</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Nkeji</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} min</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} min</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -2268,29 +2268,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="second-short">
 				<displayName>Tịm kọm</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} s</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
 				<displayName>Tịm kọm</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} s</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
 				<displayName>Mpaghara oge</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mpaghara oge</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mpaghara oge</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -4551,18 +4551,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="long">
 				<decimalFormat>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
+					<pattern type="1000" count="other">0K</pattern>
+					<pattern type="10000" count="other">00K</pattern>
+					<pattern type="100000" count="other">000K</pattern>
+					<pattern type="1000000" count="other">0M</pattern>
+					<pattern type="10000000" count="other">00M</pattern>
+					<pattern type="100000000" count="other">000M</pattern>
+					<pattern type="1000000000" count="other">0G</pattern>
+					<pattern type="10000000000" count="other">00G</pattern>
+					<pattern type="100000000000" count="other">000G</pattern>
+					<pattern type="1000000000000" count="other">0T</pattern>
+					<pattern type="10000000000000" count="other">00T</pattern>
+					<pattern type="100000000000000" count="other">000T</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
@@ -4673,24 +4673,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="AFN">
 				<displayName>Ego Afghani Obodo Afghanistan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Afghani Obodo Afghanistan</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="ALL">
 				<displayName>Ego Lek Obodo Albania</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Lek Obodo Albania</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AMD">
 				<displayName>Ego Dram obodo Armenia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dram obodo Armenia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="ANG">
 				<displayName>Ego Antillean Guilder obodo Netherlands</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Antillean Guilder obodo Netherlands</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AOA">
@@ -4701,7 +4701,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="ARS">
 				<displayName>Ego Peso obodo Argentina</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Peso obodo Argentina</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -4713,7 +4713,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="AWG">
 				<displayName>Ego Florin obodo Aruba</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Florin obodo Aruba</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AZN">
@@ -4724,35 +4724,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BAM">
 				<displayName>Akara mgbanwe ego obodo Bosnia-Herzegovina</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Akara mgbanwe ego obodo Bosnia-Herzegovina</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BBD">
 				<displayName>Ego Dollar obodo Barbados</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dollar obodo Barbados</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BDT">
 				<displayName>Ego Taka obodo Bangladesh</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Taka obodo Bangladesh</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BGN">
 				<displayName>Ego Lev mba Bulgaria</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Lev mba Bulgaria</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BHD">
 				<displayName>Ego Dinar Obodo Bahrain</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dinar Obodo Bahrain</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="BIF">
 				<displayName>Ego Franc obodo Burundi</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Franc obodo Burundi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BMD">
@@ -4769,7 +4769,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BOB">
 				<displayName>Ego Boliviano obodo Bolivia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Boliviano obodo Bolivia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -4781,13 +4781,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BSD">
 				<displayName>Ego Dollar Obodo Bahamas</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dollar Obodo Bahamas</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BTN">
 				<displayName>Ego Ngultrum obodo Bhutan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Ngultrum obodo Bhutan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="BWP">
@@ -4798,9 +4798,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BYN">
 				<displayName>Ego Ruble mba Belarus</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Ruble mba Belarus</displayName>
 				<symbol>↑↑↑</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<symbol alt="narrow">BYN</symbol>
 			</currency>
 			<currency type="BZD">
 				<displayName>Dollar Belize</displayName>
@@ -4821,18 +4821,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CHF">
 				<displayName>Ego Franc mba Switzerland</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Franc mba Switzerland</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CLP">
 				<displayName>Ego Peso obodo Chile</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Peso obodo Chile</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CNH">
 				<displayName>Ego Yuan Obodo China (ndị bi na mmiri)</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Yuan Obodo China (ndị bi na mmiri)</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CNY">
@@ -4843,7 +4843,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="COP">
 				<displayName>Ego Peso obodo Columbia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Peso obodo Columbia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -4855,7 +4855,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CUC">
 				<displayName>Ego Peso e nwere ike ịgbanwe nke obodo Cuba</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Peso e nwere ike ịgbanwe nke obodo Cuba</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -4867,12 +4867,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CVE">
 				<displayName>Escudo Caboverdiano</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Escudo Caboverdiano</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CZK">
 				<displayName>Ego Koruna obodo Czech</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Koruna obodo Czech</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -4883,24 +4883,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="DKK">
 				<displayName>Ego Krone Obodo Denmark</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Krone Obodo Denmark</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="DOP">
 				<displayName>Ego Peso Obodo Dominica</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Peso Obodo Dominica</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="DZD">
 				<displayName>Ego Dinar Obodo Algeria</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dinar Obodo Algeria</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="EGP">
 				<displayName>Ego Pound obodo Egypt</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Pound obodo Egypt</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -4928,7 +4928,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="FKP">
 				<displayName>Ego Pound obodo Falkland Islands</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Pound obodo Falkland Islands</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -4940,54 +4940,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="GEL">
 				<displayName>Ego Lari Obodo Georgia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Lari Obodo Georgia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GHS">
 				<displayName>Ego Cedi obodo Ghana</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Cedi obodo Ghana</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GIP">
 				<displayName>Ego Pound obodo Gibraltar</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Pound obodo Gibraltar</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GMD">
 				<displayName>Ego Dalasi obodo Gambia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dalasi obodo Gambia</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="GNF">
 				<displayName>Ego Franc obodo Guinea</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Franc obodo Guinea</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GTQ">
 				<displayName>Ego Quetzal obodo Guatemala</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Quetzal obodo Guatemala</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GYD">
 				<displayName>Ego Dollar obodo Guyana</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dollar obodo Guyana</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HKD">
 				<displayName>Ego Dollar Obodo Honk Kong</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dollar Obodo Honk Kong</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HNL">
 				<displayName>Ego Lempira obodo Honduras</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Lempira obodo Honduras</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -4999,24 +4999,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="HTG">
 				<displayName>Ego Gourde obodo Haiti</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Gourde obodo Haiti</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="HUF">
 				<displayName>Ego Forint obodo Hungary</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Forint obodo Hungary</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="IDR">
 				<displayName>Ego Rupiah Obodo Indonesia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Rupiah Obodo Indonesia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="ILS">
 				<displayName>Ego Shekel ọhụrụ obodo Israel</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Shekel ọhụrụ obodo Israel</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5033,24 +5033,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="IRR">
 				<displayName>Ego Rial obodo Iran</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Rial obodo Iran</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="ISK">
 				<displayName>Ego Króna obodo Iceland</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Króna obodo Iceland</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="JMD">
 				<displayName>Ego Dollar obodo Jamaica</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dollar obodo Jamaica</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="JOD">
 				<displayName>Ego Dinar Obodo Jordan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dinar Obodo Jordan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="JPY">
@@ -5061,41 +5061,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="KES">
 				<displayName>Ego Shilling obodo Kenya</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Shilling obodo Kenya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="KGS">
 				<displayName>Ego Som Obodo Kyrgyzstan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Som Obodo Kyrgyzstan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="KHR">
 				<displayName>Ego Riel obodo Cambodia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Riel obodo Cambodia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KMF">
 				<displayName>Ego Franc obodo Comoros</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Franc obodo Comoros</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KPW">
 				<displayName>Ego Won Obodo North Korea</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Won Obodo North Korea</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KRW">
 				<displayName>Ego Won Obodo South Korea</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Won Obodo South Korea</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KWD">
 				<displayName>Ego Dinar Obodo Kuwait</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dinar Obodo Kuwait</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="KYD">
@@ -5106,13 +5106,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="KZT">
 				<displayName>Ego Tenge obodo Kazakhstani</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Tenge obodo Kazakhstani</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="LAK">
 				<displayName>Ego Kip Obodo Laos</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Kip Obodo Laos</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5124,13 +5124,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="LKR">
 				<displayName>Ego Rupee obodo Sri Lanka</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Rupee obodo Sri Lanka</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="LRD">
 				<displayName>Ego Dollar obodo Liberia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dollar obodo Liberia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5141,12 +5141,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="LYD">
 				<displayName>Ego Dinar obodo Libya</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dinar obodo Libya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MAD">
 				<displayName>Ego Dirham obodo Morocco</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dirham obodo Morocco</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MDL">
@@ -5167,35 +5167,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MMK">
 				<displayName>Ego Kyat obodo Myanmar</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Kyat obodo Myanmar</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MNT">
 				<displayName>Ego Turgik Obodo Mongolia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Turgik Obodo Mongolia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MOP">
 				<displayName>Ego Pataca ndị Obodo Macanese</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Pataca ndị Obodo Macanese</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MRU">
 				<displayName>Ego Ouguiya Obodo Mauritania</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Ouguiya Obodo Mauritania</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MUR">
 				<displayName>Ego Rupee obodo Mauritania</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Rupee obodo Mauritania</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MVR">
 				<displayName>Ego Rufiyaa obodo Moldova</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Rufiyaa obodo Moldova</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MWK">
@@ -5205,13 +5205,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MXN">
 				<displayName>Ego Peso obodo Mexico</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Peso obodo Mexico</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MYR">
 				<displayName>Ego Ringgit obodo Malaysia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Ringgit obodo Malaysia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5222,31 +5222,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="NAD">
 				<displayName>Ego Dollar obodo Namibia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dollar obodo Namibia</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NGN">
 				<displayName>Naịra</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Naịra</displayName>
 				<symbol>₦</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NIO">
 				<displayName>Ego Córodoba obodo Nicaragua</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Córodoba obodo Nicaragua</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NOK">
 				<displayName>Ego Krone Obodo Norway</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Krone Obodo Norway</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NPR">
 				<displayName>Ego Rupee obodo Nepal</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Rupee obodo Nepal</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5263,40 +5263,40 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="PAB">
 				<displayName>Ego Balboa obodo Panama</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Balboa obodo Panama</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PEN">
 				<displayName>Ego Sol obodo Peru</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Sol obodo Peru</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PGK">
 				<displayName>Ego Kina obodo Papua New Guinea</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Kina obodo Papua New Guinea</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PHP">
 				<displayName>Ego piso obodo Philippine</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego piso obodo Philippine</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="PKR">
 				<displayName>Ego Rupee obodo Pakistan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Rupee obodo Pakistan</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="PLN">
 				<displayName>Ego Zloty mba Poland</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Zloty mba Poland</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="PYG">
 				<displayName>Ego Guarani obodo Paraguay</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Guarani obodo Paraguay</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5313,7 +5313,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="RSD">
 				<displayName>Ego Dinar obodo Serbia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dinar obodo Serbia</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="RUB">
@@ -5324,13 +5324,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="RWF">
 				<displayName>Ego Franc obodo Rwanda</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Franc obodo Rwanda</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SAR">
 				<displayName>Ego Riyal obodo Saudi</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Riyal obodo Saudi</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SBD">
@@ -5346,35 +5346,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="SDG">
 				<displayName>Ego Pound obodo Sudan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Pound obodo Sudan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SEK">
 				<displayName>Ego Krona Obodo Sweden</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Krona Obodo Sweden</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SGD">
 				<displayName>Ego Dollar obodo Singapore</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dollar obodo Singapore</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SHP">
 				<displayName>Ego Pound obodo St Helena</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Pound obodo St Helena</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SLL">
 				<displayName>Ego Leone obodo Sierra Leone</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Leone obodo Sierra Leone</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SOS">
 				<displayName>Ego shilling obodo Somali</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego shilling obodo Somali</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SRD">
@@ -5391,13 +5391,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="STN">
 				<displayName>Ego Dobra nke obodo Sāo Tomé na Principe</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dobra nke obodo Sāo Tomé na Principe</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SYP">
 				<displayName>Ego Pound obodo Syria</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Pound obodo Syria</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5408,34 +5408,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="THB">
 				<displayName>Ego Baht obodo Thai</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Baht obodo Thai</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TJS">
 				<displayName>Who Somoni obodo Tajikistan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Who Somoni obodo Tajikistan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="TMT">
 				<displayName>Ego Manat Obodo Turkmenistan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Manat Obodo Turkmenistan</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="TND">
 				<displayName>Ego Dinar Obodo Tunisia</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dinar Obodo Tunisia</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="TOP">
 				<displayName>Ego paʻanga obodo Tonga</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego paʻanga obodo Tonga</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TRY">
 				<displayName>Ego Lira obodo Turkey</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Lira obodo Turkey</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 				<symbol alt="variant">↑↑↑</symbol>
@@ -5448,7 +5448,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="TWD">
 				<displayName>Dollar obodo New Taiwan</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dollar obodo New Taiwan</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5459,7 +5459,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="UAH">
 				<displayName>Ego Hryvnia obodo Ukraine</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Hryvnia obodo Ukraine</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5476,7 +5476,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="UYU">
 				<displayName>Ego Peso obodo Uruguay</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Peso obodo Uruguay</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5487,12 +5487,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="VES">
 				<displayName>Ego Bolivar obodo Venezuela</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Bolivar obodo Venezuela</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="VND">
 				<displayName>Ego Dong obodo Vietnam</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dong obodo Vietnam</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5503,7 +5503,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="WST">
 				<displayName>Ego Tala obodo Samoa</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Tala obodo Samoa</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="XAF">
@@ -5513,7 +5513,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="XCD">
 				<displayName>Ego Dollar obodo East Carribbean</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Dollar obodo East Carribbean</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
@@ -5533,7 +5533,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="YER">
 				<displayName>Ego Rial obodo Yemeni</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ego Rial obodo Yemeni</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="ZAR">
@@ -5563,91 +5563,91 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="other">{0} square</compoundUnitPattern1>
@@ -5656,189 +5656,189 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">{0} cubic</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>g-force</displayName>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>deg</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcmin</displayName>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcsec</displayName>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hectare</displayName>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre</displayName>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>ihe</displayName>
 				<unitPattern count="other">{0} ihe</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/100km</displayName>
+				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg US</displayName>
+				<unitPattern count="other">{0} mpg US</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>byte</displayName>
+				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>Ọtụtụ nari afọ</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<displayName>Ọtụtụ afọ iri</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>Ọtụtụ Afọ</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} y</unitPattern>
+				<perUnitPattern>{0}/y</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>Nkeji Nkeano</displayName>
@@ -5847,582 +5847,582 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-month">
 				<displayName>Ọtụtụ Ọnwa</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>Ọtụtụ Izu</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} w</unitPattern>
+				<perUnitPattern>{0}/w</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>Ọtụtụ Ubochi</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} d</unitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>hr</displayName>
+				<unitPattern count="other">{0} h</unitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>min</displayName>
+				<unitPattern count="other">{0} min</unitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sec</displayName>
+				<unitPattern count="other">{0} s</unitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ms</displayName>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joule</displayName>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>radius uwa</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>meter</displayName>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi</displayName>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd</displayName>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in</displayName>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ly</displayName>
+				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gram</displayName>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>lb</displayName>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>CD</displayName>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>watt</displayName>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/h</displayName>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°C</displayName>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>liter</displayName>
+				<unitPattern count="other">{0} l</unitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>US gal</displayName>
+				<unitPattern count="other">{0} gal US</unitPattern>
+				<perUnitPattern>{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="other">{0} gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cup</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US fl oz</displayName>
+				<unitPattern count="other">{0} fl oz US</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>ngaji mégharia onu</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dobé</displayName>
+				<unitPattern count="other">{0} drop</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>mmiri dram</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="other">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>direction</displayName>
+				<coordinateUnitPattern type="east">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<unitLength type="short">
@@ -6778,8 +6778,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>↑↑↑</displayName>
@@ -6854,16 +6854,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
@@ -7293,186 +7293,186 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>g-force</displayName>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>deg</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcmin</displayName>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcsec</displayName>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hectare</displayName>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre</displayName>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mmol/L</displayName>
 				<unitPattern count="other">{0}mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
@@ -7484,8 +7484,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
@@ -7493,84 +7493,84 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/100km</displayName>
+				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg US</displayName>
+				<unitPattern count="other">{0} mpg US</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>byte</displayName>
+				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>yr</displayName>
+				<unitPattern count="other">{0} y</unitPattern>
+				<perUnitPattern>{0}/y</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>qtr</displayName>
@@ -7578,38 +7578,38 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mon</displayName>
+				<unitPattern count="other">{0} m</unitPattern>
 				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>wk</displayName>
+				<unitPattern count="other">{0} w</unitPattern>
 				<perUnitPattern>{0}/w</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>day</displayName>
+				<unitPattern count="other">{0} d</unitPattern>
 				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hr</displayName>
+				<unitPattern count="other">{0} h</unitPattern>
 				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>min</displayName>
+				<unitPattern count="other">{0} min</unitPattern>
 				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sec</displayName>
+				<unitPattern count="other">{0} s</unitPattern>
 				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ms</displayName>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>μsec</displayName>
@@ -7620,541 +7620,541 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joule</displayName>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>N</displayName>
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>meter</displayName>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi</displayName>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd</displayName>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in</displayName>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ly</displayName>
+				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gram</displayName>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>lb</displayName>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>CD</displayName>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>watt</displayName>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/h</displayName>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°C</displayName>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>liter</displayName>
+				<unitPattern count="other">{0} l</unitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>US gal</displayName>
+				<unitPattern count="other">{0} gal US</unitPattern>
+				<perUnitPattern>{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="other">{0} gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cup</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US fl oz</displayName>
+				<unitPattern count="other">{0} fl oz US</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dobé</displayName>
+				<unitPattern count="other">{0} drop</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram fluid</displayName>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="other">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>direction</displayName>
+				<coordinateUnitPattern type="east">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -8181,46 +8181,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">↑↑↑</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, or {1}</listPatternPart>
+			<listPatternPart type="2">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, or {1}</listPatternPart>
+			<listPatternPart type="2">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, na {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, na {1}</listPatternPart>
+			<listPatternPart type="2">{0} na {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, na {1}</listPatternPart>
+			<listPatternPart type="2">{0} na {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, na {1}</listPatternPart>
+			<listPatternPart type="2">{0} na {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, na {1}</listPatternPart>
+			<listPatternPart type="2">{0} na {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>
@@ -8409,22 +8409,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -102,8 +102,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">Cherokee-mál</language>
 			<language type="chy">sjeyen</language>
 			<language type="ckb">miðkúrdíska</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">miðkúrdíska</language>
+			<language type="ckb" alt="variant">miðkúrdíska</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">korsíska</language>
 			<language type="cop">koptíska</language>
@@ -973,7 +973,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Túnis</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Tyrkland</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Tyrkland</territory>
 			<territory type="TT">Trínidad og Tóbagó</territory>
 			<territory type="TV">Túvalú</territory>
 			<territory type="TW">Taívan</territory>
@@ -1304,54 +1304,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d">d.–d.</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MM.y GGGGG – MM.y GGGGG</greatestDifference>
+							<greatestDifference id="M">MM.y – MM.y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM.y – MM.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd.MM.y – dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="G">dd.MM.y GGGGG – dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd.MM.y – dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd.MM.y – dd.MM.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd.MM.y – E, dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, dd.MM.y GGGGG – E, dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, dd.MM.y – E, dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, dd.MM.y – E, dd.MM.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d.–d. MMM y G</greatestDifference>
+							<greatestDifference id="G">d. MMM y G – d. MMM y G</greatestDifference>
+							<greatestDifference id="M">d. MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d. MMM y – d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, d. MMM – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="G">E, d. MMM y G – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="M">E, d. MMM – E, d. MMM y G</greatestDifference>
+							<greatestDifference id="y">E, d. MMM y – E, d. MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a">h a – h a</greatestDifference>
@@ -2094,7 +2094,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2102,7 +2102,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2668,7 +2668,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2676,7 +2676,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4576,14 +4576,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">í þessari viku</relative>
 				<relative type="1">í næstu viku</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">eftir {0} viku</relativeTimePattern>
+					<relativeTimePattern count="other">eftir {0} vikur</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">fyrir {0} viku</relativeTimePattern>
+					<relativeTimePattern count="other">fyrir {0} vikum</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>vika {0}</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName>vika í mánuði</displayName>
@@ -4634,12 +4634,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="1">á morgun</relative>
 				<relative type="2">eftir tvo daga</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">eftir {0} dag</relativeTimePattern>
+					<relativeTimePattern count="other">eftir {0} daga</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">fyrir {0} degi</relativeTimePattern>
+					<relativeTimePattern count="other">fyrir {0} dögum</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
@@ -4696,7 +4696,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">síðasta sun.</relative>
 				<relative type="0">á sun.</relative>
 				<relative type="1">nk. sun.</relative>
 				<relativeTime type="future">
@@ -4735,7 +4735,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">síðasta mán.</relative>
 				<relative type="0">þessi mán.</relative>
 				<relative type="1">nk. mán.</relative>
 				<relativeTime type="future">
@@ -7480,8 +7480,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="ARP">
 				<displayName>Argentískur pesi (1983–1985)</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Argentískur pesi (1983–1985)</displayName>
+				<displayName count="other">Argentískur pesi (1983–1985)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ARS">
@@ -7582,8 +7582,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="BOP">
 				<displayName>Bólivískur pesi</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Bólivískur pesi</displayName>
+				<displayName count="other">Bólivískur pesi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BOV">
@@ -7624,7 +7624,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">hvítrússnesk rúbla</displayName>
 				<displayName count="other">hvítrússneskar rúblur</displayName>
 				<symbol>BYN</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<symbol alt="narrow">BYN</symbol>
 			</currency>
 			<currency type="BYR">
 				<displayName>hvítrússnesk rúbla (2000–2016)</displayName>
@@ -8205,8 +8205,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="MXP">
 				<displayName>Mexíkóskur silfurpesi (1861–1992)</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Mexíkóskur silfurpesi (1861–1992)</displayName>
+				<displayName count="other">Mexíkóskur silfurpesi (1861–1992)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MXV">
@@ -8598,14 +8598,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="USN">
 				<displayName>Bandaríkjadalur (næsta dag)</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Bandaríkjadalur (næsta dag)</displayName>
+				<displayName count="other">Bandaríkjadalur (næsta dag)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="USS">
 				<displayName>Bandaríkjadalur (sama dag)</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Bandaríkjadalur (sama dag)</displayName>
+				<displayName count="other">Bandaríkjadalur (sama dag)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="UYU">
@@ -8862,69 +8862,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="one">fer{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="dative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="dative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">fer{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">fer{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="dative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="dative">fer{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">fer{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1 count="one">rúm{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="dative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="dative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">rúm{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">rúm{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="dative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="dative">rúm{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">rúm{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>feminine</gender>
 				<displayName>þyngdarhröðun</displayName>
 				<unitPattern count="one">{0} þyngdarhröðun</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} þyngdarhröðun</unitPattern>
+				<unitPattern count="one" case="dative">{0} þyngdarhröðun</unitPattern>
 				<unitPattern count="one" case="genitive">{0} þyngdarhröðunar</unitPattern>
 				<unitPattern count="other">{0} þyngdarhröðun</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} þyngdarhröðun</unitPattern>
+				<unitPattern count="other" case="dative">{0} þyngdarhröðun</unitPattern>
 				<unitPattern count="other" case="genitive">{0} þyngdarhröðunar</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
@@ -8955,7 +8955,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>radíanar</displayName>
 				<unitPattern count="one">{0} radían</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} radían</unitPattern>
 				<unitPattern count="one" case="dative">{0} radíani</unitPattern>
 				<unitPattern count="one" case="genitive">{0} radíans</unitPattern>
 				<unitPattern count="other">{0} radíanar</unitPattern>
@@ -8971,7 +8971,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} gráðu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gráðu</unitPattern>
 				<unitPattern count="other">{0} gráður</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gráður</unitPattern>
 				<unitPattern count="other" case="dative">{0} gráðum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} gráða</unitPattern>
 			</unit>
@@ -8983,7 +8983,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} bogamínútu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bogamínútu</unitPattern>
 				<unitPattern count="other">{0} bogamínútur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bogamínútur</unitPattern>
 				<unitPattern count="other" case="dative">{0} bogamínútum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} bogamínútna</unitPattern>
 			</unit>
@@ -9086,11 +9086,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>karöt</displayName>
 				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karat</unitPattern>
 				<unitPattern count="one" case="dative">{0} karati</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karats</unitPattern>
 				<unitPattern count="other">{0} karöt</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karöt</unitPattern>
 				<unitPattern count="other" case="dative">{0} karötum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} karata</unitPattern>
 			</unit>
@@ -9103,11 +9103,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>millimól á lítra</displayName>
 				<unitPattern count="one">{0} millimól á lítra</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} millimól á lítra</unitPattern>
 				<unitPattern count="one" case="dative">{0} millimóli á lítra</unitPattern>
 				<unitPattern count="one" case="genitive">{0} millimóls á lítra</unitPattern>
 				<unitPattern count="other">{0} millimól á lítra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} millimól á lítra</unitPattern>
 				<unitPattern count="other" case="dative">{0} millimólum á lítra</unitPattern>
 				<unitPattern count="other" case="genitive">{0} millimóla á lítra</unitPattern>
 			</unit>
@@ -9115,11 +9115,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>atriði</displayName>
 				<unitPattern count="one">{0} atriði</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} atriði</unitPattern>
+				<unitPattern count="one" case="dative">{0} atriði</unitPattern>
 				<unitPattern count="one" case="genitive">{0} atriðis</unitPattern>
 				<unitPattern count="other">{0} atriði</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} atriði</unitPattern>
 				<unitPattern count="other" case="dative">{0} atriðum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} atriða</unitPattern>
 			</unit>
@@ -9139,11 +9139,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>prósent</displayName>
 				<unitPattern count="one">{0} prósent</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} prósent</unitPattern>
 				<unitPattern count="one" case="dative">{0} prósenti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} prósents</unitPattern>
 				<unitPattern count="other">{0} prósent</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} prósent</unitPattern>
 				<unitPattern count="other" case="dative">{0} prósentum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} prósenta</unitPattern>
 			</unit>
@@ -9151,11 +9151,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>prómill</displayName>
 				<unitPattern count="one">{0} prómill</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} prómill</unitPattern>
 				<unitPattern count="one" case="dative">{0} prómilli</unitPattern>
 				<unitPattern count="one" case="genitive">{0} prómills</unitPattern>
 				<unitPattern count="other">{0} prómill</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} prómill</unitPattern>
 				<unitPattern count="other" case="dative">{0} prómillum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} prómilla</unitPattern>
 			</unit>
@@ -9163,23 +9163,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>permyriad</displayName>
 				<unitPattern count="one">{0} permyriad</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} permyriad</unitPattern>
+				<unitPattern count="one" case="dative">{0} permyriad</unitPattern>
+				<unitPattern count="one" case="genitive">{0} permyriad</unitPattern>
 				<unitPattern count="other">{0} permyriad</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} permyriad</unitPattern>
+				<unitPattern count="other" case="dative">{0} permyriad</unitPattern>
+				<unitPattern count="other" case="genitive">{0} permyriad</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>neuter</gender>
 				<displayName>mól</displayName>
 				<unitPattern count="one">{0} mól</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mól</unitPattern>
 				<unitPattern count="one" case="dative">{0} móli</unitPattern>
 				<unitPattern count="one" case="genitive">{0} móls</unitPattern>
 				<unitPattern count="other">{0} mól</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mól</unitPattern>
 				<unitPattern count="other" case="dative">{0} mólum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} móla</unitPattern>
 			</unit>
@@ -9221,11 +9221,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>petabæti</displayName>
 				<unitPattern count="one">{0} petabæti</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} petabæti</unitPattern>
 				<unitPattern count="one" case="dative">{0} petabæti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} petabætis</unitPattern>
 				<unitPattern count="other">{0} petabæti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} petabæti</unitPattern>
 				<unitPattern count="other" case="dative">{0} petabætum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} petabæta</unitPattern>
 			</unit>
@@ -9233,11 +9233,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>terabæti</displayName>
 				<unitPattern count="one">{0} terabæti</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabæti</unitPattern>
+				<unitPattern count="one" case="dative">{0} terabæti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabætis</unitPattern>
 				<unitPattern count="other">{0} terabæti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabæti</unitPattern>
 				<unitPattern count="other" case="dative">{0} terabætum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} terabæta</unitPattern>
 			</unit>
@@ -9257,11 +9257,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>gígabæti</displayName>
 				<unitPattern count="one">{0} gígabæti</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gígabæti</unitPattern>
+				<unitPattern count="one" case="dative">{0} gígabæti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gígabætis</unitPattern>
 				<unitPattern count="other">{0} gígabæti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gígabæti</unitPattern>
 				<unitPattern count="other" case="dative">{0} gígabætum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} gígabæta</unitPattern>
 			</unit>
@@ -9281,11 +9281,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>megabæti</displayName>
 				<unitPattern count="one">{0} megabæti</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabæti</unitPattern>
+				<unitPattern count="one" case="dative">{0} megabæti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabætis</unitPattern>
 				<unitPattern count="other">{0} megabæti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabæti</unitPattern>
 				<unitPattern count="other" case="dative">{0} megabætum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} megabæta</unitPattern>
 			</unit>
@@ -9305,11 +9305,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>kílóbæti</displayName>
 				<unitPattern count="one">{0} kílóbæti</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kílóbæti</unitPattern>
+				<unitPattern count="one" case="dative">{0} kílóbæti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kílóbætis</unitPattern>
 				<unitPattern count="other">{0} kílóbæti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kílóbæti</unitPattern>
 				<unitPattern count="other" case="dative">{0} kílóbætum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kílóbæta</unitPattern>
 			</unit>
@@ -9329,11 +9329,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>bæti</displayName>
 				<unitPattern count="one">{0} bæti</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bæti</unitPattern>
+				<unitPattern count="one" case="dative">{0} bæti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bætis</unitPattern>
 				<unitPattern count="other">{0} bæti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bæti</unitPattern>
 				<unitPattern count="other" case="dative">{0} bætum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} bæta</unitPattern>
 			</unit>
@@ -9377,11 +9377,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>ár</displayName>
 				<unitPattern count="one">{0} ár</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ár</unitPattern>
 				<unitPattern count="one" case="dative">{0} ári</unitPattern>
 				<unitPattern count="one" case="genitive">{0} árs</unitPattern>
 				<unitPattern count="other">{0} ár</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ár</unitPattern>
 				<unitPattern count="other" case="dative">{0} árum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ára</unitPattern>
 				<perUnitPattern>{0} á ári</perUnitPattern>
@@ -9401,7 +9401,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-month">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>mánuðir</displayName>
 				<unitPattern count="one">{0} mánuður</unitPattern>
 				<unitPattern count="one" case="accusative">{0} mánuð</unitPattern>
 				<unitPattern count="one" case="dative">{0} mánuði</unitPattern>
@@ -9440,11 +9440,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-day-person">
 				<gender>masculine</gender>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dagur</unitPattern>
 				<unitPattern count="one" case="accusative">{0} dag</unitPattern>
 				<unitPattern count="one" case="dative">{0} degi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dags</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dagar</unitPattern>
 				<unitPattern count="other" case="accusative">{0} daga</unitPattern>
 				<unitPattern count="other" case="dative">{0} dögum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} daga</unitPattern>
@@ -9470,7 +9470,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} mínútu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mínútu</unitPattern>
 				<unitPattern count="other">{0} mínútur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mínútur</unitPattern>
 				<unitPattern count="other" case="dative">{0} mínútum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mínútna</unitPattern>
 				<perUnitPattern>{0} á mínútu</perUnitPattern>
@@ -9483,7 +9483,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} sekúndu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} sekúndu</unitPattern>
 				<unitPattern count="other">{0} sekúndur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sekúndur</unitPattern>
 				<unitPattern count="other" case="dative">{0} sekúndum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} sekúndna</unitPattern>
 				<perUnitPattern>{0} á sekúndu</perUnitPattern>
@@ -9496,7 +9496,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} millisekúndu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} millisekúndu</unitPattern>
 				<unitPattern count="other">{0} millisekúndur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} millisekúndur</unitPattern>
 				<unitPattern count="other" case="dative">{0} millisekúndum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} millisekúndna</unitPattern>
 			</unit>
@@ -9508,7 +9508,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} míkrósekúndu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} míkrósekúndu</unitPattern>
 				<unitPattern count="other">{0} míkrósekúndur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} míkrósekúndur</unitPattern>
 				<unitPattern count="other" case="dative">{0} míkrósekúndum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} míkrósekúndna</unitPattern>
 			</unit>
@@ -9520,7 +9520,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} nanósekúndu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} nanósekúndu</unitPattern>
 				<unitPattern count="other">{0} nanósekúndur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanósekúndur</unitPattern>
 				<unitPattern count="other" case="dative">{0} nanósekúndum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} nanósekúndna</unitPattern>
 			</unit>
@@ -9528,11 +9528,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>amper</displayName>
 				<unitPattern count="one">{0} amper</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} amper</unitPattern>
 				<unitPattern count="one" case="dative">{0} amperi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ampers</unitPattern>
 				<unitPattern count="other">{0} amper</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} amper</unitPattern>
 				<unitPattern count="other" case="dative">{0} amperum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ampera</unitPattern>
 			</unit>
@@ -9540,11 +9540,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>milliamper</displayName>
 				<unitPattern count="one">{0} milliamper</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milliamper</unitPattern>
 				<unitPattern count="one" case="dative">{0} milliamperi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milliampers</unitPattern>
 				<unitPattern count="other">{0} milliamper</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milliamper</unitPattern>
 				<unitPattern count="other" case="dative">{0} milliamperum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} milliampera</unitPattern>
 			</unit>
@@ -9564,11 +9564,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>volt</displayName>
 				<unitPattern count="one">{0} volt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} volt</unitPattern>
 				<unitPattern count="one" case="dative">{0} volti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} volts</unitPattern>
 				<unitPattern count="other">{0} volt</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} volt</unitPattern>
 				<unitPattern count="other" case="dative">{0} voltum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} volta</unitPattern>
 			</unit>
@@ -9585,7 +9585,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} kaloríu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kaloríu</unitPattern>
 				<unitPattern count="other">{0} kaloríur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kaloríur</unitPattern>
 				<unitPattern count="other" case="dative">{0} kaloríum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kaloría</unitPattern>
 			</unit>
@@ -9598,11 +9598,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>kílójúl</displayName>
 				<unitPattern count="one">{0} kílójúl</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kílójúl</unitPattern>
 				<unitPattern count="one" case="dative">{0} kílójúli</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kílójúls</unitPattern>
 				<unitPattern count="other">{0} kílójúl</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kílójúl</unitPattern>
 				<unitPattern count="other" case="dative">{0} kílójúlum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kílójúla</unitPattern>
 			</unit>
@@ -9610,11 +9610,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>júl</displayName>
 				<unitPattern count="one">{0} júl</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} júl</unitPattern>
 				<unitPattern count="one" case="dative">{0} júli</unitPattern>
 				<unitPattern count="one" case="genitive">{0} júls</unitPattern>
 				<unitPattern count="other">{0} júl</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} júl</unitPattern>
 				<unitPattern count="other" case="dative">{0} júlum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} júla</unitPattern>
 			</unit>
@@ -9622,11 +9622,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>kílóvattstundir</displayName>
 				<unitPattern count="one">{0} kílóvattstund</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kílóvattstund</unitPattern>
+				<unitPattern count="one" case="dative">{0} kílóvattstund</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kílóvattstundar</unitPattern>
 				<unitPattern count="other">{0} kílóvattstundir</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kílóvattstundir</unitPattern>
 				<unitPattern count="other" case="dative">{0} kílóvattstundum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kílóvattstunda</unitPattern>
 			</unit>
@@ -9654,23 +9654,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>njúton</displayName>
 				<unitPattern count="one">{0} njúton</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} njúton</unitPattern>
 				<unitPattern count="one" case="dative">{0} njútoni</unitPattern>
 				<unitPattern count="one" case="genitive">{0} njútons</unitPattern>
 				<unitPattern count="other">{0} njúton</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} njúton</unitPattern>
 				<unitPattern count="other" case="dative">{0} njútoni</unitPattern>
 				<unitPattern count="other" case="genitive">{0} njútons</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0} kílóvatt á 100 kílómetra</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kílóvatt á 100 kílómetra</unitPattern>
 				<unitPattern count="one" case="dative">{0} kílóvatti á 100 kílómetra</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kílóvatts á 100 kílómetra</unitPattern>
 				<unitPattern count="other">{0} kílóvött á 100 kílómetra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kílóvött á 100 kílómetra</unitPattern>
 				<unitPattern count="other" case="dative">{0} kílóvöttum á 100 kílómetra</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kílóvatta á 100 kílómetra</unitPattern>
 			</unit>
@@ -9678,61 +9678,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>gígahertz</displayName>
 				<unitPattern count="one">{0} gígahertz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gígahertz</unitPattern>
+				<unitPattern count="one" case="dative">{0} gígahertz</unitPattern>
+				<unitPattern count="one" case="genitive">{0} gígahertz</unitPattern>
 				<unitPattern count="other">{0} gígahertz</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gígahertz</unitPattern>
+				<unitPattern count="other" case="dative">{0} gígahertz</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gígahertz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>neuter</gender>
 				<displayName>megahertz</displayName>
 				<unitPattern count="one">{0} megahertz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megahertz</unitPattern>
+				<unitPattern count="one" case="dative">{0} megahertz</unitPattern>
+				<unitPattern count="one" case="genitive">{0} megahertz</unitPattern>
 				<unitPattern count="other">{0} megahertz</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megahertz</unitPattern>
+				<unitPattern count="other" case="dative">{0} megahertz</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megahertz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>neuter</gender>
 				<displayName>kílóhertz</displayName>
 				<unitPattern count="one">{0} kílóhertz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kílóhertz</unitPattern>
+				<unitPattern count="one" case="dative">{0} kílóhertz</unitPattern>
+				<unitPattern count="one" case="genitive">{0} kílóhertz</unitPattern>
 				<unitPattern count="other">{0} kílóhertz</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kílóhertz</unitPattern>
+				<unitPattern count="other" case="dative">{0} kílóhertz</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kílóhertz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>neuter</gender>
 				<displayName>hertz</displayName>
 				<unitPattern count="one">{0} hertz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hertz</unitPattern>
 				<unitPattern count="one" case="dative">{0} hertzi</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} hertz</unitPattern>
 				<unitPattern count="other">{0} hertz</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hertz</unitPattern>
 				<unitPattern count="other" case="dative">{0} hertzum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} hertza</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="accusative">{0} em</unitPattern>
+				<unitPattern count="one" case="dative">{0} em</unitPattern>
+				<unitPattern count="one" case="genitive">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="accusative">{0} em</unitPattern>
+				<unitPattern count="other" case="dative">{0} em</unitPattern>
+				<unitPattern count="other" case="genitive">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
@@ -9954,7 +9954,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} sænskri mílu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} sænskrar mílu</unitPattern>
 				<unitPattern count="other">{0} sænskar mílur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sænskar mílur</unitPattern>
 				<unitPattern count="other" case="dative">{0} sænskum mílum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} sænskra mílna</unitPattern>
 			</unit>
@@ -9972,11 +9972,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>lúx</displayName>
 				<unitPattern count="one">{0} lúx</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} lúx</unitPattern>
 				<unitPattern count="one" case="dative">{0} lúxi</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} lúx</unitPattern>
 				<unitPattern count="other">{0} lúx</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} lúx</unitPattern>
 				<unitPattern count="other" case="dative">{0} lúxum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} lúxa</unitPattern>
 			</unit>
@@ -9984,11 +9984,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>kerti</displayName>
 				<unitPattern count="one">{0} kerti</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kerti</unitPattern>
+				<unitPattern count="one" case="dative">{0} kerti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kertis</unitPattern>
 				<unitPattern count="other">{0} kerti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kerti</unitPattern>
 				<unitPattern count="other" case="dative">{0} kertum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kerta</unitPattern>
 			</unit>
@@ -9996,16 +9996,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>lúmen</displayName>
 				<unitPattern count="one">{0} lúmen</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} lúmen</unitPattern>
 				<unitPattern count="one" case="dative">{0} lúmeni</unitPattern>
 				<unitPattern count="one" case="genitive">{0} lúmens</unitPattern>
 				<unitPattern count="other">{0} lúmen</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} lúmen</unitPattern>
 				<unitPattern count="other" case="dative">{0} lúmenum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} lúmena</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>ljósafl sólar</displayName>
 				<unitPattern count="one">{0} ljósafl sólar</unitPattern>
 				<unitPattern count="other">{0} ljósafl sólar</unitPattern>
 			</unit>
@@ -10013,11 +10013,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>tonn</displayName>
 				<unitPattern count="one">{0} tonn</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} tonn</unitPattern>
 				<unitPattern count="one" case="dative">{0} tonni</unitPattern>
 				<unitPattern count="one" case="genitive">{0} tonns</unitPattern>
 				<unitPattern count="other">{0} tonn</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} tonn</unitPattern>
 				<unitPattern count="other" case="dative">{0} tonnum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} tonna</unitPattern>
 			</unit>
@@ -10025,11 +10025,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>kílógrömm</displayName>
 				<unitPattern count="one">{0} kílógramm</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kílógramm</unitPattern>
 				<unitPattern count="one" case="dative">{0} kílógrammi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kílógramms</unitPattern>
 				<unitPattern count="other">{0} kílógrömm</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kílógrömm</unitPattern>
 				<unitPattern count="other" case="dative">{0} kílógrömmum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kílógramma</unitPattern>
 				<perUnitPattern>{0} á kílógramm</perUnitPattern>
@@ -10038,11 +10038,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>grömm</displayName>
 				<unitPattern count="one">{0} gramm</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gramm</unitPattern>
 				<unitPattern count="one" case="dative">{0} grammi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gramms</unitPattern>
 				<unitPattern count="other">{0} grömm</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} grömm</unitPattern>
 				<unitPattern count="other" case="dative">{0} grömmum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} gramma</unitPattern>
 				<perUnitPattern>{0} á gramm</perUnitPattern>
@@ -10051,11 +10051,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>milligrömm</displayName>
 				<unitPattern count="one">{0} milligramm</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milligramm</unitPattern>
 				<unitPattern count="one" case="dative">{0} milligrammi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milligramms</unitPattern>
 				<unitPattern count="other">{0} milligrömm</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milligrömm</unitPattern>
 				<unitPattern count="other" case="dative">{0} milligrömmum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} milligramma</unitPattern>
 			</unit>
@@ -10063,11 +10063,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>míkrógrömm</displayName>
 				<unitPattern count="one">{0} míkrógramm</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} míkrógramm</unitPattern>
 				<unitPattern count="one" case="dative">{0} míkrógrammi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} míkrógramms</unitPattern>
 				<unitPattern count="other">{0} míkrógrömm</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} míkrógrömm</unitPattern>
 				<unitPattern count="other" case="dative">{0} míkrógrömmum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} míkrógramma</unitPattern>
 			</unit>
@@ -10102,11 +10102,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>karöt</displayName>
 				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karat</unitPattern>
 				<unitPattern count="one" case="dative">{0} karati</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karats</unitPattern>
 				<unitPattern count="other">{0} karöt</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karöt</unitPattern>
 				<unitPattern count="other" case="dative">{0} karötum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} karata</unitPattern>
 			</unit>
@@ -10134,11 +10134,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>gígavött</displayName>
 				<unitPattern count="one">{0} gígavatt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gígavatt</unitPattern>
 				<unitPattern count="one" case="dative">{0} gígavatti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gígavatts</unitPattern>
 				<unitPattern count="other">{0} gígavött</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gígavött</unitPattern>
 				<unitPattern count="other" case="dative">{0} gígavöttum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} gígavatta</unitPattern>
 			</unit>
@@ -10146,11 +10146,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>megavött</displayName>
 				<unitPattern count="one">{0} megavatt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megavatt</unitPattern>
 				<unitPattern count="one" case="dative">{0} megavatti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megavatts</unitPattern>
 				<unitPattern count="other">{0} megavött</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megavött</unitPattern>
 				<unitPattern count="other" case="dative">{0} megavöttum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} megavatta</unitPattern>
 			</unit>
@@ -10158,11 +10158,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>kílóvött</displayName>
 				<unitPattern count="one">{0} kílóvatt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kílóvatt</unitPattern>
+				<unitPattern count="one" case="dative">{0} kílóvatt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kílóvatts</unitPattern>
 				<unitPattern count="other">{0} kílóvött</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kílóvött</unitPattern>
 				<unitPattern count="other" case="dative">{0} kílóvöttum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kílóvatta</unitPattern>
 			</unit>
@@ -10170,11 +10170,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>vött</displayName>
 				<unitPattern count="one">{0} vatt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} vatt</unitPattern>
 				<unitPattern count="one" case="dative">{0} vatti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} vatts</unitPattern>
 				<unitPattern count="other">{0} vött</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} vött</unitPattern>
 				<unitPattern count="other" case="dative">{0} vöttum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} vatta</unitPattern>
 			</unit>
@@ -10182,11 +10182,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>millivött</displayName>
 				<unitPattern count="one">{0} millivatt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} millivatt</unitPattern>
 				<unitPattern count="one" case="dative">{0} millivatti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} millivatts</unitPattern>
 				<unitPattern count="other">{0} millivött</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} millivött</unitPattern>
 				<unitPattern count="other" case="dative">{0} millivöttum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} millivatta</unitPattern>
 			</unit>
@@ -10214,11 +10214,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>bör</displayName>
 				<unitPattern count="one">{0} bar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bar</unitPattern>
 				<unitPattern count="one" case="dative">{0} bari</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bars</unitPattern>
 				<unitPattern count="other">{0} bör</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bör</unitPattern>
 				<unitPattern count="other" case="dative">{0} börum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} bara</unitPattern>
 			</unit>
@@ -10226,11 +10226,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>millibör</displayName>
 				<unitPattern count="one">{0} millibar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} millibar</unitPattern>
+				<unitPattern count="one" case="dative">{0} millibar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} millibars</unitPattern>
 				<unitPattern count="other">{0} millibör</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} millibör</unitPattern>
 				<unitPattern count="other" case="dative">{0} millibörum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} millibara</unitPattern>
 			</unit>
@@ -10238,11 +10238,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>loftþyngdir</displayName>
 				<unitPattern count="one">{0} loftþyngd</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} loftþyngd</unitPattern>
+				<unitPattern count="one" case="dative">{0} loftþyngd</unitPattern>
 				<unitPattern count="one" case="genitive">{0} loftþyngdar</unitPattern>
 				<unitPattern count="other">{0} loftþyngdir</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} loftþyngdir</unitPattern>
 				<unitPattern count="other" case="dative">{0} loftþyngdum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} loftþyngda</unitPattern>
 			</unit>
@@ -10250,11 +10250,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>pasköl</displayName>
 				<unitPattern count="one">{0} paskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} paskal</unitPattern>
 				<unitPattern count="one" case="dative">{0} paskali</unitPattern>
 				<unitPattern count="one" case="genitive">{0} paskals</unitPattern>
 				<unitPattern count="other">{0} pasköl</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pasköl</unitPattern>
 				<unitPattern count="other" case="dative">{0} paskölum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} paskala</unitPattern>
 			</unit>
@@ -10262,11 +10262,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>hektópasköl</displayName>
 				<unitPattern count="one">{0} hektópaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektópaskal</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektópaskali</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektópaskals</unitPattern>
 				<unitPattern count="other">{0} hektópasköl</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektópasköl</unitPattern>
 				<unitPattern count="other" case="dative">{0} hektópaskölum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} hektópaskala</unitPattern>
 			</unit>
@@ -10274,11 +10274,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>kílópasköl</displayName>
 				<unitPattern count="one">{0} kílópaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kílópaskal</unitPattern>
 				<unitPattern count="one" case="dative">{0} kílópaskali</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kílópaskals</unitPattern>
 				<unitPattern count="other">{0} kílópasköl</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kílópasköl</unitPattern>
 				<unitPattern count="other" case="dative">{0} kílópaskölum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kílópaskala</unitPattern>
 			</unit>
@@ -10286,11 +10286,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>megapasköl</displayName>
 				<unitPattern count="one">{0} megapaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapaskal</unitPattern>
 				<unitPattern count="one" case="dative">{0} megapaskali</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megapaskals</unitPattern>
 				<unitPattern count="other">{0} megapasköl</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapasköl</unitPattern>
 				<unitPattern count="other" case="dative">{0} megapaskölum</unitPattern>
 				<unitPattern count="other" case="genitive">{0} megapaskala</unitPattern>
 			</unit>
@@ -10348,7 +10348,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} gráðu á Celsíus</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gráðu á Celsíus</unitPattern>
 				<unitPattern count="other">{0} gráður á Celsíus</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gráður á Celsíus</unitPattern>
 				<unitPattern count="other" case="dative">{0} gráðum á Celsíus</unitPattern>
 				<unitPattern count="other" case="genitive">{0} gráða á Celsíus</unitPattern>
 			</unit>
@@ -10361,8 +10361,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>kelvin</displayName>
 				<unitPattern count="one">{0} kelvin</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kelvin</unitPattern>
+				<unitPattern count="one" case="dative">{0} kelvin</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kelvins</unitPattern>
 				<unitPattern count="other">{0} kelvin</unitPattern>
 				<unitPattern count="other" case="accusative">{0} kelvin</unitPattern>
@@ -10521,13 +10521,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>mpt</displayName>
 				<unitPattern count="one">{0} mpt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mpt</unitPattern>
+				<unitPattern count="one" case="dative">{0} mpt</unitPattern>
+				<unitPattern count="one" case="genitive">{0} mpt</unitPattern>
 				<unitPattern count="other">{0} mpt</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mpt</unitPattern>
+				<unitPattern count="other" case="dative">{0} mpt</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>masculine</gender>
@@ -10547,7 +10547,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ekrufet</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>skeppur</displayName>
 				<unitPattern count="one">{0} skeppa</unitPattern>
 				<unitPattern count="other">{0} skeppur</unitPattern>
 			</unit>
@@ -10631,7 +10631,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-pinch">
 				<displayName>klípur</displayName>
 				<unitPattern count="one">{0} klípa</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} klípur</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>lagarmál</displayName>
@@ -10736,12 +10736,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10874,7 +10874,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>permyriad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -11082,12 +11082,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>rafeindarvolt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -11097,17 +11097,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>kraftur punds</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>njúton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -11132,7 +11132,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -11166,13 +11166,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pixlar</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -11297,7 +11297,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -11366,12 +11366,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>jarðmassar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
@@ -11456,12 +11456,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -11506,12 +11506,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -11699,64 +11699,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -11765,38 +11765,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-hröðun</displayName>
@@ -11809,35 +11809,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sn.</displayName>
+				<unitPattern count="one">{0} sn.</unitPattern>
+				<unitPattern count="other">{0} sn.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>gráður</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>bogamín.</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>bogasek.</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hektari</displayName>
@@ -11845,22 +11845,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>fermetrar</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
 				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
 				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>fermílur</displayName>
 				<unitPattern count="one">{0}mí²</unitPattern>
 				<unitPattern count="other">{0}mí²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>ekra</displayName>
@@ -11869,8 +11869,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ft²</displayName>
@@ -11878,23 +11878,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>tommur²</displayName>
+				<unitPattern count="one">{0} t²</unitPattern>
+				<unitPattern count="other">{0} t²</unitPattern>
+				<perUnitPattern>{0}/t²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dúnam</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dúnam</unitPattern>
+				<unitPattern count="other">{0} dúnam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg/dl</displayName>
 				<unitPattern count="one">{0}mg/dl</unitPattern>
 				<unitPattern count="other">{0}mg/dl</unitPattern>
 			</unit>
@@ -11904,7 +11904,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mmól/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>atriði</displayName>
 				<unitPattern count="one">{0} atriði</unitPattern>
 				<unitPattern count="other">{0} atriði</unitPattern>
 			</unit>
@@ -11919,24 +11919,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>prómill</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mól</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mól</unitPattern>
+				<unitPattern count="other">{0} mól</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lítrar/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100km</displayName>
@@ -11944,14 +11944,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mílur/gallon</displayName>
+				<unitPattern count="one">{0} mí./gal.</unitPattern>
+				<unitPattern count="other">{0} mí./gal.</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mílur/breskt gal.</displayName>
+				<unitPattern count="one">{0} mí./br.g.</unitPattern>
+				<unitPattern count="other">{0} mí./br.g.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>PB</displayName>
@@ -11959,54 +11959,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bæti</displayName>
+				<unitPattern count="one">{0} bæti</unitPattern>
+				<unitPattern count="other">{0} bæti</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>biti</displayName>
+				<unitPattern count="one">{0} biti</unitPattern>
+				<unitPattern count="other">{0} bitar</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>árh</displayName>
@@ -12014,9 +12014,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}árh</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>árat.</displayName>
+				<unitPattern count="one">{0} árat.</unitPattern>
+				<unitPattern count="other">{0} árat.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ár</displayName>
@@ -12058,7 +12058,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mín.</displayName>
 				<unitPattern count="one">{0} mín.</unitPattern>
 				<unitPattern count="other">{0} mín.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mín.</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>sek.</displayName>
@@ -12082,149 +12082,149 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>óm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kal</displayName>
+				<unitPattern count="one">{0} kal</unitPattern>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kJ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>júl</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bandarísk varmaeining</displayName>
+				<unitPattern count="one">{0} bna varmaeining</unitPattern>
+				<unitPattern count="other">{0} bna varmaeiningar</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kraftur punds</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>njúton</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapixlar</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pixlar</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -12322,7 +12322,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} sml</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
+				<displayName>sæ. míl.</displayName>
 				<unitPattern count="one">{0} sæ. míl</unitPattern>
 				<unitPattern count="other">{0} sæ. míl</unitPattern>
 			</unit>
@@ -12332,29 +12332,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} stig</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sólarradíusar</displayName>
+				<unitPattern count="one">{0} Rsól</unitPattern>
+				<unitPattern count="other">{0} Rsól</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lúx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kerti</displayName>
+				<unitPattern count="one">{0} kerti</unitPattern>
+				<unitPattern count="other">{0} kerti</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ljósafl sólar</displayName>
+				<unitPattern count="one">{0} Lsól</unitPattern>
+				<unitPattern count="other">{0} Lsól</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -12416,54 +12416,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kt.</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dalton</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jarðmassar</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sólmassar</displayName>
+				<unitPattern count="one">{0} Msól</unitPattern>
+				<unitPattern count="other">{0} Msól</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ögn</displayName>
+				<unitPattern count="one">{0} ögn</unitPattern>
+				<unitPattern count="other">{0} agnir</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>vött</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hö</displayName>
+				<unitPattern count="one">{0} hö</unitPattern>
+				<unitPattern count="other">{0} hö</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>mm Hg</displayName>
@@ -12481,8 +12481,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bör</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -12491,14 +12491,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mbör</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -12506,14 +12506,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/klst.</displayName>
@@ -12556,154 +12556,154 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="one">{0}lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
 				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
 				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mí³</displayName>
 				<unitPattern count="one">{0}mi³</unitPattern>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yardar³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fet³</displayName>
+				<unitPattern count="one">{0} fet³</unitPattern>
+				<unitPattern count="other">{0} fet³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tommur³</displayName>
+				<unitPattern count="one">{0} t³</unitPattern>
+				<unitPattern count="other">{0} t³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>lítri</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ástr. bolli</displayName>
+				<unitPattern count="one">{0} ástr. bolli</unitPattern>
+				<unitPattern count="other">{0} ástr. bollar</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ekrufet</displayName>
+				<unitPattern count="one">{0} ekrufet</unitPattern>
+				<unitPattern count="other">{0} ekrufet</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>skeppa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} skeppa</unitPattern>
+				<unitPattern count="other">{0} skeppur</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>breskt gal.</displayName>
+				<unitPattern count="one">{0} breskt gal.</unitPattern>
+				<unitPattern count="other">{0} breskt gal.</unitPattern>
+				<perUnitPattern>{0} breskt gal.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hálfp.</displayName>
+				<unitPattern count="one">{0} hálfp.</unitPattern>
+				<unitPattern count="other">{0} hálfp.</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>bolli</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bolli</unitPattern>
+				<unitPattern count="other">{0} bollar</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>breskar fl oz</displayName>
+				<unitPattern count="one">{0} bresk fl oz</unitPattern>
+				<unitPattern count="other">{0} breskar fl oz</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>msk</displayName>
+				<unitPattern count="one">{0} msk</unitPattern>
+				<unitPattern count="other">{0} msk</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsk</displayName>
+				<unitPattern count="one">{0} tsk</unitPattern>
+				<unitPattern count="other">{0} tsk</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tunna</displayName>
+				<unitPattern count="one">{0} tunna</unitPattern>
+				<unitPattern count="other">{0} tunnur</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>áb.skeið</displayName>
@@ -12716,27 +12716,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} br áb.sk</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dropi</displayName>
+				<unitPattern count="one">{0} dropi</unitPattern>
+				<unitPattern count="other">{0} dropar</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dramm</displayName>
+				<unitPattern count="one">{0} dramm</unitPattern>
+				<unitPattern count="other">{0} drömm</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sjúss</displayName>
+				<unitPattern count="one">{0} sjúss</unitPattern>
+				<unitPattern count="other">{0} sjússar</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>klípa</displayName>
+				<unitPattern count="one">{0} klípa</unitPattern>
+				<unitPattern count="other">{0} klípur</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>lagarmál</displayName>
 				<unitPattern count="one">{0} l.mál</unitPattern>
 				<unitPattern count="other">{0} l.mál</unitPattern>
 			</unit>
@@ -12772,20 +12772,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} eða {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} eða {1}</listPatternPart>
+			<listPatternPart type="2">{0} eða {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} eða {1}</listPatternPart>
+			<listPatternPart type="2">{0} eða {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -125,7 +125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">cheyenne</language>
 			<language type="ckb">curdo sorani</language>
 			<language type="ckb" alt="menu">curdo centrale</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">curdo sorani</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">corso</language>
 			<language type="cop">copto</language>
@@ -1523,7 +1523,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1531,7 +1531,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1831,7 +1831,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="wed">M</day>
 							<day type="thu">G</day>
 							<day type="fri">V</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">dom</day>
@@ -2091,7 +2091,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2099,7 +2099,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -6000,7 +6000,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="ITL">
 				<pattern>¤ #,##0.00</pattern>
 				<displayName>lira italiana</displayName>
-				<displayName count="one" draft="contributed">↑↑↑</displayName>
+				<displayName count="one" draft="contributed">lire italiane</displayName>
 				<displayName count="other" draft="contributed">lire italiane</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<decimal>,</decimal>
@@ -7434,8 +7434,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="graphics-em">
 				<gender>feminine</gender>
 				<displayName>em tipografica</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
@@ -7772,9 +7772,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>masculine</gender>
@@ -8061,7 +8061,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>jigger</displayName>
 				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
@@ -8175,12 +8175,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8313,12 +8313,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -8521,7 +8521,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -8536,17 +8536,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -8571,33 +8571,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
@@ -8611,7 +8611,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -8696,7 +8696,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
@@ -8721,7 +8721,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -8731,17 +8731,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8778,7 +8778,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -8810,12 +8810,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8870,7 +8870,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -8885,7 +8885,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8895,12 +8895,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -9038,7 +9038,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>staia</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -9095,12 +9095,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -9115,7 +9115,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -9138,104 +9138,104 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
 				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -9243,40 +9243,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s²</displayName>
 				<unitPattern count="one">{0}m/s²</unitPattern>
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
+				<displayName>riv</displayName>
 				<unitPattern count="one">{0}riv</unitPattern>
 				<unitPattern count="other">{0}riv</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>rad</displayName>
 				<unitPattern count="one">{0}rad</unitPattern>
 				<unitPattern count="other">{0}rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>′</displayName>
+				<unitPattern count="one">{0}′</unitPattern>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>″</displayName>
+				<unitPattern count="one">{0}″</unitPattern>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0}km²</unitPattern>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ha</displayName>
@@ -9284,22 +9284,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm²</displayName>
 				<unitPattern count="one">{0}cm²</unitPattern>
 				<unitPattern count="other">{0}cm²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0}mi²</unitPattern>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>ac</displayName>
@@ -9307,7 +9307,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd²</displayName>
 				<unitPattern count="one">{0}yd²</unitPattern>
 				<unitPattern count="other">{0}yd²</unitPattern>
 			</unit>
@@ -9317,38 +9317,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in²</displayName>
 				<unitPattern count="one">{0}in²</unitPattern>
 				<unitPattern count="other">{0}in²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>dunum</displayName>
 				<unitPattern count="one">{0}dunum</unitPattern>
 				<unitPattern count="other">{0}dunum</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>kt</displayName>
 				<unitPattern count="one">{0}kt</unitPattern>
 				<unitPattern count="other">{0}kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg/dl</displayName>
 				<unitPattern count="one">{0}mg/dl</unitPattern>
 				<unitPattern count="other">{0}mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mmol/l</displayName>
 				<unitPattern count="one">{0}mmol/l</unitPattern>
 				<unitPattern count="other">{0}mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>elem.</displayName>
 				<unitPattern count="one">{0}elem.</unitPattern>
 				<unitPattern count="other">{0}elem.</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppm</displayName>
 				<unitPattern count="one">{0}ppm</unitPattern>
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
@@ -9358,22 +9358,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0}mol</unitPattern>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>L/km</displayName>
 				<unitPattern count="one" draft="contributed">{0}L/km</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}L/km</unitPattern>
 			</unit>
@@ -9383,17 +9383,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpg</displayName>
 				<unitPattern count="one">{0}mpg</unitPattern>
 				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/Imp gal</displayName>
 				<unitPattern count="one" draft="contributed">{0}mi/Imp gal</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}mi/Imp gal</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pbyte</displayName>
 				<unitPattern count="one">{0}PB</unitPattern>
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
@@ -9403,37 +9403,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Tbit</displayName>
 				<unitPattern count="one">{0}Tb</unitPattern>
 				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gbyte</displayName>
 				<unitPattern count="one">{0}GB</unitPattern>
 				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gbit</displayName>
 				<unitPattern count="one">{0}Gb</unitPattern>
 				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mbyte</displayName>
 				<unitPattern count="one">{0}MB</unitPattern>
 				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mbit</displayName>
 				<unitPattern count="one">{0}Mb</unitPattern>
 				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>kbyte</displayName>
 				<unitPattern count="one">{0}kB</unitPattern>
 				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>kbit</displayName>
 				<unitPattern count="one">{0}kb</unitPattern>
 				<unitPattern count="other">{0}kb</unitPattern>
 			</unit>
@@ -9443,17 +9443,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>bit</displayName>
 				<unitPattern count="one">{0}bit</unitPattern>
 				<unitPattern count="other">{0}bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>sec.</displayName>
 				<unitPattern count="one">{0}sec.</unitPattern>
 				<unitPattern count="other">{0}secc.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>dec.</displayName>
 				<unitPattern count="one">{0}dec.</unitPattern>
 				<unitPattern count="other">{0}dec.</unitPattern>
 			</unit>
@@ -9461,10 +9461,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>anno</displayName>
 				<unitPattern count="one">{0}anno</unitPattern>
 				<unitPattern count="other">{0}anni</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/anno</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>trim.</displayName>
 				<unitPattern count="one" draft="contributed">{0} trim.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} trim.</unitPattern>
 				<perUnitPattern>{0}/trim.</perUnitPattern>
@@ -9473,7 +9473,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mese</displayName>
 				<unitPattern count="one">{0} mese</unitPattern>
 				<unitPattern count="other">{0} mesi</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mese</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>sett.</displayName>
@@ -9491,19 +9491,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ora</displayName>
 				<unitPattern count="one">{0}h</unitPattern>
 				<unitPattern count="other">{0}h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
 				<unitPattern count="one">{0}min</unitPattern>
 				<unitPattern count="other">{0}min</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
 				<unitPattern count="one">{0}s</unitPattern>
 				<unitPattern count="other">{0}s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -9511,142 +9511,142 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>μs</displayName>
 				<unitPattern count="one">{0}μs</unitPattern>
 				<unitPattern count="other">{0}μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ns</displayName>
 				<unitPattern count="one">{0}ns</unitPattern>
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>A</displayName>
 				<unitPattern count="one">{0}A</unitPattern>
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>mA</displayName>
 				<unitPattern count="one">{0}mA</unitPattern>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ω</displayName>
 				<unitPattern count="one">{0}Ω</unitPattern>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>V</displayName>
 				<unitPattern count="one">{0}V</unitPattern>
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0}kcal</unitPattern>
 				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="one">{0}cal</unitPattern>
 				<unitPattern count="other">{0}cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>Cal</displayName>
 				<unitPattern count="one">{0}Cal</unitPattern>
 				<unitPattern count="other">{0}Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kJ</displayName>
 				<unitPattern count="one">{0}kJ</unitPattern>
 				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>J</displayName>
 				<unitPattern count="one">{0}J</unitPattern>
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh</displayName>
 				<unitPattern count="one">{0}kWh</unitPattern>
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>eV</displayName>
 				<unitPattern count="one">{0}eV</unitPattern>
 				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>BTU</displayName>
 				<unitPattern count="one">{0}BTU</unitPattern>
 				<unitPattern count="other">{0}BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>therm US</displayName>
 				<unitPattern count="one">{0}therm US</unitPattern>
 				<unitPattern count="other">{0}therm US</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf</displayName>
 				<unitPattern count="one">{0}lbf</unitPattern>
 				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>N</displayName>
 				<unitPattern count="one">{0}N</unitPattern>
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="one">{0}GHz</unitPattern>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="one">{0}MHz</unitPattern>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="one">{0}kHz</unitPattern>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="one">{0}Hz</unitPattern>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="one">{0}px</unitPattern>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>MP</displayName>
 				<unitPattern count="one">{0}MP</unitPattern>
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">{0}ppi</unitPattern>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
@@ -9656,12 +9656,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>punto</displayName>
 				<unitPattern count="one">{0}p</unitPattern>
 				<unitPattern count="other">{0}p</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">{0}R⊕</unitPattern>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
@@ -9669,16 +9669,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>km</displayName>
 				<unitPattern count="one">{0}km</unitPattern>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dm</displayName>
 				<unitPattern count="one">{0}dm</unitPattern>
 				<unitPattern count="other">{0}dm</unitPattern>
 			</unit>
@@ -9686,7 +9686,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0}cm</unitPattern>
 				<unitPattern count="other">{0}cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -9694,17 +9694,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>μm</displayName>
 				<unitPattern count="one">{0}μm</unitPattern>
 				<unitPattern count="other">{0}μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>nm</displayName>
 				<unitPattern count="one">{0}nm</unitPattern>
 				<unitPattern count="other">{0}nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0}pm</unitPattern>
 				<unitPattern count="other">{0}pm</unitPattern>
 			</unit>
@@ -9719,19 +9719,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft</displayName>
 				<unitPattern count="one">{0}ft</unitPattern>
 				<unitPattern count="other">{0}ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>pc</displayName>
 				<unitPattern count="one">{0}pc</unitPattern>
 				<unitPattern count="other">{0}pc</unitPattern>
 			</unit>
@@ -9741,62 +9741,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}al</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>au</displayName>
 				<unitPattern count="one">{0}au</unitPattern>
 				<unitPattern count="other">{0}au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>fur</displayName>
 				<unitPattern count="one">{0}fur</unitPattern>
 				<unitPattern count="other">{0}fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>fm</displayName>
 				<unitPattern count="one">{0}fm</unitPattern>
 				<unitPattern count="other">{0}fm</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>nmi</displayName>
 				<unitPattern count="one">{0}nmi</unitPattern>
 				<unitPattern count="other">{0}nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
+				<displayName>smi</displayName>
 				<unitPattern count="one">{0}smi</unitPattern>
 				<unitPattern count="other">{0}smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="one">{0}pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R☉</displayName>
 				<unitPattern count="one">{0}R☉</unitPattern>
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lx</displayName>
 				<unitPattern count="one">{0}lx</unitPattern>
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">{0}cd</unitPattern>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>L☉</displayName>
 				<unitPattern count="one">{0}L☉</unitPattern>
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>t</displayName>
 				<unitPattern count="one">{0}t</unitPattern>
 				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
@@ -9804,48 +9804,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="one">{0}mg</unitPattern>
 				<unitPattern count="other">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>μg</displayName>
 				<unitPattern count="one">{0}μg</unitPattern>
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>tn</displayName>
 				<unitPattern count="one">{0}tn</unitPattern>
 				<unitPattern count="other">{0}tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>st</displayName>
 				<unitPattern count="one">{0}st</unitPattern>
 				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0}lb</unitPattern>
 				<unitPattern count="other">{0}lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0}oz</unitPattern>
 				<unitPattern count="other">{0}oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>ozt</displayName>
 				<unitPattern count="one">{0}ozt</unitPattern>
 				<unitPattern count="other">{0}ozt</unitPattern>
 			</unit>
@@ -9855,102 +9855,102 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kt</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>Da</displayName>
 				<unitPattern count="one">{0}Da</unitPattern>
 				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M⊕</displayName>
 				<unitPattern count="one">{0}M⊕</unitPattern>
 				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M☉</displayName>
 				<unitPattern count="one">{0}M☉</unitPattern>
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>grano</displayName>
 				<unitPattern count="one">{0}grano</unitPattern>
 				<unitPattern count="other">{0}grani</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="one">{0}GW</unitPattern>
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="one">{0}MW</unitPattern>
 				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0}W</unitPattern>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">{0}mW</unitPattern>
 				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>mm Hg</displayName>
 				<unitPattern count="one">{0}mm Hg</unitPattern>
 				<unitPattern count="other">{0}mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 				<unitPattern count="one">{0}psi</unitPattern>
 				<unitPattern count="other">{0}psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0}inHg</unitPattern>
 				<unitPattern count="other">{0}inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="one">{0}bar</unitPattern>
 				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm</displayName>
 				<unitPattern count="one">{0}atm</unitPattern>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="one">{0}Pa</unitPattern>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0}hPa</unitPattern>
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="one">{0}kPa</unitPattern>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="one">{0}MPa</unitPattern>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
@@ -9960,24 +9960,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="one">{0}m/s</unitPattern>
 				<unitPattern count="other">{0}m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/h</displayName>
 				<unitPattern count="one">{0}mi/h</unitPattern>
 				<unitPattern count="other">{0}mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kn</displayName>
 				<unitPattern count="one">{0}kn</unitPattern>
 				<unitPattern count="other">{0}kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9985,41 +9985,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="one">{0}K</unitPattern>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb-ft</displayName>
 				<unitPattern count="one" draft="contributed">{0}lb-ft</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}lb-ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Nm</displayName>
 				<unitPattern count="one" draft="contributed">{0}Nm</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">{0}m³</unitPattern>
 				<unitPattern count="other">{0}m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0}cm³</unitPattern>
 				<unitPattern count="other">{0}cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>mi³</displayName>
@@ -10027,27 +10027,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd³</displayName>
 				<unitPattern count="one">{0}yd³</unitPattern>
 				<unitPattern count="other">{0}yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft³</displayName>
 				<unitPattern count="one">{0}ft³</unitPattern>
 				<unitPattern count="other">{0}ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in³</displayName>
 				<unitPattern count="one">{0}in³</unitPattern>
 				<unitPattern count="other">{0}in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ml</displayName>
 				<unitPattern count="one">{0}Ml</unitPattern>
 				<unitPattern count="other">{0}Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>hl</displayName>
 				<unitPattern count="one">{0}hl</unitPattern>
 				<unitPattern count="other">{0}hl</unitPattern>
 			</unit>
@@ -10055,25 +10055,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>l</displayName>
 				<unitPattern count="one">{0}l</unitPattern>
 				<unitPattern count="other">{0}l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0}dl</unitPattern>
 				<unitPattern count="other">{0}dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cl</displayName>
 				<unitPattern count="one">{0}cl</unitPattern>
 				<unitPattern count="other">{0}cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ml</displayName>
 				<unitPattern count="one">{0}ml</unitPattern>
 				<unitPattern count="other">{0}ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpt</displayName>
 				<unitPattern count="one">{0}mpt</unitPattern>
 				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
@@ -10083,7 +10083,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ac ft</displayName>
 				<unitPattern count="one">{0}ac ft</unitPattern>
 				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
@@ -10093,10 +10093,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">{0}gal</unitPattern>
 				<unitPattern count="other">{0}gal</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>gal im</displayName>
@@ -10105,22 +10105,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/gal im</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt</displayName>
 				<unitPattern count="one">{0}qt</unitPattern>
 				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="one">{0}pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>c</displayName>
 				<unitPattern count="one">{0}c</unitPattern>
 				<unitPattern count="other">{0}c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz</displayName>
 				<unitPattern count="one">{0}fl oz</unitPattern>
 				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
@@ -10130,12 +10130,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl oz im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>tbsp</displayName>
 				<unitPattern count="one">{0}tbsp</unitPattern>
 				<unitPattern count="other">{0}tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>tsp</displayName>
 				<unitPattern count="one">{0}tsp</unitPattern>
 				<unitPattern count="other">{0}tsp</unitPattern>
 			</unit>
@@ -10145,7 +10145,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstspn</displayName>
 				<unitPattern count="one">{0}dstspn</unitPattern>
 				<unitPattern count="other">{0}dstspn</unitPattern>
 			</unit>
@@ -10155,7 +10155,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dstspn im</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>goccia</displayName>
 				<unitPattern count="one">{0}goccia</unitPattern>
 				<unitPattern count="other">{0}gocce</unitPattern>
 			</unit>
@@ -10165,17 +10165,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dr liq</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>jigger</displayName>
 				<unitPattern count="one">{0}jigger</unitPattern>
 				<unitPattern count="other">{0}jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>pizzico</displayName>
 				<unitPattern count="one">{0}pizzico</unitPattern>
 				<unitPattern count="other">{0}pizzichi</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>imp qt</displayName>
 				<unitPattern count="one" draft="contributed">{0}imp qt</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}imp qt</unitPattern>
 			</unit>
@@ -10211,22 +10211,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} o {1}</listPatternPart>
+			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} o {1}</listPatternPart>
+			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} e {1}</listPatternPart>
+			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -2429,7 +2429,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2437,7 +2437,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2445,7 +2445,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2453,7 +2453,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3029,7 +3029,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -3037,7 +3037,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -3045,7 +3045,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -3053,7 +3053,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4161,7 +4161,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -4169,7 +4169,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -4177,7 +4177,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4185,7 +4185,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -9417,7 +9417,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>フォントサイズ em</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>ピクセル</displayName>
@@ -9445,7 +9445,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ドット</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ドット</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>地球半径</displayName>
@@ -10741,64 +10741,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -10828,12 +10828,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
@@ -10855,43 +10855,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>度</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>分</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>秒</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ヘクタール</displayName>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm²</displayName>
 				<unitPattern count="other">{0}cm²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>エーカー</displayName>
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
@@ -10905,14 +10905,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-inch">
 				<displayName>in²</displayName>
 				<unitPattern count="other">{0}in²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ドゥナム</displayName>
+				<unitPattern count="other">{0}ドゥナム</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>金</displayName>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
@@ -10924,11 +10924,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>項目</displayName>
 				<unitPattern count="other">{0}項目</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppm</displayName>
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
@@ -10937,18 +10937,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mol</displayName>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>L/km</displayName>
 				<unitPattern count="other">{0}L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
@@ -10976,7 +10976,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>GB</displayName>
 				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
@@ -10984,7 +10984,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
@@ -10992,7 +10992,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>KB</displayName>
 				<unitPattern count="other">{0}KB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
@@ -11004,7 +11004,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ビット</displayName>
 				<unitPattern count="other">{0}b</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -11012,7 +11012,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}世紀</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>十年</displayName>
 				<unitPattern count="other">{0}十年</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -11068,39 +11068,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>アンペア</displayName>
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>ミリアンペア</displayName>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>オーム</displayName>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ボルト</displayName>
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="other">{0}calth</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="other">{0}cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>キロジュール</displayName>
 				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>ジュール</displayName>
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
@@ -11109,14 +11109,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>英熱量</displayName>
 				<unitPattern count="other">{0}BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>米サーム</displayName>
 				<unitPattern count="other">{0}米サーム</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
@@ -11132,23 +11132,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -11160,27 +11160,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpcm</displayName>
 				<unitPattern count="other">{0}dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpi</displayName>
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ドット</displayName>
 				<unitPattern count="other">{0}ドット</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -11249,11 +11249,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>ハロン</displayName>
 				<unitPattern count="other">{0}fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>ファゾム</displayName>
 				<unitPattern count="other">{0}fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -11303,7 +11303,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="other">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
@@ -11311,11 +11311,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>米トン</displayName>
 				<unitPattern count="other">{0}s/t</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>ストーン</displayName>
 				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -11333,7 +11333,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>カラット</displayName>
 				<unitPattern count="other">{0}ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
@@ -11349,15 +11349,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>グレーン</displayName>
 				<unitPattern count="other">{0}グレーン</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ギガワット</displayName>
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>メガワット</displayName>
 				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
@@ -11365,7 +11365,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ワット</displayName>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
@@ -11373,7 +11373,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>馬力</displayName>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -11389,7 +11389,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>バール</displayName>
 				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -11397,7 +11397,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>気圧</displayName>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
@@ -11409,11 +11409,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -11457,18 +11457,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="other">{0}m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="other">{0}cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>mi³</displayName>
@@ -11497,7 +11497,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-liter">
 				<displayName>L</displayName>
 				<unitPattern count="other">{0}L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>dL</displayName>
@@ -11512,11 +11512,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>メトリックパイント</displayName>
 				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>メトリックカップ</displayName>
 				<unitPattern count="other">{0}mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
@@ -11524,18 +11524,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>ブッシェル</displayName>
 				<unitPattern count="other">{0}bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>gal</displayName>
 				<unitPattern count="other">{0}gal</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>Imp gal</displayName>
 				<unitPattern count="other">{0}gal Imp.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qt</displayName>
@@ -11546,7 +11546,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>カップ</displayName>
 				<unitPattern count="other">{0}カップ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
@@ -11558,11 +11558,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Imp fl oz</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>大さじ</displayName>
 				<unitPattern count="other">大さじ{0}</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>小さじ</displayName>
 				<unitPattern count="other">小さじ{0}</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
@@ -11570,27 +11570,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>中さじ</displayName>
 				<unitPattern count="other">中さじ{0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>英デザートスプーン</displayName>
 				<unitPattern count="other">{0}英デザートスプーン</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>滴</displayName>
 				<unitPattern count="other">{0}滴</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>液量ドラム</displayName>
 				<unitPattern count="other">{0}fl dr</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>ジガー</displayName>
 				<unitPattern count="other">{0}ジガー</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>つまみ</displayName>
 				<unitPattern count="other">{0}つまみ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
@@ -11629,22 +11629,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0}または{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}、または{1}</listPatternPart>
+			<listPatternPart type="2">{0}または{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}、または{1}</listPatternPart>
+			<listPatternPart type="2">{0}または{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}、{1}</listPatternPart>
+			<listPatternPart type="2">{0}、{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}、{1}</listPatternPart>
@@ -11861,7 +11861,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal} {surname}{title}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname} {generation}{title}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
 			<namePattern>{given-informal} {surname}{title}</namePattern>
@@ -11870,10 +11870,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname} {generation}{title}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}{title}</namePattern>
@@ -11885,10 +11885,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal} {surname}{title}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{given} {surname}{title}</namePattern>
@@ -11903,10 +11903,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}{title}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{surname}{given2}{given}{title}</namePattern>
@@ -11924,7 +11924,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname}{given}{title}</namePattern>
@@ -11939,10 +11939,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}{given-informal}{title}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{surname}{given}{title}</namePattern>
@@ -11957,10 +11957,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}{title}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>{surname} {given2} {given}</namePattern>
@@ -11969,7 +11969,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given2} {given}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {given-informal}</namePattern>

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -44,7 +44,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="awa">Awadhi</language>
 			<language type="ay">Aymara</language>
 			<language type="az">Azerbaijan</language>
-			<language type="az" alt="short">↑↑↑</language>
+			<language type="az" alt="short">Azerbaijan</language>
 			<language type="ba">Bashkir</language>
 			<language type="ban">Bali</language>
 			<language type="bas">Basaa</language>
@@ -78,8 +78,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">Cherokee</language>
 			<language type="chy">Cheyenne</language>
 			<language type="ckb">Kurdi Tengah</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">Kurdi Tengah</language>
+			<language type="ckb" alt="variant">Kurdi Tengah</language>
 			<language type="clc">Chilcotin</language>
 			<language type="co">Korsika</language>
 			<language type="crg">Michif</language>
@@ -599,7 +599,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CG" alt="variant">Républik Kongo</territory>
 			<territory type="CH">Switserlan</territory>
 			<territory type="CI">Pasisir Gadhing</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
+			<territory type="CI" alt="variant">Pasisir Gadhing</territory>
 			<territory type="CK">Kapuloan Cook</territory>
 			<territory type="CL">Cilé</territory>
 			<territory type="CM">Kamerun</territory>
@@ -738,7 +738,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">Selandia Anyar</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Selandia Anyar</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -798,7 +798,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turki</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turki</territory>
 			<territory type="TT">Trinidad lan Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1291,7 +1291,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
+							<day type="sun">Ahad</day>
 							<day type="mon">Sen</day>
 							<day type="tue">Sel</day>
 							<day type="wed">Rab</day>
@@ -1301,12 +1301,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">A</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
+							<day type="mon">S</day>
+							<day type="tue">S</day>
 							<day type="wed">R</day>
 							<day type="thu">K</day>
 							<day type="fri">J</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">Ahad</day>
@@ -1332,9 +1332,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sun">Ahad</day>
 							<day type="mon">Sen</day>
 							<day type="tue">Sel</day>
-							<day type="wed">↑↑↑</day>
+							<day type="wed">Rab</day>
 							<day type="thu">Kam</day>
-							<day type="fri">↑↑↑</day>
+							<day type="fri">Jum</day>
 							<day type="sat">Sab</day>
 						</dayWidth>
 						<dayWidth type="narrow">
@@ -1348,20 +1348,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">Ahad</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
+							<day type="mon">Sen</day>
+							<day type="tue">Sel</day>
+							<day type="wed">Rab</day>
+							<day type="thu">Kam</day>
 							<day type="fri">Jum</day>
 							<day type="sat">Sab</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">Ahad</day>
-							<day type="mon">↑↑↑</day>
+							<day type="mon">Senin</day>
 							<day type="tue">Selasa</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
+							<day type="wed">Rabu</day>
+							<day type="thu">Kamis</day>
+							<day type="fri">Jumat</day>
 							<day type="sat">Sabtu</day>
 						</dayWidth>
 					</dayContext>
@@ -1751,18 +1751,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Bsar.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Sura</month>
@@ -1781,18 +1781,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Sur.</month>
+							<month type="2">Sap.</month>
+							<month type="3">Mul.</month>
+							<month type="4">B. Mul.</month>
+							<month type="5">Jum. Aw.</month>
+							<month type="6">Jum. Ak.</month>
+							<month type="7">Rej.</month>
+							<month type="8">Ruw.</month>
+							<month type="9">Pso.</month>
+							<month type="10">Shaw.</month>
+							<month type="11">Slo.</month>
+							<month type="12">Bsar.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -1832,53 +1832,53 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd-MM-y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">d E</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
 						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">dd/MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd/MM</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
 						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd - MM - y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd - MM - y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -1888,10 +1888,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>era</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>era</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>era</displayName>
 			</field>
 			<field type="year">
 				<displayName>taun</displayName>
@@ -1907,21 +1907,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>taun</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">taun wingi</relative>
+				<relative type="0">taun iki</relative>
+				<relative type="1">taun ngarep</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} taun</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} taun kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
 				<displayName>taun</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">taun wingi</relative>
+				<relative type="0">taun iki</relative>
+				<relative type="1">taun ngarep</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ing {0} taun</relativeTimePattern>
 				</relativeTime>
@@ -1973,21 +1973,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName>sasi</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">sasi wingi</relative>
+				<relative type="0">sasi iki</relative>
+				<relative type="1">sasi ngarep</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} sasi</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} sasi kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
 				<displayName>sasi</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">sasi wingi</relative>
+				<relative type="0">sasi iki</relative>
+				<relative type="1">sasi ngarep</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ing {0} sasi</relativeTimePattern>
 				</relativeTime>
@@ -2057,23 +2057,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>dino</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">wingi</relative>
 				<relative type="0">dino iki</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">sesuk</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} dina</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dina kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
 				<displayName>dino</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">wingi</relative>
 				<relative type="0">dino iki</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">sesuk</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} dina</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0} dino kepungkur</relativeTimePattern>
@@ -2092,16 +2092,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>dino sepekan</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>dino sepekan</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>dino sepekan</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>dina jroning sasi</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>dina jroning sasi</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
 				<displayName>dino jroning sasi</displayName>
@@ -2129,14 +2129,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Ahad wingi</relative>
+				<relative type="0">Ahad iki</relative>
+				<relative type="1">Ahad ngarep</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} Ahad</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Ahad kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2195,14 +2195,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Sel. wingi</relative>
+				<relative type="0">Sel. iki</relative>
+				<relative type="1">Sel. ngarep</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} Sel.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Sel. kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -2228,14 +2228,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Reb. wingi</relative>
+				<relative type="0">Reb. iki</relative>
+				<relative type="1">Reb. ngarep</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} Reb.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Reb. kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -2261,14 +2261,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Kms. wingi</relative>
+				<relative type="0">Kms. iki</relative>
+				<relative type="1">Kms. ngarep</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} Kms.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Kms. kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -2294,14 +2294,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Jem. wingi</relative>
+				<relative type="0">Jem. iki</relative>
+				<relative type="1">Jem. ngarep</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} Jem.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Jem. kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -2334,17 +2334,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">ing {0} St</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Set. kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>isuk/wengi</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>isuk/wengi</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>isuk/wengi</displayName>
 			</field>
 			<field type="hour">
 				<displayName>jam</displayName>
@@ -2359,10 +2359,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="hour-short">
 				<displayName>jam</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} jam</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} jam kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
@@ -2415,10 +2415,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="second-short">
 				<displayName>detik</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ing {0} detik</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} detik kepungkur</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
@@ -2434,10 +2434,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>zona wektu</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>zona wektu</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>zona wektu</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -4880,7 +4880,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Ruble Belarusia</displayName>
 				<displayName count="other">Ruble Belarusia</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">BYN</symbol>
 			</currency>
 			<currency type="BZD">
 				<displayName>Dolar Belise</displayName>
@@ -5259,7 +5259,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MOP">
 				<displayName>Pataca Macau</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Pataca Macau</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MRO">
@@ -5821,8 +5821,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} saben inci pesagi</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karat</displayName>
@@ -5857,8 +5857,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} permiriad</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>liter saben kilometer</displayName>
@@ -6062,7 +6062,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipografi em</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piksel</displayName>
@@ -6073,12 +6073,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} megapiksel</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>titek saben sentimeter</displayName>
@@ -6302,8 +6302,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} inci saka raksa</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>milibar</displayName>
@@ -6499,8 +6499,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} banyu dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>sak juwit</displayName>
@@ -7386,194 +7386,194 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
 				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tenaga-g</displayName>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>meter/detik²</displayName>
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>derajat</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>menit saka busur</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>detik saka busur</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hektar</displayName>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mil²</displayName>
+				<unitPattern count="other">{0} mil²</unitPattern>
+				<perUnitPattern>{0}/mil²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>are</displayName>
+				<unitPattern count="other">{0} are</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yard²</displayName>
+				<unitPattern count="other">{0} yard²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kaki pesagi</displayName>
 				<unitPattern count="other">{0} kaki²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>inci²</displayName>
+				<unitPattern count="other">{0} inci²</unitPattern>
+				<perUnitPattern>{0}/inci²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>iji</displayName>
 				<unitPattern count="other">{0} iji</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>bagean/yuta</displayName>
 				<unitPattern count="other">{0}bpj</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
@@ -7581,89 +7581,89 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>permil</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>permiriad</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>liter/km</displayName>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100 km</displayName>
 				<unitPattern count="other">{0} L/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil/galon</displayName>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg inggris</displayName>
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PBite</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TBite</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tbit</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GBite</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gbit</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MBite</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mbit</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kBite</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kbit</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bite</displayName>
+				<unitPattern count="other">{0} bite</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>abad</displayName>
+				<unitPattern count="other">{0} abad</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dsw</displayName>
+				<unitPattern count="other">{0} dsw</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>taun</displayName>
 				<unitPattern count="other">{0} taun</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/taun</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>seprapat</displayName>
@@ -7673,573 +7673,573 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-month">
 				<displayName>sasi</displayName>
 				<unitPattern count="other">{0} sasi</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sasi</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>peken</displayName>
 				<unitPattern count="other">{0} peken</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/peken</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>dina</displayName>
 				<unitPattern count="other">{0}d</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>jam</displayName>
 				<unitPattern count="other">{0}j</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/jam</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>mnt</displayName>
 				<unitPattern count="other">{0} mnt</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mnt</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>dtk</displayName>
 				<unitPattern count="other">{0} dtk</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/dtk</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>mdtk</displayName>
 				<unitPattern count="other">{0} md</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μdtk</displayName>
+				<unitPattern count="other">{0} μd</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nanodtk</displayName>
+				<unitPattern count="other">{0} nd</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amper</displayName>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miliamper</displayName>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kkal</displayName>
+				<unitPattern count="other">{0} kkal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kal</displayName>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kal</displayName>
+				<unitPattern count="other">{0} Kal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilojol</displayName>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jol</displayName>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW-jam</displayName>
+				<unitPattern count="other">{0} kW-jam</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>elektronvolt</displayName>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>takeran panas AS</displayName>
 				<unitPattern count="other">{0}panas AS</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pon gaya</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>newton</displayName>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="other">{0}kWh/km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tscm</displayName>
+				<unitPattern count="other">{0} tscm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsi</displayName>
+				<unitPattern count="other">{0} tsi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>titik</displayName>
+				<unitPattern count="other">{0} titik</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μmeter</displayName>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil</displayName>
+				<unitPattern count="other">{0} mil</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yard</displayName>
+				<unitPattern count="other">{0} yard</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kaki</displayName>
+				<unitPattern count="other">{0} kaki</unitPattern>
+				<perUnitPattern>{0}/kaki</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>inci</displayName>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>parsek</displayName>
+				<unitPattern count="other">{0} ps</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>taun cahya</displayName>
+				<unitPattern count="other">{0} tc</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ua</displayName>
+				<unitPattern count="other">{0} ua</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>furlongs</displayName>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fathoms</displayName>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>poin</displayName>
+				<unitPattern count="other">{0} p</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>radii srengenge</displayName>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>luk</displayName>
+				<unitPattern count="other">{0} luk</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kandela</displayName>
+				<unitPattern count="other">{0} kandela</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>luminositas srengenge</displayName>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>metrik ton</displayName>
 				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gram</displayName>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mikrogram</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ton</displayName>
+				<unitPattern count="other">{0} ton</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>watu</displayName>
+				<unitPattern count="other">{0} watu</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>pon</displayName>
+				<unitPattern count="other">{0} pon</unitPattern>
+				<perUnitPattern>{0}/pon</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ons</displayName>
+				<unitPattern count="other">{0} ons</unitPattern>
+				<perUnitPattern>{0}/ons</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>troy ons</displayName>
+				<unitPattern count="other">{0} troy ons</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="other">{0} karat</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dalton</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>massa Bumi</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>massa srengenge</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>wiji</displayName>
+				<unitPattern count="other">{0} wiji</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>watt</displayName>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>tenogo jaran</displayName>
 				<unitPattern count="other">{0}dj</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/jam</displayName>
 				<unitPattern count="other">{0} km/jam</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>meter/dtk</displayName>
+				<unitPattern count="other">{0} m/dtk</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil/jam</displayName>
+				<unitPattern count="other">{0} mil/jam</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>knot</displayName>
+				<unitPattern count="other">{0} knot</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>pon-kaki</displayName>
 				<unitPattern count="other">{0}lbf⋅kaki</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil³</displayName>
+				<unitPattern count="other">{0} mil³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yard³</displayName>
+				<unitPattern count="other">{0} yard³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kaki³</displayName>
+				<unitPattern count="other">{0} kaki³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inci³</displayName>
+				<unitPattern count="other">{0} inci³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>liter</displayName>
 				<unitPattern count="other">{0} L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>sentiliter</displayName>
 				<unitPattern count="other">{0}cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>metrik pin</displayName>
 				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metrik kup</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>are-kaki</displayName>
+				<unitPattern count="other">{0} are-kaki</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gantang</displayName>
+				<unitPattern count="other">{0} gantang</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>galon</displayName>
+				<unitPattern count="other">{0} galon</unitPattern>
+				<perUnitPattern>{0}/galon</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>galon inggris</displayName>
 				<unitPattern count="other">{0}gallm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/galon inggris</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>seprapat galon</displayName>
 				<unitPattern count="other">{0}sprt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pin</displayName>
+				<unitPattern count="other">{0} pin</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kup</displayName>
+				<unitPattern count="other">{0} kup</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>ons banyu</displayName>
 				<unitPattern count="other">{0}ons by</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. ons banyu</displayName>
 				<unitPattern count="other">{0}oz lm by</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>sdk mgn</displayName>
 				<unitPattern count="other">{0}sdm</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sdk teh</displayName>
+				<unitPattern count="other">{0} sdk teh</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>barel</displayName>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>sendok es</displayName>
 				<unitPattern count="other">{0}sde</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. sendok es</displayName>
 				<unitPattern count="other">{0}sde-lmp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tetes</displayName>
+				<unitPattern count="other">{0} tetes</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>banyu dram</displayName>
 				<unitPattern count="other">{0}by.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>juwit</displayName>
 				<unitPattern count="other">{0}juwit</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. seprapat galon</displayName>
 				<unitPattern count="other">{0}spt-lmp.</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -8274,20 +8274,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} utowo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, utowo {1}</listPatternPart>
+			<listPatternPart type="2">{0} utowo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, utowo {1}</listPatternPart>
+			<listPatternPart type="2">{0} utowo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -8610,7 +8610,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname}, {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname}, {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname-core}, {given} {given2-initial} {surname-prefix}</namePattern>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -95,8 +95,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">ჩეროკი</language>
 			<language type="chy">ჩეიენი</language>
 			<language type="ckb">ცენტრალური ქურთული</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">ცენტრალური ქურთული</language>
+			<language type="ckb" alt="variant">ცენტრალური ქურთული</language>
 			<language type="clc">ჩილკოტინი</language>
 			<language type="co">კორსიკული</language>
 			<language type="cop">კოპტური</language>
@@ -980,7 +980,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="SX">სინტ-მარტენი</territory>
 			<territory type="SY">სირია</territory>
 			<territory type="SZ">სვაზილენდი</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
+			<territory type="SZ" alt="variant">სვაზილენდი</territory>
 			<territory type="TA">ტრისტან-და-კუნია</territory>
 			<territory type="TC">თერქს-ქაიქოსის კუნძულები</territory>
 			<territory type="TD">ჩადი</territory>
@@ -995,7 +995,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ტუნისი</territory>
 			<territory type="TO">ტონგა</territory>
 			<territory type="TR">თურქეთი</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">თურქეთი</territory>
 			<territory type="TT">ტრინიდადი და ტობაგო</territory>
 			<territory type="TV">ტუვალუ</territory>
 			<territory type="TW">ტაივანი</territory>
@@ -1293,7 +1293,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1301,7 +1301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1309,7 +1309,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1317,7 +1317,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1777,7 +1777,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="midnight">შუაღამე</dayPeriod>
 							<dayPeriod type="am">AM</dayPeriod>
 							<dayPeriod type="noon">შუადღე</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 							<dayPeriod type="morning1">დილა</dayPeriod>
 							<dayPeriod type="afternoon1">ნაშუადღევი</dayPeriod>
 							<dayPeriod type="evening1">საღამო</dayPeriod>
@@ -1865,7 +1865,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1873,7 +1873,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1881,7 +1881,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -6794,7 +6794,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">კუბური {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ინერციის ძალა</displayName>
@@ -6922,14 +6922,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} პრომილე</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>ლიტრი კილომეტრზე</displayName>
@@ -7145,14 +7145,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} აშშ თერმი</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>კვტსთ/100კმ</displayName>
@@ -7974,12 +7974,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -8197,12 +8197,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -8471,12 +8471,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8896,7 +8896,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<unitPattern count="one">{0} ინ. ძ.</unitPattern>
@@ -8939,7 +8939,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ფტ²</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>ერთეული</displayName>
 				<unitPattern count="one">{0} ერთე.</unitPattern>
 				<unitPattern count="other">{0} ერთე.</unitPattern>
 			</unit>
@@ -8954,20 +8954,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ლ/100კმ</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ს.</displayName>
+				<unitPattern count="one">{0} ს.</unitPattern>
+				<unitPattern count="other">{0} ს.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">დეკადა</displayName>
+				<unitPattern count="one">{0} დეკადა</unitPattern>
+				<unitPattern count="other">{0} დეკადა</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>წ</displayName>
 				<unitPattern count="one">{0} წ</unitPattern>
 				<unitPattern count="other">{0} წ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/წ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>კვარტ</displayName>
@@ -8985,31 +8985,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>კვრ</displayName>
 				<unitPattern count="one">{0} კვრ</unitPattern>
 				<unitPattern count="other">{0} კვრ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/კვრ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>დღე</displayName>
 				<unitPattern count="one">{0} დღე</unitPattern>
 				<unitPattern count="other">{0} დღე</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/დღე</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>საათი</displayName>
 				<unitPattern count="one">{0}სთ</unitPattern>
 				<unitPattern count="other">{0}სთ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/სთ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>წთ</displayName>
 				<unitPattern count="one">{0}წთ</unitPattern>
 				<unitPattern count="other">{0}წთ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/წთ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>წმ</displayName>
 				<unitPattern count="one">{0}წმ</unitPattern>
 				<unitPattern count="other">{0}წმ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/წმ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>მწმ</displayName>
@@ -9017,17 +9017,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} მწმ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>მკწმ</displayName>
+				<unitPattern count="one">{0} მკწმ</unitPattern>
+				<unitPattern count="other">{0} მკწმ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ნწმ</displayName>
+				<unitPattern count="one">{0} ნწმ</unitPattern>
+				<unitPattern count="other">{0} ნწმ</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>კვტსთ/100კმ</displayName>
 				<unitPattern count="one">{0} კვტსთ/100კმ</unitPattern>
 				<unitPattern count="other">{0} კვტსთ/100კმ</unitPattern>
 			</unit>
@@ -9076,9 +9076,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} სწ</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ლუქსი</displayName>
+				<unitPattern count="one">{0} ლუქსი</unitPattern>
+				<unitPattern count="other">{0} ლუქსი</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>კგ</displayName>
@@ -9095,7 +9095,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}მგ</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>მკგ</displayName>
 				<unitPattern count="one">{0}მკგ</unitPattern>
 				<unitPattern count="other">{0}მკგ</unitPattern>
 			</unit>
@@ -9202,22 +9202,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ან {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ან {1}</listPatternPart>
+			<listPatternPart type="2">{0} ან {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ან {1}</listPatternPart>
+			<listPatternPart type="2">{0} ან {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} და {1}</listPatternPart>
+			<listPatternPart type="2">{0} და {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -9431,13 +9431,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>{given-monogram}{given2-monogram}{surname-monogram}</namePattern>
@@ -9446,112 +9446,112 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram}{surname-monogram}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram}{given2-monogram}{surname-monogram}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram}{given2-monogram}{surname-monogram}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram}{given2-monogram}{surname-monogram}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram}{given2-monogram}{surname-monogram}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>{surname-monogram}{given-monogram}{given2-monogram}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram}{given-monogram}{given2-monogram}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram}{given-monogram}{given2-monogram}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram}{given-monogram}{given2-monogram}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram}{given-monogram}{given2-monogram}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram}{given-monogram}{given2-monogram}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">ნინო</nameField>

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -76,8 +76,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr" draft="unconfirmed">Tacirukit</language>
 			<language type="chy" draft="unconfirmed">Taciyant</language>
 			<language type="ckb" draft="unconfirmed">Takurdit Talemmast</language>
-			<language type="ckb" alt="menu" draft="unconfirmed">↑↑↑</language>
-			<language type="ckb" alt="variant" draft="unconfirmed">↑↑↑</language>
+			<language type="ckb" alt="menu" draft="unconfirmed">Takurdit Talemmast</language>
+			<language type="ckb" alt="variant" draft="unconfirmed">Takurdit Talemmast</language>
 			<language type="clc" draft="unconfirmed">Tacilkuṭint</language>
 			<language type="co" draft="unconfirmed">Takuṛsit</language>
 			<language type="crs" draft="unconfirmed">Takriyult n Saycal</language>
@@ -552,7 +552,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CG" alt="variant" draft="unconfirmed">Kungu (Tagduda)</territory>
 			<territory type="CH">Swis</territory>
 			<territory type="CI">Kuṭ Divwar</territory>
-			<territory type="CI" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="CI" alt="variant" draft="unconfirmed">Kuṭ Divwar</territory>
 			<territory type="CK">Tigzirin n Kuk</territory>
 			<territory type="CL">Cili</territory>
 			<territory type="CM">Kamirun</territory>
@@ -691,7 +691,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">Nuru</territory>
 			<territory type="NU">Niwi</territory>
 			<territory type="NZ">Ziland Tamaynut</territory>
-			<territory type="NZ" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="NZ" alt="variant" draft="unconfirmed">Ziland Tamaynut</territory>
 			<territory type="OM">Ɛuman</territory>
 			<territory type="PA">Panam</territory>
 			<territory type="PE">Piru</territory>
@@ -750,7 +750,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunes</territory>
 			<territory type="TO">Ṭunga</territory>
 			<territory type="TR">Ṭurk</territory>
-			<territory type="TR" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="TR" alt="variant" draft="unconfirmed">Ṭurk</territory>
 			<territory type="TT">Ṭrindad d Ṭubagu</territory>
 			<territory type="TV">Ṭuvalu</territory>
 			<territory type="TW">Ṭaywan</territory>
@@ -1144,16 +1144,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<monthWidth type="narrow">
 							<month type="1" draft="unconfirmed">Y</month>
 							<month type="2" draft="unconfirmed">F</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="3" draft="unconfirmed">M</month>
+							<month type="4" draft="unconfirmed">Y</month>
+							<month type="5" draft="unconfirmed">M</month>
+							<month type="6" draft="unconfirmed">Y</month>
+							<month type="7" draft="unconfirmed">Y</month>
+							<month type="8" draft="unconfirmed">Ɣ</month>
+							<month type="9" draft="unconfirmed">C</month>
+							<month type="10" draft="unconfirmed">T</month>
+							<month type="11" draft="unconfirmed">N</month>
+							<month type="12" draft="unconfirmed">D</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Yennayer</month>
@@ -1182,8 +1182,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="8" draft="unconfirmed">Ɣuc</month>
 							<month type="9" draft="unconfirmed">Cte</month>
 							<month type="10" draft="unconfirmed">Tub</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="11" draft="unconfirmed">Nun</month>
+							<month type="12" draft="unconfirmed">Duǧ</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">Y</month>
@@ -1208,9 +1208,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="6" draft="unconfirmed">Yunyu</month>
 							<month type="7" draft="unconfirmed">Yulyu</month>
 							<month type="8" draft="unconfirmed">Ɣuct</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
+							<month type="9" draft="unconfirmed">Ctembeṛ</month>
+							<month type="10" draft="unconfirmed">Tubeṛ</month>
+							<month type="11" draft="unconfirmed">Nunembeṛ</month>
 							<month type="12" draft="unconfirmed">Duǧembeṛ</month>
 						</monthWidth>
 					</monthContext>
@@ -1233,7 +1233,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="wed" draft="unconfirmed">H</day>
 							<day type="thu" draft="unconfirmed">M</day>
 							<day type="fri" draft="unconfirmed">S</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sat" draft="unconfirmed">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun" draft="unconfirmed">Cr</day>
@@ -1714,7 +1714,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">sg</displayName>
 				<relative type="-1" draft="unconfirmed">ilindi</relative>
 				<relative type="0" draft="unconfirmed">aseggas-a</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="1" draft="unconfirmed">qabel</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} sg.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">deg {0} sg.</relativeTimePattern>
@@ -1740,9 +1740,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="quarter-short">
 				<displayName draft="unconfirmed">kyr.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">akraḍyur izrin</relative>
+				<relative type="0" draft="unconfirmed">akraḍyur-agi</relative>
+				<relative type="1" draft="unconfirmed">akraḍyur d-iteddun</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} kyr.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">deg {0} kyrn.</relativeTimePattern>
@@ -1754,9 +1754,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="quarter-narrow">
 				<displayName draft="unconfirmed">kyr.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">akraḍyur izrin</relative>
+				<relative type="0" draft="unconfirmed">akraḍyur-agi</relative>
+				<relative type="1" draft="unconfirmed">akraḍyur d-iteddun</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} kyr.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">deg {0} kyrn.</relativeTimePattern>
@@ -1782,8 +1782,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName draft="unconfirmed">yr.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">ayyur izrin</relative>
+				<relative type="0" draft="unconfirmed">ayyur-a</relative>
 				<relative type="1" draft="unconfirmed">ayyur i d-itteddun</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} yr.</relativeTimePattern>
@@ -1796,8 +1796,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName draft="unconfirmed">yr.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">ayyur izrin</relative>
+				<relative type="0" draft="unconfirmed">ayyur-a</relative>
 				<relative type="1" draft="unconfirmed">ayyur i d-itteddun</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} yr.</relativeTimePattern>
@@ -1842,16 +1842,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">dṛ.</displayName>
 				<relative type="-1" draft="unconfirmed">ddurt izrin</relative>
 				<relative type="0" draft="unconfirmed">ddurt-a</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="1" draft="unconfirmed">dduṛt i d-itteddun</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">deg {0} mls.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">deg {0} mls.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one" draft="unconfirmed">{0} mls. aya</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">{0} mls. aya</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod draft="unconfirmed">↑↑↑</relativePeriod>
+				<relativePeriod draft="unconfirmed">ddurt n {0}</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName draft="unconfirmed">dduṛt n wayyur</displayName>
@@ -1891,8 +1891,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
+				<displayName draft="unconfirmed">ass</displayName>
+				<relative type="-1" draft="unconfirmed">iḍelli</relative>
 				<relative type="0" draft="unconfirmed">ass-a</relative>
 				<relative type="1" draft="unconfirmed">azekka</relative>
 				<relativeTime type="future">
@@ -2227,7 +2227,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-short">
 				<displayName draft="unconfirmed">sr.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">asrag-agi</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} sr.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">deg {0} sr.</relativeTimePattern>
@@ -2239,7 +2239,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-narrow">
 				<displayName draft="unconfirmed">sr.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">asrag-agi</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} sr.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">deg {0} sr.</relativeTimePattern>
@@ -2263,7 +2263,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-short">
 				<displayName draft="unconfirmed">tsd.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">tasdat-agi</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} tsd.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">deg {0} tsd.</relativeTimePattern>
@@ -2275,7 +2275,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-narrow">
 				<displayName draft="unconfirmed">tsd.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">tasdat-agi</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} tsd.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">deg {0} tsd.</relativeTimePattern>
@@ -2299,7 +2299,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="second-short">
 				<displayName draft="unconfirmed">tsn.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">tura</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} tsn.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">deg {0} tsn.</relativeTimePattern>
@@ -2311,7 +2311,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="second-narrow">
 				<displayName draft="unconfirmed">tsn.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">tura</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">deg {0} tsn.</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">deg {0} tsn.</relativeTimePattern>
@@ -4615,7 +4615,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -5238,7 +5238,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="GBP">
 				<displayName>Apund Aglizi</displayName>
 				<displayName count="one" draft="unconfirmed">Apund aglizi</displayName>
-				<displayName count="other" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="other" draft="unconfirmed">Apund Aglizi</displayName>
 				<symbol draft="unconfirmed">£</symbol>
 				<symbol alt="narrow" draft="unconfirmed">£</symbol>
 			</currency>
@@ -6489,7 +6489,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern draft="unconfirmed">{0} deg {1}</compoundUnitPattern>
@@ -6648,7 +6648,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern draft="unconfirmed">{0} i useggas</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ayyuren</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0} n wayyur</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} n wayyuren</unitPattern>
 				<perUnitPattern draft="unconfirmed">{0} i wayyur</perUnitPattern>
@@ -7363,9 +7363,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} nqd</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ipiksilen</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} pks</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} pks</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName draft="unconfirmed">R⊕</displayName>
@@ -7739,56 +7739,56 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0}Aṭ</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">st</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} st</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} st</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mrw</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} mrw</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} mrw</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName draft="unconfirmed">sg</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}g</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}g</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/g</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName draft="unconfirmed">ayyur</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}y</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}y</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/y</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName draft="unconfirmed">ml</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}m</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}m</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName draft="unconfirmed">ass</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}s</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}s</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName draft="unconfirmed">asrag</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}r</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}r</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/r</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName draft="unconfirmed">tsd</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}d</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}d</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/tsd</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName draft="unconfirmed">tsn</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}n</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}n</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/n</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName draft="unconfirmed">mtsn</displayName>
@@ -7796,53 +7796,53 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} mn</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">μtsn</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} μn</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} μn</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">nanutsn</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} nn</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} nn</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<unitPattern count="one" draft="unconfirmed">{0}kWh/100km</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">em</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} em</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName draft="unconfirmed">pks</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} pks</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} pks</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName draft="unconfirmed">MP</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} MP</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ppsm</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ppsm</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ppsm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ppi</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ppi</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">nqsm</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} nqsm</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} nqsm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">nqd</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} nqd</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} nqd</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName draft="unconfirmed">taneqqiḍt</displayName>
@@ -7853,18 +7853,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">km</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}km</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}km</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName draft="unconfirmed">m</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0} m</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} m</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">dm</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} dm</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName draft="unconfirmed">sm</displayName>
@@ -7877,22 +7877,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">pm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}pm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">imilen</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mi</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">iyarden</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} yd</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-inch">
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/db</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName draft="unconfirmed">aparsik</displayName>
@@ -7901,13 +7901,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-light-year">
 				<displayName draft="unconfirmed">gf</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} gf</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} gf</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">fl</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} fl</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} fl</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName draft="unconfirmed">kg</displayName>
@@ -7935,19 +7935,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">m³</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} m³</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} m³</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">sm³</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} sm³</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} sm³</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/sm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mi³</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mi³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mi³</unitPattern>
 			</unit>
@@ -7967,7 +7967,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0}db³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ML</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}ML</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}ML</unitPattern>
 			</unit>
@@ -8030,20 +8030,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0} neɣ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0}, neɣ {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} neɣ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0}, neɣ {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} neɣ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0}, {1}</listPatternPart>
 		</listPattern>

--- a/common/main/kea.xml
+++ b/common/main/kea.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1149,8 +1149,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">pm</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">am</dayPeriod>
+							<dayPeriod type="pm">pm</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">am</dayPeriod>
@@ -1159,16 +1159,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">am</dayPeriod>
+							<dayPeriod type="pm">pm</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">am</dayPeriod>
+							<dayPeriod type="pm">pm</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">am</dayPeriod>
+							<dayPeriod type="pm">pm</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -1465,10 +1465,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>era</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>era</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>era</displayName>
 			</field>
 			<field type="year">
 				<displayName>anu</displayName>
@@ -1484,9 +1484,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>anu</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">anu pasadu</relative>
+				<relative type="0">es anu li</relative>
+				<relative type="1">prósimu anu</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">di li {0} anu</relativeTimePattern>
 				</relativeTime>
@@ -1496,9 +1496,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>anu</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">anu pasadu</relative>
+				<relative type="0">es anu li</relative>
+				<relative type="1">prósimu anu</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">di li {0} anu</relativeTimePattern>
 				</relativeTime>
@@ -1550,9 +1550,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName>mes</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mes pasadu</relative>
+				<relative type="0">es mes li</relative>
+				<relative type="1">prósimu mes</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">di li {0} mes</relativeTimePattern>
 				</relativeTime>
@@ -1562,9 +1562,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>mes</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mes pasadu</relative>
+				<relative type="0">es mes li</relative>
+				<relative type="1">prósimu mes</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">di li {0} mes</relativeTimePattern>
 				</relativeTime>
@@ -1587,9 +1587,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>sim.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">simana pasadu</relative>
+				<relative type="0">es simana li</relative>
+				<relative type="1">prósimu simana</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">di li {0} sim.</relativeTimePattern>
 				</relativeTime>
@@ -1600,9 +1600,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>sim.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">simana pasadu</relative>
+				<relative type="0">es simana li</relative>
+				<relative type="1">prósimu simana</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">di li {0} sim.</relativeTimePattern>
 				</relativeTime>
@@ -1634,8 +1634,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>dia</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">onti</relative>
+				<relative type="0">oji</relative>
 				<relative type="1">manhan</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">di li {0} dia</relativeTimePattern>
@@ -1646,8 +1646,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>dia</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">onti</relative>
+				<relative type="0">oji</relative>
 				<relative type="1">manhan</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">di li {0} dia</relativeTimePattern>
@@ -1672,7 +1672,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>dia di sim.</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>dia di sim.</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>dia di simana di mes</displayName>
@@ -1915,13 +1915,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>am/pm</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>am/pm</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>am/pm</displayName>
 			</field>
 			<field type="hour">
 				<displayName>ora</displayName>
@@ -2011,10 +2011,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ora lokal</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ora lokal</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ora lokal</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -2817,7 +2817,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="GHC">
 				<displayName>Sedi di Gana (1979–2007)</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Sedi di Gana (1979–2007)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GMD">
@@ -3117,7 +3117,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="STN">
 				<displayName>Dobra di San Tume i Prínsipi</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dobra di San Tume i Prínsipi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -3385,8 +3385,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} pur pulegada kuadradu</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>kilati</displayName>
@@ -3417,8 +3417,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} pontu bazi</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litru pur kilómetru</displayName>
@@ -3544,11 +3544,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} miliamper</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>ohm</displayName>
 				<unitPattern count="other">{0} ohm</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>volt</displayName>
 				<unitPattern count="other">{0} volt</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
@@ -3568,7 +3568,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} kilojoule</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>J</displayName>
 				<unitPattern count="other">{0} joule</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
@@ -3881,8 +3881,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} nó</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>grau Celsius</displayName>
@@ -4439,16 +4439,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
@@ -4862,80 +4862,80 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100km</displayName>
@@ -4990,20 +4990,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
+				<displayName>kg</displayName>
 				<unitPattern count="other">{0}kg</unitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°C</displayName>
+				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
@@ -5011,10 +5011,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<coordinateUnit>
 				<displayName>direson</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="east">{0} E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0} S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0} W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -5041,28 +5041,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} o {1}</listPatternPart>
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} o {1}</listPatternPart>
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} i {1}</listPatternPart>
+			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} i {1}</listPatternPart>
+			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/kgp.xml
+++ b/common/main/kgp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -7062,7 +7062,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0} por {1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>tar g</displayName>
@@ -7151,7 +7151,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">dunam {0}</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -7185,13 +7185,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mil ki</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>pãntu mase</displayName>
 				<unitPattern count="one">{0} pãntu mase</unitPattern>
 				<unitPattern count="other">{0} pãntu mase ag</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mol ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7261,12 +7261,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-byte">
 				<displayName>byte ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} byte</unitPattern>
 				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>bit ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bit</unitPattern>
 				<unitPattern count="other">{0} bit ag</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -7433,8 +7433,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipografiko em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pixel ag</displayName>
@@ -7707,7 +7707,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>bar ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bar ag</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -7761,9 +7761,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kagje ag</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>grav Celsius ag</displayName>
@@ -7942,27 +7942,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>tar g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>mẽturo/seg²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rev</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>radiano ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>grav ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
@@ -7977,46 +7977,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hegtar ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>mẽturo² ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>milha² ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>akre ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>jarda² ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>tipẽn² ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
@@ -8047,7 +8047,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>kupar ‘e/milhão ki</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
@@ -8062,12 +8062,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>pãntu mase</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -8181,13 +8181,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-hour">
 				<displayName>óra ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>mĩn</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -8199,47 +8199,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>mĩrisigũnu ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amps</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>mĩriamps</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>ohms</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>volts</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
@@ -8249,22 +8249,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kirojoule</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>joule ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kW-óra</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elétron-volt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -8279,120 +8279,120 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>rimra-tar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pixel ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapixel ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>milha ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>jarda ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
@@ -8409,7 +8409,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-parsec">
 				<displayName>parsec ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
@@ -8437,27 +8437,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pãntu ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>rã nogno</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>jẽngrẽ ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>rã jẽngrẽ ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8467,24 +8467,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>grỹmỹ ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
@@ -8497,19 +8497,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-pound">
 				<displayName>rimra ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz troy</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-carat">
@@ -8519,42 +8519,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>ga-pãgoj ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>rã-pãgoj ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>watt ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
@@ -8569,12 +8569,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} psi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
@@ -8584,7 +8584,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
@@ -8594,32 +8594,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>mẽturo ag/seg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
@@ -8634,7 +8634,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
@@ -8649,49 +8649,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>jarda³ ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>tipẽn3 ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
@@ -8711,7 +8711,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ritru ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -8759,12 +8759,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qts</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pint ag</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup">
@@ -8779,7 +8779,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -8794,7 +8794,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>marir</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -8807,10 +8807,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName draft="contributed">tar g</displayName>
@@ -8923,13 +8923,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-hour">
 				<displayName>óra</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} h</unitPattern>
+				<unitPattern count="other">{0} h</unitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mĩn</displayName>
+				<unitPattern count="one">{0} min</unitPattern>
+				<unitPattern count="other">{0} min</unitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>sig</displayName>
@@ -8939,29 +8939,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern draft="contributed">{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName draft="contributed">mil</displayName>
@@ -9007,7 +9007,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} mn</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
+				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
 			</unit>
@@ -9045,7 +9045,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>km/h</displayName>
 				<unitPattern count="one">{0} km/h</unitPattern>
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
@@ -9080,8 +9080,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<coordinateUnit>
 				<displayName>kãtá</displayName>
 				<coordinateUnitPattern type="east">{0}L</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0} S</coordinateUnitPattern>
 				<coordinateUnitPattern type="west">{0}O</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
@@ -9109,20 +9109,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ketũmỹr {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ketũmỹr {1}</listPatternPart>
+			<listPatternPart type="2">{0} ketũmỹr {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ketũmỹr {1}</listPatternPart>
+			<listPatternPart type="2">{0} ketũmỹr {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -9133,8 +9133,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} kar {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} kar {1}</listPatternPart>
 			<listPatternPart type="2">{0} kar {1}</listPatternPart>
 		</listPattern>
@@ -9145,8 +9145,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} kar {1}</listPatternPart>
 			<listPatternPart type="2">{0} kar {1}</listPatternPart>
 		</listPattern>

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -82,8 +82,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">чероки тілі</language>
 			<language type="chy">шайен тілі</language>
 			<language type="ckb">сорани тілі</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">сорани тілі</language>
+			<language type="ckb" alt="variant">сорани тілі</language>
 			<language type="clc">чилкотин тілі</language>
 			<language type="co">корсика тілі</language>
 			<language type="crg">мичиф тілі</language>
@@ -938,7 +938,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Тунис</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Түркия</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Түркия</territory>
 			<territory type="TT">Тринидад және Тобаго</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тайвань</territory>
@@ -1290,19 +1290,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Тут</month>
+							<month type="2" draft="contributed">Баба</month>
+							<month type="3" draft="contributed">Хатур</month>
+							<month type="4" draft="contributed">Кийяк</month>
+							<month type="5" draft="contributed">Туба</month>
+							<month type="6" draft="contributed">Ашмир</month>
+							<month type="7" draft="contributed">Барамхат</month>
+							<month type="8" draft="contributed">Барамуда</month>
+							<month type="9" draft="contributed">Башанс</month>
+							<month type="10" draft="contributed">Ба’уна</month>
+							<month type="11" draft="contributed">’абиб</month>
+							<month type="12" draft="contributed">Мисра</month>
+							<month type="13" draft="contributed">Наси’</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="contributed">1</month>
@@ -1337,19 +1337,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Тут</month>
+							<month type="2" draft="contributed">Баба</month>
+							<month type="3" draft="contributed">Хатур</month>
+							<month type="4" draft="contributed">Кийяк</month>
+							<month type="5" draft="contributed">Туба</month>
+							<month type="6" draft="contributed">Ашмир</month>
+							<month type="7" draft="contributed">Барамхат</month>
+							<month type="8" draft="contributed">Барамуда</month>
+							<month type="9" draft="contributed">Башанс</month>
+							<month type="10" draft="contributed">Ба’уна</month>
+							<month type="11" draft="contributed">’абиб</month>
+							<month type="12" draft="contributed">Мисра</month>
+							<month type="13" draft="contributed">Наси’</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="contributed">↑↑↑</month>
@@ -1367,8 +1367,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="13" draft="contributed">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Тут</month>
+							<month type="2" draft="contributed">Баба</month>
 							<month type="3" draft="contributed">Хатур</month>
 							<month type="4" draft="contributed">Кийяк</month>
 							<month type="5" draft="contributed">Туба</month>
@@ -1417,7 +1417,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1425,7 +1425,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1433,7 +1433,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1441,7 +1441,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1918,15 +1918,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraNames>
 					<eraAbbr>
 						<era type="0">б.з.д.</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">б.з.д.</era>
 						<era type="1">б.з.</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">б.з.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
-						<era type="0" alt="variant" draft="contributed">↑↑↑</era>
-						<era type="1" draft="contributed">↑↑↑</era>
-						<era type="1" alt="variant" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">б.з.д.</era>
+						<era type="0" alt="variant" draft="contributed">б.з.д.</era>
+						<era type="1" draft="contributed">б.з.</era>
+						<era type="1" alt="variant" draft="contributed">б.з.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -1987,7 +1987,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1995,7 +1995,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2003,7 +2003,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2011,7 +2011,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2216,20 +2216,70 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Тишрей</month>
+							<month type="2" draft="contributed">Хешван</month>
+							<month type="3" draft="contributed">Кислев</month>
+							<month type="4" draft="contributed">Тевет</month>
+							<month type="5" draft="contributed">Шват</month>
+							<month type="6" draft="contributed">Адар I</month>
+							<month type="7" draft="contributed">Адар</month>
+							<month type="7" yeartype="leap" draft="contributed">Адар II</month>
+							<month type="8" draft="contributed">Нисан</month>
+							<month type="9" draft="contributed">Ияр</month>
+							<month type="10" draft="contributed">Сиван</month>
+							<month type="11" draft="contributed">Тамуз</month>
+							<month type="12" draft="contributed">Ав</month>
+							<month type="13" draft="contributed">Элул</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1" draft="contributed">1</month>
+							<month type="2" draft="contributed">2</month>
+							<month type="3" draft="contributed">3</month>
+							<month type="4" draft="contributed">4</month>
+							<month type="5" draft="contributed">5</month>
+							<month type="6" draft="contributed">6</month>
+							<month type="7" draft="contributed">7</month>
+							<month type="7" yeartype="leap" draft="contributed">7</month>
+							<month type="8" draft="contributed">8</month>
+							<month type="9" draft="contributed">9</month>
+							<month type="10" draft="contributed">10</month>
+							<month type="11" draft="contributed">11</month>
+							<month type="12" draft="contributed">12</month>
+							<month type="13" draft="contributed">13</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1" draft="contributed">Тишрей</month>
+							<month type="2" draft="contributed">Хешван</month>
+							<month type="3" draft="contributed">Кислев</month>
+							<month type="4" draft="contributed">Тевет</month>
+							<month type="5" draft="contributed">Шват</month>
+							<month type="6" draft="contributed">Адар I</month>
+							<month type="7" draft="contributed">Адар</month>
+							<month type="7" yeartype="leap" draft="contributed">Адар II</month>
+							<month type="8" draft="contributed">Нисан</month>
+							<month type="9" draft="contributed">Ияр</month>
+							<month type="10" draft="contributed">Сиван</month>
+							<month type="11" draft="contributed">Тамуз</month>
+							<month type="12" draft="contributed">Ав</month>
+							<month type="13" draft="contributed">Элул</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1" draft="contributed">Тишрей</month>
+							<month type="2" draft="contributed">Хешван</month>
+							<month type="3" draft="contributed">Кислев</month>
+							<month type="4" draft="contributed">Тевет</month>
+							<month type="5" draft="contributed">Шват</month>
+							<month type="6" draft="contributed">Адар I</month>
+							<month type="7" draft="contributed">Адар</month>
+							<month type="7" yeartype="leap" draft="contributed">Адар II</month>
+							<month type="8" draft="contributed">Нисан</month>
+							<month type="9" draft="contributed">Ияр</month>
+							<month type="10" draft="contributed">Сиван</month>
+							<month type="11" draft="contributed">Тамуз</month>
+							<month type="12" draft="contributed">Ав</month>
+							<month type="13" draft="contributed">Элул</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="contributed">↑↑↑</month>
@@ -2264,74 +2314,68 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="13" draft="contributed">Элул</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 			</calendar>
 			<calendar type="indian">
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Чайтра</month>
+							<month type="2" draft="contributed">Вайшакха</month>
+							<month type="3" draft="contributed">Джьештха</month>
+							<month type="4" draft="contributed">Ашадха</month>
+							<month type="5" draft="contributed">Шравана</month>
+							<month type="6" draft="contributed">Бхадрапада</month>
+							<month type="7" draft="contributed">Ашвина</month>
+							<month type="8" draft="contributed">Картика</month>
+							<month type="9" draft="contributed">Маргаширша</month>
+							<month type="10" draft="contributed">Пауша</month>
+							<month type="11" draft="contributed">Магха</month>
+							<month type="12" draft="contributed">Пхальгуна</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1" draft="contributed">1</month>
+							<month type="2" draft="contributed">2</month>
+							<month type="3" draft="contributed">3</month>
+							<month type="4" draft="contributed">4</month>
+							<month type="5" draft="contributed">5</month>
+							<month type="6" draft="contributed">6</month>
+							<month type="7" draft="contributed">7</month>
+							<month type="8" draft="contributed">8</month>
+							<month type="9" draft="contributed">9</month>
+							<month type="10" draft="contributed">10</month>
+							<month type="11" draft="contributed">11</month>
+							<month type="12" draft="contributed">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1" draft="contributed">Чайтра</month>
+							<month type="2" draft="contributed">Вайшакха</month>
+							<month type="3" draft="contributed">Джьештха</month>
+							<month type="4" draft="contributed">Ашадха</month>
+							<month type="5" draft="contributed">Шравана</month>
+							<month type="6" draft="contributed">Бхадрапада</month>
+							<month type="7" draft="contributed">Ашвина</month>
+							<month type="8" draft="contributed">Картика</month>
+							<month type="9" draft="contributed">Маргаширша</month>
+							<month type="10" draft="contributed">Пауша</month>
+							<month type="11" draft="contributed">Магха</month>
+							<month type="12" draft="contributed">Пхальгуна</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1" draft="contributed">Чайтра</month>
+							<month type="2" draft="contributed">Вайшакха</month>
+							<month type="3" draft="contributed">Джьештха</month>
+							<month type="4" draft="contributed">Ашадха</month>
+							<month type="5" draft="contributed">Шравана</month>
+							<month type="6" draft="contributed">Бхадрапада</month>
+							<month type="7" draft="contributed">Ашвина</month>
+							<month type="8" draft="contributed">Картика</month>
+							<month type="9" draft="contributed">Маргаширша</month>
+							<month type="10" draft="contributed">Пауша</month>
+							<month type="11" draft="contributed">Магха</month>
+							<month type="12" draft="contributed">Пхальгуна</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="contributed">↑↑↑</month>
@@ -2362,50 +2406,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12" draft="contributed">Пхальгуна</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 			</calendar>
 			<calendar type="islamic">
@@ -2426,18 +2426,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12" draft="contributed">Жел.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">1</month>
+							<month type="2" draft="contributed">2</month>
+							<month type="3" draft="contributed">3</month>
+							<month type="4" draft="contributed">4</month>
+							<month type="5" draft="contributed">5</month>
+							<month type="6" draft="contributed">6</month>
+							<month type="7" draft="contributed">7</month>
+							<month type="8" draft="contributed">8</month>
+							<month type="9" draft="contributed">9</month>
+							<month type="10" draft="contributed">10</month>
+							<month type="11" draft="contributed">11</month>
+							<month type="12" draft="contributed">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1" draft="contributed">Мұхаррам</month>
@@ -2470,18 +2470,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12" draft="contributed">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Мұхаррам</month>
+							<month type="2" draft="contributed">Сафар</month>
+							<month type="3" draft="contributed">Рабиғ әл-әууәл</month>
+							<month type="4" draft="contributed">Рабиғ әс-сәни</month>
+							<month type="5" draft="contributed">Джумада әл-әууәл</month>
+							<month type="6" draft="contributed">Жумад ас-сәни</month>
+							<month type="7" draft="contributed">Раджаб</month>
+							<month type="8" draft="contributed">Шағбан</month>
+							<month type="9" draft="contributed">Рамадан</month>
+							<month type="10" draft="contributed">Шәууәл</month>
+							<month type="11" draft="contributed">Зул-Қағда</month>
+							<month type="12" draft="contributed">Зул-Хиджа</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -2490,18 +2490,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Фарвардин</month>
+							<month type="2" draft="contributed">Ордибехешт</month>
+							<month type="3" draft="contributed">Хордад</month>
+							<month type="4" draft="contributed">Тир</month>
+							<month type="5" draft="contributed">Мордад</month>
+							<month type="6" draft="contributed">Шахривар</month>
+							<month type="7" draft="contributed">Мехр</month>
+							<month type="8" draft="contributed">Абан</month>
+							<month type="9" draft="contributed">Азар</month>
+							<month type="10" draft="contributed">Дей</month>
+							<month type="11" draft="contributed">Бахман</month>
+							<month type="12" draft="contributed">Эсфанд</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1" draft="contributed">1</month>
+							<month type="2" draft="contributed">2</month>
+							<month type="3" draft="contributed">3</month>
+							<month type="4" draft="contributed">4</month>
+							<month type="5" draft="contributed">5</month>
+							<month type="6" draft="contributed">6</month>
+							<month type="7" draft="contributed">7</month>
+							<month type="8" draft="contributed">8</month>
+							<month type="9" draft="contributed">9</month>
+							<month type="10" draft="contributed">10</month>
+							<month type="11" draft="contributed">11</month>
+							<month type="12" draft="contributed">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1" draft="contributed">Фарвардин</month>
+							<month type="2" draft="contributed">Ордибехешт</month>
+							<month type="3" draft="contributed">Хордад</month>
+							<month type="4" draft="contributed">Тир</month>
+							<month type="5" draft="contributed">Мордад</month>
+							<month type="6" draft="contributed">Шахривар</month>
+							<month type="7" draft="contributed">Мехр</month>
+							<month type="8" draft="contributed">Абан</month>
+							<month type="9" draft="contributed">Азар</month>
+							<month type="10" draft="contributed">Дей</month>
+							<month type="11" draft="contributed">Бахман</month>
+							<month type="12" draft="contributed">Эсфанд</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1" draft="contributed">Фарвардин</month>
+							<month type="2" draft="contributed">Ордибехешт</month>
+							<month type="3" draft="contributed">Хордад</month>
+							<month type="4" draft="contributed">Тир</month>
+							<month type="5" draft="contributed">Мордад</month>
+							<month type="6" draft="contributed">Шахривар</month>
+							<month type="7" draft="contributed">Мехр</month>
+							<month type="8" draft="contributed">Абан</month>
+							<month type="9" draft="contributed">Азар</month>
+							<month type="10" draft="contributed">Дей</month>
+							<month type="11" draft="contributed">Бахман</month>
+							<month type="12" draft="contributed">Эсфанд</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="contributed">↑↑↑</month>
@@ -2530,50 +2574,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="10" draft="contributed">Дей</month>
 							<month type="11" draft="contributed">Бахман</month>
 							<month type="12" draft="contributed">Эсфанд</month>
-						</monthWidth>
-					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -2605,9 +2605,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>ж.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">былтырғы жыл</relative>
+				<relative type="0">биылғы жыл</relative>
+				<relative type="1">келесі жыл</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ж. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ж. кейін</relativeTimePattern>
@@ -2619,9 +2619,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>ж.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">былтырғы жыл</relative>
+				<relative type="0">биылғы жыл</relative>
+				<relative type="1">келесі жыл</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ж. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ж. кейін</relativeTimePattern>
@@ -2647,9 +2647,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-short">
 				<displayName>ш.</displayName>
-				<relative type="-1" draft="contributed">↑↑↑</relative>
-				<relative type="0" draft="contributed">↑↑↑</relative>
-				<relative type="1" draft="contributed">↑↑↑</relative>
+				<relative type="-1" draft="contributed">өткен тоқсан</relative>
+				<relative type="0" draft="contributed">осы тоқсан</relative>
+				<relative type="1" draft="contributed">келесі тоқсан</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} тқс. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} тқс. кейін</relativeTimePattern>
@@ -2661,9 +2661,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-narrow">
 				<displayName>ш.</displayName>
-				<relative type="-1" draft="contributed">↑↑↑</relative>
-				<relative type="0" draft="contributed">↑↑↑</relative>
-				<relative type="1" draft="contributed">↑↑↑</relative>
+				<relative type="-1" draft="contributed">өткен тоқсан</relative>
+				<relative type="0" draft="contributed">осы тоқсан</relative>
+				<relative type="1" draft="contributed">келесі тоқсан</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} тқс. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} тқс. кейін</relativeTimePattern>
@@ -2732,9 +2732,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>ап.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">өткен апта</relative>
+				<relative type="0">осы апта</relative>
+				<relative type="1">келесі апта</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ап. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ап. кейін</relativeTimePattern>
@@ -2747,9 +2747,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>ап.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">өткен апта</relative>
+				<relative type="0">осы апта</relative>
+				<relative type="1">келесі апта</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ап. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ап. кейін</relativeTimePattern>
@@ -3140,7 +3140,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>сағ</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">осы сағат</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} сағ. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} сағ. кейін</relativeTimePattern>
@@ -3152,7 +3152,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>сағ</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">осы сағат</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} сағ. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} сағ. кейін</relativeTimePattern>
@@ -3176,7 +3176,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>мин.</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">осы минут</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} мин. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} мин. кейін</relativeTimePattern>
@@ -3188,7 +3188,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>мин</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">осы минут</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} мин. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} мин. кейін</relativeTimePattern>
@@ -3212,7 +3212,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>с</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">қазір</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} сек. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} сек. кейін</relativeTimePattern>
@@ -3224,7 +3224,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>с</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">қазір</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} сек. кейін</relativeTimePattern>
 					<relativeTimePattern count="other">{0} сек. кейін</relativeTimePattern>
@@ -6776,7 +6776,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">текше {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>гравитациялық күш</displayName>
@@ -7023,7 +7023,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>аптасына {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
+				<displayName>күн</displayName>
 				<unitPattern count="one">{0} күн</unitPattern>
 				<unitPattern count="other">{0} күн</unitPattern>
 				<perUnitPattern>күніне {0}</perUnitPattern>
@@ -7692,8 +7692,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>британдық десерт қасығы</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} брит. дес. қас.</unitPattern>
+				<unitPattern count="other">{0} брит. дес. қас.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>тамшы</displayName>
@@ -7716,9 +7716,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} шөкім</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>брит. кварта</displayName>
 				<unitPattern count="one">{0} британдық кварта</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} брит. кварта</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>негізгі бағыт</displayName>
@@ -7818,12 +7818,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8219,7 +8219,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>пиксель</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} пиксель</unitPattern>
 				<unitPattern count="other">{0} пиксель</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
@@ -8229,7 +8229,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>пиксель/см</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} пиксель/см</unitPattern>
 				<unitPattern count="other">{0} пиксель/см</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
@@ -8254,7 +8254,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -8359,7 +8359,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-point">
 				<displayName>пункт</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} пункт</unitPattern>
 				<unitPattern count="other">{0} пункт</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
@@ -8868,40 +8868,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName draft="contributed">гр-күш</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName draft="contributed">м/с²</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} м/с²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} м/с²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">айн.</displayName>
+				<unitPattern count="one" draft="contributed">{0} айн.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} айн.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName draft="contributed">рад</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} рад</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} рад</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">градус</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
@@ -8916,27 +8916,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">км²</displayName>
 				<unitPattern count="one">{0} км²</unitPattern>
 				<unitPattern count="other">{0} км²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/км²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">гектар</displayName>
 				<unitPattern count="one">{0} га</unitPattern>
 				<unitPattern count="other">{0} га</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">метр²</displayName>
 				<unitPattern count="one">{0} м²</unitPattern>
 				<unitPattern count="other">{0} м²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/м²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">cм²</displayName>
+				<unitPattern count="one" draft="contributed">{0} cм²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cм²</unitPattern>
+				<perUnitPattern draft="contributed">{0}/см²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName draft="contributed">миль²</displayName>
@@ -8945,14 +8945,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/миль²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">акр</displayName>
 				<unitPattern count="one">{0} акр</unitPattern>
 				<unitPattern count="other">{0} акр</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ярд²</displayName>
+				<unitPattern count="one" draft="contributed">{0} ярд²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ярд²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName draft="contributed">фут²</displayName>
@@ -8960,30 +8960,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} фут²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">дюйм²</displayName>
+				<unitPattern count="one" draft="contributed">{0} дюйм²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дюйм²</unitPattern>
+				<perUnitPattern draft="contributed">{0}/дюйм²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дунам</displayName>
+				<unitPattern count="one" draft="contributed">{0} дунам</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дунам</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">карат</displayName>
+				<unitPattern count="one" draft="contributed">{0} кар.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кар.</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мг/дл</displayName>
+				<unitPattern count="one" draft="contributed">{0} мг/дл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мг/дл</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ммоль/л</displayName>
+				<unitPattern count="one" draft="contributed">{0} ммоль/л</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ммоль/л</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>элемент</displayName>
@@ -8991,9 +8991,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} элемент</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ppm</displayName>
+				<unitPattern count="one" draft="contributed">{0} ppm</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9002,23 +9002,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName draft="contributed">‰</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0}‰</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">промириад</displayName>
+				<unitPattern count="one" draft="contributed">{0}‱</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">моль</displayName>
+				<unitPattern count="one" draft="contributed">{0} моль</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} моль</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName draft="contributed">л/км</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} л/км</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} л/км</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>л/100 км</displayName>
@@ -9037,74 +9037,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName draft="contributed">ПБ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ПБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ПБ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName draft="contributed">ТБ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} TБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} TБ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Тбит</displayName>
+				<unitPattern count="one" draft="contributed">{0} Tб</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Tб</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName draft="contributed">ГБ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ГБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ГБ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName draft="contributed">Гб</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Гб</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Гб</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName draft="contributed">МБ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} MБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MБ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName draft="contributed">Мб</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Mб</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Mб</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName draft="contributed">кБ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} кБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кБ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName draft="contributed">кб</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} кб</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кб</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">байт</displayName>
+				<unitPattern count="one" draft="contributed">{0} байт</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} байт</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">бит</displayName>
+				<unitPattern count="one" draft="contributed">{0} бит</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} бит</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ғ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} ғ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ғ.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">декада</displayName>
+				<unitPattern count="one">{0} декада</unitPattern>
+				<unitPattern count="other">{0} декада</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ж.</displayName>
 				<unitPattern count="one">{0} ж.</unitPattern>
 				<unitPattern count="other">{0} ж.</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/ж.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName draft="contributed">тоқсан</displayName>
@@ -9116,7 +9116,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ай</displayName>
 				<unitPattern count="one">{0} ай</unitPattern>
 				<unitPattern count="other">{0} ай</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/ай</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ап.</displayName>
@@ -9128,25 +9128,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>күн</displayName>
 				<unitPattern count="one">{0} к.</unitPattern>
 				<unitPattern count="other">{0} к.</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/күн</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>сағ</displayName>
 				<unitPattern count="one">{0} сағ</unitPattern>
 				<unitPattern count="other">{0} сағ</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/сағ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>мин</displayName>
 				<unitPattern count="one">{0} мин</unitPattern>
 				<unitPattern count="other">{0} мин</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/мин</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>с</displayName>
 				<unitPattern count="one">{0} с</unitPattern>
 				<unitPattern count="other">{0} с</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/с</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>мс</displayName>
@@ -9154,74 +9154,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мс</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мкс</displayName>
+				<unitPattern count="one" draft="contributed">{0} мкс</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мкс</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">нс</displayName>
+				<unitPattern count="one" draft="contributed">{0} нс</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} нс</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">А</displayName>
+				<unitPattern count="one" draft="contributed">{0} A</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName draft="contributed">мА</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} мA</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Ом</displayName>
+				<unitPattern count="one" draft="contributed">{0} Ом</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Ом</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">вольт</displayName>
+				<unitPattern count="one" draft="contributed">{0} В</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} В</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ккал</displayName>
+				<unitPattern count="one" draft="contributed">{0} ккал</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">кал</displayName>
+				<unitPattern count="one" draft="contributed">{0} кал</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName draft="contributed">Кал</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} кал</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName draft="contributed">кДж</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} кДж</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кДж</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">джоуль</displayName>
+				<unitPattern count="one" draft="contributed">{0} Дж</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Дж</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">кВт-сағ</displayName>
+				<unitPattern count="one" draft="contributed">{0} кВт-сағ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кВт-сағ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">эВ</displayName>
+				<unitPattern count="one" draft="contributed">{0} эВ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} эВ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">BTU</displayName>
+				<unitPattern count="one" draft="contributed">{0} Btu</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName draft="contributed">АҚШ термі</displayName>
@@ -9229,14 +9229,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} АҚШ термі</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">фунт-күш</displayName>
+				<unitPattern count="one" draft="contributed">{0} lbf</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Н</displayName>
+				<unitPattern count="one" draft="contributed">{0} Н</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Н</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>кВт-сағ/100 км</displayName>
@@ -9244,29 +9244,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} кВт-сағ/100 км</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ГГц</displayName>
+				<unitPattern count="one" draft="contributed">{0} ГГц</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ГГц</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">МГц</displayName>
+				<unitPattern count="one" draft="contributed">{0} MГц</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MГц</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">кГц</displayName>
+				<unitPattern count="one" draft="contributed">{0} кГц</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кГц</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Гц</displayName>
+				<unitPattern count="one" draft="contributed">{0} Гц</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Гц</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">эм</displayName>
+				<unitPattern count="one" draft="contributed">{0} эм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} эм</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName draft="contributed">пиксель</displayName>
@@ -9274,14 +9274,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} пиксель</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мегапиксель</displayName>
+				<unitPattern count="one" draft="contributed">{0} Мп</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Мп</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">пиксель/см</displayName>
+				<unitPattern count="one" draft="contributed">{0} пиксель/см</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} пиксель/см</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName draft="contributed">пиксель/дюйм</displayName>
@@ -9289,47 +9289,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} пиксель/дюйм</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">нүкте/см</displayName>
+				<unitPattern count="one" draft="contributed">{0} нүкте/см</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} нүкте/см</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">нүкте/дюйм</displayName>
+				<unitPattern count="one" draft="contributed">{0} нүкте/дюйм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} нүкте/дюйм</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">пиксель</displayName>
+				<unitPattern count="one" draft="contributed">{0} пиксель</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} пиксель</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">R⊕</displayName>
+				<unitPattern count="one" draft="contributed">{0} R⊕</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>км</displayName>
 				<unitPattern count="one">{0} км</unitPattern>
 				<unitPattern count="other">{0} км</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/км</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>м</displayName>
 				<unitPattern count="one">{0} м</unitPattern>
 				<unitPattern count="other">{0} м</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/м</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дм</displayName>
+				<unitPattern count="one" draft="contributed">{0} дм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дм</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>см</displayName>
 				<unitPattern count="one">{0} см</unitPattern>
 				<unitPattern count="other">{0} см</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/см</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>мм</displayName>
@@ -9337,17 +9337,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мм</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мкм</displayName>
+				<unitPattern count="one" draft="contributed">{0} мкм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мкм</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">нм</displayName>
+				<unitPattern count="one" draft="contributed">{0} нм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} нм</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">пм</displayName>
 				<unitPattern count="one">{0} пм</unitPattern>
 				<unitPattern count="other">{0} пм</unitPattern>
 			</unit>
@@ -9357,31 +9357,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} миля</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ярд</displayName>
 				<unitPattern count="one">{0} ярд</unitPattern>
 				<unitPattern count="other">{0} ярд</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">фут</displayName>
 				<unitPattern count="one">{0} фут</unitPattern>
 				<unitPattern count="other">{0} фут</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/фут</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">дюйм</displayName>
 				<unitPattern count="one">{0} дюйм</unitPattern>
 				<unitPattern count="other">{0} дюйм</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/дюйм</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">парсек</displayName>
+				<unitPattern count="one" draft="contributed">{0} пк</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} пк</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName draft="contributed">ж. ж.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ж. ж.</unitPattern>
+				<unitPattern count="other">{0} ж. ж.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName draft="contributed">а. б.</displayName>
@@ -9389,12 +9389,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} а. б.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">фурлонг</displayName>
 				<unitPattern count="one" draft="contributed">{0} Ф</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} Ф</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">фатом</displayName>
 				<unitPattern count="one" draft="contributed">{0} фатом</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} фатом</unitPattern>
 			</unit>
@@ -9409,19 +9409,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} ск. миль</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">пункт</displayName>
+				<unitPattern count="one" draft="contributed">{0} пункт</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} пункт</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Күн радиусы</displayName>
+				<unitPattern count="one" draft="contributed">{0} R☉</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">люкс</displayName>
+				<unitPattern count="one" draft="contributed">{0} лк</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} лк</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName draft="contributed">кд</displayName>
@@ -9429,103 +9429,103 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} кд</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">лм</displayName>
+				<unitPattern count="one" draft="contributed">{0} лм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} лм</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Күн жарықтығы</displayName>
+				<unitPattern count="one" draft="contributed">{0} L☉</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">т</displayName>
+				<unitPattern count="one" draft="contributed">{0} т</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} т</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>кг</displayName>
 				<unitPattern count="one">{0} кг</unitPattern>
 				<unitPattern count="other">{0} кг</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/кг</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>грамм</displayName>
 				<unitPattern count="one">{0} г</unitPattern>
 				<unitPattern count="other">{0} г</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/г</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мг</displayName>
+				<unitPattern count="one" draft="contributed">{0} мг</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мг</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мкг</displayName>
+				<unitPattern count="one" draft="contributed">{0} мкг</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мкг</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">тонна</displayName>
+				<unitPattern count="one" draft="contributed">{0} тн</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} тн</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">стоун</displayName>
+				<unitPattern count="one" draft="contributed">{0} стоун</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} стоун</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">фунт</displayName>
 				<unitPattern count="one">{0} фунт</unitPattern>
 				<unitPattern count="other">{0} фунт</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/фунт</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">унц.</displayName>
 				<unitPattern count="one">{0} унция</unitPattern>
 				<unitPattern count="other">{0} унция</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/унц.</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">тр. унц.</displayName>
+				<unitPattern count="one" draft="contributed">{0} тр. унц.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} тр. унц.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">карат</displayName>
+				<unitPattern count="one" draft="contributed">{0} кар.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кар.</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Да</displayName>
+				<unitPattern count="one" draft="contributed">{0} Да</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Да</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">M⊕</displayName>
+				<unitPattern count="one" draft="contributed">{0} M⊕</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Күн массасы</displayName>
+				<unitPattern count="one" draft="contributed">{0} M☉</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">гран</displayName>
+				<unitPattern count="one" draft="contributed">{0} гран</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} гран</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ГВт</displayName>
+				<unitPattern count="one" draft="contributed">{0} ГВт</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ГВт</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">МВт</displayName>
+				<unitPattern count="one" draft="contributed">{0} МВт</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} МВт</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName draft="contributed">кВт</displayName>
@@ -9533,54 +9533,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}кВт</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ватт</displayName>
 				<unitPattern count="one">{0} Вт</unitPattern>
 				<unitPattern count="other">{0} Вт</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мВт</displayName>
+				<unitPattern count="one" draft="contributed">{0} мВт</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мВт</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">а. к.</displayName>
 				<unitPattern count="one">{0} ат күші</unitPattern>
 				<unitPattern count="other">{0} ат күші</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мм с.б.</displayName>
+				<unitPattern count="one" draft="contributed">{0} мм с.б.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мм с.б.</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">psi</displayName>
+				<unitPattern count="one" draft="contributed">{0} psi</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName draft="contributed">дюйм с.б.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} дюйм с.б.</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">бар</displayName>
+				<unitPattern count="one" draft="contributed">{0} бар</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} бар</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">мбар</displayName>
 				<unitPattern count="one">{0} мб</unitPattern>
 				<unitPattern count="other">{0} мб</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">атм</displayName>
+				<unitPattern count="one" draft="contributed">{0} атм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} атм</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Па</displayName>
+				<unitPattern count="one" draft="contributed">{0} Па</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Па</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName draft="contributed">гПа</displayName>
@@ -9588,14 +9588,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">кПа</displayName>
+				<unitPattern count="one" draft="contributed">{0} кПа</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кПа</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">МПа</displayName>
+				<unitPattern count="one" draft="contributed">{0} МПа</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} МПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/сағ</displayName>
@@ -9618,9 +9618,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} түйін</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">°</displayName>
+				<unitPattern count="one" draft="contributed">{0}°</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9633,87 +9633,87 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">K</displayName>
+				<unitPattern count="one" draft="contributed">{0} К</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} К</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">lbf⋅ft</displayName>
+				<unitPattern count="one" draft="contributed">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Н⋅м</displayName>
+				<unitPattern count="one" draft="contributed">{0} Н⋅м</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Н⋅м</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">км³</displayName>
 				<unitPattern count="one">{0} км³</unitPattern>
 				<unitPattern count="other">{0} км³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">м³</displayName>
+				<unitPattern count="one" draft="contributed">{0} м³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} м³</unitPattern>
+				<perUnitPattern draft="contributed">{0}/м³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">cм³</displayName>
+				<unitPattern count="one" draft="contributed">{0} cм³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cм³</unitPattern>
+				<perUnitPattern draft="contributed">{0}/см³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">миля³</displayName>
 				<unitPattern count="one">{0} миля³</unitPattern>
 				<unitPattern count="other">{0} миля³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ярд³</displayName>
+				<unitPattern count="one" draft="contributed">{0} ярд³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ярд³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">фут³</displayName>
+				<unitPattern count="one" draft="contributed">{0} фут³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} фут³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дюйм³</displayName>
+				<unitPattern count="one" draft="contributed">{0} дюйм³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дюйм³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Мл</displayName>
+				<unitPattern count="one" draft="contributed">{0} Мл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Мл</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">гл</displayName>
+				<unitPattern count="one" draft="contributed">{0} гл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} гл</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>литр</displayName>
 				<unitPattern count="one">{0} л</unitPattern>
 				<unitPattern count="other">{0} л</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/л</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дл</displayName>
+				<unitPattern count="one" draft="contributed">{0} дл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дл</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">сл</displayName>
+				<unitPattern count="one" draft="contributed">{0} cл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cл</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мл</displayName>
+				<unitPattern count="one" draft="contributed">{0} мл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мл</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName draft="contributed">мпт</displayName>
@@ -9721,7 +9721,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} мпт</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">мк</displayName>
 				<unitPattern count="one" draft="contributed">{0} мша</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} мша</unitPattern>
 			</unit>
@@ -9736,10 +9736,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} бш</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">гал.</displayName>
+				<unitPattern count="one" draft="contributed">{0} гал.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} гал.</unitPattern>
+				<perUnitPattern draft="contributed">{0}/гал.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName draft="contributed">ағыл. галлоны</displayName>
@@ -9753,7 +9753,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} кт</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">пинта</displayName>
 				<unitPattern count="one" draft="contributed">{0} пт</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} пт</unitPattern>
 			</unit>
@@ -9763,9 +9763,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} ша</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">сұй. унц.</displayName>
+				<unitPattern count="one" draft="contributed">{0} сұй. унц.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} сұй. унц.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName draft="contributed">имп. сұй. унц.</displayName>
@@ -9773,14 +9773,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} имп. сұй. унц.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ас қ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} ас қ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ас қ.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ш. қ.</displayName>
+				<unitPattern count="one" draft="contributed">{0} ш. қ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ш. қ.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName draft="contributed">баррель</displayName>
@@ -9788,9 +9788,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} баррель</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дес. қас.</displayName>
+				<unitPattern count="one" draft="contributed">{0} дес. қас.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дес. қас.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName draft="contributed">имп. дес. қас.</displayName>
@@ -9798,29 +9798,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} имп. дес. қас.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">тамшы</displayName>
+				<unitPattern count="one" draft="contributed">{0} тамшы</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} тамшы</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">сұйық драхма</displayName>
+				<unitPattern count="one" draft="contributed">{0} сұй. драхма</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} сұй. драхма</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">джиггер</displayName>
+				<unitPattern count="one" draft="contributed">{0} джиггер</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} джиггер</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">шөкім</displayName>
+				<unitPattern count="one" draft="contributed">{0} шөкім</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} шөкім</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>брит. кварта</displayName>
+				<unitPattern count="one">{0} брит. кварта</unitPattern>
+				<unitPattern count="other">{0} брит. кварта</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>бағыт</displayName>
@@ -9854,27 +9854,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} не {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, не болмаса {1}</listPatternPart>
+			<listPatternPart type="2">{0} не {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, не болмаса {1}</listPatternPart>
+			<listPatternPart type="2">{0} не {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0} және {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0} және {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
@@ -10098,7 +10098,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {surname} {generation}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -10152,7 +10152,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {given-informal}</namePattern>

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -83,8 +83,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">ឆេរូគី</language>
 			<language type="chy">ឈីយីនី</language>
 			<language type="ckb">ឃើដភាគកណ្តាល</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">ឃើដភាគកណ្តាល</language>
+			<language type="ckb" alt="variant">ឃើដភាគកណ្តាល</language>
 			<language type="clc">ឈីលកូទីន</language>
 			<language type="co">កូស៊ីខាន</language>
 			<language type="crg">មីឈីហ្វ</language>
@@ -796,7 +796,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">ណូរូ</territory>
 			<territory type="NU">ណៀ</territory>
 			<territory type="NZ">នូវែល​សេឡង់</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">នូវែល​សេឡង់</territory>
 			<territory type="OM">អូម៉ង់</territory>
 			<territory type="PA">ប៉ាណាម៉ា</territory>
 			<territory type="PE">ប៉េរូ</territory>
@@ -1089,7 +1089,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1097,7 +1097,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1653,7 +1653,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1661,7 +1661,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4764,7 +4764,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="AMD">
 				<displayName>ដ្រាំ​អាមេនី</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">ដ្រាំ​អាមេនី</displayName>
 				<symbol>AMD</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5737,28 +5737,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>យ៉ុតតា{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}​ ក្នុង​មួយ​ {1}</compoundUnitPattern>
@@ -5770,7 +5770,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}គូប</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>កម្លាំង​ទំនាញ</displayName>
@@ -5874,12 +5874,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>លីត្រ​ក្នុង​មួយ​គីឡូម៉ែត្រ</displayName>
@@ -6054,12 +6054,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ឯកតាកម្ដៅអាមេរិក</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>គីឡូវ៉ាត់ម៉ោងក្នុង 100 គីឡូម៉ែត្រ</displayName>
@@ -6082,8 +6082,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ហឺត</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>ភិចស៊ែល</displayName>
@@ -6203,8 +6203,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lux</displayName>
@@ -6219,8 +6219,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} លូមែន</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>តោនម៉ែត្រ</displayName>
@@ -6271,16 +6271,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ការ៉ាត់</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>គ្រាប់</displayName>
@@ -6323,8 +6323,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} អ៊ីញនៃបារត</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>មិល្លីបារ</displayName>
@@ -6383,12 +6383,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} អង្សា​ខែលវិន</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>គីឡូម៉ែត្រ​គូប</displayName>
@@ -6488,8 +6488,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} អោន​វត្ថុ​រាវ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>ស្លាបព្រា​បាយ</displayName>
@@ -6500,16 +6500,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ស្លាបព្រា​កាហ្វេ</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>ស្លាបព្រាបង្អែម</displayName>
 				<unitPattern count="other">{0} ស្លាបព្រាបង្អែម</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>តំណក់</displayName>
@@ -6528,8 +6528,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ច្បិច</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ទិសទាំងបួន</displayName>
@@ -6968,12 +6968,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ចំណុច</displayName>
@@ -7467,123 +7467,123 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>កម្លាំង​ទំនាញ</displayName>
 				<unitPattern count="other">{0} ក.ទ.</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ម៉ែត្រ​/​វិនាទី​ការ៉េ</displayName>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>រ៉ាដ្យង់</displayName>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>ដឺក្រេ</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>អាកនាទី</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>អាកវិនាទី</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="other">{0} គ.ម².</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ហិកតា</displayName>
 				<unitPattern count="other">{0} ហ.</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="other">{0} ម².</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="other">{0} ម៉².</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>អា</displayName>
 				<unitPattern count="other">{0} អា</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="other">{0} ហ្វ².</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>អ៊ីញការ៉េ</displayName>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ឌូណាម</displayName>
+				<unitPattern count="other">{0} ឌូណាម</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ការ៉ាត់</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>ម.ម៉ូល/លី</displayName>
@@ -7594,20 +7594,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} របស់</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>ម៉ូល</displayName>
@@ -7622,69 +7622,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ម៉ាយ​/​ហ្គាឡុង</displayName>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ម៉ាយ/gal Imp.</displayName>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>byte</displayName>
+				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ស.វ</displayName>
+				<unitPattern count="other">{0} ស.វ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ទសវត្សរ៍</displayName>
+				<unitPattern count="other">{0} ទសវត្សរ៍</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ឆ្នាំ</displayName>
 				<unitPattern count="other">{0} ឆ្នាំ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ឆ្នាំ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>ត្រីមាស</displayName>
@@ -7694,352 +7694,352 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-month">
 				<displayName>ខែ</displayName>
 				<unitPattern count="other">{0} ខែ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ខែ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>សប្ដាហ៍</displayName>
 				<unitPattern count="other">{0} សប្ដាហ៍</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/សប្តាហ៍</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ថ្ងៃ</displayName>
 				<unitPattern count="other">{0} ថ្ងៃ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ថ្ងៃ</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ម៉ោង</displayName>
 				<unitPattern count="other">{0} ម៉ោង</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ម៉ោង</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>នាទី</displayName>
 				<unitPattern count="other">{0} នាទី</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/នាទី</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>វិនាទី</displayName>
 				<unitPattern count="other">{0} វិនាទី</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/វិនាទី</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>មិល្លី​វិនាទី</displayName>
 				<unitPattern count="other">{0} ម.វិ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>មីក្រូ​វិនាទី</displayName>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ណាណូវិនាទី</displayName>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>អំពែរ</displayName>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>មិល្លីអំពែរ</displayName>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>អូម</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>វ៉ុល</displayName>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>គីឡូស៊ូល</displayName>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ស៊ូល</displayName>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ចំណុច</displayName>
+				<unitPattern count="other">{0} ចំណុច</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>គម</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} គម</unitPattern>
+				<perUnitPattern>{0}/គម</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>ម៉ែត្រ</displayName>
 				<unitPattern count="other">{0} ម</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ម</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ដម</displayName>
+				<unitPattern count="other">{0} ដម</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>សម</displayName>
 				<unitPattern count="other">{0} សម</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/សម</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>មម</displayName>
 				<unitPattern count="other">{0} មម</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>មីក្រូ​ម៉ែត្រ</displayName>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="other">{0} ព.ម.</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ម៉ាយ</displayName>
 				<unitPattern count="other">{0} ម៉.</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>យ៉ាត</displayName>
 				<unitPattern count="other">{0} យ៉.</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ហ្វីត</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>អ៊ីញ</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ផាសិក</displayName>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>ឆ្នាំ​ពន្លឺ</displayName>
 				<unitPattern count="other">{0} ឆ្នាំ​ពន្លឺ</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ហ្វឺឡង</displayName>
+				<unitPattern count="other">{0} ហ្វឺ</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ហ្វាតឹម</displayName>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>ក្រាម</displayName>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>តោនអាមេរិក</displayName>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ស្តូន</displayName>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>ផោន</displayName>
 				<unitPattern count="other">{0}#</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="other">{0} អ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz troy</displayName>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ការ៉ាត់</displayName>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>គ្រាប់</displayName>
+				<unitPattern count="other">{0} គ្រាប់</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="other">{0} គ.វ.</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>វ៉ាត់</displayName>
 				<unitPattern count="other">{0} វ.</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="other">{0} សេះ</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -8047,8 +8047,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>″ Hg</displayName>
@@ -8059,209 +8059,209 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} បារ</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
 				<unitPattern count="other">{0} kph</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ម៉ែត្រ​/​វិនាទី</displayName>
 				<unitPattern count="other">{0} ម./វិ.</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>ម៉ាយ​/​ម៉ោង</displayName>
 				<unitPattern count="other">{0} ម៉./ម៉</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="other">{0} គ.ម³.</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="other">{0} ម៉³.</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>យ៉ាតគូប</displayName>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ហ្វីត​គូប</displayName>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>អ៊ីញគូប</displayName>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>លីត្រ</displayName>
 				<unitPattern count="other">{0}L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>អាហ្វីត</displayName>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ប៊ូសែល</displayName>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="other">{0} gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qts</displayName>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ភីន</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ពែង</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>តំណក់</displayName>
+				<unitPattern count="other">{0} តំណក់</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ត្រាមរាវ</displayName>
+				<unitPattern count="other">{0} ត្រាមរាវ</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ជីកហ្គឺរ</displayName>
+				<unitPattern count="other">{0} ជីកហ្គឺរ</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ច្បិច</displayName>
+				<unitPattern count="other">{0} ច្បិច</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ទិស</displayName>
@@ -8295,27 +8295,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ឬ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ឬ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ឬ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ឬ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ឬ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} និង {1}</listPatternPart>
 			<listPatternPart type="2">{0} និង {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -100,7 +100,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">ಚೆರೋಕಿ</language>
 			<language type="chy">ಚೀಯೆನ್ನೇ</language>
 			<language type="ckb">ಮಧ್ಯ ಕುರ್ದಿಶ್</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">ಮಧ್ಯ ಕುರ್ದಿಶ್</language>
 			<language type="ckb" alt="variant">ಕುರ್ದಿಶ್, ಸೊರಾನಿ</language>
 			<language type="clc">ಚಿಲ್ಕೋಟಿನ್</language>
 			<language type="co">ಕೋರ್ಸಿಕನ್</language>
@@ -1006,7 +1006,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ಟುನೀಶಿಯ</territory>
 			<territory type="TO">ಟೊಂಗಾ</territory>
 			<territory type="TR">ಟರ್ಕಿ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ಟರ್ಕಿ</territory>
 			<territory type="TT">ಟ್ರಿನಿಡಾಡ್ ಮತ್ತು ಟೊಬಾಗೊ</territory>
 			<territory type="TV">ಟುವಾಲು</territory>
 			<territory type="TW">ತೈವಾನ್</territory>
@@ -1737,7 +1737,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="5">ಮೇ</month>
 							<month type="6">ಜೂನ್</month>
 							<month type="7">ಜುಲೈ</month>
-							<month type="8">↑↑↑</month>
+							<month type="8">ಆಗಸ್ಟ್</month>
 							<month type="9">ಸೆಪ್ಟೆಂ</month>
 							<month type="10">ಅಕ್ಟೋ</month>
 							<month type="11">ನವೆಂ</month>
@@ -2146,7 +2146,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
 						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
 						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
-						<dateFormatItem id="yw" count="one">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yw" count="one">'week' w 'of' Y</dateFormatItem>
 						<dateFormatItem id="yw" count="other">'week' w 'of' Y</dateFormatItem>
 					</availableFormats>
 					<appendItems>
@@ -5681,19 +5681,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
@@ -5726,253 +5726,253 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
 			<decimal>.</decimal>
 			<group>,</group>
-			<list draft="contributed">↑↑↑</list>
+			<list draft="contributed">;</list>
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -5981,49 +5981,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -6041,349 +6041,349 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="knda">
 			<decimalFormatLength>
@@ -7758,7 +7758,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" case="dative">ಚದರಕ್ಕೆ {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">ಚದರದ {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="locative">ಚದರದಲ್ಲಿ {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="vocative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="vocative">ಚದರವು {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">ಚದರಗಳು {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="accusative">ಚದರಗಳನ್ನು {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="dative">ಚದರಗಳಿಗೆ {0}</compoundUnitPattern1>
@@ -7773,7 +7773,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" case="dative">ಕ್ಯೂಬಿಕ್‌ಗೆ {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">ಕ್ಯೂಬಿಕ್‌ನ {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="locative">ಕ್ಯೂಬಿಕ್‌ನಲ್ಲಿ {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="vocative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="vocative">ಕ್ಯೂಬಿಕ್ {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">ಕ್ಯೂಬಿಕ್‌ಗಳು {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="accusative">ಕ್ಯೂಬಿಕ್‌ಗಳನ್ನು {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="dative">ಕ್ಯೂಬಿಕ್‌ಗಳಿಗೆ {0}</compoundUnitPattern1>
@@ -7792,13 +7792,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಜಿ-ಫೋರ್ಸ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಜಿ-ಫೋರ್ಸ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಜಿ-ಫೋರ್ಸ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಜಿ-ಫೋರ್ಸ್</unitPattern>
 				<unitPattern count="other">{0} ಜಿ-ಫೋರ್ಸ್</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಜಿ-ಫೋರ್ಸ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಜಿ-ಫೋರ್ಸ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಜಿ-ಫೋರ್ಸ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಜಿ-ಫೋರ್ಸ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಜಿ-ಫೋರ್ಸ್</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>neuter</gender>
@@ -7822,13 +7822,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ತಿರುಗುವಿಕೆಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ತಿರುಗುವಿಕೆಯ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ತಿರುಗುವಿಕೆಯಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ತಿರುಗುವಿಕೆಯು</unitPattern>
 				<unitPattern count="other">{0} ತಿರುಗುವಿಕೆಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ತಿರುಗುವಿಕೆಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ತಿರುಗುವಿಕೆಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ತಿರುಗುವಿಕೆಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ತಿರುಗುವಿಕೆಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ತಿರುಗುವಿಕೆಗಳು</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>neuter</gender>
@@ -7838,13 +7838,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ರೇಡಿಯಾನ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ರೇಡಿಯಾನ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ರೇಡಿಯಾನ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ರೇಡಿಯಾನ್‌</unitPattern>
 				<unitPattern count="other">{0} ರೇಡಿಯಾನ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ರೇಡಿಯಾನ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ರೇಡಿಯಾನ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ರೇಡಿಯಾನ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ರೇಡಿಯಾನ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ರೇಡಿಯಾನ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>neuter</gender>
@@ -7854,7 +7854,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಡಿಗ್ರಿಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಡಿಗ್ರಿಯ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಡಿಗ್ರಿಯಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಡಿಗ್ರಿಯು</unitPattern>
 				<unitPattern count="other">{0}ಡಿಗ್ರಿಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0}ಡಿಗ್ರಿಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0}ಡಿಗ್ರಿಗಳಿಗೆ</unitPattern>
@@ -7870,13 +7870,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಆರ್ಕ್‌ಮಿನಿಟ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಆರ್ಕ್‌ಮಿನಿಟ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಆರ್ಕ್‌ಮಿನಿಟ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಆರ್ಕ್‌ಮಿನಿಟ್</unitPattern>
 				<unitPattern count="other">{0} ಆರ್ಕ್‌ಮಿನಿಟ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಆರ್ಕ್‌ಮಿನಿಟ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಆರ್ಕ್‌ಮಿನಿಟ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಆರ್ಕ್‌ಮಿನಿಟ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಆರ್ಕ್‌ಮಿನಿಟ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಆರ್ಕ್‌ಮಿನಿಟ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>neuter</gender>
@@ -7886,13 +7886,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡ್</unitPattern>
 				<unitPattern count="other">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡುಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡುಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡುಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡುಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡುಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಆರ್ಕ್‌ಸೆಕೆಂಡುಗಳು</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>neuter</gender>
@@ -7917,13 +7917,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಹೆಕ್ಟೇರ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಹೆಕ್ಟೇರ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಹೆಕ್ಟೇರ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಹೆಕ್ಟೇರ್</unitPattern>
 				<unitPattern count="other">{0} ಹೆಕ್ಟೇರುಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಹೆಕ್ಟೇರುಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಹೆಕ್ಟೇರುಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಹೆಕ್ಟೇರುಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಹೆಕ್ಟೇರುಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಹೆಕ್ಟೇರುಗಳು</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>neuter</gender>
@@ -7995,13 +7995,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಕಾರಟ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಕಾರಟ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಕಾರಟ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಕಾರಟ್‌</unitPattern>
 				<unitPattern count="other">{0} ಕಾರಟ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಕಾರಟ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಕಾರಟ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಕಾರಟ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಕಾರಟ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಕಾರಟ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>ಪ್ರತಿ ಡೆಸಿಲೀಟರ್‌ಗೆ ಮಿಲಿಗ್ರಾಂಗಳು</displayName>
@@ -8044,13 +8044,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗಕ್ಕೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗವು</unitPattern>
 				<unitPattern count="other">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಪ್ರತಿ ಮಿಲಿಯನ್ ಭಾಗಗಳು</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>neuter</gender>
@@ -8060,23 +8060,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಶೇಕಡಾಕ್ಕೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಶೇಕಡಾದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಶೇಕಡಾದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಶೇಕಡಾವು</unitPattern>
 				<unitPattern count="other">{0} ಶೇಕಡಾ</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಶೇಕಡಾಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಶೇಕಡಾಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಶೇಕಡಾಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಶೇಕಡಾಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಶೇಕಡಾ</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>neuter</gender>
 				<displayName>ಪ್ರತಿ ಸಾವಿರಕ್ಕೆ</displayName>
 				<unitPattern count="one">{0} ಪ್ರತಿ ಸಾವಿರವು</unitPattern>
 				<unitPattern count="one" case="accusative">{0} ಪ್ರತಿ ಸಾವಿರವನ್ನು</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="dative">{0} ಪ್ರತಿ ಸಾವಿರವು</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಪ್ರತಿ ಸಾವಿರದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಪ್ರತಿ ಸಾವಿರದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಪ್ರತಿ ಸಾವಿರವು</unitPattern>
 				<unitPattern count="other">{0} ಪ್ರತಿ ಸಾವಿರಕ್ಕೆ</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಪ್ರತಿ ಸಾವಿರಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಪ್ರತಿ ಸಾವಿರಗಳಿಗೆ</unitPattern>
@@ -8092,13 +8092,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಪರ್‌ಮಿರಿಯಾಡ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಪರ್‌ಮಿರಿಯಾಡ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಪರ್‌ಮಿರಿಯಾಡ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಪರ್‌ಮಿರಿಯಾಡ್</unitPattern>
 				<unitPattern count="other">{0} ಪರ್‌ಮಿರಿಯಾಡ್‌</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಪರ್‌ಮಿರಿಯಾಡ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಪರ್‌ಮಿರಿಯಾಡ್‌ಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಪರ್‌ಮಿರಿಯಾಡ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಪರ್‌ಮಿರಿಯಾಡ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಪರ್‌ಮಿರಿಯಾಡ್‌</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>neuter</gender>
@@ -8114,14 +8114,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="dative">{0} ಮೋಲ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಮೋಲ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಮೋಲ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಮೋಲ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>neuter</gender>
 				<displayName>ಲೀಟರ್‌ಗಳು ಪ್ರತಿ ಕಿಲೋಮೀಟರಿಗೆ</displayName>
 				<unitPattern count="one">{0} ಲೀಟರ್ ಪ್ರತಿ ಕಿಲೋಮೀಟರ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="accusative">{0} ಲೀಟರ್ ಪ್ರತಿ ಕಿಲೋಮೀಟರ್‌ ಅನ್ನು</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="dative">{0} ಲೀಟರ್ ಪ್ರತಿ ಕಿಲೋಮೀಟರ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಲೀಟರ್ ಪ್ರತಿ ಕಿಲೋಮೀಟರ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಲೀಟರ್ ಪ್ರತಿ ಕಿಲೋಮೀಟರ್‌ನಲ್ಲಿ</unitPattern>
 				<unitPattern count="other">{0} ಪ್ರತಿ ಕಿಲೋಮೀಟರ್‌‌ಗೆ ಲೀಟರ್‌ಗಳು</unitPattern>
@@ -8288,13 +8288,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಬೈಟ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಬೈಟ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಬೈಟ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಬೈಟ್‌</unitPattern>
 				<unitPattern count="other">{0} ಬೈಟ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಬೈಟ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಬೈಟ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಬೈಟ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಬೈಟ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಬೈಟ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>neuter</gender>
@@ -8304,13 +8304,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಬಿಟ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಬಿಟ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಬಿಟ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಬಿಟ್‌</unitPattern>
 				<unitPattern count="other">{0} ಬಿಟ್‍ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಬಿಟ್‍ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಬಿಟ್‍ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಬಿಟ್‍ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಬಿಟ್‍ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಬಿಟ್‍ಗಳು</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>neuter</gender>
@@ -8320,13 +8320,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಶತಮಾನಕ್ಕೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಶತಮಾನದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಶತಮಾನದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಶತಮಾನವು</unitPattern>
 				<unitPattern count="other">{0}ಶತಮಾನಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಶತಮಾನಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಶತಮಾನಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಶತಮಾನಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಶತಮಾನಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0}ಶತಮಾನಗಳು</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>neuter</gender>
@@ -8336,13 +8336,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ದಶಕಕ್ಕೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ದಶಕದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ದಶಕದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ದಶಕವು</unitPattern>
 				<unitPattern count="other">{0} ದಶಕಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ದಶಕಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ದಶಕಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ದಶಕಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ದಶಕಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ದಶಕಗಳು</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>neuter</gender>
@@ -8352,13 +8352,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ವರ್ಷಕ್ಕೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ವರ್ಷದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ವರ್ಷದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ವರ್ಷವು</unitPattern>
 				<unitPattern count="other">{0} ವರ್ಷಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ವರ್ಷಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ವರ್ಷಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ವರ್ಷಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ವರ್ಷಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ವರ್ಷಗಳು</unitPattern>
 				<perUnitPattern>ಪ್ರತಿ ವರ್ಷಕ್ಕೆ {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -8384,7 +8384,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ತಿಂಗಳಿಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ತಿಂಗಳ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ತಿಂಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ತಿಂಗಳು</unitPattern>
 				<unitPattern count="other">{0} ತಿಂಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ತಿಂಗಳುಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ತಿಂಗಳುಗಳಿಗೆ</unitPattern>
@@ -8401,13 +8401,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ವಾರಕ್ಕೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ವಾರದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ವಾರದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ವಾರವು</unitPattern>
 				<unitPattern count="other">{0} ವಾರಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ವಾರಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ವಾರಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ವಾರಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ವಾರಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ವಾರಗಳು</unitPattern>
 				<perUnitPattern>{0} ಪ್ರತಿ ವಾರಕ್ಕೆ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
@@ -8418,13 +8418,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ದಿನಕ್ಕೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ದಿನದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ದಿನದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ದಿನವು</unitPattern>
 				<unitPattern count="other">{0} ದಿನಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ದಿನಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ದಿನಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ದಿನಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ದಿನಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ದಿನಗಳು</unitPattern>
 				<perUnitPattern>{0} ಪ್ರತಿ ದಿನಕ್ಕೆ</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -8435,13 +8435,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಗಂಟೆಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಗಂಟೆಯ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಗಂಟೆಯಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಗಂಟೆಯು</unitPattern>
 				<unitPattern count="other">{0} ಗಂಟೆಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಗಂಟೆಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಗಂಟೆಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಗಂಟೆಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಗಂಟೆಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಗಂಟೆಗಳು</unitPattern>
 				<perUnitPattern>ಪ್ರತಿ ಗಂಟೆಗೆ {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -8452,13 +8452,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ನಿಮಿಷಕ್ಕೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ನಿಮಿಷದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ನಿಮಿಷದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ನಿಮಿಷವು</unitPattern>
 				<unitPattern count="other">{0} ನಿಮಿಷಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ನಿಮಿಷಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ನಿಮಿಷಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ನಿಮಿಷಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ನಿಮಿಷಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ನಿಮಿಷಗಳು</unitPattern>
 				<perUnitPattern>ಪ್ರತಿ ನಿಮಿಷಕ್ಕೆ {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -8469,13 +8469,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಸೆಕೆಂಡಿಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಸೆಕೆಂಡಿನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಸೆಕೆಂಡಿನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಸೆಕೆಂಡ್</unitPattern>
 				<unitPattern count="other">{0} ಸೆಕೆಂಡುಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಸೆಕೆಂಡುಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಸೆಕೆಂಡುಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಸೆಕೆಂಡುಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಸೆಕೆಂಡುಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಸೆಕೆಂಡುಗಳು</unitPattern>
 				<perUnitPattern>ಪ್ರತಿ ಸೆಕೆಂಡ್‌ಗೆ {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
@@ -8558,13 +8558,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಓಂ ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಓಂ ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಓಂ ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಓಂ</unitPattern>
 				<unitPattern count="other">{0} ಓಂಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಓಂಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಓಂಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಓಂಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಓಂಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಓಂಗಳು</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>neuter</gender>
@@ -8574,13 +8574,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ವೋಲ್ಟ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ವೋಲ್ಟ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ವೋಲ್ಟ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ವೋಲ್ಟ್‌</unitPattern>
 				<unitPattern count="other">{0} ವೋಲ್ಟ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ವೋಲ್ಟ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ವೋಲ್ಟ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ವೋಲ್ಟ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ವೋಲ್ಟ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ವೋಲ್ಟ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>ಕಿಲೋಕ್ಯಾಲೋರಿಗಳು</displayName>
@@ -8595,13 +8595,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಕ್ಯಾಲೋರಿಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಕ್ಯಾಲೋರಿಯ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಕ್ಯಾಲೋರಿಯಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಕ್ಯಾಲೋರಿ</unitPattern>
 				<unitPattern count="other">{0} ಕ್ಯಾಲೋರಿಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಕ್ಯಾಲೋರಿಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಕ್ಯಾಲೋರಿಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಕ್ಯಾಲೋರಿಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಕ್ಯಾಲೋರಿಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಕ್ಯಾಲೋರಿಗಳು</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>ಕ್ಯಾಲೋರಿಗಳು</displayName>
@@ -8630,13 +8630,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಜೌಲ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಜೌಲ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಜೌಲ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಜೌಲ್‌</unitPattern>
 				<unitPattern count="other">{0} ಜೌಲ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಜೌಲ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಜೌಲ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಜೌಲ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಜೌಲ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಜೌಲ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>neuter</gender>
@@ -8694,7 +8694,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ಪ್ರತಿ 100 ಕಿಲೋಮೀಟರ್‌ಗೆ ಕಿಲೋವ್ಯಾಟ್-ಗಂಟೆ</unitPattern>
 				<unitPattern count="one" case="accusative">{0} ಪ್ರತಿ 100 ಕಿಲೋಮೀಟರ್‌ಗಳಿಗೆ ಕಿಲೋವ್ಯಾಟ್-ಗಂಟೆಯನ್ನು</unitPattern>
 				<unitPattern count="one" case="dative">{0} ಕಿಲೋವ್ಯಾಟ್-ಗಂಟೆ ಪ್ರತಿ 100 ಕಿಲೋಮೀಟರ್‌ಗಳಿಗೆ</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} ಪ್ರತಿ 100 ಕಿಲೋಮೀಟರ್‌ಗೆ ಕಿಲೋವ್ಯಾಟ್-ಗಂಟೆ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಕಿಲೋವ್ಯಾಟ್-ಗಂಟೆ ಪ್ರತಿ 100 ಕಿಲೋಮೀಟರ್‌ಗಳಲ್ಲಿ</unitPattern>
 				<unitPattern count="other">{0} ಕಿಲೋವ್ಯಾಟ್-ಗಂಟೆಗಳು ಪ್ರತಿ 100 ಕಿಲೋಮೀಟರ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಕಿಲೋವ್ಯಾಟ್-ಗಂಟೆಗಳು ಪ್ರತಿ 100 ಕಿಲೋಮೀಟರ್‌ಗಳನ್ನು</unitPattern>
@@ -8763,18 +8763,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="graphics-em">
 				<gender>neuter</gender>
 				<displayName>ಟೈಪೊಗ್ರಾಫಿಕ್ em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="one" case="accusative">{0} em ಅನ್ನು</unitPattern>
 				<unitPattern count="one" case="dative">{0} em ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} em ದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} em ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} em</unitPattern>
 				<unitPattern count="other">{0} ems ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} em ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} em ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} em ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} em ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ems ಗಳು</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>neuter</gender>
@@ -8784,13 +8784,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಪಿಕ್ಸೆಲ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಪಿಕ್ಸೆಲ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಪಿಕ್ಸೆಲ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಪಿಕ್ಸೆಲ್</unitPattern>
 				<unitPattern count="other">{0} ಪಿಕ್ಸೆಲ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಪಿಕ್ಸೆಲ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಪಿಕ್ಸೆಲ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಪಿಕ್ಸೆಲ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಪಿಕ್ಸೆಲ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಪಿಕ್ಸೆಲ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>neuter</gender>
@@ -8868,13 +8868,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಮೀಟರ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಮೀಟರ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಮೀಟರ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಮೀಟರ್</unitPattern>
 				<unitPattern count="other">{0} ಮೀಟರ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಮೀಟರ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಮೀಟರ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಮೀಟರ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಮೀಟರ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಮೀಟರ್‌ಗಳು</unitPattern>
 				<perUnitPattern>ಪ್ರತಿ ಮೀಟರ್‌ಗೆ {0}</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
@@ -9022,13 +9022,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲು</unitPattern>
 				<unitPattern count="other">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲುಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲುಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲುಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲುಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲುಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಸ್ಕ್ಯಾಂಡಿನೇವಿಯನ್-ಮೈಲುಗಳು</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>ಪಾಯಿಂಟ್ಸ್</displayName>
@@ -9048,7 +9048,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಲಕ್ಸ್‌‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಲಕ್ಸ್‌‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಲಕ್ಸ್‌‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಲಕ್ಸ್‌‌</unitPattern>
 				<unitPattern count="other">{0} ಲಕ್ಸ್‌‌</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಲಕ್ಸ್‌‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಲಕ್ಸ್‌‌ಗಳಿಗೆ</unitPattern>
@@ -9080,7 +9080,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಲೂಮೆನ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಲೂಮೆನ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಲೂಮೆನ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಲೂಮೆನ್</unitPattern>
 				<unitPattern count="other">{0} ಲೂಮೆನ್</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಲೂಮೆನ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಲೂಮೆನ್‌ಗಳಿಗೆ</unitPattern>
@@ -9101,13 +9101,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಮೆಟ್ರಿಕ್‌ ಟನ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಮೆಟ್ರಿಕ್‌ ಟನ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಮೆಟ್ರಿಕ್‌ ಟನ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಮೆಟ್ರಿಕ್‌ ಟನ್‌</unitPattern>
 				<unitPattern count="other">{0} ಮೆಟ್ರಿಕ್‌‌ ಟನ್‌‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಮೆಟ್ರಿಕ್‌‌ ಟನ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಮೆಟ್ರಿಕ್‌‌ ಟನ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಮೆಟ್ರಿಕ್‌‌ ಟನ್‌‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಮೆಟ್ರಿಕ್‌‌ ಟನ್‌‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಮೆಟ್ರಿಕ್‌‌ ಟನ್‌‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>neuter</gender>
@@ -9117,13 +9117,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಕಿಲೋಗ್ರಾಂಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಕಿಲೋಗ್ರಾಂನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಕಿಲೋಗ್ರಾಂನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಕಿಲೋಗ್ರಾಂ</unitPattern>
 				<unitPattern count="other">{0} ಕಿಲೋಗ್ರಾಂಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಕಿಲೋಗ್ರಾಂಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಕಿಲೋಗ್ರಾಂಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಕಿಲೋಗ್ರಾಂಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಕಿಲೋಗ್ರಾಂಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಕಿಲೋಗ್ರಾಂಗಳು</unitPattern>
 				<perUnitPattern>{0} ಪ್ರತಿ ಕಿಲೋಗ್ರಾಂಗೆ</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
@@ -9134,13 +9134,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಗ್ರಾಂ ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಗ್ರಾಂ ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಗ್ರಾಂ ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಗ್ರಾಂ</unitPattern>
 				<unitPattern count="other">{0} ಗ್ರಾಂಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಗ್ರಾಂಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಗ್ರಾಂಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಗ್ರಾಂಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಗ್ರಾಂಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಗ್ರಾಂಗಳು</unitPattern>
 				<perUnitPattern>{0} ಪ್ರತಿ ಗ್ರಾಂಗೆ</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
@@ -9206,13 +9206,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಕ್ಯಾರೆಟ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಕ್ಯಾರೆಟ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಕ್ಯಾರೆಟ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಕ್ಯಾರೆಟ್‌</unitPattern>
 				<unitPattern count="other">{0} ಕ್ಯಾರೆಟ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಕ್ಯಾರೆಟ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಕ್ಯಾರೆಟ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಕ್ಯಾರೆಟ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಕ್ಯಾರೆಟ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಕ್ಯಾರೆಟ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ಡಿಎ</displayName>
@@ -9284,13 +9284,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ವ್ಯಾಟ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ವ್ಯಾಟ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ವ್ಯಾಟ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ವ್ಯಾಟ್</unitPattern>
 				<unitPattern count="other">{0} ವ್ಯಾಟ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ವ್ಯಾಟ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ವ್ಯಾಟ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ವ್ಯಾಟ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ವ್ಯಾಟ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ವ್ಯಾಟ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>neuter</gender>
@@ -9334,13 +9334,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಬಾರ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಬಾರ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಬಾರ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಬಾರ್‌</unitPattern>
+				<unitPattern count="other">{0} ಬಾರ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಬಾರ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಬಾರ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಬಾರ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಬಾರ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಬಾರ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>neuter</gender>
@@ -9364,13 +9364,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ವಾತಾವರಣಕ್ಕೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ವಾತಾವರಣದ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ವಾತಾವರಣದಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ವಾತಾವರಣ</unitPattern>
 				<unitPattern count="other">{0} ವಾತಾವರಣಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ವಾತಾವರಣಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ವಾತಾವರಣಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ವಾತಾವರಣಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ವಾತಾವರಣಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ವಾತಾವರಣಗಳು</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>neuter</gender>
@@ -9449,12 +9449,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ಮೀಟರ್‌ಗಳು ಪ್ರತಿ ಸೆಕೆಂಡ್‌ಗೆ</displayName>
 				<unitPattern count="one">{0} ಮೀಟರ್‌ ಪ್ರತಿ ಸೆಕೆಂಡ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="accusative">{0} ಮೀಟರ್‌ ಪ್ರತಿ ಸೆಕೆಂಡ್‌ ಅನ್ನು</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="dative">{0} ಮೀಟರ್‌ ಪ್ರತಿ ಸೆಕೆಂಡ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಮೀಟರ್‌ ಪ್ರತಿ ಸೆಕೆಂಡ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಮೀಟರ್‌ ಪ್ರತಿ ಸೆಕೆಂಡ್‌ನಲ್ಲಿ</unitPattern>
 				<unitPattern count="other">{0} ಮೀಟರ್‌ಗಳು ಪ್ರತಿ ಸೆಕೆಂಡ್‌ಗೆ</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಮೀಟರ್‌ಗಳು ಪ್ರತಿ ಸೆಕೆಂಡ್‌ ಅನ್ನು</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="dative">{0} ಮೀಟರ್‌ಗಳು ಪ್ರತಿ ಸೆಕೆಂಡ್‌ಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಮೀಟರ್‌ಗಳು ಪ್ರತಿ ಸೆಕೆಂಡ್‌ನ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಮೀಟರ್‌ಗಳು ಪ್ರತಿ ಸೆಕೆಂಡ್‌ನಲ್ಲಿ</unitPattern>
 			</unit>
@@ -9492,13 +9492,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್</unitPattern>
 				<unitPattern count="other">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಡಿಗ್ರಿ ಸೆಲ್ಶಿಯಸ್</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>ಡಿಗ್ರಿ ಫ್ಯಾರೆನ್‌ಹಿಟ್</displayName>
@@ -9513,13 +9513,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಕೆಲ್ವಿನ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಕೆಲ್ವಿನ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಕೆಲ್ವಿನ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಕೆಲ್ವಿನ್</unitPattern>
 				<unitPattern count="other">{0} ಕೆಲ್ವಿನ್‍ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಕೆಲ್ವಿನ್‍ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಕೆಲ್ವಿನ್‍ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಕೆಲ್ವಿನ್‍ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಕೆಲ್ವಿನ್‍ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಕೆಲ್ವಿನ್‍ಗಳು</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>ಪೌಂಡ್-ಫೋರ್ಸ್-ಅಡಿ</displayName>
@@ -9640,13 +9640,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಲೀಟರ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಲೀಟರ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಲೀಟರ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಲೀಟರ್</unitPattern>
 				<unitPattern count="other">{0} ಲೀಟರ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಲೀಟರ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಲೀಟರ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಲೀಟರ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಲೀಟರ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಲೀಟರ್‌ಗಳು</unitPattern>
 				<perUnitPattern>ಪ್ರತಿ ಲೀಟರ್‌ಗೆ {0}</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
@@ -9699,13 +9699,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್</unitPattern>
 				<unitPattern count="other">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಮೆಟ್ರಿಕ್ ಪಿಂಟ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>neuter</gender>
@@ -9715,13 +9715,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌ಗೆ</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌ನ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌ನಲ್ಲಿ</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌</unitPattern>
 				<unitPattern count="other">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌ಗಳು</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌ಗಳನ್ನು</unitPattern>
 				<unitPattern count="other" case="dative">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌ಗಳಿಗೆ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌ಗಳ</unitPattern>
 				<unitPattern count="other" case="locative">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌ಗಳಲ್ಲಿ</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ಮೆಟ್ರಿಕ್‌ ಕಪ್‌ಗಳು</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>ಎಕರೆ-ಅಡಿ</displayName>
@@ -9923,7 +9923,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10314,41 +10314,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>ಪಿಕ್ಸೆಲ್‌ಗಳು</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>ಮೆಗಾಪಿಕ್ಸೆಲ್‌ಗಳು</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಪಿಕ್ಸೆಲ್‌ಗಳು</displayName>
 				<unitPattern count="one">{0} ಪಿಕ್ಸೆ</unitPattern>
 				<unitPattern count="other">{0} ಪಿಕ್ಸೆ</unitPattern>
 			</unit>
@@ -10464,7 +10464,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>ಸೋಲಾರ್‌ ರೇಡಿ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -10484,7 +10484,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>ಸೌರ ಪ್ರಕಾಶಗಳು</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -10818,7 +10818,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>ಇಂಪಿ. ಫ್ಲೂ. ಔ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -10833,7 +10833,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>ಬ್ಯಾರೆಲ್</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -10968,20 +10968,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಜಿ-ಫೋರ್ಸ್</displayName>
 				<unitPattern count="one">{0}ಜಿ-ಫೋ.</unitPattern>
 				<unitPattern count="other">{0}ಜಿ-ಫೋ.</unitPattern>
 			</unit>
@@ -10991,35 +10991,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಮೀ/ಸೆ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
+				<displayName>ತಿರುಗು</displayName>
 				<unitPattern count="one">{0}ತಿರುಗು</unitPattern>
 				<unitPattern count="other">{0}ತಿರುಗು</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>ರೇಡಿಯಾನ್‌ಗಳು</displayName>
 				<unitPattern count="one">{0}ರೇಡಿ.</unitPattern>
 				<unitPattern count="other">{0}ರೇಡಿ.</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಡಿಗ್ರಿಗಳು</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಆರ್ಕ್‌ಮಿನಿ</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಆರ್ಕ್‌ಸೆಕೆಂ</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಿಮೀ²</displayName>
 				<unitPattern count="one">{0} ಚ.ಕಿಮೀ.</unitPattern>
 				<unitPattern count="other">{0} ಚ.ಕಿಮೀ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ಕಿಮೀ²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ಹೆಕ್ಟೇರ್</displayName>
@@ -11027,22 +11027,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ಹೆ.</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮೀಟರ್‌ಗಳು²</displayName>
 				<unitPattern count="one">{0} ಮೀ²</unitPattern>
 				<unitPattern count="other">{0} ಮೀ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ಮೀ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ಸೆಂ.ಮೀ²</displayName>
+				<unitPattern count="one">{0} ಸೆಂ.ಮೀ²</unitPattern>
+				<unitPattern count="other">{0} ಸೆಂ.ಮೀ²</unitPattern>
+				<perUnitPattern>{0}/ಸೆಂ.ಮೀ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಚದರ ಮೈಲುಗಳು</displayName>
 				<unitPattern count="one">{0}ಚ.ಮೀ.</unitPattern>
 				<unitPattern count="other">{0}ಚ.ಮೀ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ಚ.ಮೀ²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>ಎಕರೆ</displayName>
@@ -11051,8 +11051,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>ಗ²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ಗ²</unitPattern>
+				<unitPattern count="other">{0} ಗ²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ft²</displayName>
@@ -11060,30 +11060,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಚ.ಅ</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ಅಂಗುಲಗಳು²</displayName>
+				<unitPattern count="one">{0} ಅಂ²</unitPattern>
+				<unitPattern count="other">{0} ಅಂ²</unitPattern>
+				<perUnitPattern>{0}/ಅಂ²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಡುನಮ್‌</displayName>
 				<unitPattern count="one">{0}ಡುನಮ್</unitPattern>
 				<unitPattern count="other">{0}ಡುನಮ್</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಾರಟ್‌ಗಳು</displayName>
 				<unitPattern count="one">{0}ಕಾರ.</unitPattern>
 				<unitPattern count="other">{0}ಕಾರ.</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮಿಗ್ರಾಂ/ಡೆಲೀ</displayName>
 				<unitPattern count="one">{0}ಮಿಗ್ರಾಂ/ಡೆಲೀ</unitPattern>
 				<unitPattern count="other">{0}ಮಿಗ್ರಾಂ/ಡೆಲೀ</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ಮಿಲ್ಲಿಮೊ/ಲೀಟರ್</displayName>
+				<unitPattern count="one">{0} ಮಿಮೊಲ್/ಲೀ</unitPattern>
+				<unitPattern count="other">{0} ಮಿಮೋಲ್/ಲೀ</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>ವಸ್ತು</displayName>
@@ -11102,23 +11102,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮೋಲ್‌</displayName>
 				<unitPattern count="one">{0}ಮೋಲ್</unitPattern>
 				<unitPattern count="other">{0}ಮೋಲ್</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>ಲೀ/ಕಿಮೀ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ಲೀ/ಕಿ.ಮೀ</unitPattern>
+				<unitPattern count="other">{0} ಲೀ/ಕಿ.ಮೀ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ಲೀ/100ಕಿ.ಮೀ</displayName>
@@ -11146,7 +11146,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಟೆ.ಬೈ.</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಟೆ.ಬಿ.</displayName>
 				<unitPattern count="one">{0}ಟೆ.ಬಿ.</unitPattern>
 				<unitPattern count="other">{0}ಟೆ.ಬಿ.</unitPattern>
 			</unit>
@@ -11166,34 +11166,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಮೆ.ಬೈ.</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮೆ.ಬಿ.</displayName>
 				<unitPattern count="one">{0}ಮೆ.ಬಿ.</unitPattern>
 				<unitPattern count="other">{0}ಮೆ.ಬಿ.</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಿ.ಬೈ.</displayName>
 				<unitPattern count="one">{0}ಕಿ.ಬೈ.</unitPattern>
 				<unitPattern count="other">{0}ಕಿ.ಬೈ.</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಿ.ಬಿ.</displayName>
 				<unitPattern count="one">{0}ಕಿ.ಬಿ.</unitPattern>
 				<unitPattern count="other">{0}ಕಿ.ಬಿ.</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಬೈಟ್</displayName>
 				<unitPattern count="one">{0}ಬೈ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ಬೈ.</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಬಿಟ್‌</displayName>
 				<unitPattern count="one">{0}ಬಿಟ್</unitPattern>
 				<unitPattern count="other">{0}ಬಿಟ್</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ಶ</displayName>
+				<unitPattern count="one">{0} ಶ</unitPattern>
+				<unitPattern count="other">{0} ಶ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<displayName>ದಶಕ</displayName>
@@ -11204,7 +11204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ವ</displayName>
 				<unitPattern count="one">{0}ವ</unitPattern>
 				<unitPattern count="other">{0}ವ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ವ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>ತ್ರೈಮಾಸಿಕ</displayName>
@@ -11222,7 +11222,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ವಾರ</displayName>
 				<unitPattern count="one">{0}ವಾ</unitPattern>
 				<unitPattern count="other">{0}ವಾ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ವಾ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ದಿನ</displayName>
@@ -11255,16 +11255,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>μsec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ನ್ಯಾ.ಸೆ</displayName>
 				<unitPattern count="one">{0}ನ್ಯಾಸೆ</unitPattern>
 				<unitPattern count="other">{0}ನ್ಯಾಸೆ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಆಂ.</displayName>
 				<unitPattern count="one">{0}ಆಂ.</unitPattern>
 				<unitPattern count="other">{0}ಆಂ.</unitPattern>
 			</unit>
@@ -11274,22 +11274,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಓಂಗಳು</displayName>
 				<unitPattern count="one">{0}Ω</unitPattern>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ವೋ.</displayName>
 				<unitPattern count="one">{0}ವೋ</unitPattern>
 				<unitPattern count="other">{0}ವೋ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಿ.ಕ್ಯಾ</displayName>
 				<unitPattern count="one">{0}ಕಿ.ಕ್ಯಾ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ಕಿ.ಕ್ಯಾ</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕ್ಯಾಲೊ</displayName>
 				<unitPattern count="one">{0}ಕ್ಯಾಲೊ</unitPattern>
 				<unitPattern count="other">{0}ಕ್ಯಾಲೊ</unitPattern>
 			</unit>
@@ -11299,22 +11299,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಕ್ಯಾಲೊ</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಿ.ಜೌ</displayName>
 				<unitPattern count="one">{0}ಕಿ.ಜೌ</unitPattern>
 				<unitPattern count="other">{0}ಕಿ.ಜೌ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಜೌಲ್‌ಗಳು</displayName>
 				<unitPattern count="one">{0}ಜೌ</unitPattern>
 				<unitPattern count="other">{0}ಜೌ</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಿ.ವ್ಯಾ-ಗಂ</displayName>
 				<unitPattern count="one">{0}ಕಿವ್ಯಾಗಂ</unitPattern>
 				<unitPattern count="other">{0}ಕಿವ್ಯಾಗಂ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಎಲೆಕ್ಟ್ರಾನ್‌ವೋಲ್ಟ್‌</displayName>
 				<unitPattern count="one">{0}ಎವೋ</unitPattern>
 				<unitPattern count="other">{0}ಎವೋ</unitPattern>
 			</unit>
@@ -11324,14 +11324,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಬ್ರಿಉಯು</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಯುಎಸ್ ಥರ್ಮ್ಸ್</displayName>
 				<unitPattern count="one">{0}ಯುಎಸ್ ಥರ್ಮ್ಸ್</unitPattern>
 				<unitPattern count="other">{0}ಯುಎಸ್ ಥರ್ಮ್ಸ್</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>ಎಲ್‌ಬಿಎಫ್</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ಎಲ್‌ಬಿಎಫ್</unitPattern>
+				<unitPattern count="other">{0} ಎಲ್‌ಬಿಎಫ್</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>ನ್ಯೂ</displayName>
@@ -11340,8 +11340,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>ಕಿವ್ಯಾಗಂ/100ಕಿಮೀ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ಕಿವ್ಯಾಗಂ/100ಕಿಮೀ</unitPattern>
+				<unitPattern count="other">{0} ಕಿವ್ಯಾಗಂ/100ಕಿಮೀ</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>GHz</displayName>
@@ -11364,7 +11364,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಹರ್ಟ್ಜ್</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
@@ -11379,34 +11379,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">{0}ppi</unitPattern>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpcm</displayName>
 				<unitPattern count="one">{0}dpcm</unitPattern>
 				<unitPattern count="other">{0}dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpi</displayName>
 				<unitPattern count="one">{0}dpi</unitPattern>
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ಡಾಟ್</displayName>
 				<unitPattern count="one">{0} ಡಾಟ್</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ಪಿಕ್ಸೆ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ಕಿಮೀ</displayName>
@@ -11442,12 +11442,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ನ್ಯಾ.ಮೀ</displayName>
 				<unitPattern count="one">{0}nm</unitPattern>
 				<unitPattern count="other">{0}nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಪಿ.ಮೀ</displayName>
 				<unitPattern count="one">{0}ಪಿಎಂ</unitPattern>
 				<unitPattern count="other">{0}ಪಿಎಂ</unitPattern>
 			</unit>
@@ -11475,33 +11475,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-parsec">
 				<displayName>ಪಾರ್‌ಸೆಕೆಂ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ಪಾ.ಸೆ</unitPattern>
+				<unitPattern count="other">{0} ಪಾ.ಸೆ</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>ಬೆ.ವರ್ಷ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ಬೆ.ವರ್ಷ</unitPattern>
+				<unitPattern count="other">{0} ಬೆ.ವರ್ಷ</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ಅ.ಯೂ</displayName>
+				<unitPattern count="one">{0} ಅ.ಯೂ</unitPattern>
+				<unitPattern count="other">{0} ಅ.ಯೂ</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>ಫರ್ಲಾಂಗ್</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ಫರ್</unitPattern>
+				<unitPattern count="other">{0} ಫರ್</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>ಫ್ಯಾಥಮ್</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ನಾ.ಮೈ</displayName>
+				<unitPattern count="one">{0} ನಾ.ಮೈ</unitPattern>
+				<unitPattern count="other">{0} ನಾ.ಮೈ</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>ಸ್ಕ್ಯಾಂ.ಮೈ</displayName>
@@ -11509,7 +11509,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಪಾಯಿಂಟ್‌ಗಳು</displayName>
 				<unitPattern count="one">{0}ಪಾಯಿಂಟ್</unitPattern>
 				<unitPattern count="other">{0}ಪಾಯಿಂಟ್</unitPattern>
 			</unit>
@@ -11519,27 +11519,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಲಕ್ಸ್</displayName>
 				<unitPattern count="one">{0}ಎಲ್‌ಎಕ್ಸ್</unitPattern>
 				<unitPattern count="other">{0}ಎಲ್‌ಎಕ್ಸ್</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕ್ಯಾಂ</displayName>
 				<unitPattern count="one">{0}ಕ್ಯಾಂ</unitPattern>
 				<unitPattern count="other">{0}ಕ್ಯಾಂ</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಎಲ್ಎಮ್</displayName>
 				<unitPattern count="one">{0}ಎಲ್ಎಮ್</unitPattern>
 				<unitPattern count="other">{0}ಎಲ್ಎಮ್</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಟ</displayName>
 				<unitPattern count="one">{0}ಟ</unitPattern>
 				<unitPattern count="other">{0}ಟ</unitPattern>
 			</unit>
@@ -11556,7 +11556,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/ಗ್ರಾ</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮಿ.ಗ್ರಾಂ</displayName>
 				<unitPattern count="one">{0}ಮಿ.ಗ್ರಾಂ</unitPattern>
 				<unitPattern count="other">{0}ಮಿ.ಗ್ರಾಂ</unitPattern>
 			</unit>
@@ -11566,7 +11566,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಟನ್‍ಗಳು</displayName>
 				<unitPattern count="one">{0}ಟನ್‌</unitPattern>
 				<unitPattern count="other">{0}ಟನ್‌</unitPattern>
 			</unit>
@@ -11598,9 +11598,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಡಿಎ</displayName>
 				<unitPattern count="one">{0}ಡಿಎ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
@@ -11613,37 +11613,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಗ್ರೇನ್</displayName>
 				<unitPattern count="one">{0}ಗ್ರೇನ್</unitPattern>
 				<unitPattern count="other">{0}ಗ್ರೇನ್</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಗಿ.ವ್ಯಾ</displayName>
 				<unitPattern count="one">{0}ಗಿ.ವ್ಯಾ</unitPattern>
 				<unitPattern count="other">{0}ಗಿ.ವ್ಯಾ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮೆ.ವ್ಯಾ</displayName>
 				<unitPattern count="one">{0}ಮೆ.ವ್ಯಾ</unitPattern>
 				<unitPattern count="other">{0}ಮೆ.ವ್ಯಾ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಿ.ವ್ಯಾ</displayName>
 				<unitPattern count="one">{0}ಕಿ.ವ್ಯಾ</unitPattern>
 				<unitPattern count="other">{0}ಕಿ.ವ್ಯಾ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ವ್ಯಾಟ್‌ಗಳು</displayName>
 				<unitPattern count="one">{0}ವ್ಯಾ.</unitPattern>
 				<unitPattern count="other">{0}ವ್ಯಾ.</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮಿ.ವ್ಯಾ</displayName>
 				<unitPattern count="one">{0}ಮಿ.ವ್ಯಾ</unitPattern>
 				<unitPattern count="other">{0}ಮಿ.ವ್ಯಾ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಹೆಚ್‌ಪಿ</displayName>
 				<unitPattern count="one">{0}ಹೆಚ್‌ಪಿ</unitPattern>
 				<unitPattern count="other">{0}ಹೆಚ್‌ಪಿ</unitPattern>
 			</unit>
@@ -11663,7 +11663,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಬಾರ್‌</displayName>
 				<unitPattern count="one">{0}ಬಾರ್‌</unitPattern>
 				<unitPattern count="other">{0}ಬಾರ್‌</unitPattern>
 			</unit>
@@ -11673,12 +11673,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಮಿ.ಬಾ.</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>ವಾತಾವರಣಗಳು</displayName>
 				<unitPattern count="one">{0}ವಾತಾವರಣ</unitPattern>
 				<unitPattern count="other">{0}ವಾತಾವರಣ</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಪಾ</displayName>
 				<unitPattern count="one">{0}ಪ್ಯಾ</unitPattern>
 				<unitPattern count="other">{0}ಪ್ಯಾ</unitPattern>
 			</unit>
@@ -11699,8 +11699,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ಕಿ.ಮೀ/ಗಂ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ಕಿ.ಮೀ./ಗಂ</unitPattern>
+				<unitPattern count="other">{0} ಕಿ.ಮೀ./ಗಂ</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>ಮೀ.ಗಳು/ಸೆ</displayName>
@@ -11713,7 +11713,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಮೈ/ಗಂ</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ನಾ</displayName>
 				<unitPattern count="one">{0}ನಾ</unitPattern>
 				<unitPattern count="other">{0}ನಾ</unitPattern>
 			</unit>
@@ -11743,54 +11743,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ಎಲ್‌ಬಿಎಫ್-ಎಫ್‌ಟಿ</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ನ್ಯೂ.ಮೀ</displayName>
 				<unitPattern count="one">{0}ನ್ಯೂ.ಮೀ</unitPattern>
 				<unitPattern count="other">{0}ನ್ಯೂ.ಮೀ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಿಮೀ³</displayName>
 				<unitPattern count="one">{0}ಕಿಮೀ³</unitPattern>
 				<unitPattern count="other">{0}ಕಿಮೀ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮೀ³</displayName>
 				<unitPattern count="one">{0}ಮೀ³</unitPattern>
 				<unitPattern count="other">{0}ಮೀ³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ಮೀ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ಸೆಮೀ³</displayName>
+				<unitPattern count="one">{0} ಸೆಮೀ³</unitPattern>
+				<unitPattern count="other">{0} ಸೆಮೀ³</unitPattern>
+				<perUnitPattern>{0}/ಸೆಮೀ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮೈ³</displayName>
 				<unitPattern count="one">{0}ಮೈ³</unitPattern>
 				<unitPattern count="other">{0}ಮೈ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ಗಜಗಳು³</displayName>
+				<unitPattern count="one">{0} ಗಜ³</unitPattern>
+				<unitPattern count="other">{0} ಗಜ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ಅಡಿ³</displayName>
+				<unitPattern count="one">{0} ಅಡಿ³</unitPattern>
+				<unitPattern count="other">{0} ಅಡಿ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಅಂಗುಲಗಳು³</displayName>
 				<unitPattern count="one">{0}ಅಂ³</unitPattern>
 				<unitPattern count="other">{0}ಅಂ³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ಮೆ.ಲೀ</displayName>
+				<unitPattern count="one">{0} ಮೆ.ಲೀ</unitPattern>
+				<unitPattern count="other">{0} ಮೆ.ಲೀ</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಹೆ.ಲೀ</displayName>
 				<unitPattern count="one">{0}ಹೆ.ಲೀ</unitPattern>
 				<unitPattern count="other">{0}ಹೆ.ಲೀ</unitPattern>
 			</unit>
@@ -11798,127 +11798,127 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ಲೀಟರ್</displayName>
 				<unitPattern count="one">{0}ಲೀ</unitPattern>
 				<unitPattern count="other">{0}ಲೀ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ಲೀ</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಡೆ.ಲೀ</displayName>
 				<unitPattern count="one">{0}ಡೆ.ಲೀ</unitPattern>
 				<unitPattern count="other">{0}ಡೆ.ಲೀ</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಸೆಂ.ಲೀ</displayName>
 				<unitPattern count="one">{0}ಸೆಂ.ಲೀ</unitPattern>
 				<unitPattern count="other">{0}ಸೆಂ.ಲೀ</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮಿ.ಲೀ</displayName>
 				<unitPattern count="one">{0}ಮಿ.ಲೀ</unitPattern>
 				<unitPattern count="other">{0}ಮಿ.ಲೀ</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮೆ.ಪಿಂ</displayName>
 				<unitPattern count="one">{0}ಮೆ.ಪಿಂ</unitPattern>
 				<unitPattern count="other">{0}ಮೆ.ಪಿಂ</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಮೆ.ಕಪ್‌</displayName>
 				<unitPattern count="one">{0}ಮೆ.ಕಪ್‌</unitPattern>
 				<unitPattern count="other">{0}ಮೆ.ಕ</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಎಕರೆ ಅಡಿ</displayName>
 				<unitPattern count="one">{0}ಎ. ಅ</unitPattern>
 				<unitPattern count="other">{0}ಎ. ಅ</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಬುಶಲ್‌ಗಳು</displayName>
 				<unitPattern count="one">{0}ಬು</unitPattern>
 				<unitPattern count="other">{0}ಬು</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ಗ್ಯಾ</displayName>
+				<unitPattern count="one">{0} ಗ್ಯಾ</unitPattern>
+				<unitPattern count="other">{0} ಗ್ಯಾ</unitPattern>
+				<perUnitPattern>{0}/ಗ್ಯಾ</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp ಗ್ಯಾಲನ್</displayName>
 				<unitPattern count="one">{0}galIm</unitPattern>
 				<unitPattern count="other">{0}galIm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} / Imp ಗ್ಯಾ</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಾ.ಭಾ</displayName>
 				<unitPattern count="one">{0}ಕಾ.ಭಾ</unitPattern>
 				<unitPattern count="other">{0}ಕಾ.ಭಾ</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ಪಿಂಟ್‍ಗಳು</displayName>
+				<unitPattern count="one">{0} ಪಿಂಟ್‌</unitPattern>
+				<unitPattern count="other">{0} ಪಿಂಟ್‌</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕಪ್‍ಗಳು</displayName>
 				<unitPattern count="one">{0}ಕ</unitPattern>
 				<unitPattern count="other">{0}ಕ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಫ್ಲೂ.ಔ</displayName>
 				<unitPattern count="one">{0}ಫ್ಲೂ.ಔ</unitPattern>
 				<unitPattern count="other">{0}ಫ್ಲೂ.ಔ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಇಂಪಿ. ಫ್ಲೂ. ಔ.</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಟೇ.ಸ್ಪೂ</displayName>
 				<unitPattern count="one">{0}ಟೇ.ಸ್ಪೂ</unitPattern>
 				<unitPattern count="other">{0}ಟೇ.ಸ್ಪೂ</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಟೀ ಸ್ಪೂ</displayName>
 				<unitPattern count="one">{0}ಟೀಸ್ಪೂ</unitPattern>
 				<unitPattern count="other">{0}ಟೀಸ್ಪೂ</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ಬ್ಯಾರೆಲ್</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಡೆ.ಸ್ಪೂ</displayName>
 				<unitPattern count="one">{0}ಡೆಸ್ಪೂ</unitPattern>
 				<unitPattern count="other">{0}ಡೆಸ್ಪೂ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಡೆ.ಸ್ಪೂ.ಇಂಪಿ</displayName>
 				<unitPattern count="one">{0}dsp-Imp</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಡ್ರಾಪ್</displayName>
 				<unitPattern count="one">{0}ಡ್ರಾಪ್</unitPattern>
 				<unitPattern count="other">{0}ಡ್ರಾಪ್</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಡ್ರಾಮ್ ಫ್ಲೂಡ್</displayName>
 				<unitPattern count="one">{0}fl.dr.</unitPattern>
 				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ಜಿಗರ್</displayName>
+				<unitPattern count="one">{0} ಜಿಗರ್</unitPattern>
+				<unitPattern count="other">{0} ಜಿಗರ್</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಪಿಂಚ್</displayName>
 				<unitPattern count="one">{0}ಪಿಂಚ್</unitPattern>
 				<unitPattern count="other">{0}ಪಿಂಚ್</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ಕ್ವಾ.ಇಂಪ್</displayName>
 				<unitPattern count="one">{0}qt-Imp.</unitPattern>
 				<unitPattern count="other">{0}qt-Imp.</unitPattern>
 			</unit>
@@ -11954,20 +11954,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ಅಥವಾ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, ಅಥವಾ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ಅಥವಾ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, ಅಥವಾ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ಅಥವಾ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -1006,7 +1006,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">나우루</territory>
 			<territory type="NU">니우에</territory>
 			<territory type="NZ">뉴질랜드</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">뉴질랜드</territory>
 			<territory type="OM">오만</territory>
 			<territory type="PA">파나마</territory>
 			<territory type="PE">페루</territory>
@@ -1066,7 +1066,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">튀니지</territory>
 			<territory type="TO">통가</territory>
 			<territory type="TR">튀르키예</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">튀르키예</territory>
 			<territory type="TT">트리니다드 토바고</territory>
 			<territory type="TV">투발루</territory>
 			<territory type="TW">대만</territory>
@@ -1503,190 +1503,190 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="14" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="15" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="16" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="17" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="18" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="19" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="20" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="21" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="22" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="23" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="24" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="25" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="26" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="27" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="28" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="29" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="30" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="31" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="32" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="33" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="34" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="35" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="36" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="37" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="38" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="39" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="40" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="41" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="42" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="43" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="44" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="45" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="46" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="47" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="48" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="49" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="50" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="51" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="52" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="53" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="54" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="55" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="56" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="57" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="58" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="59" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="60" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">갑자</cyclicName>
+								<cyclicName type="2" draft="contributed">을축</cyclicName>
+								<cyclicName type="3" draft="contributed">병인</cyclicName>
+								<cyclicName type="4" draft="contributed">정묘</cyclicName>
+								<cyclicName type="5" draft="contributed">무진</cyclicName>
+								<cyclicName type="6" draft="contributed">기사</cyclicName>
+								<cyclicName type="7" draft="contributed">경오</cyclicName>
+								<cyclicName type="8" draft="contributed">신미</cyclicName>
+								<cyclicName type="9" draft="contributed">임신</cyclicName>
+								<cyclicName type="10" draft="contributed">계유</cyclicName>
+								<cyclicName type="11" draft="contributed">갑술</cyclicName>
+								<cyclicName type="12" draft="contributed">을해</cyclicName>
+								<cyclicName type="13" draft="contributed">병자</cyclicName>
+								<cyclicName type="14" draft="contributed">정축</cyclicName>
+								<cyclicName type="15" draft="contributed">무인</cyclicName>
+								<cyclicName type="16" draft="contributed">기묘</cyclicName>
+								<cyclicName type="17" draft="contributed">경진</cyclicName>
+								<cyclicName type="18" draft="contributed">신사</cyclicName>
+								<cyclicName type="19" draft="contributed">임오</cyclicName>
+								<cyclicName type="20" draft="contributed">계미</cyclicName>
+								<cyclicName type="21" draft="contributed">갑신</cyclicName>
+								<cyclicName type="22" draft="contributed">을유</cyclicName>
+								<cyclicName type="23" draft="contributed">병술</cyclicName>
+								<cyclicName type="24" draft="contributed">정해</cyclicName>
+								<cyclicName type="25" draft="contributed">무자</cyclicName>
+								<cyclicName type="26" draft="contributed">기축</cyclicName>
+								<cyclicName type="27" draft="contributed">경인</cyclicName>
+								<cyclicName type="28" draft="contributed">신묘</cyclicName>
+								<cyclicName type="29" draft="contributed">임진</cyclicName>
+								<cyclicName type="30" draft="contributed">계사</cyclicName>
+								<cyclicName type="31" draft="contributed">갑오</cyclicName>
+								<cyclicName type="32" draft="contributed">을미</cyclicName>
+								<cyclicName type="33" draft="contributed">병신</cyclicName>
+								<cyclicName type="34" draft="contributed">정유</cyclicName>
+								<cyclicName type="35" draft="contributed">무술</cyclicName>
+								<cyclicName type="36" draft="contributed">기해</cyclicName>
+								<cyclicName type="37" draft="contributed">경자</cyclicName>
+								<cyclicName type="38" draft="contributed">신축</cyclicName>
+								<cyclicName type="39" draft="contributed">임인</cyclicName>
+								<cyclicName type="40" draft="contributed">계묘</cyclicName>
+								<cyclicName type="41" draft="contributed">갑진</cyclicName>
+								<cyclicName type="42" draft="contributed">을사</cyclicName>
+								<cyclicName type="43" draft="contributed">병오</cyclicName>
+								<cyclicName type="44" draft="contributed">정미</cyclicName>
+								<cyclicName type="45" draft="contributed">무신</cyclicName>
+								<cyclicName type="46" draft="contributed">기유</cyclicName>
+								<cyclicName type="47" draft="contributed">경술</cyclicName>
+								<cyclicName type="48" draft="contributed">신해</cyclicName>
+								<cyclicName type="49" draft="contributed">임자</cyclicName>
+								<cyclicName type="50" draft="contributed">계축</cyclicName>
+								<cyclicName type="51" draft="contributed">갑인</cyclicName>
+								<cyclicName type="52" draft="contributed">을묘</cyclicName>
+								<cyclicName type="53" draft="contributed">병진</cyclicName>
+								<cyclicName type="54" draft="contributed">정사</cyclicName>
+								<cyclicName type="55" draft="contributed">무오</cyclicName>
+								<cyclicName type="56" draft="contributed">기미</cyclicName>
+								<cyclicName type="57" draft="contributed">경신</cyclicName>
+								<cyclicName type="58" draft="contributed">신유</cyclicName>
+								<cyclicName type="59" draft="contributed">임술</cyclicName>
+								<cyclicName type="60" draft="contributed">계해</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="14" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="15" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="16" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="17" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="18" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="19" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="20" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="21" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="22" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="23" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="24" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="25" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="26" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="27" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="28" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="29" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="30" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="31" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="32" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="33" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="34" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="35" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="36" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="37" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="38" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="39" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="40" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="41" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="42" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="43" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="44" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="45" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="46" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="47" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="48" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="49" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="50" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="51" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="52" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="53" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="54" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="55" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="56" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="57" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="58" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="59" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="60" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">갑자</cyclicName>
+								<cyclicName type="2" draft="contributed">을축</cyclicName>
+								<cyclicName type="3" draft="contributed">병인</cyclicName>
+								<cyclicName type="4" draft="contributed">정묘</cyclicName>
+								<cyclicName type="5" draft="contributed">무진</cyclicName>
+								<cyclicName type="6" draft="contributed">기사</cyclicName>
+								<cyclicName type="7" draft="contributed">경오</cyclicName>
+								<cyclicName type="8" draft="contributed">신미</cyclicName>
+								<cyclicName type="9" draft="contributed">임신</cyclicName>
+								<cyclicName type="10" draft="contributed">계유</cyclicName>
+								<cyclicName type="11" draft="contributed">갑술</cyclicName>
+								<cyclicName type="12" draft="contributed">을해</cyclicName>
+								<cyclicName type="13" draft="contributed">병자</cyclicName>
+								<cyclicName type="14" draft="contributed">정축</cyclicName>
+								<cyclicName type="15" draft="contributed">무인</cyclicName>
+								<cyclicName type="16" draft="contributed">기묘</cyclicName>
+								<cyclicName type="17" draft="contributed">경진</cyclicName>
+								<cyclicName type="18" draft="contributed">신사</cyclicName>
+								<cyclicName type="19" draft="contributed">임오</cyclicName>
+								<cyclicName type="20" draft="contributed">계미</cyclicName>
+								<cyclicName type="21" draft="contributed">갑신</cyclicName>
+								<cyclicName type="22" draft="contributed">을유</cyclicName>
+								<cyclicName type="23" draft="contributed">병술</cyclicName>
+								<cyclicName type="24" draft="contributed">정해</cyclicName>
+								<cyclicName type="25" draft="contributed">무자</cyclicName>
+								<cyclicName type="26" draft="contributed">기축</cyclicName>
+								<cyclicName type="27" draft="contributed">경인</cyclicName>
+								<cyclicName type="28" draft="contributed">신묘</cyclicName>
+								<cyclicName type="29" draft="contributed">임진</cyclicName>
+								<cyclicName type="30" draft="contributed">계사</cyclicName>
+								<cyclicName type="31" draft="contributed">갑오</cyclicName>
+								<cyclicName type="32" draft="contributed">을미</cyclicName>
+								<cyclicName type="33" draft="contributed">병신</cyclicName>
+								<cyclicName type="34" draft="contributed">정유</cyclicName>
+								<cyclicName type="35" draft="contributed">무술</cyclicName>
+								<cyclicName type="36" draft="contributed">기해</cyclicName>
+								<cyclicName type="37" draft="contributed">경자</cyclicName>
+								<cyclicName type="38" draft="contributed">신축</cyclicName>
+								<cyclicName type="39" draft="contributed">임인</cyclicName>
+								<cyclicName type="40" draft="contributed">계묘</cyclicName>
+								<cyclicName type="41" draft="contributed">갑진</cyclicName>
+								<cyclicName type="42" draft="contributed">을사</cyclicName>
+								<cyclicName type="43" draft="contributed">병오</cyclicName>
+								<cyclicName type="44" draft="contributed">정미</cyclicName>
+								<cyclicName type="45" draft="contributed">무신</cyclicName>
+								<cyclicName type="46" draft="contributed">기유</cyclicName>
+								<cyclicName type="47" draft="contributed">경술</cyclicName>
+								<cyclicName type="48" draft="contributed">신해</cyclicName>
+								<cyclicName type="49" draft="contributed">임자</cyclicName>
+								<cyclicName type="50" draft="contributed">계축</cyclicName>
+								<cyclicName type="51" draft="contributed">갑인</cyclicName>
+								<cyclicName type="52" draft="contributed">을묘</cyclicName>
+								<cyclicName type="53" draft="contributed">병진</cyclicName>
+								<cyclicName type="54" draft="contributed">정사</cyclicName>
+								<cyclicName type="55" draft="contributed">무오</cyclicName>
+								<cyclicName type="56" draft="contributed">기미</cyclicName>
+								<cyclicName type="57" draft="contributed">경신</cyclicName>
+								<cyclicName type="58" draft="contributed">신유</cyclicName>
+								<cyclicName type="59" draft="contributed">임술</cyclicName>
+								<cyclicName type="60" draft="contributed">계해</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="14" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="15" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="16" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="17" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="18" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="19" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="20" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="21" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="22" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="23" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="24" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="25" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="26" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="27" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="28" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="29" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="30" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="31" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="32" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="33" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="34" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="35" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="36" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="37" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="38" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="39" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="40" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="41" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="42" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="43" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="44" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="45" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="46" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="47" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="48" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="49" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="50" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="51" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="52" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="53" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="54" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="55" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="56" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="57" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="58" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="59" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="60" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">갑자</cyclicName>
+								<cyclicName type="2" draft="contributed">을축</cyclicName>
+								<cyclicName type="3" draft="contributed">병인</cyclicName>
+								<cyclicName type="4" draft="contributed">정묘</cyclicName>
+								<cyclicName type="5" draft="contributed">무진</cyclicName>
+								<cyclicName type="6" draft="contributed">기사</cyclicName>
+								<cyclicName type="7" draft="contributed">경오</cyclicName>
+								<cyclicName type="8" draft="contributed">신미</cyclicName>
+								<cyclicName type="9" draft="contributed">임신</cyclicName>
+								<cyclicName type="10" draft="contributed">계유</cyclicName>
+								<cyclicName type="11" draft="contributed">갑술</cyclicName>
+								<cyclicName type="12" draft="contributed">을해</cyclicName>
+								<cyclicName type="13" draft="contributed">병자</cyclicName>
+								<cyclicName type="14" draft="contributed">정축</cyclicName>
+								<cyclicName type="15" draft="contributed">무인</cyclicName>
+								<cyclicName type="16" draft="contributed">기묘</cyclicName>
+								<cyclicName type="17" draft="contributed">경진</cyclicName>
+								<cyclicName type="18" draft="contributed">신사</cyclicName>
+								<cyclicName type="19" draft="contributed">임오</cyclicName>
+								<cyclicName type="20" draft="contributed">계미</cyclicName>
+								<cyclicName type="21" draft="contributed">갑신</cyclicName>
+								<cyclicName type="22" draft="contributed">을유</cyclicName>
+								<cyclicName type="23" draft="contributed">병술</cyclicName>
+								<cyclicName type="24" draft="contributed">정해</cyclicName>
+								<cyclicName type="25" draft="contributed">무자</cyclicName>
+								<cyclicName type="26" draft="contributed">기축</cyclicName>
+								<cyclicName type="27" draft="contributed">경인</cyclicName>
+								<cyclicName type="28" draft="contributed">신묘</cyclicName>
+								<cyclicName type="29" draft="contributed">임진</cyclicName>
+								<cyclicName type="30" draft="contributed">계사</cyclicName>
+								<cyclicName type="31" draft="contributed">갑오</cyclicName>
+								<cyclicName type="32" draft="contributed">을미</cyclicName>
+								<cyclicName type="33" draft="contributed">병신</cyclicName>
+								<cyclicName type="34" draft="contributed">정유</cyclicName>
+								<cyclicName type="35" draft="contributed">무술</cyclicName>
+								<cyclicName type="36" draft="contributed">기해</cyclicName>
+								<cyclicName type="37" draft="contributed">경자</cyclicName>
+								<cyclicName type="38" draft="contributed">신축</cyclicName>
+								<cyclicName type="39" draft="contributed">임인</cyclicName>
+								<cyclicName type="40" draft="contributed">계묘</cyclicName>
+								<cyclicName type="41" draft="contributed">갑진</cyclicName>
+								<cyclicName type="42" draft="contributed">을사</cyclicName>
+								<cyclicName type="43" draft="contributed">병오</cyclicName>
+								<cyclicName type="44" draft="contributed">정미</cyclicName>
+								<cyclicName type="45" draft="contributed">무신</cyclicName>
+								<cyclicName type="46" draft="contributed">기유</cyclicName>
+								<cyclicName type="47" draft="contributed">경술</cyclicName>
+								<cyclicName type="48" draft="contributed">신해</cyclicName>
+								<cyclicName type="49" draft="contributed">임자</cyclicName>
+								<cyclicName type="50" draft="contributed">계축</cyclicName>
+								<cyclicName type="51" draft="contributed">갑인</cyclicName>
+								<cyclicName type="52" draft="contributed">을묘</cyclicName>
+								<cyclicName type="53" draft="contributed">병진</cyclicName>
+								<cyclicName type="54" draft="contributed">정사</cyclicName>
+								<cyclicName type="55" draft="contributed">무오</cyclicName>
+								<cyclicName type="56" draft="contributed">기미</cyclicName>
+								<cyclicName type="57" draft="contributed">경신</cyclicName>
+								<cyclicName type="58" draft="contributed">신유</cyclicName>
+								<cyclicName type="59" draft="contributed">임술</cyclicName>
+								<cyclicName type="60" draft="contributed">계해</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2355,7 +2355,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2363,7 +2363,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2371,7 +2371,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2379,7 +2379,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2944,7 +2944,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2952,7 +2952,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2960,7 +2960,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2968,7 +2968,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3323,11 +3323,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="japanese">
 				<eras>
 					<eraNames>
-						<era type="232" draft="contributed">↑↑↑</era>
-						<era type="233" draft="contributed">↑↑↑</era>
-						<era type="234" draft="contributed">↑↑↑</era>
-						<era type="235" draft="contributed">↑↑↑</era>
-						<era type="236" draft="contributed">↑↑↑</era>
+						<era type="232" draft="contributed">메이지</era>
+						<era type="233" draft="contributed">다이쇼</era>
+						<era type="234" draft="contributed">쇼와</era>
+						<era type="235" draft="contributed">헤이세이</era>
+						<era type="236" draft="contributed">레이와</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">다이카 (645 ~ 650)</era>
@@ -3708,9 +3708,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>년</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">작년</relative>
+				<relative type="0">올해</relative>
+				<relative type="1">내년</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}년 후</relativeTimePattern>
 				</relativeTime>
@@ -3720,9 +3720,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>년</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">작년</relative>
+				<relative type="0">올해</relative>
+				<relative type="1">내년</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}년 후</relativeTimePattern>
 				</relativeTime>
@@ -3744,9 +3744,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-short">
 				<displayName>분기</displayName>
-				<relative type="-1" draft="contributed">↑↑↑</relative>
-				<relative type="0" draft="contributed">↑↑↑</relative>
-				<relative type="1" draft="contributed">↑↑↑</relative>
+				<relative type="-1" draft="contributed">지난 분기</relative>
+				<relative type="0" draft="contributed">이번 분기</relative>
+				<relative type="1" draft="contributed">다음 분기</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}분기 후</relativeTimePattern>
 				</relativeTime>
@@ -3756,9 +3756,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-narrow">
 				<displayName>분기</displayName>
-				<relative type="-1" draft="contributed">↑↑↑</relative>
-				<relative type="0" draft="contributed">↑↑↑</relative>
-				<relative type="1" draft="contributed">↑↑↑</relative>
+				<relative type="-1" draft="contributed">지난 분기</relative>
+				<relative type="0" draft="contributed">이번 분기</relative>
+				<relative type="1" draft="contributed">다음 분기</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}분기 후</relativeTimePattern>
 				</relativeTime>
@@ -3780,9 +3780,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>월</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">지난달</relative>
+				<relative type="0">이번 달</relative>
+				<relative type="1">다음 달</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}개월 후</relativeTimePattern>
 				</relativeTime>
@@ -3792,9 +3792,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>월</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">지난달</relative>
+				<relative type="0">이번 달</relative>
+				<relative type="1">다음 달</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}개월 후</relativeTimePattern>
 				</relativeTime>
@@ -3817,9 +3817,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>주</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">지난주</relative>
+				<relative type="0">이번 주</relative>
+				<relative type="1">다음 주</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}주 후</relativeTimePattern>
 				</relativeTime>
@@ -3830,9 +3830,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>주</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">지난주</relative>
+				<relative type="0">이번 주</relative>
+				<relative type="1">다음 주</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}주 후</relativeTimePattern>
 				</relativeTime>
@@ -3866,11 +3866,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>일</displayName>
-				<relative type="-2" draft="contributed">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2" draft="contributed">↑↑↑</relative>
+				<relative type="-2" draft="contributed">그저께</relative>
+				<relative type="-1">어제</relative>
+				<relative type="0">오늘</relative>
+				<relative type="1">내일</relative>
+				<relative type="2" draft="contributed">모레</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}일 후</relativeTimePattern>
 				</relativeTime>
@@ -3880,11 +3880,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>일</displayName>
-				<relative type="-2" draft="contributed">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2" draft="contributed">↑↑↑</relative>
+				<relative type="-2" draft="contributed">그저께</relative>
+				<relative type="-1">어제</relative>
+				<relative type="0">오늘</relative>
+				<relative type="1">내일</relative>
+				<relative type="2" draft="contributed">모레</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}일 후</relativeTimePattern>
 				</relativeTime>
@@ -4227,7 +4227,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>초</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">지금</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}초 후</relativeTimePattern>
 				</relativeTime>
@@ -4237,7 +4237,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>초</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">지금</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0}초 후</relativeTimePattern>
 				</relativeTime>
@@ -8070,7 +8070,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">세제곱{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>중력가속도</displayName>
@@ -8174,8 +8174,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>몰</displayName>
@@ -8246,8 +8246,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}세기</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="other">{0}dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>년</displayName>
@@ -8382,35 +8382,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}헤르츠</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>MP</displayName>
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="other">{0}dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpi</displayName>
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="other">{0}dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
@@ -8683,7 +8683,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}켈빈</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -9276,7 +9276,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="other">{0}dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
@@ -9707,102 +9707,102 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-force</displayName>
@@ -9813,85 +9813,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0}rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="other">{0}rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>′</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>″</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ha</displayName>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="other">{0}cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ac</displayName>
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="other">{0}yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="other">{0}in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>두남</displayName>
+				<unitPattern count="other">{0}두남</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="other">{0}kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0}mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other">{0}mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>항목</displayName>
+				<unitPattern count="other">{0}개 항목</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
@@ -9906,80 +9906,80 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="other">{0}L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="other">{0}mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0}kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>byte</displayName>
+				<unitPattern count="other">{0}byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0}bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>C</displayName>
 				<unitPattern count="other">{0}C</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="other">{0}dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>년</displayName>
@@ -10034,120 +10034,120 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="other">{0}cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="other">{0}Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>줄</displayName>
+				<unitPattern count="other">{0}줄</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>미국 섬</displayName>
+				<unitPattern count="other">{0}섬</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100km</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="other">{0}dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0}dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -10235,24 +10235,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -10303,43 +10303,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="other">{0}grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>w</displayName>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="other">{0}HP</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -10352,35 +10352,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>inHg</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -10415,153 +10415,153 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="other">{0}m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0}cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="other">{0}yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="other">{0}ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="other">{0}in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0}ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0}hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ℓ</displayName>
 				<unitPattern count="other">{0}ℓ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0}dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="other">{0}cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other">{0}mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="other">{0}mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="other">{0}bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="other">{0}gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="other">{0}gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>컵</displayName>
+				<unitPattern count="other">{0}컵</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="other">{0}fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="other">{0}tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="other">{0}tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="other">{0}dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>dsp Imp</displayName>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>drop</displayName>
+				<unitPattern count="other">{0}drop</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram fluid</displayName>
+				<unitPattern count="other">{0}dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="other">{0}jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="other">{0}pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="other">{0}qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>쪽</displayName>
@@ -10595,22 +10595,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} 또는 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} 또는 {1}</listPatternPart>
+			<listPatternPart type="2">{0} 또는 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} 또는 {1}</listPatternPart>
+			<listPatternPart type="2">{0} 또는 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} 및 {1}</listPatternPart>
+			<listPatternPart type="2">{0} 및 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -10836,7 +10836,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{given} {surname} {credentials}</namePattern>
@@ -10851,10 +10851,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{given} {surname}</namePattern>
@@ -10869,10 +10869,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{surname}{given} {given2} {credentials}</namePattern>
@@ -10890,7 +10890,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname}{given} {credentials}</namePattern>
@@ -10905,10 +10905,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{surname}{given}</namePattern>
@@ -10923,10 +10923,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>{surname-core}{given} {given2} {surname-prefix}</namePattern>
@@ -10935,7 +10935,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}{given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}{given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}{given-informal}</namePattern>

--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -752,7 +752,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">नावरू</territory>
 			<territory type="NU">नीयू</territory>
 			<territory type="NZ">न्युझीलॅन्ड</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">न्युझीलॅन्ड</territory>
 			<territory type="OM">ओमान</territory>
 			<territory type="PA">पनामा</territory>
 			<territory type="PE">पेरू</territory>
@@ -812,7 +812,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">ट्यूनीशिया</territory>
 			<territory type="TO">टोंगा</territory>
 			<territory type="TR">तुर्की</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">तुर्की</territory>
 			<territory type="TT">ट्रिनीदाद आनी टोबॅगो</territory>
 			<territory type="TV">टुवालू</territory>
 			<territory type="TW">तायवान</territory>
@@ -1212,7 +1212,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="6">जून</month>
 							<month type="7">जुलय</month>
 							<month type="8">ऑगस्ट</month>
-							<month type="9">↑↑↑</month>
+							<month type="9">सप्टेंबर</month>
 							<month type="10">ऑक्टोबर</month>
 							<month type="11">नोव्हेंबर</month>
 							<month type="12">डिसेंबर</month>
@@ -1281,9 +1281,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="3">मार्च</month>
 							<month type="4">एप्रील</month>
 							<month type="5">मे</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
+							<month type="6">जून</month>
+							<month type="7">जुलय</month>
+							<month type="8">ऑगस्ट</month>
 							<month type="9">सप्टेंबर</month>
 							<month type="10">ऑक्टोबर</month>
 							<month type="11">नोव्हेंबर</month>
@@ -1298,7 +1298,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon">सोमार</day>
 							<day type="tue">मंगळार</day>
 							<day type="wed">बुधवार</day>
-							<day type="thu">↑↑↑</day>
+							<day type="thu">बिरेस्तार</day>
 							<day type="fri">शुक्रार</day>
 							<day type="sat">शेनवार</day>
 						</dayWidth>
@@ -1336,7 +1336,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon">सोमार</day>
 							<day type="tue">मंगळार</day>
 							<day type="wed">बुधवार</day>
-							<day type="thu">↑↑↑</day>
+							<day type="thu">बिरेस्तार</day>
 							<day type="fri">शुक्रार</day>
 							<day type="sat">शेनवार</day>
 						</dayWidth>
@@ -1354,7 +1354,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon">सोम</day>
 							<day type="tue">मंगळ</day>
 							<day type="wed">बुध</day>
-							<day type="thu">↑↑↑</day>
+							<day type="thu">बिरे</day>
 							<day type="fri">शुक्र</day>
 							<day type="sat">शेन</day>
 						</dayWidth>
@@ -1363,7 +1363,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon">सोमार</day>
 							<day type="tue">मंगळार</day>
 							<day type="wed">बुधवार</day>
-							<day type="thu">↑↑↑</day>
+							<day type="thu">बिरेस्तार</day>
 							<day type="fri">शुक्रार</day>
 							<day type="sat">शेनवार</day>
 						</dayWidth>
@@ -1392,10 +1392,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">Q1</quarter>
+							<quarter type="2">Q2</quarter>
+							<quarter type="3">Q3</quarter>
+							<quarter type="4">Q4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">1</quarter>
@@ -1404,10 +1404,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">1लें त्रैमासीक</quarter>
+							<quarter type="2">2रें त्रैमासीक</quarter>
+							<quarter type="3">3रें त्रैमासीक</quarter>
+							<quarter type="4">4थें त्रैमासीक</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -1858,9 +1858,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>वर्स</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">फाटलें वर्स</relative>
+				<relative type="0">हें वर्स</relative>
+				<relative type="1">फुडलें वर्स</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} वर्सांनीं</relativeTimePattern>
 				</relativeTime>
@@ -1870,9 +1870,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>वर्स</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">फाटलें वर्स</relative>
+				<relative type="0">हें वर्स</relative>
+				<relative type="1">फुडलें वर्स</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} वर्सांनीं</relativeTimePattern>
 				</relativeTime>
@@ -1924,9 +1924,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName>म्हयनो</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">फाटलो म्हयनो</relative>
+				<relative type="0">हो म्हयनो</relative>
+				<relative type="1">फुडलो म्हयनो</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} म्हयन्यानीं</relativeTimePattern>
 				</relativeTime>
@@ -1936,9 +1936,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>म्हयनो</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">फाटलो म्हयनो</relative>
+				<relative type="0">हो म्हयनो</relative>
+				<relative type="1">फुडलो म्हयनो</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} म्हयन्यानीं</relativeTimePattern>
 				</relativeTime>
@@ -1961,11 +1961,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>सप्तक</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">निमाणो सप्तक</relative>
+				<relative type="0">हो सप्तक</relative>
+				<relative type="1">फुडलो सप्तक</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सप्तकांनीं</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0} सप्तकां आदीं</relativeTimePattern>
@@ -1974,9 +1974,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>सप्तक</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">निमाणो सप्तक</relative>
+				<relative type="0">हो सप्तक</relative>
+				<relative type="1">फुडलो सप्तक</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} सप्तकांनीं</relativeTimePattern>
 				</relativeTime>
@@ -2008,9 +2008,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>दीस</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">काल</relative>
+				<relative type="0">आयज</relative>
+				<relative type="1">फाल्यां</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} दिसानीं</relativeTimePattern>
 				</relativeTime>
@@ -2020,9 +2020,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>दीस</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">काल</relative>
+				<relative type="0">आयज</relative>
+				<relative type="1">फाल्यां</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} दिसानीं</relativeTimePattern>
 				</relativeTime>
@@ -2373,7 +2373,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>सेकंद</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} सेकंदानीं</relativeTimePattern>
 				</relativeTime>
@@ -5094,7 +5094,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="INR">
 				<displayName>भारतीय रुपया</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">भारतीय रुपया</displayName>
 				<symbol>₹</symbol>
 				<symbol alt="narrow">₹</symbol>
 			</currency>
@@ -5915,9 +5915,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>दर वर्सा {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>qtr</displayName>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>म्हयने</displayName>
@@ -6201,8 +6201,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} मिलिग्राम</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>टन</displayName>
@@ -6327,8 +6327,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} नॉट</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>अंश सेल्सियस</displayName>
@@ -6386,7 +6386,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>हॅक्टोलीटर</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>लिटर</displayName>
@@ -7454,11 +7454,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7647,9 +7647,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/वर्सां</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>qtr</displayName>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>म्हयनो</displayName>
@@ -7899,15 +7899,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>लक्स</displayName>
 				<unitPattern count="other">{0}लक्स</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -8154,7 +8154,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>गॅ</displayName>
 				<unitPattern count="other">{0}गॅ</unitPattern>
 				<perUnitPattern>{0}/गॅ</perUnitPattern>
 			</unit>
@@ -8483,127 +8483,127 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">दिशा</nameField>

--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -664,7 +664,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CG" alt="variant">کونگو (جمہوریہ)</territory>
 			<territory type="CH">سُوِزَرلینڑ</territory>
 			<territory type="CI">کوٹ ڈلوائر</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
+			<territory type="CI" alt="variant">کوٹ ڈلوائر</territory>
 			<territory type="CK">کُک جٔزیٖرٕ</territory>
 			<territory type="CL">چِلی</territory>
 			<territory type="CM">کیمِروٗن</territory>
@@ -678,7 +678,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CX">کرِسمَس جٔزیٖرٕ</territory>
 			<territory type="CY">سائپرس</territory>
 			<territory type="CZ">چیکیا</territory>
-			<territory type="CZ" alt="variant">↑↑↑</territory>
+			<territory type="CZ" alt="variant">چیکیا</territory>
 			<territory type="DE">جرمٔنی</territory>
 			<territory type="DG">ڈیگو گریشیا</territory>
 			<territory type="DJ">جِبوٗتی</territory>
@@ -699,13 +699,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="FI">فِن لینڈ</territory>
 			<territory type="FJ">فِجی</territory>
 			<territory type="FK">فٕلاکلینڑ جٔزیٖرٕ</territory>
-			<territory type="FK" alt="variant">↑↑↑</territory>
+			<territory type="FK" alt="variant">فٕلاکلینڑ جٔزیٖرٕ</territory>
 			<territory type="FM">مائیکرونیشیا</territory>
 			<territory type="FO">فارو جزیرہ</territory>
 			<territory type="FR">فرانس</territory>
 			<territory type="GA">گیبان</territory>
 			<territory type="GB">متحدہ مملِکت</territory>
-			<territory type="GB" alt="short">↑↑↑</territory>
+			<territory type="GB" alt="short">متحدہ مملِکت</territory>
 			<territory type="GD">گرینیڈا</territory>
 			<territory type="GE">جارجِیا</territory>
 			<territory type="GF">فرانسِسی گِانا</territory>
@@ -857,7 +857,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TJ">تاجکِستان</territory>
 			<territory type="TK">ٹوکلو</territory>
 			<territory type="TL">تیمور-لیسٹ</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">تیمور-لیسٹ</territory>
 			<territory type="TM">تُرکمنستان</territory>
 			<territory type="TN">ٹونیشِیا</territory>
 			<territory type="TO">ٹونگا</territory>
@@ -871,7 +871,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UM">یوٗنایٹِڑ سِٹیٹِس ماینَر آوُٹلییِنگ جٔزیٖرٕ</territory>
 			<territory type="UN">متحدہ مُمٲلک</territory>
 			<territory type="US">یوٗنایٹِڑ سِٹیٹِس</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">یوٗنایٹِڑ سِٹیٹِس</territory>
 			<territory type="UY">یوٗروگے</territory>
 			<territory type="UZ">اُزبِکِستان</territory>
 			<territory type="VA">ویٹِکَن سِٹی</territory>
@@ -1023,7 +1023,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1031,7 +1031,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1181,32 +1181,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
+							<month type="1">جنؤری</month>
+							<month type="2">فرؤری</month>
+							<month type="3">مارٕچ</month>
+							<month type="4">اپریل</month>
 							<month type="5">مئی</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="6">جوٗن</month>
+							<month type="7">جوٗلایی</month>
+							<month type="8">اگست</month>
+							<month type="9">ستمبر</month>
+							<month type="10">اکتوٗبر</month>
+							<month type="11">نومبر</month>
+							<month type="12">دسمبر</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">ج</month>
+							<month type="2">ف</month>
+							<month type="3">م</month>
+							<month type="4">ا</month>
+							<month type="5">م</month>
+							<month type="6">ج</month>
+							<month type="7">ج</month>
+							<month type="8">ا</month>
+							<month type="9">س</month>
+							<month type="10">س</month>
+							<month type="11">ا</month>
+							<month type="12">ن</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">جنؤری</month>
@@ -1225,18 +1225,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
+							<month type="1">جنؤری</month>
+							<month type="2">فرؤری</month>
+							<month type="3">مارٕچ</month>
+							<month type="4">اپریل</month>
 							<month type="5">مئی</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="6">جوٗن</month>
+							<month type="7">جوٗلایی</month>
+							<month type="8">اگست</month>
+							<month type="9">ستمبر</month>
+							<month type="10">اکتوٗبر</month>
+							<month type="11">نومبر</month>
+							<month type="12">دسمبر</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">ج</month>
@@ -1253,18 +1253,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">ن</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
+							<month type="1">جنؤری</month>
+							<month type="2">فرؤری</month>
+							<month type="3">مارٕچ</month>
+							<month type="4">اپریل</month>
 							<month type="5">مئی</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="6">جوٗن</month>
+							<month type="7">جوٗلایی</month>
+							<month type="8">اگست</month>
+							<month type="9">ستمبر</month>
+							<month type="10">اکتوٗبر</month>
+							<month type="11">نومبر</month>
+							<month type="12">دسمبر</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1280,22 +1280,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">بٹوار</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">ا</day>
+							<day type="mon">ژ</day>
+							<day type="tue">ب</day>
+							<day type="wed">ب</day>
+							<day type="thu">ب</day>
+							<day type="fri">ج</day>
+							<day type="sat">ب</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">آتھوار</day>
+							<day type="mon">ژٔندٕروار</day>
+							<day type="tue">بۆموار</day>
+							<day type="wed">بودوار</day>
+							<day type="thu">برؠسوار</day>
+							<day type="fri">جُمہ</day>
+							<day type="sat">بٹوار</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">اَتھوار</day>
@@ -1309,13 +1309,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">آتھوار</day>
+							<day type="mon">ژٔندٕروار</day>
+							<day type="tue">بۆموار</day>
+							<day type="wed">بودوار</day>
+							<day type="thu">برؠسوار</day>
+							<day type="fri">جُمہ</day>
+							<day type="sat">بٹوار</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">ا</day>
@@ -1327,22 +1327,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">ب</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">آتھوار</day>
+							<day type="mon">ژٔندٕروار</day>
+							<day type="tue">بۆموار</day>
+							<day type="wed">بودوار</day>
+							<day type="thu">برؠسوار</day>
+							<day type="fri">جُمہ</day>
+							<day type="sat">بٹوار</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">اَتھوار</day>
+							<day type="mon">ژٔندرٕروار</day>
+							<day type="tue">بۆموار</day>
+							<day type="wed">بودوار</day>
+							<day type="thu">برؠسوار</day>
+							<day type="fri">جُمہ</day>
+							<day type="sat">بٹوار</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -1355,10 +1355,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">کیو 4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">1</quarter>
+							<quarter type="2">2</quarter>
+							<quarter type="3">3</quarter>
+							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1">گۄڑنیُک ژۄباگ</quarter>
@@ -1381,10 +1381,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">↑↑↑</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">گۄڑنیُک ژۄباگ</quarter>
+							<quarter type="2">دۆیِم ژۄباگ</quarter>
+							<quarter type="3">تریِم ژۄباگ</quarter>
+							<quarter type="4">ژوٗرِم ژۄباگ</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -1405,16 +1405,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -1506,7 +1506,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1514,7 +1514,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1711,18 +1711,62 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">محرم</month>
+							<month type="2">صفر</month>
+							<month type="3">ربیٖع الاول</month>
+							<month type="4">ربیٖع الثانی</month>
+							<month type="5">جمادی الاول</month>
+							<month type="6">جمادی الثانی</month>
+							<month type="7">رجب</month>
+							<month type="8">شعبان</month>
+							<month type="9">رمضان</month>
+							<month type="10">شوال</month>
+							<month type="11">ذِی القعدہ</month>
+							<month type="12">ذِی الحج</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">محرم</month>
+							<month type="2">صفر</month>
+							<month type="3">ربیٖع الاول</month>
+							<month type="4">ربیٖع الثانی</month>
+							<month type="5">جمادی الاول</month>
+							<month type="6">جمادی الثانی</month>
+							<month type="7">رجب</month>
+							<month type="8">شعبان</month>
+							<month type="9">رمضان</month>
+							<month type="10">شوال</month>
+							<month type="11">ذِی القعدہ</month>
+							<month type="12">ذِی الحج</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">محرم</month>
+							<month type="2">صفر</month>
+							<month type="3">ربیٖع الاول</month>
+							<month type="4">ربیٖع الثانی</month>
+							<month type="5">جمادی الاول</month>
+							<month type="6">جمادی الثانی</month>
+							<month type="7">رجب</month>
+							<month type="8">شعبان</month>
+							<month type="9">رمضان</month>
+							<month type="10">شوال</month>
+							<month type="11">ذِی القعدہ</month>
+							<month type="12">ذِی الحج</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -1753,50 +1797,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">ذِی الحج</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraAbbr>
@@ -1816,13 +1816,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">نو ؤری</relative>
 			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ؤری</displayName>
 				<relative type="-1">پٔتِم ؤری</relative>
 				<relative type="0">یٕہ ؤری</relative>
 				<relative type="1">نو ؤری</relative>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ؤری</displayName>
 				<relative type="-1">پٔتِم ؤری</relative>
 				<relative type="0">یٕہ ؤری</relative>
 				<relative type="1">نو ؤری</relative>
@@ -1843,13 +1843,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">نو ریتھۍ</relative>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>رؠتھ</displayName>
 				<relative type="-1">پٔتِم ریتھۍ</relative>
 				<relative type="0">یٕہ ریتھۍ</relative>
 				<relative type="1">نو ریتھۍ</relative>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>رؠتھ</displayName>
 				<relative type="-1">پٔتِم ریتھۍ</relative>
 				<relative type="0">یٕہ ریتھۍ</relative>
 				<relative type="1">نو ریتھۍ</relative>
@@ -1862,14 +1862,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativePeriod>{0} ہُک ہفتہ</relativePeriod>
 			</field>
 			<field type="week-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ہفتہٕ</displayName>
 				<relative type="-1">پٔتِم ہفتہ</relative>
 				<relative type="0">یٕہ ہفتہ</relative>
 				<relative type="1">نو ہفتہ</relative>
 				<relativePeriod>{0} ہُک ہفتہ</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ہفتہٕ</displayName>
 				<relative type="-1">پٔتِم ہفتہ</relative>
 				<relative type="0">یٕہ ہفتہ</relative>
 				<relative type="1">نو ہفتہ</relative>
@@ -1882,16 +1882,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">پگاہ</relative>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>دۄہ</displayName>
+				<relative type="-1">راتھ</relative>
+				<relative type="0">اَز</relative>
+				<relative type="1">پگاہ</relative>
 			</field>
 			<field type="day-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>دۄہ</displayName>
+				<relative type="-1">راتھ</relative>
+				<relative type="0">اَز</relative>
+				<relative type="1">پگاہ</relative>
 			</field>
 			<field type="weekday">
 				<displayName>ہفتُک دۄہ</displayName>
@@ -1903,19 +1903,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>گٲنٹہٕ</displayName>
 			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>گٲنٹہٕ</displayName>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>گٲنٹہٕ</displayName>
 			</field>
 			<field type="minute">
 				<displayName>مِنَٹ</displayName>
 			</field>
 			<field type="minute-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>مِنَٹ</displayName>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>مِنَٹ</displayName>
 			</field>
 			<field type="second">
 				<displayName>سؠکَنڈ</displayName>
@@ -4284,7 +4284,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencies>
@@ -4499,8 +4499,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="EUR">
 				<displayName>یوٗرو</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">یوٗرو</displayName>
+				<displayName count="other">یوٗرو</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4597,8 +4597,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="INR">
 				<displayName>ہِندُستٲنۍ رۄپَے</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">ہِندُستٲنۍ رۄپَے</displayName>
+				<displayName count="other">ہِندُستٲنۍ رۄپَے</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>

--- a/common/main/ks_Deva.xml
+++ b/common/main/ks_Deva.xml
@@ -199,17 +199,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
 							<month type="1">जनवरी</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="2">फ़रवरी</month>
+							<month type="3">मार्च</month>
+							<month type="4">अप्रैल</month>
+							<month type="5">मे</month>
+							<month type="6">जून</month>
+							<month type="7">जुलाई</month>
+							<month type="8">अगस्त</month>
+							<month type="9">सतुंबर</month>
+							<month type="10">अकतुम्बर</month>
+							<month type="11">नवूमबर</month>
+							<month type="12">दसूमबर</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">ज</month>
@@ -242,18 +242,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">जनवरी</month>
+							<month type="2">फ़रवरी</month>
+							<month type="3">मार्च</month>
+							<month type="4">अप्रैल</month>
+							<month type="5">मे</month>
+							<month type="6">जून</month>
+							<month type="7">जुलाई</month>
+							<month type="8">अगस्त</month>
+							<month type="9">सतुंबर</month>
+							<month type="10">अकतुम्बर</month>
+							<month type="11">नवूमबर</month>
+							<month type="12">दसूमबर</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">ज</month>
@@ -273,28 +273,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="1">जनवरी</month>
 							<month type="2">फ़रवरी</month>
 							<month type="3">मार्च</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="4">अप्रैल</month>
+							<month type="5">मे</month>
+							<month type="6">जून</month>
+							<month type="7">जुलाई</month>
+							<month type="8">अगस्त</month>
+							<month type="9">सतुंबर</month>
+							<month type="10">अकतुम्बर</month>
+							<month type="11">नवूमबर</month>
+							<month type="12">दसूमबर</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">आथवार</day>
+							<day type="mon">चंदिरवार</day>
+							<day type="tue">बुवार</day>
+							<day type="wed">बोदवार</day>
+							<day type="thu">ब्रेसवार</day>
+							<day type="fri">जुम्मा</day>
+							<day type="sat">बटवार</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">अ</day>
@@ -317,13 +317,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">आथवार</day>
+							<day type="mon">चंदिरवार</day>
+							<day type="tue">बुवार</day>
+							<day type="wed">बोदवार</day>
+							<day type="thu">ब्रेसवार</day>
+							<day type="fri">जुम्मा</day>
+							<day type="sat">बटवार</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">अ</day>
@@ -336,12 +336,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">आथवार</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="mon">चंदिरवार</day>
+							<day type="tue">बुवार</day>
+							<day type="wed">बोदवार</day>
+							<day type="thu">ब्रेसवार</day>
+							<day type="fri">जुम्मा</day>
+							<day type="sat">बटवार</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -354,10 +354,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">Q4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">1</quarter>
+							<quarter type="2">2</quarter>
+							<quarter type="3">3</quarter>
+							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1">1st सह माह</quarter>
@@ -369,9 +369,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
 							<quarter type="1">Q1</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="2">Q2</quarter>
+							<quarter type="3">Q3</quarter>
+							<quarter type="4">Q4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">↑↑↑</quarter>
@@ -404,14 +404,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<eras>
 					<eraNames>
 						<era type="0">ईसा ब्रोंठ</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">BC</era>
 						<era type="1">ईस्वी</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">BC</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">BC</era>
 						<era type="1">AD</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">AD</era>
 					</eraAbbr>
 				</eras>
 				<dateFormats>
@@ -742,7 +742,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -756,7 +756,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<scientificFormats numberSystem="arabext">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -770,7 +770,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="arabext">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -784,7 +784,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -794,7 +794,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencies>

--- a/common/main/ku.xml
+++ b/common/main/ku.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -857,8 +857,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">PN</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">BN</dayPeriod>
+							<dayPeriod type="pm">PN</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">BN</dayPeriod>
@@ -867,16 +867,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">BN</dayPeriod>
+							<dayPeriod type="pm">PN</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">BN</dayPeriod>
+							<dayPeriod type="pm">PN</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">BN</dayPeriod>
+							<dayPeriod type="pm">PN</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -940,10 +940,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>serdem</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>serdem</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>serdem</displayName>
 			</field>
 			<field type="year">
 				<displayName>sal</displayName>
@@ -961,8 +961,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>sal</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">par</relative>
+				<relative type="0">îsal</relative>
 				<relative type="1">sala bê</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">piştî salekê</relativeTimePattern>
@@ -975,8 +975,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>sl</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">par</relative>
+				<relative type="0">îsal</relative>
 				<relative type="1">sala bê</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">piştî salekê</relativeTimePattern>
@@ -1008,12 +1008,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">vê mehê</relative>
 				<relative type="1">meha bê</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} m</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} m</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} m</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} m</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
@@ -1022,12 +1022,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">vê mehê</relative>
 				<relative type="1">meha bê</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">+{0} m</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} m</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">-{0} m</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} m</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -1055,10 +1055,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>hefteya mehê</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>hefteya mehê</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>hefteya mehê</displayName>
 			</field>
 			<field type="day">
 				<displayName>roj</displayName>
@@ -1068,15 +1068,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>r.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">duh</relative>
+				<relative type="0">îro</relative>
+				<relative type="1">sibe</relative>
 			</field>
 			<field type="day-narrow">
 				<displayName>r.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">duh</relative>
+				<relative type="0">îro</relative>
+				<relative type="1">sibe</relative>
 			</field>
 			<field type="dayOfYear">
 				<displayName>roja salê</displayName>
@@ -1229,10 +1229,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="angle-revolution">
 				<displayName>dewr</displayName>
@@ -1336,17 +1336,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="angle-degree">
 				<displayName>derece</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>xlk. kevanî</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>çrk. kevanî</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -1411,12 +1411,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -1428,13 +1428,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
+				<displayName>%</displayName>
 				<unitPattern count="one">%{0}</unitPattern>
 				<unitPattern count="other">%{0}</unitPattern>
 			</unit>
@@ -1499,22 +1499,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} an {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} an {1}</listPatternPart>
+			<listPatternPart type="2">{0} an {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} an {1}</listPatternPart>
+			<listPatternPart type="2">{0} an {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} û {1}</listPatternPart>
+			<listPatternPart type="2">{0} û {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -82,8 +82,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">черокиче</language>
 			<language type="chy">шайеннче</language>
 			<language type="ckb">борбордук курдча</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">борбордук курдча</language>
+			<language type="ckb" alt="variant">борбордук курдча</language>
 			<language type="clc">чилкотинче (британдык колумбиядагы аймак)</language>
 			<language type="co">корсиканча</language>
 			<language type="crg">мичифче (индей тили)</language>
@@ -470,7 +470,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="zh">кытайча</language>
 			<language type="zh" alt="menu">кытайча (мандарин)</language>
 			<language type="zh_Hans">кытайча (жөнөкөйлөштүрүлгөн)</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">кытайча (жөнөкөйлөштүрүлгөн)</language>
 			<language type="zh_Hant">кытайча (салттуу)</language>
 			<language type="zh_Hant" alt="long">кытайча (салттуу)</language>
 			<language type="zu">зулуча</language>
@@ -758,7 +758,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">Науру</territory>
 			<territory type="NU">Ниуэ</territory>
 			<territory type="NZ">Жаңы Зеландия</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Жаңы Зеландия</territory>
 			<territory type="OM">Оман</territory>
 			<territory type="PA">Панама</territory>
 			<territory type="PE">Перу</territory>
@@ -803,7 +803,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="SX">Синт-Мартен</territory>
 			<territory type="SY">Сирия</territory>
 			<territory type="SZ">Свазиленд</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
+			<territory type="SZ" alt="variant">Свазиленд</territory>
 			<territory type="TA">Тристан-да-Кунья</territory>
 			<territory type="TC">Түркс жана Кайкос аралдары</territory>
 			<territory type="TD">Чад</territory>
@@ -1029,7 +1029,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1037,7 +1037,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1045,7 +1045,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1053,7 +1053,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1593,7 +1593,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1601,7 +1601,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1609,7 +1609,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1617,7 +1617,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5968,28 +5968,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>йотта{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
@@ -6005,7 +6005,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">кубик {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>оордук күчү</displayName>
@@ -6391,44 +6391,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} герц</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>чекит</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} графикалык чекит</unitPattern>
+				<unitPattern count="other">{0} графикалык чекит</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>жер радиусу</displayName>
@@ -6516,14 +6516,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} астрономиялык бирдик</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>деңиз милясы</displayName>
@@ -6598,9 +6598,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} тонна</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>фунт</displayName>
@@ -6690,9 +6690,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} дюйм сымап мамычасы</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>миллибар</displayName>
@@ -6705,9 +6705,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} атм</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>гектопаскаль</displayName>
@@ -6915,14 +6915,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>дроп</displayName>
@@ -6945,9 +6945,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} пинч</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>негизги багыт</displayName>
@@ -7047,12 +7047,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7443,38 +7443,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>графикалык чекит</displayName>
@@ -7483,7 +7483,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7553,7 +7553,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-parsec">
 				<displayName>парсек</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} пс</unitPattern>
 				<unitPattern count="other">{0} пс</unitPattern>
 			</unit>
 			<unit type="length-light-year">
@@ -7568,12 +7568,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -7603,12 +7603,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -7650,7 +7650,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -7742,7 +7742,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -7757,7 +7757,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -7910,7 +7910,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>бушел</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -7967,12 +7967,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -7982,7 +7982,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>драм суюктук</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
@@ -7997,7 +7997,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -8019,7 +8019,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>м{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
 				<unitPrefixPattern>н{0}</unitPrefixPattern>
@@ -8070,147 +8070,147 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Й{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>оордук күчү</displayName>
 				<unitPattern count="one">{0} о.к.</unitPattern>
 				<unitPattern count="other">{0} о.к.</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>метр/сек²</displayName>
+				<unitPattern count="one">{0} м/сек²</unitPattern>
+				<unitPattern count="other">{0} м/сек²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>рад.</displayName>
+				<unitPattern count="one">{0} рад</unitPattern>
+				<unitPattern count="other">{0} рад.</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>градус</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>аркмүн</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>арксек</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>км²</displayName>
 				<unitPattern count="one">{0} км²</unitPattern>
 				<unitPattern count="other">{0} км²</unitPattern>
 				<perUnitPattern>{0}/км²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>гектар</displayName>
 				<unitPattern count="one">{0} га</unitPattern>
 				<unitPattern count="other">{0} га</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>метр²</displayName>
 				<unitPattern count="one">{0} м²</unitPattern>
 				<unitPattern count="other">{0} м²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/м²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>см²</displayName>
+				<unitPattern count="one">{0} см²</unitPattern>
+				<unitPattern count="other">{0} см²</unitPattern>
+				<perUnitPattern>{0}/см²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>чарчы миля</displayName>
 				<unitPattern count="one">{0} ми²</unitPattern>
 				<unitPattern count="other">{0} ми²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ми²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>акр</displayName>
 				<unitPattern count="one">{0} акр</unitPattern>
 				<unitPattern count="other">{0} акр</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ярд²</displayName>
+				<unitPattern count="one">{0} ярд²</unitPattern>
+				<unitPattern count="other">{0} ярд²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>чарчы фут</displayName>
 				<unitPattern count="one">{0} фут²</unitPattern>
 				<unitPattern count="other">{0} фут²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>дюйм²</displayName>
+				<unitPattern count="one">{0} дюйм²</unitPattern>
+				<unitPattern count="other">{0} дюйм²</unitPattern>
+				<perUnitPattern>{0}/дюйм²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>карат</displayName>
+				<unitPattern count="one">{0} кт</unitPattern>
+				<unitPattern count="other">{0} кт</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мг/дл</displayName>
+				<unitPattern count="one">{0} мг/дл</unitPattern>
+				<unitPattern count="other">{0} мг/дл</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>миллимоль/литр</displayName>
 				<unitPattern count="one">{0}ммоль/л</unitPattern>
 				<unitPattern count="other">{0}ммоль/л</unitPattern>
 			</unit>
@@ -8220,9 +8220,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} нерсе</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>миллионго/бөлүк</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -8230,24 +8230,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>промилле</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>моль</displayName>
+				<unitPattern count="one">{0} моль</unitPattern>
+				<unitPattern count="other">{0} моль</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>литр/км</displayName>
+				<unitPattern count="one">{0} л/км</unitPattern>
+				<unitPattern count="other">{0} л/км</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>100 км/л</displayName>
@@ -8255,74 +8255,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} л/100км</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мил/гал</displayName>
+				<unitPattern count="one">{0} мил/гал</unitPattern>
+				<unitPattern count="other">{0} мил/гал</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>миля/англ. галлонуна</displayName>
 				<unitPattern count="one">{0} мил/анг.гал</unitPattern>
 				<unitPattern count="other">{0}мил/англ.гал</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ПТб</displayName>
+				<unitPattern count="one">{0} Птб</unitPattern>
+				<unitPattern count="other">{0} Птб</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ТБайт</displayName>
+				<unitPattern count="one">{0} ТБ</unitPattern>
+				<unitPattern count="other">{0} ТБ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Тбит</displayName>
+				<unitPattern count="one">{0} Тб</unitPattern>
+				<unitPattern count="other">{0} Тб</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гбайт</displayName>
+				<unitPattern count="one">{0} ГБ</unitPattern>
+				<unitPattern count="other">{0} ГБ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гбит</displayName>
+				<unitPattern count="one">{0} Гб</unitPattern>
+				<unitPattern count="other">{0} Гб</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МБайт</displayName>
+				<unitPattern count="one">{0} МБ</unitPattern>
+				<unitPattern count="other">{0} МБ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мбит</displayName>
+				<unitPattern count="one">{0} Мб</unitPattern>
+				<unitPattern count="other">{0} Мб</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кБайт</displayName>
+				<unitPattern count="one">{0} кБ</unitPattern>
+				<unitPattern count="other">{0} кБ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кбит</displayName>
+				<unitPattern count="one">{0} кб</unitPattern>
+				<unitPattern count="other">{0} кб</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>байт</displayName>
+				<unitPattern count="one">{0} байт</unitPattern>
+				<unitPattern count="other">{0} байт</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бит</displayName>
+				<unitPattern count="one">{0} бит</unitPattern>
+				<unitPattern count="other">{0} бит</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>к.</displayName>
+				<unitPattern count="one">{0} к.</unitPattern>
+				<unitPattern count="other">{0} к.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<displayName>декада</displayName>
@@ -8333,49 +8333,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>жыл</displayName>
 				<unitPattern count="one">{0} ж.</unitPattern>
 				<unitPattern count="other">{0} ж.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ж</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>чрк</displayName>
 				<unitPattern count="one">{0}/ч</unitPattern>
 				<unitPattern count="other">{0}/ч</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ч</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>ай</displayName>
 				<unitPattern count="one">{0} ай</unitPattern>
 				<unitPattern count="other">{0} ай</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>а/{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>апт</displayName>
 				<unitPattern count="one">{0} ап</unitPattern>
 				<unitPattern count="other">{0} ап</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/апт</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>күн</displayName>
 				<unitPattern count="one">{0} кн</unitPattern>
 				<unitPattern count="other">{0} кн</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/күн</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>саат</displayName>
 				<unitPattern count="one">{0} ст</unitPattern>
 				<unitPattern count="other">{0} ст</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ст</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>мүн</displayName>
 				<unitPattern count="one">{0} мүн</unitPattern>
 				<unitPattern count="other">{0} мүн</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/мүн</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>сек</displayName>
 				<unitPattern count="one">{0} сек</unitPattern>
 				<unitPattern count="other">{0} сек</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/сек</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>миллисек</displayName>
@@ -8383,89 +8383,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мсек</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μсек</displayName>
+				<unitPattern count="one">{0}μс</unitPattern>
+				<unitPattern count="other">{0}μс</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>наносек</displayName>
+				<unitPattern count="one">{0} нс</unitPattern>
+				<unitPattern count="other">{0} нс</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>амп</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>миллиамп</displayName>
+				<unitPattern count="one">{0} мА</unitPattern>
+				<unitPattern count="other">{0} мА</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ом</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>вольт</displayName>
+				<unitPattern count="one">{0} В</unitPattern>
+				<unitPattern count="other">{0} В</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ккал</displayName>
+				<unitPattern count="one">{0} ккал</unitPattern>
+				<unitPattern count="other">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кал</displayName>
+				<unitPattern count="one">{0} кал</unitPattern>
+				<unitPattern count="other">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Кал</displayName>
+				<unitPattern count="one">{0} Кал</unitPattern>
+				<unitPattern count="other">{0} Кал</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>киложоул</displayName>
+				<unitPattern count="one">{0} кж</unitPattern>
+				<unitPattern count="other">{0} кж</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>жоул</displayName>
+				<unitPattern count="one">{0} ж</unitPattern>
+				<unitPattern count="other">{0} ж</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кВ-саат</displayName>
+				<unitPattern count="one">{0} кВ-саат</unitPattern>
+				<unitPattern count="other">{0} кВ-саат</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>Терм АКШ</displayName>
 				<unitPattern count="one">{0}термАКШ</unitPattern>
 				<unitPattern count="other">{0}термАКШ</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>күч-фунттары</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>кВт*с/100км</displayName>
@@ -8473,92 +8473,92 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}кВт*с/100км</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ггц</displayName>
+				<unitPattern count="one">{0} Ггц</unitPattern>
+				<unitPattern count="other">{0} Ггц</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МГЦ</displayName>
+				<unitPattern count="one">{0} МГЦ</unitPattern>
+				<unitPattern count="other">{0} МГЦ</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кГц</displayName>
+				<unitPattern count="one">{0} кГц</unitPattern>
+				<unitPattern count="other">{0} кГц</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гц</displayName>
+				<unitPattern count="one">{0} Гц</unitPattern>
+				<unitPattern count="other">{0} Гц</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>графикалык чекит</displayName>
 				<unitPattern count="one">{0}грф чкт</unitPattern>
 				<unitPattern count="other">{0}грф чкт</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>км</displayName>
 				<unitPattern count="one">{0} км</unitPattern>
 				<unitPattern count="other">{0} км</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/км</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>метр</displayName>
 				<unitPattern count="one">{0}м</unitPattern>
 				<unitPattern count="other">{0}м</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/м</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дм</displayName>
+				<unitPattern count="one">{0} дм</unitPattern>
+				<unitPattern count="other">{0} дм</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>см</displayName>
 				<unitPattern count="one">{0} см</unitPattern>
 				<unitPattern count="other">{0} см</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/см</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>мм</displayName>
@@ -8566,117 +8566,117 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мм</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μметр</displayName>
+				<unitPattern count="one">{0} μм</unitPattern>
+				<unitPattern count="other">{0} μм</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>нм</displayName>
+				<unitPattern count="one">{0} нм</unitPattern>
+				<unitPattern count="other">{0} нм</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>пм</displayName>
 				<unitPattern count="one">{0} пм</unitPattern>
 				<unitPattern count="other">{0} пм</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>миля</displayName>
+				<unitPattern count="one">{0} миля</unitPattern>
+				<unitPattern count="other">{0} миля</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>ярд</displayName>
 				<unitPattern count="one">{0} ярд</unitPattern>
 				<unitPattern count="other">{0} ярд</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>фут</displayName>
 				<unitPattern count="one">{0} фут</unitPattern>
 				<unitPattern count="other">{0} фут</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ф</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дюйм</displayName>
+				<unitPattern count="one">{0} дюйм</unitPattern>
+				<unitPattern count="other">{0} дюйм</unitPattern>
 				<perUnitPattern>{0} дюйм</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>парсек</displayName>
 				<unitPattern count="one">{0} пс</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} пс</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>жарык жыл</displayName>
 				<unitPattern count="one">{0} жар.ж.</unitPattern>
 				<unitPattern count="other">{0} жар.ж.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>а. б.</displayName>
+				<unitPattern count="one">{0} а.б.</unitPattern>
+				<unitPattern count="other">{0} а.б.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>дең. мил.</displayName>
 				<unitPattern count="one">{0}nmi</unitPattern>
 				<unitPattern count="other">{0}nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>чекиттер</displayName>
+				<unitPattern count="one">{0} чкт</unitPattern>
+				<unitPattern count="other">{0} чкт</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>күн радиустары</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>люкс</displayName>
+				<unitPattern count="one">{0} лк</unitPattern>
+				<unitPattern count="other">{0} лк</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>күндүн жарык күчү</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>т</displayName>
+				<unitPattern count="one">{0} т</unitPattern>
+				<unitPattern count="other">{0} т</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
+				<displayName>кг</displayName>
 				<unitPattern count="one">{0} кг</unitPattern>
 				<unitPattern count="other">{0} кг</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/кг</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>грамм</displayName>
@@ -8685,14 +8685,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/гр</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мг</displayName>
+				<unitPattern count="one">{0} мг</unitPattern>
+				<unitPattern count="other">{0} мг</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мкг</displayName>
+				<unitPattern count="one">{0} мкг</unitPattern>
+				<unitPattern count="other">{0} мкг</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>тонна</displayName>
@@ -8700,131 +8700,131 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} тон.</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>фунт</displayName>
 				<unitPattern count="one">{0}#</unitPattern>
 				<unitPattern count="other">{0}#</unitPattern>
 				<perUnitPattern>{0}/фунт</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>унц.</displayName>
+				<unitPattern count="one">{0} унц.</unitPattern>
+				<unitPattern count="other">{0} унц.</unitPattern>
 				<perUnitPattern>{0}/унц.</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>тр. унц.</displayName>
+				<unitPattern count="one">{0} тр. унц.</unitPattern>
+				<unitPattern count="other">{0} тр. унц.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>карат</displayName>
+				<unitPattern count="one">{0} кар.</unitPattern>
+				<unitPattern count="other">{0} кар.</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>күн массасы</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>грэйн</displayName>
+				<unitPattern count="one">{0} грэйн</unitPattern>
+				<unitPattern count="other">{0} грэйн</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ГВт</displayName>
+				<unitPattern count="one">{0} ГВт</unitPattern>
+				<unitPattern count="other">{0} ГВт</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МВт</displayName>
+				<unitPattern count="one">{0} МВт</unitPattern>
+				<unitPattern count="other">{0} МВт</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>кВт</displayName>
 				<unitPattern count="one">{0} кВт</unitPattern>
 				<unitPattern count="other">{0} кВт</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ватт</displayName>
 				<unitPattern count="one">{0} Вт</unitPattern>
 				<unitPattern count="other">{0} Вт</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мвт</displayName>
+				<unitPattern count="one">{0} мвт</unitPattern>
+				<unitPattern count="other">{0} мвт</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>а.к.</displayName>
 				<unitPattern count="one">{0} ат</unitPattern>
 				<unitPattern count="other">{0} ат</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мм.с.м.</displayName>
+				<unitPattern count="one">{0} мм.с. м.</unitPattern>
+				<unitPattern count="other">{0} мм.с. м.</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фчд</displayName>
+				<unitPattern count="one">{0} фчд</unitPattern>
+				<unitPattern count="other">{0} фчд</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>дюйм сымап мамычасы</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>миллибар</displayName>
 				<unitPattern count="one">{0} мб</unitPattern>
 				<unitPattern count="other">{0} мб</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>атм</displayName>
+				<unitPattern count="one">{0} атм</unitPattern>
+				<unitPattern count="other">{0} атм</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>гПа</displayName>
 				<unitPattern count="one">{0} гПа</unitPattern>
 				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/саат</displayName>
@@ -8832,24 +8832,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} км/с</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>метр/сек.</displayName>
 				<unitPattern count="one">{0} м/с</unitPattern>
 				<unitPattern count="other">{0} м/с</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>миля/саатына</displayName>
 				<unitPattern count="one">{0} чак/с</unitPattern>
 				<unitPattern count="other">{0} чак/с</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>тн</displayName>
+				<unitPattern count="one">{0} тн</unitPattern>
+				<unitPattern count="other">{0} тн</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -8857,164 +8857,164 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ф. град</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>К град.</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>куб километр</displayName>
 				<unitPattern count="one">{0} км³</unitPattern>
 				<unitPattern count="other">{0} км³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>м³</displayName>
+				<unitPattern count="one">{0} м³</unitPattern>
+				<unitPattern count="other">{0} м³</unitPattern>
+				<perUnitPattern>{0}/м³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>см³</displayName>
+				<unitPattern count="one">{0} см³</unitPattern>
+				<unitPattern count="other">{0} см³</unitPattern>
+				<perUnitPattern>{0}/см³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мил³</displayName>
+				<unitPattern count="one">{0} мил³</unitPattern>
+				<unitPattern count="other">{0} мил³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ярд³</displayName>
+				<unitPattern count="one">{0} ярд³</unitPattern>
+				<unitPattern count="other">{0} ярд³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фут³</displayName>
+				<unitPattern count="one">{0} фут³</unitPattern>
+				<unitPattern count="other">{0} фут³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дюйм³</displayName>
+				<unitPattern count="one">{0} дюйм³</unitPattern>
+				<unitPattern count="other">{0} дюйм³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мгл</displayName>
+				<unitPattern count="one">{0} мгл</unitPattern>
+				<unitPattern count="other">{0} мгл</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>гл</displayName>
+				<unitPattern count="one">{0} гл</unitPattern>
+				<unitPattern count="other">{0} гл</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>литр</displayName>
 				<unitPattern count="one">{0} л</unitPattern>
 				<unitPattern count="other">{0} л</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/л</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дл</displayName>
+				<unitPattern count="one">{0} дл</unitPattern>
+				<unitPattern count="other">{0} дл</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>сЛ</displayName>
+				<unitPattern count="one">{0} сЛ</unitPattern>
+				<unitPattern count="other">{0} сЛ</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мл</displayName>
+				<unitPattern count="one">{0} мл</unitPattern>
+				<unitPattern count="other">{0} мл</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>пт</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} мпт</unitPattern>
+				<unitPattern count="other">{0} мпт</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>акр-фут</displayName>
+				<unitPattern count="one">{0} ак. фт.</unitPattern>
+				<unitPattern count="other">{0} ак. фт.</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бушел</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>гал</displayName>
+				<unitPattern count="one">{0} гал</unitPattern>
+				<unitPattern count="other">{0} гал</unitPattern>
+				<perUnitPattern>{0}/АКШ гал</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>англ. гал</displayName>
 				<unitPattern count="one">{0}англ.гал</unitPattern>
 				<unitPattern count="other">{0}англ.гал</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>англ. гал/{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>квр</displayName>
+				<unitPattern count="one">{0} квр</unitPattern>
+				<unitPattern count="other">{0} квр</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пт</displayName>
+				<unitPattern count="one">{0} пт</unitPattern>
+				<unitPattern count="other">{0} пт</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>чөйчөк</displayName>
+				<unitPattern count="one">{0} чөй.</unitPattern>
+				<unitPattern count="other">{0} чөй.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>с. унц.</displayName>
+				<unitPattern count="one">{0} с. унц.</unitPattern>
+				<unitPattern count="other">{0} с. унц.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Имп.суюк.унц</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>чоң каш.</displayName>
 				<unitPattern count="one">{0}чң.кш</unitPattern>
 				<unitPattern count="other">{0}чң.кш</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>чай каш.</displayName>
 				<unitPattern count="one">{0}чй.кш</unitPattern>
 				<unitPattern count="other">{0}чй.кш</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dsp</displayName>
@@ -9027,27 +9027,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дроп</displayName>
+				<unitPattern count="one">{0} дроп</unitPattern>
+				<unitPattern count="other">{0} дроп</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>драм суюктук</displayName>
 				<unitPattern count="one">{0}fl.dr.</unitPattern>
 				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>жиггер</displayName>
+				<unitPattern count="one">{0} жиггер</unitPattern>
+				<unitPattern count="other">{0} жиггер</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пинч</displayName>
+				<unitPattern count="one">{0} пинч</unitPattern>
+				<unitPattern count="other">{0} пинч</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt Imp</displayName>
 				<unitPattern count="one">{0}qt-Imp.</unitPattern>
 				<unitPattern count="other">{0}qt-Imp.</unitPattern>
 			</unit>
@@ -9083,22 +9083,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} же {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} же {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} же {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} же {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} же {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} жана {1}</listPatternPart>
+			<listPatternPart type="2">{0} жана {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -9312,7 +9312,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
 			<namePattern>{title} {surname}</namePattern>
@@ -9324,13 +9324,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
 			<namePattern>{title} {surname}</namePattern>
@@ -9339,10 +9339,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
@@ -9357,10 +9357,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
@@ -9378,7 +9378,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2-initial} {credentials}</namePattern>
@@ -9393,10 +9393,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{surname} {given-initial} {given2-initial}</namePattern>
@@ -9411,25 +9411,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/lij.xml
+++ b/common/main/lij.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -82,7 +82,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr" draft="unconfirmed">cherokee</language>
 			<language type="chy" draft="unconfirmed">cheyenne</language>
 			<language type="ckb" draft="unconfirmed">curdo sorani</language>
-			<language type="ckb" alt="menu" draft="unconfirmed">↑↑↑</language>
+			<language type="ckb" alt="menu" draft="unconfirmed">curdo sorani</language>
 			<language type="ckb" alt="variant" draft="unconfirmed">curdo do mezo</language>
 			<language type="clc" draft="unconfirmed">chilcotin</language>
 			<language type="co" draft="unconfirmed">còrso</language>
@@ -799,7 +799,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN" draft="unconfirmed">Tunexia</territory>
 			<territory type="TO" draft="unconfirmed">Tonga</territory>
 			<territory type="TR" draft="unconfirmed">Turchia</territory>
-			<territory type="TR" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="TR" alt="variant" draft="unconfirmed">Turchia</territory>
 			<territory type="TT" draft="unconfirmed">Trinidad e Tobago</territory>
 			<territory type="TV" draft="unconfirmed">Tuvalu</territory>
 			<territory type="TW" draft="unconfirmed">Taiwan</territory>
@@ -1015,7 +1015,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1023,7 +1023,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1294,13 +1294,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat" draft="unconfirmed">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">dom.</day>
+							<day type="mon" draft="unconfirmed">lun.</day>
+							<day type="tue" draft="unconfirmed">mät.</day>
+							<day type="wed" draft="unconfirmed">mäc.</day>
+							<day type="thu" draft="unconfirmed">zeu.</day>
+							<day type="fri" draft="unconfirmed">ven.</day>
+							<day type="sat" draft="unconfirmed">sab.</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun" draft="unconfirmed">domenega</day>
@@ -1314,13 +1314,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">dom.</day>
+							<day type="mon" draft="unconfirmed">lun.</day>
+							<day type="tue" draft="unconfirmed">mät.</day>
+							<day type="wed" draft="unconfirmed">mäc.</day>
+							<day type="thu" draft="unconfirmed">zeu.</day>
+							<day type="fri" draft="unconfirmed">ven.</day>
+							<day type="sat" draft="unconfirmed">sab.</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun" draft="unconfirmed">D</day>
@@ -1332,27 +1332,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat" draft="unconfirmed">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">dom.</day>
+							<day type="mon" draft="unconfirmed">lun.</day>
+							<day type="tue" draft="unconfirmed">mät.</day>
+							<day type="wed" draft="unconfirmed">mäc.</day>
+							<day type="thu" draft="unconfirmed">zeu.</day>
+							<day type="fri" draft="unconfirmed">ven.</day>
+							<day type="sat" draft="unconfirmed">sab.</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">domenega</day>
+							<day type="mon" draft="unconfirmed">lunesdì</day>
+							<day type="tue" draft="unconfirmed">mätesdì</day>
+							<day type="wed" draft="unconfirmed">mäcordì</day>
+							<day type="thu" draft="unconfirmed">zeuggia</day>
+							<day type="fri" draft="unconfirmed">venardì</day>
+							<day type="sat" draft="unconfirmed">sabbo</day>
 						</dayWidth>
 					</dayContext>
 				</days>
 				<quarters>
 					<quarterContext type="format">
+						<quarterWidth type="abbreviated">
+							<quarter type="1" draft="unconfirmed">T1</quarter>
+							<quarter type="2" draft="unconfirmed">T2</quarter>
+							<quarter type="3" draft="unconfirmed">T3</quarter>
+							<quarter type="4" draft="unconfirmed">T4</quarter>
+						</quarterWidth>
+						<quarterWidth type="narrow">
+							<quarter type="1" draft="unconfirmed">1</quarter>
+							<quarter type="2" draft="unconfirmed">2</quarter>
+							<quarter type="3" draft="unconfirmed">3</quarter>
+							<quarter type="4" draft="unconfirmed">4</quarter>
+						</quarterWidth>
+						<quarterWidth type="wide">
+							<quarter type="1" draft="unconfirmed">1º trimestre</quarter>
+							<quarter type="2" draft="unconfirmed">2º trimestre</quarter>
+							<quarter type="3" draft="unconfirmed">3º trimestre</quarter>
+							<quarter type="4" draft="unconfirmed">4º trimestre</quarter>
+						</quarterWidth>
+					</quarterContext>
+					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
 							<quarter type="1" draft="unconfirmed">T1</quarter>
 							<quarter type="2" draft="unconfirmed">T2</quarter>
@@ -1370,26 +1390,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<quarter type="2" draft="unconfirmed">2º trimestre</quarter>
 							<quarter type="3" draft="unconfirmed">3º trimestre</quarter>
 							<quarter type="4" draft="unconfirmed">4º trimestre</quarter>
-						</quarterWidth>
-					</quarterContext>
-					<quarterContext type="stand-alone">
-						<quarterWidth type="abbreviated">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
-						</quarterWidth>
-						<quarterWidth type="narrow">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
-						</quarterWidth>
-						<quarterWidth type="wide">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -1417,9 +1417,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="midnight" draft="unconfirmed">mëzaneutte</dayPeriod>
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
 							<dayPeriod type="noon" draft="unconfirmed">mëzogiorno</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 							<dayPeriod type="morning1" draft="unconfirmed">da mattin</dayPeriod>
 							<dayPeriod type="afternoon1" draft="unconfirmed">do poidisnâ</dayPeriod>
 							<dayPeriod type="evening1" draft="unconfirmed">da seia</dayPeriod>
@@ -1428,31 +1428,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="midnight" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="noon" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="midnight" draft="unconfirmed">mëzaneutte</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="noon" draft="unconfirmed">mëzogiorno</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 							<dayPeriod type="morning1" draft="unconfirmed">mattin</dayPeriod>
 							<dayPeriod type="afternoon1" draft="unconfirmed">poidisnâ</dayPeriod>
 							<dayPeriod type="evening1" draft="unconfirmed">seia</dayPeriod>
 							<dayPeriod type="night1" draft="unconfirmed">neutte</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="midnight" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="midnight" draft="unconfirmed">mëzaneutte</dayPeriod>
 							<dayPeriod type="am" draft="unconfirmed">m.</dayPeriod>
-							<dayPeriod type="noon" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="noon" draft="unconfirmed">mëzogiorno</dayPeriod>
 							<dayPeriod type="pm" draft="unconfirmed">p.</dayPeriod>
-							<dayPeriod type="morning1" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="night1" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="morning1" draft="unconfirmed">mattin</dayPeriod>
+							<dayPeriod type="afternoon1" draft="unconfirmed">poidisnâ</dayPeriod>
+							<dayPeriod type="evening1" draft="unconfirmed">seia</dayPeriod>
+							<dayPeriod type="night1" draft="unconfirmed">neutte</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="midnight" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="noon" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="morning1" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="midnight" draft="unconfirmed">mëzaneutte</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="noon" draft="unconfirmed">mëzogiorno</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
+							<dayPeriod type="morning1" draft="unconfirmed">mattin</dayPeriod>
 							<dayPeriod type="afternoon1" draft="unconfirmed">poidisnâ</dayPeriod>
 							<dayPeriod type="evening1" draft="unconfirmed">seia</dayPeriod>
 							<dayPeriod type="night1" draft="unconfirmed">neutte</dayPeriod>
@@ -1473,10 +1473,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<era type="1" alt="variant" draft="unconfirmed">EC</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="unconfirmed">↑↑↑</era>
-						<era type="0" alt="variant" draft="unconfirmed">↑↑↑</era>
-						<era type="1" draft="unconfirmed">↑↑↑</era>
-						<era type="1" alt="variant" draft="unconfirmed">↑↑↑</era>
+						<era type="0" draft="unconfirmed">aC</era>
+						<era type="0" alt="variant" draft="unconfirmed">AEC</era>
+						<era type="1" draft="unconfirmed">dC</era>
+						<era type="1" alt="variant" draft="unconfirmed">EC</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -1760,10 +1760,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="unconfirmed">era</displayName>
 			</field>
 			<field type="era-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">era</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">era</displayName>
 			</field>
 			<field type="year">
 				<displayName draft="unconfirmed">anno</displayName>
@@ -1780,17 +1780,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="year-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<displayName draft="unconfirmed">anno</displayName>
+				<relative type="-1" draft="unconfirmed">l’anno passou</relative>
+				<relative type="0" draft="unconfirmed">st’anno</relative>
 				<relative type="1" draft="unconfirmed">l’anno ch’o ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} anno</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} anni</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">l’é {0} anno</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">l’é {0} anni</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
@@ -1865,8 +1865,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName draft="unconfirmed">meise</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">o meise passou</relative>
+				<relative type="0" draft="unconfirmed">sto meise</relative>
 				<relative type="1" draft="unconfirmed">o meise ch’o ven</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} meise</relativeTimePattern>
@@ -1960,10 +1960,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<displayName draft="unconfirmed">giorno</displayName>
+				<relative type="-1" draft="unconfirmed">vëi</relative>
+				<relative type="0" draft="unconfirmed">ancheu</relative>
+				<relative type="1" draft="unconfirmed">doman</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} giorno</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} giorni</relativeTimePattern>
@@ -1975,9 +1975,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName draft="unconfirmed">g</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">vëi</relative>
+				<relative type="0" draft="unconfirmed">ancheu</relative>
+				<relative type="1" draft="unconfirmed">doman</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">+{0}g</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">+{0}g</relativeTimePattern>
@@ -2009,7 +2009,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="unconfirmed">giorno do meise</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">giorno do meise</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
 				<displayName draft="unconfirmed">g do meise</displayName>
@@ -2041,16 +2041,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">dom. passâ</relative>
+				<relative type="0" draft="unconfirmed">sta dom.</relative>
+				<relative type="1" draft="unconfirmed">dom. ch’a ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} dom.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} dom.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">l’é {0} dom.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">l’é {0} dom.</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2080,16 +2080,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">lun. passou</relative>
+				<relative type="0" draft="unconfirmed">sto lun.</relative>
+				<relative type="1" draft="unconfirmed">lun. ch’o ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} lun.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} lun.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">l’é {0} lun.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">l’é {0} lun.</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -2119,16 +2119,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">mät. passou</relative>
+				<relative type="0" draft="unconfirmed">sto mät.</relative>
+				<relative type="1" draft="unconfirmed">mät. ch’o ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} mät.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} mät.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">l’é {0} mät.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">l’é {0} mät.</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -2158,16 +2158,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">mäc. passou</relative>
+				<relative type="0" draft="unconfirmed">sto mäc.</relative>
+				<relative type="1" draft="unconfirmed">mäc. ch’o ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} mäc.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} mäc.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">l’é {0} mäc.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">l’é {0} mäc.</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -2197,16 +2197,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">zeu. passâ</relative>
+				<relative type="0" draft="unconfirmed">sta zeu.</relative>
+				<relative type="1" draft="unconfirmed">zeu. ch’a ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} zeu.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} zeu.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">l’é {0} zeu.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">l’é {0} zeu.</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -2236,16 +2236,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">ven. passou</relative>
+				<relative type="0" draft="unconfirmed">sto ven.</relative>
+				<relative type="1" draft="unconfirmed">ven. ch’o ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} ven.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} ven.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">l’é {0} ven.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">l’é {0} ven.</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -2275,26 +2275,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">sab. passou</relative>
+				<relative type="0" draft="unconfirmed">sto sab.</relative>
+				<relative type="1" draft="unconfirmed">sab. ch’o ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} sab.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} sab.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one" draft="unconfirmed">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one" draft="unconfirmed">l’é {0} sab.</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">l’é {0} sab.</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">AM/PM</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName draft="unconfirmed">AM/PM</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">AM/PM</displayName>
 			</field>
 			<field type="hour">
 				<displayName draft="unconfirmed">oa</displayName>
@@ -2309,8 +2309,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="hour-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<displayName draft="unconfirmed">oa</displayName>
+				<relative type="0" draft="unconfirmed">st’oa chì</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} oa</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} oe</relativeTimePattern>
@@ -2322,7 +2322,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName draft="unconfirmed">h</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">st’oa chì</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">+{0}h</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">+{0}h</relativeTimePattern>
@@ -2357,8 +2357,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<displayName draft="unconfirmed">men</displayName>
+				<relative type="0" draft="unconfirmed">sto men. chì</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">+{0}men</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">+{0}men</relativeTimePattern>
@@ -2382,7 +2382,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName draft="unconfirmed">s</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">oua</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">de chì à {0} s</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">de chì à {0} s</relativeTimePattern>
@@ -2394,7 +2394,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName draft="unconfirmed">s</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">oua</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one" draft="unconfirmed">+{0}s</relativeTimePattern>
 					<relativeTimePattern count="other" draft="unconfirmed">+{0}s</relativeTimePattern>
@@ -4733,7 +4733,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencies>
@@ -5933,7 +5933,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-hectare">
 				<displayName draft="unconfirmed">ettari</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0} ettaro</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName draft="unconfirmed">metri quaddri</displayName>
@@ -5961,7 +5961,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-yard">
 				<displayName draft="unconfirmed">iarde quaddre</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0} iarda quaddra</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName draft="unconfirmed">pê quaddri</displayName>
@@ -5975,9 +5975,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="unconfirmed">{0} pe pòlliçe quaddro</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">dunam</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} dunam</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName draft="unconfirmed">caratti</displayName>
@@ -6095,9 +6095,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">bit</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} bit</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName draft="unconfirmed">secoli</displayName>
@@ -6208,7 +6208,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0} chillojoule</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">J</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0} joule</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} joule</unitPattern>
 			</unit>
@@ -6269,13 +6269,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName draft="unconfirmed">emme tipografica</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} em</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName draft="unconfirmed">pixel</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} px</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName draft="unconfirmed">megapixel</displayName>
@@ -6553,8 +6553,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName draft="unconfirmed">bar</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} bar</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName draft="unconfirmed">millibar</displayName>
@@ -6797,9 +6797,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0} dramme liquide</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">jigger</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} jigger</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName draft="unconfirmed">spellinsegæ</displayName>
@@ -6908,11 +6908,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" draft="unconfirmed">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" draft="unconfirmed">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -6920,97 +6920,97 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName draft="unconfirmed">fòrsa g</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} G</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} m/s²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} rev</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} rad</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName draft="unconfirmed">°</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}°</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName draft="unconfirmed">′</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}′</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName draft="unconfirmed">″</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}″</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} km²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName draft="unconfirmed">ha</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ha</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} m²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} cm²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mi²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName draft="unconfirmed">ac</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ac</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} yd²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ft²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} in²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} dunam</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kt</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
@@ -7030,27 +7030,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ppm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}%</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}‰</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}‱</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mol</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7075,47 +7075,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} PB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} TB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} Tb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} GB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} Gb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} MB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} Mb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-byte">
@@ -7125,7 +7125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-bit">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} bit</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -7203,52 +7203,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="electric-ampere">
 				<displayName draft="unconfirmed">A</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} A</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mA</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName draft="unconfirmed">Ω</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} Ω</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName draft="unconfirmed">V</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} V</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kcal</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} cal</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kJ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName draft="unconfirmed">J</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} J</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kWh</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} eV</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -7263,47 +7263,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} lbf</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} N</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kWh/100km</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} GHz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} MHz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kHz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} Hz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} em</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName draft="unconfirmed">pixel</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} px</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
@@ -7323,191 +7323,191 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} R⊕</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} km</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName draft="unconfirmed">m</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} m</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} dm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} cm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} μm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} nm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} pm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mi</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} yd</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ft</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} in</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} pc</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ly</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} au</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} fur</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} fth</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} nmi</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} smi</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} pt</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} R☉</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} lx</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} cd</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} lm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} L☉</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} t</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kg</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName draft="unconfirmed">g</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} g</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mg</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} μg</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} tn</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} st</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} lb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} oz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} oz t</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-carat">
@@ -7517,17 +7517,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} Da</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} M⊕</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} M☉</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -7537,32 +7537,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} GW</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} MW</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kW</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName draft="unconfirmed">W</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} W</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mW</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} hp</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -7572,134 +7572,134 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} psi</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} inHg</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} bar</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mbar</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} atm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} Pa</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} hPa</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kPa</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} MPa</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} km/h</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} m/s</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mi/h</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} kn</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}°</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}°C</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}°F</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} K</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} N⋅m</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} km³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} m³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} cm³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mi³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} yd³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ft³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} in³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
@@ -7709,7 +7709,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName draft="unconfirmed">hl</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} hL</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-liter">
@@ -7735,22 +7735,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mpt</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName draft="unconfirmed">mc</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mc</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ac ft</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} bu</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -7777,7 +7777,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cup">
 				<displayName draft="unconfirmed">c</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} c</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
@@ -7792,22 +7792,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} tbsp</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} tsp</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} bbl</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} dstspn</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
@@ -7827,7 +7827,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} jigger</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -7850,140 +7850,140 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" draft="unconfirmed">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" draft="unconfirmed">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" draft="unconfirmed">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" draft="unconfirmed">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">fòrsa g</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} G</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">m/s²</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}m/s²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">rev</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}rev</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">rad</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}rad</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">°</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}°</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName draft="unconfirmed">′</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}′</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName draft="unconfirmed">″</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}″</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">km²</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}km²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}km²</unitPattern>
 				<perUnitPattern draft="unconfirmed">{0}/km²</perUnitPattern>
@@ -7994,22 +7994,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">m²</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}m²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}m²</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">cm²</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}cm²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}cm²</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mi²</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mi²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mi²</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName draft="unconfirmed">ac</displayName>
@@ -8017,40 +8017,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">yd²</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}yd²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ft²</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}ft²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">in²</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}in²</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}in²</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">dunam</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}dunam</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kt</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kt</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mg/dl</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} mg/dl</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName draft="unconfirmed">mmol/l</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} mmol/l</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName draft="unconfirmed">elem</displayName>
@@ -8058,32 +8058,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}elem</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ppm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}ppm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">%</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}%</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">‰</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}‰</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">‱</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}‱</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mol</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mol</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">l/km</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}l/km</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}l/km</unitPattern>
 			</unit>
@@ -8103,57 +8103,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}mpg im</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">PB</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}PB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">TB</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}TB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Tb</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}Tb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">GB</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}GB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Gb</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}Gb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">MB</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}MB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Mb</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}Mb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kB</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kB</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kb</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">B</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}B</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">bit</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}bit</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}bit</unitPattern>
 			</unit>
@@ -8236,7 +8236,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mA</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mA</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mA</unitPattern>
 			</unit>
@@ -8251,17 +8251,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kcal</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kcal</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">cal</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}cal</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kJ</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kJ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kJ</unitPattern>
 			</unit>
@@ -8271,12 +8271,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kWh</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kWh</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">eV</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}eV</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}eV</unitPattern>
 			</unit>
@@ -8291,42 +8291,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}thm US</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">lbf</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}lbf</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">N</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}N</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kWh/100km</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kWh/100km</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">GHz</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}GHz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">MHz</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}MHz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kHz</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kHz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Hz</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}Hz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">em</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}em</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}em</unitPattern>
 			</unit>
@@ -8351,191 +8351,191 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0} px/in</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">R⊕</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}R⊕</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">km</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}km</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}km</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName draft="unconfirmed">m</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}m</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}m</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">dm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}dm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">cm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}cm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}cm</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">μm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}μm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">nm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}nm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">pm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}pm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mi</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mi</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">yd</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}yd</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ft</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}ft</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}ft</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">in</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}in</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}in</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">pc</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}pc</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ly</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}ly</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">au</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}au</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">fur</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}fur</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">fm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}fth</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">nmi</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}nmi</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">smi</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}smi</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">pt</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}pt</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">R☉</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}R☉</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">lx</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}lx</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">cd</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}cd</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">lm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}lm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">L☉</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}L☉</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">t</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}t</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kg</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kg</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kg</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName draft="unconfirmed">g</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}g</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}g</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mg</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mg</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">μg</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}μg</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">tn</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}tn</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">st</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}st</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">lb</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}lb</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}lb</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">oz</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}oz</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}oz</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">oz t</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}oz t</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}oz t</unitPattern>
 			</unit>
@@ -8545,17 +8545,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Da</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}Da</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">M⊕</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}M⊕</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">M☉</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}M☉</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}M☉</unitPattern>
 			</unit>
@@ -8565,17 +8565,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}grañe</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">GW</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}GW</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">MW</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}MW</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kW</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kW</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kW</unitPattern>
 			</unit>
@@ -8585,12 +8585,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mW</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mW</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">hp</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}hp</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}hp</unitPattern>
 			</unit>
@@ -8600,134 +8600,134 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">psi</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}psi</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">inHg</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}inHg</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">bar</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}bar</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mbar</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mbar</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">atm</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}atm</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Pa</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}Pa</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">hPa</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}hPa</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kPa</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kPa</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">MPa</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}MPa</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">km/h</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}km/h</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">m/s</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}m/s</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mi/h</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mi/h</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">kn</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}kn</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">°</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}°</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">°C</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}°C</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">°F</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}°F</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">K</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}K</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">lbf⋅ft</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}lbf⋅ft</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">N⋅m</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}N⋅m</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">km³</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}km³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">m³</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}m³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}m³</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">cm³</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}cm³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}cm³</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mi³</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mi³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">yd³</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}yd³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ft³</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}ft³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">in³</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}in³</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}in³</unitPattern>
 			</unit>
@@ -8763,7 +8763,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">mpt</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}mpt</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}mpt</unitPattern>
 			</unit>
@@ -8778,7 +8778,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">bu</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}bu</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}bu</unitPattern>
 			</unit>
@@ -8820,17 +8820,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}fl oz im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">tbsp</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}tbsp</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">tsp</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}tsp</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">bbl</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}bbl</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}bbl</unitPattern>
 			</unit>
@@ -8855,7 +8855,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}dr liq</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">jigger</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0}jigger</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0}jigger</unitPattern>
 			</unit>
@@ -8870,7 +8870,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="unconfirmed">{0}qt im</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ponto</displayName>
 				<coordinateUnitPattern type="east" draft="unconfirmed">{0}E</coordinateUnitPattern>
 				<coordinateUnitPattern type="north" draft="unconfirmed">{0}N</coordinateUnitPattern>
 				<coordinateUnitPattern type="south" draft="unconfirmed">{0}S</coordinateUnitPattern>
@@ -8901,34 +8901,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2" draft="unconfirmed">{0} ò {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} ò {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} ò {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} ò {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} ò {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} e {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} e {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} e {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
 			<listPatternPart type="start" draft="unconfirmed">{0} {1}</listPatternPart>
@@ -8937,10 +8937,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2" draft="unconfirmed">{0} {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} e {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} e {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<characterLabels>
@@ -9151,7 +9151,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern draft="unconfirmed">{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern draft="unconfirmed">↑↑↑</namePattern>
+			<namePattern draft="unconfirmed">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
 			<namePattern draft="unconfirmed">{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -107,8 +107,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">ຊີໂຣກີ</language>
 			<language type="chy">ຊີເຢນນີ</language>
 			<language type="ckb">ໂຊຣານິ ເຄີດິຊ</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">ໂຊຣານິ ເຄີດິຊ</language>
+			<language type="ckb" alt="variant">ໂຊຣານິ ເຄີດິຊ</language>
 			<language type="clc">ຊິວໂຄຕິນ</language>
 			<language type="co">ຄໍຊິກາ</language>
 			<language type="cop">ຄອບຕິກ</language>
@@ -881,7 +881,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="FR">ຝຣັ່ງ</territory>
 			<territory type="GA">ກາບອນ</territory>
 			<territory type="GB">ສະຫະລາດຊະອະນາຈັກ</territory>
-			<territory type="GB" alt="short">↑↑↑</territory>
+			<territory type="GB" alt="short">ສະຫະລາດຊະອະນາຈັກ</territory>
 			<territory type="GD">ເກຣເນດາ</territory>
 			<territory type="GE">ຈໍເຈຍ</territory>
 			<territory type="GF">ເຟຣນຊ໌ ກຸຍອານາ</territory>
@@ -979,7 +979,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">ນາອູຣູ</territory>
 			<territory type="NU">ນີອູເອ</territory>
 			<territory type="NZ">ນິວຊີແລນ</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">ນິວຊີແລນ</territory>
 			<territory type="OM">ໂອມານ</territory>
 			<territory type="PA">ພານາມາ</territory>
 			<territory type="PE">ເປຣູ</territory>
@@ -1039,7 +1039,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ຕູນິເຊຍ</territory>
 			<territory type="TO">ທອງກາ</territory>
 			<territory type="TR">ເທີຄີ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ເທີຄີ</territory>
 			<territory type="TT">ທຣິນິແດດ ແລະ ໂທແບໂກ</territory>
 			<territory type="TV">ຕູວາລູ</territory>
 			<territory type="TW">ໄຕ້ຫວັນ</territory>
@@ -1756,7 +1756,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1764,7 +1764,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1772,7 +1772,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1780,7 +1780,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2195,10 +2195,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="night1">ກາງຄືນ</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="midnight">↑↑↑</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="noon">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="midnight">ທ່ຽງຄືນ</dayPeriod>
+							<dayPeriod type="am">ກ່ອນທ່ຽງ</dayPeriod>
+							<dayPeriod type="noon">ຕອນທ່ຽງ</dayPeriod>
+							<dayPeriod type="pm">ຫຼັງທ່ຽງ</dayPeriod>
 							<dayPeriod type="morning1">ຕອນເຊົ້າ</dayPeriod>
 							<dayPeriod type="afternoon1">ຕອນທ່ຽງ</dayPeriod>
 							<dayPeriod type="evening1">ຕອນແລງ</dayPeriod>
@@ -2227,14 +2227,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="night1">​ກາງ​ຄືນ</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="midnight">↑↑↑</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
+							<dayPeriod type="midnight">ທ່ຽງ​ຄືນ</dayPeriod>
+							<dayPeriod type="am">ກ່ອນທ່ຽງ</dayPeriod>
 							<dayPeriod type="noon">ຕອນທ່ຽງ</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">ຫຼັງທ່ຽງ</dayPeriod>
+							<dayPeriod type="morning1">​ເຊົ້າ</dayPeriod>
 							<dayPeriod type="afternoon1">ສ</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
+							<dayPeriod type="evening1">ແລງ</dayPeriod>
+							<dayPeriod type="night1">​ກາງ​ຄືນ</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="midnight">ທ່ຽງຄືນ</dayPeriod>
@@ -2320,7 +2320,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2328,7 +2328,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2336,7 +2336,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2344,7 +2344,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3236,9 +3236,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>ປີ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ປີກາຍ</relative>
+				<relative type="0">ປີນີ້</relative>
+				<relative type="1">ປີໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນອີກ {0} ປີ</relativeTimePattern>
 				</relativeTime>
@@ -3248,9 +3248,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>ປີ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ປີກາຍ</relative>
+				<relative type="0">ປີນີ້</relative>
+				<relative type="1">ປີໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນອີກ {0} ປີ</relativeTimePattern>
 				</relativeTime>
@@ -3285,7 +3285,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">ໃນ {0} ຕມ.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} ຕມ. ກ່ອນ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -3302,9 +3302,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>ດ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ເດືອນແລ້ວ</relative>
+				<relative type="0">ເດືອນນີ້</relative>
+				<relative type="1">ເດືອນໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນອີກ {0} ດ.</relativeTimePattern>
 				</relativeTime>
@@ -3314,9 +3314,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>ດ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ເດືອນແລ້ວ</relative>
+				<relative type="0">ເດືອນນີ້</relative>
+				<relative type="1">ເດືອນໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນອີກ {0} ດ.</relativeTimePattern>
 				</relativeTime>
@@ -3339,9 +3339,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>ອ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ອາທິດແລ້ວ</relative>
+				<relative type="0">ອາທິດນີ້</relative>
+				<relative type="1">ອາທິດໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນອີກ {0} ອທ.</relativeTimePattern>
 				</relativeTime>
@@ -3352,9 +3352,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>ອ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ອາທິດແລ້ວ</relative>
+				<relative type="0">ອາທິດນີ້</relative>
+				<relative type="1">ອາທິດໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນອີກ {0} ອທ.</relativeTimePattern>
 				</relativeTime>
@@ -3464,9 +3464,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ວັນທິດແລ້ວ</relative>
+				<relative type="0">ວັນທິດນີ້</relative>
+				<relative type="1">ວັນທິດໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນ {0} ວັນອາທິດ</relativeTimePattern>
 				</relativeTime>
@@ -3497,9 +3497,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ຈັນແລ້ວ</relative>
+				<relative type="0">ຈັນນີ້</relative>
+				<relative type="1">ຈັນໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນ {0} ວັນຈັນ</relativeTimePattern>
 				</relativeTime>
@@ -3563,9 +3563,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ພຸດແລ້ວ</relative>
+				<relative type="0">ພຸດນີ້</relative>
+				<relative type="1">ພຸດໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນ {0} ວັນພຸດ</relativeTimePattern>
 				</relativeTime>
@@ -3596,9 +3596,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ພະຫັດແລ້ວ</relative>
+				<relative type="0">ພະຫັດນີ້</relative>
+				<relative type="1">ພະຫັດໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນ {0} ວັນພະຫັດ</relativeTimePattern>
 				</relativeTime>
@@ -3629,9 +3629,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ສຸກແລ້ວ</relative>
+				<relative type="0">ສຸກນີ້</relative>
+				<relative type="1">ສຸກໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນອີກ {0} ວັນສຸກ</relativeTimePattern>
 				</relativeTime>
@@ -3662,9 +3662,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ເສົາແລ້ວ</relative>
+				<relative type="0">ເສົານີ້</relative>
+				<relative type="1">ເສົາໜ້າ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ໃນ {0} ວັນເສົາ</relativeTimePattern>
 				</relativeTime>
@@ -6857,7 +6857,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>ໂລຕິ ເລໂຊໂຕ</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">ໂລຕິ ເລໂຊໂຕ</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -7619,7 +7619,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}ກ້ອນ</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ແຮງຕົກຕາມລຳພັງ</displayName>
@@ -7899,8 +7899,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ຫົວ​ໜ່ວຍ​ວັດ​ແທກ​ປະ​ລິ​ມານ​ຄວາມ​ຮ້ອນ​ຂ​ອງ​ອັງ​ກິດ</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>ແຮງປ​ອນ</displayName>
@@ -7931,40 +7931,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ດັອດ</displayName>
 				<unitPattern count="other">{0} ດັອດ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ກິໂລແມັດ</displayName>
@@ -8032,8 +8032,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} astronomical units</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>ftm</displayName>
@@ -8172,8 +8172,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ນິ້ວໃນບາຫຼອດ</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>ມິນລິບາ</displayName>
@@ -8184,8 +8184,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} atmospheres</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hectopascals</displayName>
@@ -8307,8 +8307,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>ແກລລອນ</displayName>
@@ -8337,8 +8337,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>tbsp</displayName>
@@ -8353,12 +8353,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ບາ​ເຣວ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>ຢອດ</displayName>
@@ -8369,16 +8369,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ແດຣມ</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>ຢິບ</displayName>
 				<unitPattern count="other">{0} ຢິບ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ທິດທາງຕາມລຳດັບ</displayName>
@@ -8817,12 +8817,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ດັອດ</displayName>
@@ -9316,60 +9316,60 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>ຢ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ແຮງຕົກຕາມລຳພັງ</displayName>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ແມັດ/ວິນາທີ²</displayName>
+				<unitPattern count="other">{0} ມ/ວນທ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>ອົງສາ</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
@@ -9381,298 +9381,298 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-kilometer">
 				<displayName>ກມ²</displayName>
 				<unitPattern count="other">{0} ກມ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ເຮັກຕາ</displayName>
 				<unitPattern count="other">{0} ຮຕ</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>ແມັດ²</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} ມ²</unitPattern>
+				<perUnitPattern>{0}/ມ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ຊມ²</displayName>
+				<unitPattern count="other">{0} ຊມ²</unitPattern>
+				<perUnitPattern>{0}/ຊມ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ເອເຄີ</displayName>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ຟຸດ²</displayName>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ນິ້ວ²</displayName>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ດູ​ນຳ</displayName>
+				<unitPattern count="other">{0} ດູ​ນຳ</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ກະຣັດ</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ມິລິໂມນ/ລິດ</displayName>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>ອັນ</displayName>
 				<unitPattern count="other">{0} ອັນ</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ພາດ/ລ້ານ</displayName>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ລ/ກມ</displayName>
+				<unitPattern count="other">{0} ລ/ກມ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ລ/ 100 ກມ</displayName>
 				<unitPattern count="other">{0} ລ / 100 ກມ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ໄມລ໌/ແກລ</displayName>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg UK</displayName>
 				<unitPattern count="other">{0} m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PByte</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ທົດສະວັດ</displayName>
+				<unitPattern count="other">{0} ທົດສະວັດ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ປີ</displayName>
 				<unitPattern count="other">{0} ປ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ປີ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ໄຕມາດ</displayName>
+				<unitPattern count="other">{0} ໄຕມາດ</unitPattern>
+				<perUnitPattern>{0}/ໄຕມາດ</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>ເດືອນ</displayName>
 				<unitPattern count="other">{0} ດ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ເດືອນ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ອທ.</displayName>
 				<unitPattern count="other">{0} ອທ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ອາທິດ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ມື້</displayName>
 				<unitPattern count="other">{0} ມ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ມື້</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ຊົ່ວໂມງ</displayName>
 				<unitPattern count="other">{0} ຊມ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ຊມ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>ນທ.</displayName>
 				<unitPattern count="other">{0} ນທ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ນາທີ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ວິ.</displayName>
 				<unitPattern count="other">{0} ວິ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ວິ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ມລວ</displayName>
 				<unitPattern count="other">{0} ມລ. ວິ.</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μວິ</displayName>
+				<unitPattern count="other">{0} μວິ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ນາ​ໂນ​ວິ​</displayName>
+				<unitPattern count="other">{0} ນນ​ວິ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ໂວລ</displayName>
+				<unitPattern count="other">{0} ໂວລ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ກິໂລແຄລໍລີ່</displayName>
+				<unitPattern count="other">{0} ກິໂລແຄລໍລີ່</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ຄລ</displayName>
+				<unitPattern count="other">{0} ຄລ</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ຄລ</displayName>
+				<unitPattern count="other">{0} ຄລ</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>ຈູນ</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
@@ -9683,50 +9683,50 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ດັອດ</displayName>
+				<unitPattern count="other">{0} ດັອດ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ກມ</displayName>
 				<unitPattern count="other">{0} ກມ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ກມ</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>ແມັດ</displayName>
 				<unitPattern count="other">{0} ມ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ມ</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ດມ</displayName>
+				<unitPattern count="other">{0} ດມ</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>ຊມ</displayName>
 				<unitPattern count="other">{0} ຊມ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ຊັງຕີແມັດ</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>ມມ</displayName>
 				<unitPattern count="other">{0} ມມ</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ນມ</displayName>
+				<unitPattern count="other">{0} ນມ</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ປມ</displayName>
+				<unitPattern count="other">{0} ປມ</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ໄມລ໌</displayName>
 				<unitPattern count="other">{0} ໄມ</unitPattern>
 			</unit>
 			<unit type="length-yard">
@@ -9736,212 +9736,212 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-foot">
 				<displayName>ຟຸດ</displayName>
 				<unitPattern count="other">{0} ຟ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ຟ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>ນິ້ວ</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} ນິ</unitPattern>
+				<perUnitPattern>{0}/ນິ</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>parsecs</displayName>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>ປີແສງ</displayName>
 				<unitPattern count="other">{0} ປສ</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ftm</displayName>
+				<unitPattern count="other">{0} ftm</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ຈຸດ</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>ກິໂລກຣາມ</displayName>
 				<unitPattern count="other">{0} ກລ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>ກຣາມ</displayName>
 				<unitPattern count="other">{0} ກຼ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ມກ</displayName>
+				<unitPattern count="other">{0} ມກ</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ຕ</displayName>
+				<unitPattern count="other">{0} ຕ</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>ສະໂຕນ</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>ປອນ</displayName>
 				<unitPattern count="other">{0} ປ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ປ</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>ອອນສ</displayName>
 				<unitPattern count="other">{0} ອ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ອ</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>ກະຣັດ</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gr</displayName>
+				<unitPattern count="other">{0} gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ກິໂລວັດ</displayName>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ວັດ</displayName>
+				<unitPattern count="other">{0} ວັດ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>ແຮງມ້າ</displayName>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>in Hg</displayName>
 				<unitPattern count="other">{0} in Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPA</displayName>
 				<unitPattern count="other">{0} hPA</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ກມ/ຊມ</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ກມ/ຊມ</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>ມ/ວ</displayName>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ໄມລ໌/ຊົ່ວໂມງ</displayName>
+				<unitPattern count="other">{0} ມ/ຊມ</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9952,157 +9952,157 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ອົງສາ ເຄ.</displayName>
+				<unitPattern count="other">{0}°K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ກມ³</displayName>
+				<unitPattern count="other">{0} ກມ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ມ³</displayName>
+				<unitPattern count="other">{0} ມ³</unitPattern>
+				<perUnitPattern>{0}/ມ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ລິດ</displayName>
 				<unitPattern count="other">{0}L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ແກລລອນ</displayName>
+				<unitPattern count="other">{0} ແກລລອນ</unitPattern>
+				<perUnitPattern>{0}/ແກລລອນ</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. gal</displayName>
 				<unitPattern count="other">{0} galIm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cup</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="other">{0} fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>dsp Imp</displayName>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ຢອດ</displayName>
+				<unitPattern count="other">{0} ຢອດ</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl.dr.</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dr fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ຢິບ</displayName>
+				<unitPattern count="other">{0} ຢິບ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ທິດທາງ</displayName>
@@ -10136,22 +10136,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ຫຼື {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ຫຼື {1}</listPatternPart>
+			<listPatternPart type="2">{0} ຫຼື {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ຫຼື {1}</listPatternPart>
+			<listPatternPart type="2">{0} ຫຼື {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} ແລະ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -10430,7 +10430,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{credentials} {surname} {given} {given2} {generation}</namePattern>
@@ -10475,13 +10475,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -124,8 +124,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">čerokių</language>
 			<language type="chy">čajenų</language>
 			<language type="ckb">soranių kurdų</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">soranių kurdų</language>
+			<language type="ckb" alt="variant">soranių kurdų</language>
 			<language type="clc">čilkotinų</language>
 			<language type="co">korsikiečių</language>
 			<language type="cop">koptų</language>
@@ -1073,7 +1073,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niujė</territory>
 			<territory type="NZ">Naujoji Zelandija</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Naujoji Zelandija</territory>
 			<territory type="OM">Omanas</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -1128,12 +1128,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TJ">Tadžikija</territory>
 			<territory type="TK">Tokelau</territory>
 			<territory type="TL">Rytų Timoras</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">Rytų Timoras</territory>
 			<territory type="TM">Turkmėnistanas</territory>
 			<territory type="TN">Tunisas</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkija</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkija</territory>
 			<territory type="TT">Trinidadas ir Tobagas</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taivanas</territory>
@@ -2452,7 +2452,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2460,7 +2460,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2468,7 +2468,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2476,7 +2476,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3023,7 +3023,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -3031,7 +3031,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -3039,7 +3039,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -3047,7 +3047,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -8498,7 +8498,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>Lesoto lotis</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Lesoto lotis</displayName>
 				<displayName count="few">Lesoto lotis</displayName>
 				<displayName count="many">Lesoto lotis</displayName>
 				<displayName count="other">Lesoto lotis</displayName>
@@ -9805,106 +9805,106 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="one">{0} kvadratu</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="instrumental">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="locative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="dative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="locative">{0} kvadratu</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">{0} kvadratu</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="dative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="instrumental">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="locative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="dative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="locative">{0} kvadratu</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">{0} kvadratu</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="accusative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="dative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="genitive">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="instrumental">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="locative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="dative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="locative">{0} kvadratu</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0} kvadratu</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="dative">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">{0} kvadratu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="locative">{0} kvadratu</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1 count="one">{0} kubu</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="instrumental">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="locative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="dative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="locative">{0} kubu</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">{0} kubu</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="dative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="instrumental">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="locative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="dative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="locative">{0} kubu</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">{0} kubu</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="accusative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="dative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="genitive">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="instrumental">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="locative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="dative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="locative">{0} kubu</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0} kubu</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="dative">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">{0} kubu</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="locative">{0} kubu</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>masculine</gender>
@@ -9922,17 +9922,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} laisvojo kritimo pagreičiais</unitPattern>
 				<unitPattern count="few" case="locative">{0} laisvojo kritimo pagreičiuose</unitPattern>
 				<unitPattern count="many">{0} laisvojo kritimo pagreičio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} laisvojo kritimo pagreičio</unitPattern>
+				<unitPattern count="many" case="dative">{0} laisvojo kritimo pagreičio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} laisvojo kritimo pagreičio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} laisvojo kritimo pagreičio</unitPattern>
+				<unitPattern count="many" case="locative">{0} laisvojo kritimo pagreičio</unitPattern>
 				<unitPattern count="other">{0} laisvojo kritimo pagreičių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} laisvojo kritimo pagreičių</unitPattern>
+				<unitPattern count="other" case="dative">{0} laisvojo kritimo pagreičių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} laisvojo kritimo pagreičių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} laisvojo kritimo pagreičių</unitPattern>
+				<unitPattern count="other" case="locative">{0} laisvojo kritimo pagreičių</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>masculine</gender>
@@ -9956,11 +9956,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} metro per kvadratinę sekundę</unitPattern>
 				<unitPattern count="many" case="locative">{0} metro per kvadratinę sekundę</unitPattern>
 				<unitPattern count="other">{0} metrų per kvadratinę sekundę</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrų per kvadratinę sekundę</unitPattern>
+				<unitPattern count="other" case="dative">{0} metrų per kvadratinę sekundę</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metrų per kvadratinę sekundę</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metrų per kvadratinę sekundę</unitPattern>
+				<unitPattern count="other" case="locative">{0} metrų per kvadratinę sekundę</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>masculine</gender>
@@ -9978,17 +9978,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} pilnais apsisukimais</unitPattern>
 				<unitPattern count="few" case="locative">{0} pilnuose apsisukimuose</unitPattern>
 				<unitPattern count="many">{0} pilno apsisukimo</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pilno apsisukimo</unitPattern>
+				<unitPattern count="many" case="dative">{0} pilno apsisukimo</unitPattern>
+				<unitPattern count="many" case="genitive">{0} pilno apsisukimo</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} pilno apsisukimo</unitPattern>
+				<unitPattern count="many" case="locative">{0} pilno apsisukimo</unitPattern>
 				<unitPattern count="other">{0} pilnų apsisukimų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pilnų apsisukimų</unitPattern>
+				<unitPattern count="other" case="dative">{0} pilnų apsisukimų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pilnų apsisukimų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} pilnų apsisukimų</unitPattern>
+				<unitPattern count="other" case="locative">{0} pilnų apsisukimų</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>masculine</gender>
@@ -10006,17 +10006,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} radianais</unitPattern>
 				<unitPattern count="few" case="locative">{0} radianuose</unitPattern>
 				<unitPattern count="many">{0} radiano</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} radiano</unitPattern>
+				<unitPattern count="many" case="dative">{0} radiano</unitPattern>
+				<unitPattern count="many" case="genitive">{0} radiano</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} radiano</unitPattern>
+				<unitPattern count="many" case="locative">{0} radiano</unitPattern>
 				<unitPattern count="other">{0} radianų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} radianų</unitPattern>
+				<unitPattern count="other" case="dative">{0} radianų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} radianų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} radianų</unitPattern>
+				<unitPattern count="other" case="locative">{0} radianų</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>masculine</gender>
@@ -10034,17 +10034,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} laipsniais</unitPattern>
 				<unitPattern count="few" case="locative">{0} laipsniuose</unitPattern>
 				<unitPattern count="many">{0} laipsnio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} laipsnio</unitPattern>
+				<unitPattern count="many" case="dative">{0} laipsnio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} laipsnio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} laipsnio</unitPattern>
+				<unitPattern count="many" case="locative">{0} laipsnio</unitPattern>
 				<unitPattern count="other">{0} laipsnių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} laipsnių</unitPattern>
+				<unitPattern count="other" case="dative">{0} laipsnių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} laipsnių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} laipsnių</unitPattern>
+				<unitPattern count="other" case="locative">{0} laipsnių</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>feminine</gender>
@@ -10062,17 +10062,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kampo minutėmis</unitPattern>
 				<unitPattern count="few" case="locative">{0} kampo minutėse</unitPattern>
 				<unitPattern count="many">{0} kampo minutės</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kampo minutės</unitPattern>
+				<unitPattern count="many" case="dative">{0} kampo minutės</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kampo minutės</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kampo minutės</unitPattern>
+				<unitPattern count="many" case="locative">{0} kampo minutės</unitPattern>
 				<unitPattern count="other">{0} kampo minučių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kampo minučių</unitPattern>
+				<unitPattern count="other" case="dative">{0} kampo minučių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kampo minučių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kampo minučių</unitPattern>
+				<unitPattern count="other" case="locative">{0} kampo minučių</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>feminine</gender>
@@ -10090,17 +10090,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kampo sekundėmis</unitPattern>
 				<unitPattern count="few" case="locative">{0} kampo sekundėse</unitPattern>
 				<unitPattern count="many">{0} kampo sekundės</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kampo sekundės</unitPattern>
+				<unitPattern count="many" case="dative">{0} kampo sekundės</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kampo sekundės</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kampo sekundės</unitPattern>
+				<unitPattern count="many" case="locative">{0} kampo sekundės</unitPattern>
 				<unitPattern count="other">{0} kampo sekundžių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kampo sekundžių</unitPattern>
+				<unitPattern count="other" case="dative">{0} kampo sekundžių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kampo sekundžių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kampo sekundžių</unitPattern>
+				<unitPattern count="other" case="locative">{0} kampo sekundžių</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>masculine</gender>
@@ -10118,17 +10118,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kvadratiniais kilometrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kvadratiniuose kilometruose</unitPattern>
 				<unitPattern count="many">{0} kvadratinio kilometro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kvadratinio kilometro</unitPattern>
+				<unitPattern count="many" case="dative">{0} kvadratinio kilometro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kvadratinio kilometro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kvadratinio kilometro</unitPattern>
+				<unitPattern count="many" case="locative">{0} kvadratinio kilometro</unitPattern>
 				<unitPattern count="other">{0} kvadratinių kilometrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratinių kilometrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kvadratinių kilometrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kvadratinių kilometrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kvadratinių kilometrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kvadratinių kilometrų</unitPattern>
 				<perUnitPattern>{0} kv. km</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
@@ -10147,17 +10147,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} hektarais</unitPattern>
 				<unitPattern count="few" case="locative">{0} hektaruose</unitPattern>
 				<unitPattern count="many">{0} hektaro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hektaro</unitPattern>
+				<unitPattern count="many" case="dative">{0} hektaro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hektaro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} hektaro</unitPattern>
+				<unitPattern count="many" case="locative">{0} hektaro</unitPattern>
 				<unitPattern count="other">{0} hektarų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektarų</unitPattern>
+				<unitPattern count="other" case="dative">{0} hektarų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektarų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektarų</unitPattern>
+				<unitPattern count="other" case="locative">{0} hektarų</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>masculine</gender>
@@ -10175,17 +10175,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kvadratiniais metrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kvadratiniuose metruose</unitPattern>
 				<unitPattern count="many">{0} kvadratinio metro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kvadratinio metro</unitPattern>
+				<unitPattern count="many" case="dative">{0} kvadratinio metro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kvadratinio metro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kvadratinio metro</unitPattern>
+				<unitPattern count="many" case="locative">{0} kvadratinio metro</unitPattern>
 				<unitPattern count="other">{0} kvadratinių metrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratinių metrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kvadratinių metrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kvadratinių metrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kvadratinių metrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kvadratinių metrų</unitPattern>
 				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
@@ -10204,17 +10204,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kvadratiniais centimetrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kvadratiniuose centimetruose</unitPattern>
 				<unitPattern count="many">{0} kvadratinio centimetro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kvadratinio centimetro</unitPattern>
+				<unitPattern count="many" case="dative">{0} kvadratinio centimetro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kvadratinio centimetro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kvadratinio centimetro</unitPattern>
+				<unitPattern count="many" case="locative">{0} kvadratinio centimetro</unitPattern>
 				<unitPattern count="other">{0} kvadratinių centimetrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratinių centimetrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kvadratinių centimetrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kvadratinių centimetrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kvadratinių centimetrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kvadratinių centimetrų</unitPattern>
 				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -10277,17 +10277,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} karatais</unitPattern>
 				<unitPattern count="few" case="locative">{0} karatuose</unitPattern>
 				<unitPattern count="many">{0} karato</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} karato</unitPattern>
+				<unitPattern count="many" case="dative">{0} karato</unitPattern>
+				<unitPattern count="many" case="genitive">{0} karato</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} karato</unitPattern>
+				<unitPattern count="many" case="locative">{0} karato</unitPattern>
 				<unitPattern count="other">{0} karatų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karatų</unitPattern>
+				<unitPattern count="other" case="dative">{0} karatų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karatų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} karatų</unitPattern>
+				<unitPattern count="other" case="locative">{0} karatų</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>miligramai decilitre</displayName>
@@ -10318,11 +10318,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} milimolio litre</unitPattern>
 				<unitPattern count="many" case="locative">{0} milimolio litre</unitPattern>
 				<unitPattern count="other">{0} milimolių litre</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimolių litre</unitPattern>
+				<unitPattern count="other" case="dative">{0} milimolių litre</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimolių litre</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milimolių litre</unitPattern>
+				<unitPattern count="other" case="locative">{0} milimolių litre</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>masculine</gender>
@@ -10340,17 +10340,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} elementais</unitPattern>
 				<unitPattern count="few" case="locative">{0} elementuose</unitPattern>
 				<unitPattern count="many">{0} elemento</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} elemento</unitPattern>
+				<unitPattern count="many" case="dative">{0} elemento</unitPattern>
+				<unitPattern count="many" case="genitive">{0} elemento</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} elemento</unitPattern>
+				<unitPattern count="many" case="locative">{0} elemento</unitPattern>
 				<unitPattern count="other">{0} elementų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} elementų</unitPattern>
+				<unitPattern count="other" case="dative">{0} elementų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} elementų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} elementų</unitPattern>
+				<unitPattern count="other" case="locative">{0} elementų</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>feminine</gender>
@@ -10368,17 +10368,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} milijoninėmis dalimis</unitPattern>
 				<unitPattern count="few" case="locative">{0} milijoninėse dalyse</unitPattern>
 				<unitPattern count="many">{0} milijoninės dalies</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milijoninės dalies</unitPattern>
+				<unitPattern count="many" case="dative">{0} milijoninės dalies</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milijoninės dalies</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milijoninės dalies</unitPattern>
+				<unitPattern count="many" case="locative">{0} milijoninės dalies</unitPattern>
 				<unitPattern count="other">{0} milijoninių dalių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milijoninių dalių</unitPattern>
+				<unitPattern count="other" case="dative">{0} milijoninių dalių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milijoninių dalių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milijoninių dalių</unitPattern>
+				<unitPattern count="other" case="locative">{0} milijoninių dalių</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>masculine</gender>
@@ -10438,31 +10438,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="one" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="one" case="dative">{0}‱</unitPattern>
+				<unitPattern count="one" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="one" case="instrumental">{0}‱</unitPattern>
+				<unitPattern count="one" case="locative">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="few" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="few" case="dative">{0}‱</unitPattern>
+				<unitPattern count="few" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="few" case="instrumental">{0}‱</unitPattern>
+				<unitPattern count="few" case="locative">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
+				<unitPattern count="many" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="many" case="dative">{0}‱</unitPattern>
+				<unitPattern count="many" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="many" case="instrumental">{0}‱</unitPattern>
+				<unitPattern count="many" case="locative">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
+				<unitPattern count="other" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="other" case="dative">{0}‱</unitPattern>
+				<unitPattern count="other" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="other" case="instrumental">{0}‱</unitPattern>
+				<unitPattern count="other" case="locative">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>masculine</gender>
@@ -10480,17 +10480,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} moliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} moliuose</unitPattern>
 				<unitPattern count="many">{0} molio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} molio</unitPattern>
+				<unitPattern count="many" case="dative">{0} molio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} molio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} molio</unitPattern>
+				<unitPattern count="many" case="locative">{0} molio</unitPattern>
 				<unitPattern count="other">{0} molių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} molių</unitPattern>
+				<unitPattern count="other" case="dative">{0} molių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} molių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} molių</unitPattern>
+				<unitPattern count="other" case="locative">{0} molių</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>masculine</gender>
@@ -10508,17 +10508,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} litrais kilometrui</unitPattern>
 				<unitPattern count="few" case="locative">{0} litruose kilometrui</unitPattern>
 				<unitPattern count="many">{0} litro kilometrui</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} litro kilometrui</unitPattern>
+				<unitPattern count="many" case="dative">{0} litro kilometrui</unitPattern>
+				<unitPattern count="many" case="genitive">{0} litro kilometrui</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} litro kilometrui</unitPattern>
+				<unitPattern count="many" case="locative">{0} litro kilometrui</unitPattern>
 				<unitPattern count="other">{0} litrų kilometrui</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litrų kilometrui</unitPattern>
+				<unitPattern count="other" case="dative">{0} litrų kilometrui</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litrų kilometrui</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litrų kilometrui</unitPattern>
+				<unitPattern count="other" case="locative">{0} litrų kilometrui</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>masculine</gender>
@@ -10536,17 +10536,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} litrais 100 kilometrų</unitPattern>
 				<unitPattern count="few" case="locative">{0} litruose 100 kilometrų</unitPattern>
 				<unitPattern count="many">{0} litro 100 kilometrų</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} litro 100 kilometrų</unitPattern>
+				<unitPattern count="many" case="dative">{0} litro 100 kilometrų</unitPattern>
+				<unitPattern count="many" case="genitive">{0} litro 100 kilometrų</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} litro 100 kilometrų</unitPattern>
+				<unitPattern count="many" case="locative">{0} litro 100 kilometrų</unitPattern>
 				<unitPattern count="other">{0} litrų 100 kilometrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litrų 100 kilometrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} litrų 100 kilometrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litrų 100 kilometrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litrų 100 kilometrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} litrų 100 kilometrų</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mylios už galoną</displayName>
@@ -10584,11 +10584,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} pentabaito</unitPattern>
 				<unitPattern count="many" case="locative">{0} pentabaito</unitPattern>
 				<unitPattern count="other">{0} pentabaitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pentabaitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} pentabaitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pentabaitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} pentabaitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} pentabaitų</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>masculine</gender>
@@ -10606,17 +10606,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} terabaitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} terabaituose</unitPattern>
 				<unitPattern count="many">{0} terabaito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} terabaito</unitPattern>
+				<unitPattern count="many" case="dative">{0} terabaito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} terabaito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} terabaito</unitPattern>
+				<unitPattern count="many" case="locative">{0} terabaito</unitPattern>
 				<unitPattern count="other">{0} terabaitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabaitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} terabaitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabaitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} terabaitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} terabaitų</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>masculine</gender>
@@ -10634,17 +10634,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} terabitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} terabituose</unitPattern>
 				<unitPattern count="many">{0} terabito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} terabito</unitPattern>
+				<unitPattern count="many" case="dative">{0} terabito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} terabito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} terabito</unitPattern>
+				<unitPattern count="many" case="locative">{0} terabito</unitPattern>
 				<unitPattern count="other">{0} terabitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} terabitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} terabitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} terabitų</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>masculine</gender>
@@ -10662,17 +10662,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} gigabaitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigabaituose</unitPattern>
 				<unitPattern count="many">{0} gigabaito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigabaito</unitPattern>
+				<unitPattern count="many" case="dative">{0} gigabaito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigabaito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gigabaito</unitPattern>
+				<unitPattern count="many" case="locative">{0} gigabaito</unitPattern>
 				<unitPattern count="other">{0} gigabaitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabaitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} gigabaitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabaitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigabaitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} gigabaitų</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>masculine</gender>
@@ -10690,17 +10690,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} gigabitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigabituose</unitPattern>
 				<unitPattern count="many">{0} gigabito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigabito</unitPattern>
+				<unitPattern count="many" case="dative">{0} gigabito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigabito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gigabito</unitPattern>
+				<unitPattern count="many" case="locative">{0} gigabito</unitPattern>
 				<unitPattern count="other">{0} gigabitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} gigabitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigabitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} gigabitų</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>masculine</gender>
@@ -10718,17 +10718,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} megabaitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} megabaituose</unitPattern>
 				<unitPattern count="many">{0} megabaito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megabaito</unitPattern>
+				<unitPattern count="many" case="dative">{0} megabaito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megabaito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megabaito</unitPattern>
+				<unitPattern count="many" case="locative">{0} megabaito</unitPattern>
 				<unitPattern count="other">{0} megabaitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabaitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} megabaitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabaitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megabaitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} megabaitų</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>masculine</gender>
@@ -10746,17 +10746,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} megabitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} megabituose</unitPattern>
 				<unitPattern count="many">{0} megabito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megabito</unitPattern>
+				<unitPattern count="many" case="dative">{0} megabito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megabito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megabito</unitPattern>
+				<unitPattern count="many" case="locative">{0} megabito</unitPattern>
 				<unitPattern count="other">{0} megabitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} megabitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megabitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} megabitų</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>masculine</gender>
@@ -10774,17 +10774,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilobaitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilobaituose</unitPattern>
 				<unitPattern count="many">{0} kilobaito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilobaito</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilobaito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilobaito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilobaito</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilobaito</unitPattern>
 				<unitPattern count="other">{0} kilobaitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobaitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilobaitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobaitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilobaitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilobaitų</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>masculine</gender>
@@ -10802,17 +10802,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilobitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilobituose</unitPattern>
 				<unitPattern count="many">{0} kilobito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilobito</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilobito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilobito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilobito</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilobito</unitPattern>
 				<unitPattern count="other">{0} kilobitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilobitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilobitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilobitų</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>masculine</gender>
@@ -10830,17 +10830,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} baitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} baituose</unitPattern>
 				<unitPattern count="many">{0} baito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} baito</unitPattern>
+				<unitPattern count="many" case="dative">{0} baito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} baito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} baito</unitPattern>
+				<unitPattern count="many" case="locative">{0} baito</unitPattern>
 				<unitPattern count="other">{0} baitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} baitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} baitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} baitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} baitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} baitų</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>masculine</gender>
@@ -10858,17 +10858,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} bitais</unitPattern>
 				<unitPattern count="few" case="locative">{0} bituose</unitPattern>
 				<unitPattern count="many">{0} bito</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} bito</unitPattern>
+				<unitPattern count="many" case="dative">{0} bito</unitPattern>
+				<unitPattern count="many" case="genitive">{0} bito</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} bito</unitPattern>
+				<unitPattern count="many" case="locative">{0} bito</unitPattern>
 				<unitPattern count="other">{0} bitų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bitų</unitPattern>
+				<unitPattern count="other" case="dative">{0} bitų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bitų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} bitų</unitPattern>
+				<unitPattern count="other" case="locative">{0} bitų</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>masculine</gender>
@@ -10886,17 +10886,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} amžiais</unitPattern>
 				<unitPattern count="few" case="locative">{0} amžiuose</unitPattern>
 				<unitPattern count="many">{0} amžiaus</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} amžiaus</unitPattern>
+				<unitPattern count="many" case="dative">{0} amžiaus</unitPattern>
+				<unitPattern count="many" case="genitive">{0} amžiaus</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} amžiaus</unitPattern>
+				<unitPattern count="many" case="locative">{0} amžiaus</unitPattern>
 				<unitPattern count="other">{0} amžių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} amžių</unitPattern>
+				<unitPattern count="other" case="dative">{0} amžių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} amžių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} amžių</unitPattern>
+				<unitPattern count="other" case="locative">{0} amžių</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>feminine</gender>
@@ -10905,7 +10905,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} dekadą</unitPattern>
 				<unitPattern count="one" case="dative">{0} dekadai</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dekados</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} dekada</unitPattern>
 				<unitPattern count="one" case="locative">{0} dekadoje</unitPattern>
 				<unitPattern count="few">{0} dekados</unitPattern>
 				<unitPattern count="few" case="accusative">{0} dekadas</unitPattern>
@@ -10914,17 +10914,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} dekadomis</unitPattern>
 				<unitPattern count="few" case="locative">{0} dekadose</unitPattern>
 				<unitPattern count="many">{0} dekados</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} dekados</unitPattern>
+				<unitPattern count="many" case="dative">{0} dekados</unitPattern>
+				<unitPattern count="many" case="genitive">{0} dekados</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} dekados</unitPattern>
+				<unitPattern count="many" case="locative">{0} dekados</unitPattern>
 				<unitPattern count="other">{0} dekadų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dekadų</unitPattern>
+				<unitPattern count="other" case="dative">{0} dekadų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dekadų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} dekadų</unitPattern>
+				<unitPattern count="other" case="locative">{0} dekadų</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>masculine</gender>
@@ -10942,17 +10942,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} metais</unitPattern>
 				<unitPattern count="few" case="locative">{0} metuose</unitPattern>
 				<unitPattern count="many">{0} metų</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metų</unitPattern>
+				<unitPattern count="many" case="dative">{0} metų</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metų</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metų</unitPattern>
+				<unitPattern count="many" case="locative">{0} metų</unitPattern>
 				<unitPattern count="other">{0} metų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metų</unitPattern>
+				<unitPattern count="other" case="dative">{0} metų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metų</unitPattern>
+				<unitPattern count="other" case="locative">{0} metų</unitPattern>
 				<perUnitPattern>{0} per metus</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -11000,17 +11000,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} mėnesiais</unitPattern>
 				<unitPattern count="few" case="locative">{0} mėnesiuose</unitPattern>
 				<unitPattern count="many">{0} mėnesio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mėnesio</unitPattern>
+				<unitPattern count="many" case="dative">{0} mėnesio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mėnesio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mėnesio</unitPattern>
+				<unitPattern count="many" case="locative">{0} mėnesio</unitPattern>
 				<unitPattern count="other">{0} mėnesių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mėnesių</unitPattern>
+				<unitPattern count="other" case="dative">{0} mėnesių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mėnesių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mėnesių</unitPattern>
+				<unitPattern count="other" case="locative">{0} mėnesių</unitPattern>
 				<perUnitPattern>{0} per mėnesį</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
@@ -11029,17 +11029,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} savaitėmis</unitPattern>
 				<unitPattern count="few" case="locative">{0} savaitėse</unitPattern>
 				<unitPattern count="many">{0} savaitės</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} savaitės</unitPattern>
+				<unitPattern count="many" case="dative">{0} savaitės</unitPattern>
+				<unitPattern count="many" case="genitive">{0} savaitės</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} savaitės</unitPattern>
+				<unitPattern count="many" case="locative">{0} savaitės</unitPattern>
 				<unitPattern count="other">{0} savaičių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} savaičių</unitPattern>
+				<unitPattern count="other" case="dative">{0} savaičių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} savaičių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} savaičių</unitPattern>
+				<unitPattern count="other" case="locative">{0} savaičių</unitPattern>
 				<perUnitPattern>{0} per savaitę</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
@@ -11049,7 +11049,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} dieną</unitPattern>
 				<unitPattern count="one" case="dative">{0} dienai</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dienos</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} diena</unitPattern>
 				<unitPattern count="one" case="locative">{0} dienoje</unitPattern>
 				<unitPattern count="few">{0} dienos</unitPattern>
 				<unitPattern count="few" case="accusative">{0} dienas</unitPattern>
@@ -11058,17 +11058,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} dienomis</unitPattern>
 				<unitPattern count="few" case="locative">{0} dienose</unitPattern>
 				<unitPattern count="many">{0} dienos</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} dienos</unitPattern>
+				<unitPattern count="many" case="dative">{0} dienos</unitPattern>
+				<unitPattern count="many" case="genitive">{0} dienos</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} dienos</unitPattern>
+				<unitPattern count="many" case="locative">{0} dienos</unitPattern>
 				<unitPattern count="other">{0} dienų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dienų</unitPattern>
+				<unitPattern count="other" case="dative">{0} dienų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dienų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} dienų</unitPattern>
+				<unitPattern count="other" case="locative">{0} dienų</unitPattern>
 				<perUnitPattern>{0} per dieną</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -11078,7 +11078,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} valandą</unitPattern>
 				<unitPattern count="one" case="dative">{0} valandai</unitPattern>
 				<unitPattern count="one" case="genitive">{0} valandos</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} valanda</unitPattern>
 				<unitPattern count="one" case="locative">{0} valandoje</unitPattern>
 				<unitPattern count="few">{0} valandos</unitPattern>
 				<unitPattern count="few" case="accusative">{0} valandas</unitPattern>
@@ -11087,17 +11087,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} valandomis</unitPattern>
 				<unitPattern count="few" case="locative">{0} valandose</unitPattern>
 				<unitPattern count="many">{0} valandos</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} valandos</unitPattern>
+				<unitPattern count="many" case="dative">{0} valandos</unitPattern>
+				<unitPattern count="many" case="genitive">{0} valandos</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} valandos</unitPattern>
+				<unitPattern count="many" case="locative">{0} valandos</unitPattern>
 				<unitPattern count="other">{0} valandų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} valandų</unitPattern>
+				<unitPattern count="other" case="dative">{0} valandų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} valandų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} valandų</unitPattern>
+				<unitPattern count="other" case="locative">{0} valandų</unitPattern>
 				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -11116,17 +11116,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} minutėms</unitPattern>
 				<unitPattern count="few" case="locative">{0} minutėse</unitPattern>
 				<unitPattern count="many">{0} minutės</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} minutės</unitPattern>
+				<unitPattern count="many" case="dative">{0} minutės</unitPattern>
+				<unitPattern count="many" case="genitive">{0} minutės</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} minutės</unitPattern>
+				<unitPattern count="many" case="locative">{0} minutės</unitPattern>
 				<unitPattern count="other">{0} minučių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} minučių</unitPattern>
+				<unitPattern count="other" case="dative">{0} minučių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} minučių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} minučių</unitPattern>
+				<unitPattern count="other" case="locative">{0} minučių</unitPattern>
 				<perUnitPattern>{0} per minutę</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -11145,17 +11145,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} sekundėmis</unitPattern>
 				<unitPattern count="few" case="locative">{0} sekundėse</unitPattern>
 				<unitPattern count="many">{0} sekundės</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} sekundės</unitPattern>
+				<unitPattern count="many" case="dative">{0} sekundės</unitPattern>
+				<unitPattern count="many" case="genitive">{0} sekundės</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} sekundės</unitPattern>
+				<unitPattern count="many" case="locative">{0} sekundės</unitPattern>
 				<unitPattern count="other">{0} sekundžių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sekundžių</unitPattern>
+				<unitPattern count="other" case="dative">{0} sekundžių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} sekundžių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} sekundžių</unitPattern>
+				<unitPattern count="other" case="locative">{0} sekundžių</unitPattern>
 				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
@@ -11174,17 +11174,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} milisekundėmis</unitPattern>
 				<unitPattern count="few" case="locative">{0} milisekundėse</unitPattern>
 				<unitPattern count="many">{0} milisekundės</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milisekundės</unitPattern>
+				<unitPattern count="many" case="dative">{0} milisekundės</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milisekundės</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milisekundės</unitPattern>
+				<unitPattern count="many" case="locative">{0} milisekundės</unitPattern>
 				<unitPattern count="other">{0} milisekundžių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milisekundžių</unitPattern>
+				<unitPattern count="other" case="dative">{0} milisekundžių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milisekundžių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milisekundžių</unitPattern>
+				<unitPattern count="other" case="locative">{0} milisekundžių</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>feminine</gender>
@@ -11202,17 +11202,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} mikrosekundėmis</unitPattern>
 				<unitPattern count="few" case="locative">{0} mikrosekundėse</unitPattern>
 				<unitPattern count="many">{0} mikrosekundės</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mikrosekundės</unitPattern>
+				<unitPattern count="many" case="dative">{0} mikrosekundės</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mikrosekundės</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mikrosekundės</unitPattern>
+				<unitPattern count="many" case="locative">{0} mikrosekundės</unitPattern>
 				<unitPattern count="other">{0} mikrosekundžių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrosekundžių</unitPattern>
+				<unitPattern count="other" case="dative">{0} mikrosekundžių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrosekundžių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mikrosekundžių</unitPattern>
+				<unitPattern count="other" case="locative">{0} mikrosekundžių</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>feminine</gender>
@@ -11230,17 +11230,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} nanosekundėmis</unitPattern>
 				<unitPattern count="few" case="locative">{0} nanosekundėse</unitPattern>
 				<unitPattern count="many">{0} nanosekundės</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} nanosekundės</unitPattern>
+				<unitPattern count="many" case="dative">{0} nanosekundės</unitPattern>
+				<unitPattern count="many" case="genitive">{0} nanosekundės</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} nanosekundės</unitPattern>
+				<unitPattern count="many" case="locative">{0} nanosekundės</unitPattern>
 				<unitPattern count="other">{0} nanosekundžių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanosekundžių</unitPattern>
+				<unitPattern count="other" case="dative">{0} nanosekundžių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nanosekundžių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} nanosekundžių</unitPattern>
+				<unitPattern count="other" case="locative">{0} nanosekundžių</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>masculine</gender>
@@ -11258,17 +11258,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} amperais</unitPattern>
 				<unitPattern count="few" case="locative">{0} amperuose</unitPattern>
 				<unitPattern count="many">{0} ampero</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ampero</unitPattern>
+				<unitPattern count="many" case="dative">{0} ampero</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ampero</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} ampero</unitPattern>
+				<unitPattern count="many" case="locative">{0} ampero</unitPattern>
 				<unitPattern count="other">{0} amperų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} amperų</unitPattern>
+				<unitPattern count="other" case="dative">{0} amperų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} amperų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} amperų</unitPattern>
+				<unitPattern count="other" case="locative">{0} amperų</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>masculine</gender>
@@ -11286,17 +11286,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} miliamperais</unitPattern>
 				<unitPattern count="few" case="locative">{0} miliamperuose</unitPattern>
 				<unitPattern count="many">{0} miliampero</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} miliampero</unitPattern>
+				<unitPattern count="many" case="dative">{0} miliampero</unitPattern>
+				<unitPattern count="many" case="genitive">{0} miliampero</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} miliampero</unitPattern>
+				<unitPattern count="many" case="locative">{0} miliampero</unitPattern>
 				<unitPattern count="other">{0} miliamperų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miliamperų</unitPattern>
+				<unitPattern count="other" case="dative">{0} miliamperų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miliamperų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} miliamperų</unitPattern>
+				<unitPattern count="other" case="locative">{0} miliamperų</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>masculine</gender>
@@ -11314,17 +11314,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} omais</unitPattern>
 				<unitPattern count="few" case="locative">{0} omuose</unitPattern>
 				<unitPattern count="many">{0} omo</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} omo</unitPattern>
+				<unitPattern count="many" case="dative">{0} omo</unitPattern>
+				<unitPattern count="many" case="genitive">{0} omo</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} omo</unitPattern>
+				<unitPattern count="many" case="locative">{0} omo</unitPattern>
 				<unitPattern count="other">{0} omų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} omų</unitPattern>
+				<unitPattern count="other" case="dative">{0} omų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} omų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} omų</unitPattern>
+				<unitPattern count="other" case="locative">{0} omų</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>masculine</gender>
@@ -11342,17 +11342,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} voltais</unitPattern>
 				<unitPattern count="few" case="locative">{0} voltuose</unitPattern>
 				<unitPattern count="many">{0} volto</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} volto</unitPattern>
+				<unitPattern count="many" case="dative">{0} volto</unitPattern>
+				<unitPattern count="many" case="genitive">{0} volto</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} volto</unitPattern>
+				<unitPattern count="many" case="locative">{0} volto</unitPattern>
 				<unitPattern count="other">{0} voltų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} voltų</unitPattern>
+				<unitPattern count="other" case="dative">{0} voltų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} voltų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} voltų</unitPattern>
+				<unitPattern count="other" case="locative">{0} voltų</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>kilokalorijos</displayName>
@@ -11377,17 +11377,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kalorijomis</unitPattern>
 				<unitPattern count="few" case="locative">{0} kalorijose</unitPattern>
 				<unitPattern count="many">{0} kalorijos</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kalorijos</unitPattern>
+				<unitPattern count="many" case="dative">{0} kalorijos</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kalorijos</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kalorijos</unitPattern>
+				<unitPattern count="many" case="locative">{0} kalorijos</unitPattern>
 				<unitPattern count="other">{0} kalorijų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kalorijų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kalorijų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kalorijų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kalorijų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kalorijų</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>kalorijos</displayName>
@@ -11412,17 +11412,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilodžauliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilodžauliuose</unitPattern>
 				<unitPattern count="many">{0} kilodžaulio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilodžaulio</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilodžaulio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilodžaulio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilodžaulio</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilodžaulio</unitPattern>
 				<unitPattern count="other">{0} kilodžaulių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilodžaulių</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilodžaulių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilodžaulių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilodžaulių</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilodžaulių</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>masculine</gender>
@@ -11440,17 +11440,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} džauliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} džauliuose</unitPattern>
 				<unitPattern count="many">{0} džaulio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} džaulio</unitPattern>
+				<unitPattern count="many" case="dative">{0} džaulio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} džaulio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} džaulio</unitPattern>
+				<unitPattern count="many" case="locative">{0} džaulio</unitPattern>
 				<unitPattern count="other">{0} džaulių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} džaulių</unitPattern>
+				<unitPattern count="other" case="dative">{0} džaulių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} džaulių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} džaulių</unitPattern>
+				<unitPattern count="other" case="locative">{0} džaulių</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>feminine</gender>
@@ -11468,17 +11468,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilovatvalandėmis</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilovatvalandėse</unitPattern>
 				<unitPattern count="many">{0} kilovatvalandės</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilovatvalandės</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilovatvalandės</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilovatvalandės</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilovatvalandės</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilovatvalandės</unitPattern>
 				<unitPattern count="other">{0} kilovatvalandžių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovatvalandžių</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilovatvalandžių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilovatvalandžių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilovatvalandžių</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilovatvalandžių</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronvoltai</displayName>
@@ -11489,10 +11489,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>britiškieji šilumos vienetai</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>JAV termos</displayName>
@@ -11524,17 +11524,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} niutonais</unitPattern>
 				<unitPattern count="few" case="locative">{0} niutonuose</unitPattern>
 				<unitPattern count="many">{0} niutono</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} niutono</unitPattern>
+				<unitPattern count="many" case="dative">{0} niutono</unitPattern>
+				<unitPattern count="many" case="genitive">{0} niutono</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} niutono</unitPattern>
+				<unitPattern count="many" case="locative">{0} niutono</unitPattern>
 				<unitPattern count="other">{0} niutonų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} niutonų</unitPattern>
+				<unitPattern count="other" case="dative">{0} niutonų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} niutonų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} niutonų</unitPattern>
+				<unitPattern count="other" case="locative">{0} niutonų</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>feminine</gender>
@@ -11552,17 +11552,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilovatvalandėmis šimtui kilometrų</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilovatvalandėse šimtui kilometrų</unitPattern>
 				<unitPattern count="many">{0} kilovatvalandės šimtui kilometrų</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilovatvalandės šimtui kilometrų</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilovatvalandės šimtui kilometrų</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilovatvalandės šimtui kilometrų</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilovatvalandės šimtui kilometrų</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilovatvalandės šimtui kilometrų</unitPattern>
 				<unitPattern count="other">{0} kilovatvalandžių šimtui kilometrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovatvalandžių šimtui kilometrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilovatvalandžių šimtui kilometrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilovatvalandžių šimtui kilometrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilovatvalandžių šimtui kilometrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilovatvalandžių šimtui kilometrų</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>masculine</gender>
@@ -11580,17 +11580,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} gigahercais</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigahercuose</unitPattern>
 				<unitPattern count="many">{0} gigaherco</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigaherco</unitPattern>
+				<unitPattern count="many" case="dative">{0} gigaherco</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigaherco</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gigaherco</unitPattern>
+				<unitPattern count="many" case="locative">{0} gigaherco</unitPattern>
 				<unitPattern count="other">{0} gigahercų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigahercų</unitPattern>
+				<unitPattern count="other" case="dative">{0} gigahercų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigahercų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigahercų</unitPattern>
+				<unitPattern count="other" case="locative">{0} gigahercų</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>masculine</gender>
@@ -11608,17 +11608,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} megahercais</unitPattern>
 				<unitPattern count="few" case="locative">{0} megahercuose</unitPattern>
 				<unitPattern count="many">{0} megaherco</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megaherco</unitPattern>
+				<unitPattern count="many" case="dative">{0} megaherco</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megaherco</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megaherco</unitPattern>
+				<unitPattern count="many" case="locative">{0} megaherco</unitPattern>
 				<unitPattern count="other">{0} megahercų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megahercų</unitPattern>
+				<unitPattern count="other" case="dative">{0} megahercų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megahercų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megahercų</unitPattern>
+				<unitPattern count="other" case="locative">{0} megahercų</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>masculine</gender>
@@ -11636,17 +11636,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilohercais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilohercuose</unitPattern>
 				<unitPattern count="many">{0} kiloherco</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kiloherco</unitPattern>
+				<unitPattern count="many" case="dative">{0} kiloherco</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kiloherco</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kiloherco</unitPattern>
+				<unitPattern count="many" case="locative">{0} kiloherco</unitPattern>
 				<unitPattern count="other">{0} kilohercų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilohercų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilohercų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilohercų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilohercų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilohercų</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>masculine</gender>
@@ -11664,17 +11664,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} hercais</unitPattern>
 				<unitPattern count="few" case="locative">{0} hercuose</unitPattern>
 				<unitPattern count="many">{0} herco</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} herco</unitPattern>
+				<unitPattern count="many" case="dative">{0} herco</unitPattern>
+				<unitPattern count="many" case="genitive">{0} herco</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} herco</unitPattern>
+				<unitPattern count="many" case="locative">{0} herco</unitPattern>
 				<unitPattern count="other">{0} hercų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hercų</unitPattern>
+				<unitPattern count="other" case="dative">{0} hercų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hercų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hercų</unitPattern>
+				<unitPattern count="other" case="locative">{0} hercų</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>masculine</gender>
@@ -11720,17 +11720,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} pikseliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} pikseliuose</unitPattern>
 				<unitPattern count="many">{0} pikselio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pikselio</unitPattern>
+				<unitPattern count="many" case="dative">{0} pikselio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} pikselio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} pikselio</unitPattern>
+				<unitPattern count="many" case="locative">{0} pikselio</unitPattern>
 				<unitPattern count="other">{0} pikselių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pikselių</unitPattern>
+				<unitPattern count="other" case="dative">{0} pikselių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pikselių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} pikselių</unitPattern>
+				<unitPattern count="other" case="locative">{0} pikselių</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>masculine</gender>
@@ -11748,17 +11748,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} megapikseliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} megapikseliuose</unitPattern>
 				<unitPattern count="many">{0} megapikselio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megapikselio</unitPattern>
+				<unitPattern count="many" case="dative">{0} megapikselio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megapikselio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megapikselio</unitPattern>
+				<unitPattern count="many" case="locative">{0} megapikselio</unitPattern>
 				<unitPattern count="other">{0} megapikselių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapikselių</unitPattern>
+				<unitPattern count="other" case="dative">{0} megapikselių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapikselių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megapikselių</unitPattern>
+				<unitPattern count="other" case="locative">{0} megapikselių</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>masculine</gender>
@@ -11776,17 +11776,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} pikseliais centimetre</unitPattern>
 				<unitPattern count="few" case="locative">{0} pikseliuose centimetre</unitPattern>
 				<unitPattern count="many">{0} pikselio centimetre</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pikselio centimetre</unitPattern>
+				<unitPattern count="many" case="dative">{0} pikselio centimetre</unitPattern>
+				<unitPattern count="many" case="genitive">{0} pikselio centimetre</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} pikselio centimetre</unitPattern>
+				<unitPattern count="many" case="locative">{0} pikselio centimetre</unitPattern>
 				<unitPattern count="other">{0} pikselių centimetre</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pikselių centimetre</unitPattern>
+				<unitPattern count="other" case="dative">{0} pikselių centimetre</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pikselių centimetre</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} pikselių centimetre</unitPattern>
+				<unitPattern count="other" case="locative">{0} pikselių centimetre</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>pikseliai colyje</displayName>
@@ -11839,17 +11839,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilometrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilometruose</unitPattern>
 				<unitPattern count="many">{0} kilometro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilometro</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilometro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilometro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilometro</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilometro</unitPattern>
 				<unitPattern count="other">{0} kilometrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilometrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilometrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilometrų</unitPattern>
 				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
@@ -11868,17 +11868,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} metrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} metruose</unitPattern>
 				<unitPattern count="many">{0} metro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metro</unitPattern>
+				<unitPattern count="many" case="dative">{0} metro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metro</unitPattern>
+				<unitPattern count="many" case="locative">{0} metro</unitPattern>
 				<unitPattern count="other">{0} metrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} metrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} metrų</unitPattern>
 				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
@@ -11897,17 +11897,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} decimetrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} decimetruose</unitPattern>
 				<unitPattern count="many">{0} decimetro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} decimetro</unitPattern>
+				<unitPattern count="many" case="dative">{0} decimetro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} decimetro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} decimetro</unitPattern>
+				<unitPattern count="many" case="locative">{0} decimetro</unitPattern>
 				<unitPattern count="other">{0} decimetrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decimetrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} decimetrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decimetrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} decimetrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} decimetrų</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>masculine</gender>
@@ -11923,19 +11923,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="dative">{0} centimetrams</unitPattern>
 				<unitPattern count="few" case="genitive">{0} centimetrų</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} centimetruose</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="locative">{0} centimetrai</unitPattern>
 				<unitPattern count="many">{0} centimetro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} centimetro</unitPattern>
+				<unitPattern count="many" case="dative">{0} centimetro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} centimetro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} centimetro</unitPattern>
+				<unitPattern count="many" case="locative">{0} centimetro</unitPattern>
 				<unitPattern count="other">{0} centimetrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centimetrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} centimetrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centimetrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centimetrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} centimetrų</unitPattern>
 				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
@@ -11954,17 +11954,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} milimetrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} milimetruose</unitPattern>
 				<unitPattern count="many">{0} milimetro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milimetro</unitPattern>
+				<unitPattern count="many" case="dative">{0} milimetro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milimetro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milimetro</unitPattern>
+				<unitPattern count="many" case="locative">{0} milimetro</unitPattern>
 				<unitPattern count="other">{0} milimetrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimetrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} milimetrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimetrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milimetrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} milimetrų</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>masculine</gender>
@@ -11982,17 +11982,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} mikrometrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} mikrometruose</unitPattern>
 				<unitPattern count="many">{0} mikrometro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mikrometro</unitPattern>
+				<unitPattern count="many" case="dative">{0} mikrometro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mikrometro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mikrometro</unitPattern>
+				<unitPattern count="many" case="locative">{0} mikrometro</unitPattern>
 				<unitPattern count="other">{0} mikrometrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrometrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} mikrometrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrometrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mikrometrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} mikrometrų</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>masculine</gender>
@@ -12010,17 +12010,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} nanometrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} nanometruose</unitPattern>
 				<unitPattern count="many">{0} nanometro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} nanometro</unitPattern>
+				<unitPattern count="many" case="dative">{0} nanometro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} nanometro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} nanometro</unitPattern>
+				<unitPattern count="many" case="locative">{0} nanometro</unitPattern>
 				<unitPattern count="other">{0} nanometrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanometrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} nanometrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nanometrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} nanometrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} nanometrų</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>masculine</gender>
@@ -12038,17 +12038,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} pikometrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} pikometruose</unitPattern>
 				<unitPattern count="many">{0} pikometro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pikometro</unitPattern>
+				<unitPattern count="many" case="dative">{0} pikometro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} pikometro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} pikometro</unitPattern>
+				<unitPattern count="many" case="locative">{0} pikometro</unitPattern>
 				<unitPattern count="other">{0} pikometrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pikometrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} pikometrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pikometrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} pikometrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} pikometrų</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mylios</displayName>
@@ -12138,17 +12138,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} ilgosiomis myliomis</unitPattern>
 				<unitPattern count="few" case="locative">{0} ilgosiose myliose</unitPattern>
 				<unitPattern count="many">{0} ilgosios mylios</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ilgosios mylios</unitPattern>
+				<unitPattern count="many" case="dative">{0} ilgosios mylios</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ilgosios mylios</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} ilgosios mylios</unitPattern>
+				<unitPattern count="many" case="locative">{0} ilgosios mylios</unitPattern>
 				<unitPattern count="other">{0} ilgųjų mylių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ilgųjų mylių</unitPattern>
+				<unitPattern count="other" case="dative">{0} ilgųjų mylių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ilgųjų mylių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ilgųjų mylių</unitPattern>
+				<unitPattern count="other" case="locative">{0} ilgųjų mylių</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>punktai</displayName>
@@ -12159,10 +12159,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>saulės spinduliuotė</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<gender>masculine</gender>
@@ -12180,17 +12180,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} liuksais</unitPattern>
 				<unitPattern count="few" case="locative">{0} liuksuose</unitPattern>
 				<unitPattern count="many">{0} liukso</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} liukso</unitPattern>
+				<unitPattern count="many" case="dative">{0} liukso</unitPattern>
+				<unitPattern count="many" case="genitive">{0} liukso</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} liukso</unitPattern>
+				<unitPattern count="many" case="locative">{0} liukso</unitPattern>
 				<unitPattern count="other">{0} liuksų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} liuksų</unitPattern>
+				<unitPattern count="other" case="dative">{0} liuksų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} liuksų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} liuksų</unitPattern>
+				<unitPattern count="other" case="locative">{0} liuksų</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
@@ -12214,11 +12214,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} kandelos</unitPattern>
 				<unitPattern count="many" case="locative">{0} kandelos</unitPattern>
 				<unitPattern count="other">{0} kandelų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kandelų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kandelų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kandelų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kandelų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kandelų</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>masculine</gender>
@@ -12242,18 +12242,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} liumeno</unitPattern>
 				<unitPattern count="many" case="locative">{0} liumeno</unitPattern>
 				<unitPattern count="other">{0} liumenų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} liumenų</unitPattern>
+				<unitPattern count="other" case="dative">{0} liumenų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} liumenų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} liumenų</unitPattern>
+				<unitPattern count="other" case="locative">{0} liumenų</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>saulės šviesis</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<gender>feminine</gender>
@@ -12271,17 +12271,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} metrinėmis tonomis</unitPattern>
 				<unitPattern count="few" case="locative">{0} metrinėse tonose</unitPattern>
 				<unitPattern count="many">{0} metrinės tonos</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metrinės tonos</unitPattern>
+				<unitPattern count="many" case="dative">{0} metrinės tonos</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metrinės tonos</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metrinės tonos</unitPattern>
+				<unitPattern count="many" case="locative">{0} metrinės tonos</unitPattern>
 				<unitPattern count="other">{0} metrinių tonų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrinių tonų</unitPattern>
+				<unitPattern count="other" case="dative">{0} metrinių tonų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metrinių tonų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metrinių tonų</unitPattern>
+				<unitPattern count="other" case="locative">{0} metrinių tonų</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>masculine</gender>
@@ -12299,17 +12299,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilogramais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilogramuose</unitPattern>
 				<unitPattern count="many">{0} kilogramo</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilogramo</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilogramo</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilogramo</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilogramo</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilogramo</unitPattern>
 				<unitPattern count="other">{0} kilogramų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilogramų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilogramų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilogramų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilogramų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilogramų</unitPattern>
 				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
@@ -12328,17 +12328,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} gramais</unitPattern>
 				<unitPattern count="few" case="locative">{0} gramuose</unitPattern>
 				<unitPattern count="many">{0} gramo</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gramo</unitPattern>
+				<unitPattern count="many" case="dative">{0} gramo</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gramo</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gramo</unitPattern>
+				<unitPattern count="many" case="locative">{0} gramo</unitPattern>
 				<unitPattern count="other">{0} gramų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gramų</unitPattern>
+				<unitPattern count="other" case="dative">{0} gramų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gramų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gramų</unitPattern>
+				<unitPattern count="other" case="locative">{0} gramų</unitPattern>
 				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
@@ -12357,17 +12357,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} miligramais</unitPattern>
 				<unitPattern count="few" case="locative">{0} miligramuose</unitPattern>
 				<unitPattern count="many">{0} miligramo</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} miligramo</unitPattern>
+				<unitPattern count="many" case="dative">{0} miligramo</unitPattern>
+				<unitPattern count="many" case="genitive">{0} miligramo</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} miligramo</unitPattern>
+				<unitPattern count="many" case="locative">{0} miligramo</unitPattern>
 				<unitPattern count="other">{0} miligramų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miligramų</unitPattern>
+				<unitPattern count="other" case="dative">{0} miligramų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miligramų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} miligramų</unitPattern>
+				<unitPattern count="other" case="locative">{0} miligramų</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>masculine</gender>
@@ -12385,17 +12385,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} mikrogramais</unitPattern>
 				<unitPattern count="few" case="locative">{0} mikrogramuose</unitPattern>
 				<unitPattern count="many">{0} mikrogramo</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mikrogramo</unitPattern>
+				<unitPattern count="many" case="dative">{0} mikrogramo</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mikrogramo</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mikrogramo</unitPattern>
+				<unitPattern count="many" case="locative">{0} mikrogramo</unitPattern>
 				<unitPattern count="other">{0} mikrogramų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrogramų</unitPattern>
+				<unitPattern count="other" case="dative">{0} mikrogramų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrogramų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mikrogramų</unitPattern>
+				<unitPattern count="other" case="locative">{0} mikrogramų</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>tonos</displayName>
@@ -12450,17 +12450,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} karatais</unitPattern>
 				<unitPattern count="few" case="locative">{0} karatuose</unitPattern>
 				<unitPattern count="many">{0} karato</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} karato</unitPattern>
+				<unitPattern count="many" case="dative">{0} karato</unitPattern>
+				<unitPattern count="many" case="genitive">{0} karato</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} karato</unitPattern>
+				<unitPattern count="many" case="locative">{0} karato</unitPattern>
 				<unitPattern count="other">{0} karatų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karatų</unitPattern>
+				<unitPattern count="other" case="dative">{0} karatų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karatų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} karatų</unitPattern>
+				<unitPattern count="other" case="locative">{0} karatų</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>daltonai</displayName>
@@ -12471,17 +12471,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>žemės masė</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>saulės masė</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>grūdas</displayName>
@@ -12506,17 +12506,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} gigavatais</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigavatuose</unitPattern>
 				<unitPattern count="many">{0} gigavato</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigavato</unitPattern>
+				<unitPattern count="many" case="dative">{0} gigavato</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigavato</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gigavato</unitPattern>
+				<unitPattern count="many" case="locative">{0} gigavato</unitPattern>
 				<unitPattern count="other">{0} gigavatų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigavatų</unitPattern>
+				<unitPattern count="other" case="dative">{0} gigavatų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigavatų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigavatų</unitPattern>
+				<unitPattern count="other" case="locative">{0} gigavatų</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>masculine</gender>
@@ -12534,17 +12534,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} megavatais</unitPattern>
 				<unitPattern count="few" case="locative">{0} megavatuose</unitPattern>
 				<unitPattern count="many">{0} megavato</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megavato</unitPattern>
+				<unitPattern count="many" case="dative">{0} megavato</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megavato</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megavato</unitPattern>
+				<unitPattern count="many" case="locative">{0} megavato</unitPattern>
 				<unitPattern count="other">{0} megavatų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megavatų</unitPattern>
+				<unitPattern count="other" case="dative">{0} megavatų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megavatų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megavatų</unitPattern>
+				<unitPattern count="other" case="locative">{0} megavatų</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>masculine</gender>
@@ -12562,17 +12562,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilovatais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilovatuose</unitPattern>
 				<unitPattern count="many">{0} kilovato</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilovato</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilovato</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilovato</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilovato</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilovato</unitPattern>
 				<unitPattern count="other">{0} kilovatų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovatų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilovatų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilovatų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilovatų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilovatų</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>masculine</gender>
@@ -12590,17 +12590,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} vatais</unitPattern>
 				<unitPattern count="few" case="locative">{0} vatuose</unitPattern>
 				<unitPattern count="many">{0} vato</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} vato</unitPattern>
+				<unitPattern count="many" case="dative">{0} vato</unitPattern>
+				<unitPattern count="many" case="genitive">{0} vato</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} vato</unitPattern>
+				<unitPattern count="many" case="locative">{0} vato</unitPattern>
 				<unitPattern count="other">{0} vatų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} vatų</unitPattern>
+				<unitPattern count="other" case="dative">{0} vatų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} vatų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} vatų</unitPattern>
+				<unitPattern count="other" case="locative">{0} vatų</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>masculine</gender>
@@ -12618,17 +12618,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} milivatais</unitPattern>
 				<unitPattern count="few" case="locative">{0} milivatuose</unitPattern>
 				<unitPattern count="many">{0} milivato</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milivato</unitPattern>
+				<unitPattern count="many" case="dative">{0} milivato</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milivato</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milivato</unitPattern>
+				<unitPattern count="many" case="locative">{0} milivato</unitPattern>
 				<unitPattern count="other">{0} milivatų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milivatų</unitPattern>
+				<unitPattern count="other" case="dative">{0} milivatų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milivatų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milivatų</unitPattern>
+				<unitPattern count="other" case="locative">{0} milivatų</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>arklio galios</displayName>
@@ -12674,17 +12674,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} barais</unitPattern>
 				<unitPattern count="few" case="locative">{0} baruose</unitPattern>
 				<unitPattern count="many">{0} baro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} baro</unitPattern>
+				<unitPattern count="many" case="dative">{0} baro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} baro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} baro</unitPattern>
+				<unitPattern count="many" case="locative">{0} baro</unitPattern>
 				<unitPattern count="other">{0} barų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} barų</unitPattern>
+				<unitPattern count="other" case="dative">{0} barų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} barų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} barų</unitPattern>
+				<unitPattern count="other" case="locative">{0} barų</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>masculine</gender>
@@ -12702,17 +12702,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} milibarais</unitPattern>
 				<unitPattern count="few" case="locative">{0} milibaruose</unitPattern>
 				<unitPattern count="many">{0} milibaro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milibaro</unitPattern>
+				<unitPattern count="many" case="dative">{0} milibaro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milibaro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milibaro</unitPattern>
+				<unitPattern count="many" case="locative">{0} milibaro</unitPattern>
 				<unitPattern count="other">{0} milibarų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milibarų</unitPattern>
+				<unitPattern count="other" case="dative">{0} milibarų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milibarų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milibarų</unitPattern>
+				<unitPattern count="other" case="locative">{0} milibarų</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>feminine</gender>
@@ -12730,17 +12730,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} atmosferomis</unitPattern>
 				<unitPattern count="few" case="locative">{0} atmosferose</unitPattern>
 				<unitPattern count="many">{0} atmosferos</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} atmosferos</unitPattern>
+				<unitPattern count="many" case="dative">{0} atmosferos</unitPattern>
+				<unitPattern count="many" case="genitive">{0} atmosferos</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} atmosferos</unitPattern>
+				<unitPattern count="many" case="locative">{0} atmosferos</unitPattern>
 				<unitPattern count="other">{0} atmosferų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} atmosferų</unitPattern>
+				<unitPattern count="other" case="dative">{0} atmosferų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} atmosferų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} atmosferų</unitPattern>
+				<unitPattern count="other" case="locative">{0} atmosferų</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>masculine</gender>
@@ -12758,17 +12758,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} paskaliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} paskaliuose</unitPattern>
 				<unitPattern count="many">{0} paskalio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} paskalio</unitPattern>
+				<unitPattern count="many" case="dative">{0} paskalio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} paskalio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} paskalio</unitPattern>
+				<unitPattern count="many" case="locative">{0} paskalio</unitPattern>
 				<unitPattern count="other">{0} paskalių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} paskalių</unitPattern>
+				<unitPattern count="other" case="dative">{0} paskalių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} paskalių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} paskalių</unitPattern>
+				<unitPattern count="other" case="locative">{0} paskalių</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>masculine</gender>
@@ -12786,17 +12786,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} hektopaskaliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} hektopaskaliuose</unitPattern>
 				<unitPattern count="many">{0} hektopaskalio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hektopaskalio</unitPattern>
+				<unitPattern count="many" case="dative">{0} hektopaskalio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hektopaskalio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} hektopaskalio</unitPattern>
+				<unitPattern count="many" case="locative">{0} hektopaskalio</unitPattern>
 				<unitPattern count="other">{0} hektopaskalių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektopaskalių</unitPattern>
+				<unitPattern count="other" case="dative">{0} hektopaskalių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektopaskalių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektopaskalių</unitPattern>
+				<unitPattern count="other" case="locative">{0} hektopaskalių</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>masculine</gender>
@@ -12814,17 +12814,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilopaskaliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilopaskaliuose</unitPattern>
 				<unitPattern count="many">{0} kilopaskalio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilopaskalio</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilopaskalio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilopaskalio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilopaskalio</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilopaskalio</unitPattern>
 				<unitPattern count="other">{0} kilopaskalių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilopaskalių</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilopaskalių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilopaskalių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilopaskalių</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilopaskalių</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>masculine</gender>
@@ -12842,17 +12842,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} megapaskaliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} megapaskaliuose</unitPattern>
 				<unitPattern count="many">{0} megapaskalio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megapaskalio</unitPattern>
+				<unitPattern count="many" case="dative">{0} megapaskalio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megapaskalio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megapaskalio</unitPattern>
+				<unitPattern count="many" case="locative">{0} megapaskalio</unitPattern>
 				<unitPattern count="other">{0} megapaskalių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapaskalių</unitPattern>
+				<unitPattern count="other" case="dative">{0} megapaskalių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapaskalių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megapaskalių</unitPattern>
+				<unitPattern count="other" case="locative">{0} megapaskalių</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>masculine</gender>
@@ -12870,17 +12870,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilometrais per valandą</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilometruose per valandą</unitPattern>
 				<unitPattern count="many">{0} kilometro per valandą</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilometro per valandą</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilometro per valandą</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilometro per valandą</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilometro per valandą</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilometro per valandą</unitPattern>
 				<unitPattern count="other">{0} kilometrų per valandą</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometrų per valandą</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilometrų per valandą</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometrų per valandą</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilometrų per valandą</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilometrų per valandą</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>masculine</gender>
@@ -12898,17 +12898,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} metrais per sekundę</unitPattern>
 				<unitPattern count="few" case="locative">{0} metruose per sekundę</unitPattern>
 				<unitPattern count="many">{0} metro per sekundę</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metro per sekundę</unitPattern>
+				<unitPattern count="many" case="dative">{0} metro per sekundę</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metro per sekundę</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metro per sekundę</unitPattern>
+				<unitPattern count="many" case="locative">{0} metro per sekundę</unitPattern>
 				<unitPattern count="other">{0} metrų per sekundę</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrų per sekundę</unitPattern>
+				<unitPattern count="other" case="dative">{0} metrų per sekundę</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metrų per sekundę</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metrų per sekundę</unitPattern>
+				<unitPattern count="other" case="locative">{0} metrų per sekundę</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>mylios per valandą</displayName>
@@ -12928,29 +12928,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0}°</unitPattern>
+				<unitPattern count="one" case="dative">{0}°</unitPattern>
+				<unitPattern count="one" case="genitive">{0}°</unitPattern>
+				<unitPattern count="one" case="instrumental">{0}°</unitPattern>
+				<unitPattern count="one" case="locative">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0}°</unitPattern>
+				<unitPattern count="few" case="dative">{0}°</unitPattern>
+				<unitPattern count="few" case="genitive">{0}°</unitPattern>
+				<unitPattern count="few" case="instrumental">{0}°</unitPattern>
+				<unitPattern count="few" case="locative">{0}°</unitPattern>
 				<unitPattern count="many">{0}°</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0}°</unitPattern>
+				<unitPattern count="many" case="dative">{0}°</unitPattern>
+				<unitPattern count="many" case="genitive">{0}°</unitPattern>
+				<unitPattern count="many" case="instrumental">{0}°</unitPattern>
+				<unitPattern count="many" case="locative">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0}°</unitPattern>
+				<unitPattern count="other" case="dative">{0}°</unitPattern>
+				<unitPattern count="other" case="genitive">{0}°</unitPattern>
+				<unitPattern count="other" case="instrumental">{0}°</unitPattern>
+				<unitPattern count="other" case="locative">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<gender>masculine</gender>
@@ -12968,17 +12968,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} Celsijaus laipsniais</unitPattern>
 				<unitPattern count="few" case="locative">{0} Celsijaus laipsniuose</unitPattern>
 				<unitPattern count="many">{0} Celsijaus laipsnio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} Celsijaus laipsnio</unitPattern>
+				<unitPattern count="many" case="dative">{0} Celsijaus laipsnio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} Celsijaus laipsnio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} Celsijaus laipsnio</unitPattern>
+				<unitPattern count="many" case="locative">{0} Celsijaus laipsnio</unitPattern>
 				<unitPattern count="other">{0} Celsijaus laipsnių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} Celsijaus laipsnių</unitPattern>
+				<unitPattern count="other" case="dative">{0} Celsijaus laipsnių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} Celsijaus laipsnių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} Celsijaus laipsnių</unitPattern>
+				<unitPattern count="other" case="locative">{0} Celsijaus laipsnių</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>Farenheito laipsniai</displayName>
@@ -13003,24 +13003,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kelvinais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kelvinuose</unitPattern>
 				<unitPattern count="many">{0} kelvino</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kelvino</unitPattern>
+				<unitPattern count="many" case="dative">{0} kelvino</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kelvino</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kelvino</unitPattern>
+				<unitPattern count="many" case="locative">{0} kelvino</unitPattern>
 				<unitPattern count="other">{0} kelvinų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kelvinų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kelvinų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kelvinų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kelvinų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kelvinų</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>svarų pėdos</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<gender>masculine</gender>
@@ -13038,17 +13038,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} niutonmetrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} niutonmetruose</unitPattern>
 				<unitPattern count="many">{0} niutonmetro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} niutonmetro</unitPattern>
+				<unitPattern count="many" case="dative">{0} niutonmetro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} niutonmetro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} niutonmetro</unitPattern>
+				<unitPattern count="many" case="locative">{0} niutonmetro</unitPattern>
 				<unitPattern count="other">{0} niutonmetrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} niutonmetrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} niutonmetrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} niutonmetrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} niutonmetrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} niutonmetrų</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>masculine</gender>
@@ -13066,17 +13066,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kubiniais kilometrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kubiniuose kilometruose</unitPattern>
 				<unitPattern count="many">{0} kubinio kilometro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kubinio kilometro</unitPattern>
+				<unitPattern count="many" case="dative">{0} kubinio kilometro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kubinio kilometro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kubinio kilometro</unitPattern>
+				<unitPattern count="many" case="locative">{0} kubinio kilometro</unitPattern>
 				<unitPattern count="other">{0} kubinių kilometrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubinių kilometrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kubinių kilometrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubinių kilometrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kubinių kilometrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kubinių kilometrų</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>masculine</gender>
@@ -13094,17 +13094,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kubiniais metrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kubiniuose metruose</unitPattern>
 				<unitPattern count="many">{0} kubinio metro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kubinio metro</unitPattern>
+				<unitPattern count="many" case="dative">{0} kubinio metro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kubinio metro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kubinio metro</unitPattern>
+				<unitPattern count="many" case="locative">{0} kubinio metro</unitPattern>
 				<unitPattern count="other">{0} kubinių metrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubinių metrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kubinių metrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubinių metrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kubinių metrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kubinių metrų</unitPattern>
 				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
@@ -13123,17 +13123,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kubiniais centimetrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} kubiniuose centimetruose</unitPattern>
 				<unitPattern count="many">{0} kubinio centimetro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kubinio centimetro</unitPattern>
+				<unitPattern count="many" case="dative">{0} kubinio centimetro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kubinio centimetro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kubinio centimetro</unitPattern>
+				<unitPattern count="many" case="locative">{0} kubinio centimetro</unitPattern>
 				<unitPattern count="other">{0} kubinių centimetrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubinių centimetrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} kubinių centimetrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubinių centimetrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kubinių centimetrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} kubinių centimetrų</unitPattern>
 				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -13180,17 +13180,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} megalitrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} megalitruose</unitPattern>
 				<unitPattern count="many">{0} megalitro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megalitro</unitPattern>
+				<unitPattern count="many" case="dative">{0} megalitro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megalitro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megalitro</unitPattern>
+				<unitPattern count="many" case="locative">{0} megalitro</unitPattern>
 				<unitPattern count="other">{0} megalitrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megalitrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} megalitrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megalitrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megalitrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} megalitrų</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>masculine</gender>
@@ -13208,17 +13208,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} hektolitrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} hektolitruose</unitPattern>
 				<unitPattern count="many">{0} hektolitro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hektolitro</unitPattern>
+				<unitPattern count="many" case="dative">{0} hektolitro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hektolitro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} hektolitro</unitPattern>
+				<unitPattern count="many" case="locative">{0} hektolitro</unitPattern>
 				<unitPattern count="other">{0} hektolitrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektolitrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} hektolitrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektolitrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektolitrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} hektolitrų</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>masculine</gender>
@@ -13236,17 +13236,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} litrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} litruose</unitPattern>
 				<unitPattern count="many">{0} litro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} litro</unitPattern>
+				<unitPattern count="many" case="dative">{0} litro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} litro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} litro</unitPattern>
+				<unitPattern count="many" case="locative">{0} litro</unitPattern>
 				<unitPattern count="other">{0} litrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} litrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} litrų</unitPattern>
 				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
@@ -13265,17 +13265,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} decilitrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} decilitruose</unitPattern>
 				<unitPattern count="many">{0} decilitro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} decilitro</unitPattern>
+				<unitPattern count="many" case="dative">{0} decilitro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} decilitro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} decilitro</unitPattern>
+				<unitPattern count="many" case="locative">{0} decilitro</unitPattern>
 				<unitPattern count="other">{0} decilitrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decilitrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} decilitrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decilitrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} decilitrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} decilitrų</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>masculine</gender>
@@ -13293,17 +13293,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} centilitrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} centilitruose</unitPattern>
 				<unitPattern count="many">{0} centilitro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} centilitro</unitPattern>
+				<unitPattern count="many" case="dative">{0} centilitro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} centilitro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} centilitro</unitPattern>
+				<unitPattern count="many" case="locative">{0} centilitro</unitPattern>
 				<unitPattern count="other">{0} centilitrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centilitrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} centilitrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centilitrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centilitrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} centilitrų</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>masculine</gender>
@@ -13321,17 +13321,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} mililitrais</unitPattern>
 				<unitPattern count="few" case="locative">{0} mililitruose</unitPattern>
 				<unitPattern count="many">{0} mililitro</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mililitro</unitPattern>
+				<unitPattern count="many" case="dative">{0} mililitro</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mililitro</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mililitro</unitPattern>
+				<unitPattern count="many" case="locative">{0} mililitro</unitPattern>
 				<unitPattern count="other">{0} mililitrų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mililitrų</unitPattern>
+				<unitPattern count="other" case="dative">{0} mililitrų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mililitrų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mililitrų</unitPattern>
+				<unitPattern count="other" case="locative">{0} mililitrų</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>feminine</gender>
@@ -13349,17 +13349,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} metrinėmis pintomis</unitPattern>
 				<unitPattern count="few" case="locative">{0} metrinėse pintose</unitPattern>
 				<unitPattern count="many">{0} metrinės pintos</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metrinės pintos</unitPattern>
+				<unitPattern count="many" case="dative">{0} metrinės pintos</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metrinės pintos</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metrinės pintos</unitPattern>
+				<unitPattern count="many" case="locative">{0} metrinės pintos</unitPattern>
 				<unitPattern count="other">{0} metrinių pintų</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrinių pintų</unitPattern>
+				<unitPattern count="other" case="dative">{0} metrinių pintų</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metrinių pintų</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metrinių pintų</unitPattern>
+				<unitPattern count="other" case="locative">{0} metrinių pintų</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>masculine</gender>
@@ -13377,17 +13377,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} matavimo puodeliais</unitPattern>
 				<unitPattern count="few" case="locative">{0} matavimo puodeliuose</unitPattern>
 				<unitPattern count="many">{0} matavimo puodelio</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} matavimo puodelio</unitPattern>
+				<unitPattern count="many" case="dative">{0} matavimo puodelio</unitPattern>
+				<unitPattern count="many" case="genitive">{0} matavimo puodelio</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} matavimo puodelio</unitPattern>
+				<unitPattern count="many" case="locative">{0} matavimo puodelio</unitPattern>
 				<unitPattern count="other">{0} matavimo puodelių</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} matavimo puodelių</unitPattern>
+				<unitPattern count="other" case="dative">{0} matavimo puodelių</unitPattern>
+				<unitPattern count="other" case="genitive">{0} matavimo puodelių</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} matavimo puodelių</unitPattern>
+				<unitPattern count="other" case="locative">{0} matavimo puodelių</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>pėdos akre</displayName>
@@ -13622,16 +13622,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -13812,16 +13812,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="many">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -14100,16 +14100,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -14121,23 +14121,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -14170,9 +14170,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipografinis emas</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="many">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -14184,9 +14184,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapikseliai</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="many">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
@@ -14198,9 +14198,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>pikseliai colyje</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -14378,9 +14378,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -14406,9 +14406,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -14494,23 +14494,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -14606,9 +14606,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>paskaliai</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -14620,16 +14620,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -14690,9 +14690,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -14891,9 +14891,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="many">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -14955,64 +14955,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -15042,21 +15042,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -15073,78 +15073,78 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>apsisuk.</displayName>
+				<unitPattern count="one">{0} apsisuk.</unitPattern>
+				<unitPattern count="few">{0} apsisuk.</unitPattern>
+				<unitPattern count="many">{0} apsisuk.</unitPattern>
+				<unitPattern count="other">{0} apsisuk.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="many">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>laipsniai</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
 				<unitPattern count="many">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>kampo minutės</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="many">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>kampo sekundės</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="many">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kv. km</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="many">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hektarai</displayName>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="few">{0} ha</unitPattern>
+				<unitPattern count="many">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>kv. m</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="many">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="many">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>kv. mylios</displayName>
 				<unitPattern count="one">{0} my²</unitPattern>
 				<unitPattern count="few">{0} my²</unitPattern>
 				<unitPattern count="many">{0} my²</unitPattern>
 				<unitPattern count="other">{0} my²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/my²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>akras</displayName>
@@ -15154,54 +15154,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ak</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="many">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kv. pėda</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="few">{0} ft²</unitPattern>
 				<unitPattern count="many">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="many">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunamai</displayName>
+				<unitPattern count="one">{0} dunamas</unitPattern>
+				<unitPattern count="few">{0} dunamai</unitPattern>
+				<unitPattern count="many">{0} dunamo</unitPattern>
+				<unitPattern count="other">{0} dunamų</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="many">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="few">{0} mg/dl</unitPattern>
+				<unitPattern count="many">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/l</displayName>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="few">{0} mmol/l</unitPattern>
+				<unitPattern count="many">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>elementas</displayName>
@@ -15211,11 +15211,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} elem.</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="many">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -15225,32 +15225,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>promilė</displayName>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="few">{0} ‰</unitPattern>
+				<unitPattern count="many">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="many">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="few">{0} l/km</unitPattern>
+				<unitPattern count="many">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -15260,95 +15260,95 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>my/gal</displayName>
 				<unitPattern count="one">{0} mi/gal</unitPattern>
 				<unitPattern count="few">{0} mi/gal</unitPattern>
 				<unitPattern count="many">{0} mi/gal</unitPattern>
 				<unitPattern count="other">{0} mi/gal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>my/imp. g</displayName>
+				<unitPattern count="one">{0} my/imp. g</unitPattern>
+				<unitPattern count="few">{0} my/imp. g</unitPattern>
+				<unitPattern count="many">{0} my/imp. g</unitPattern>
+				<unitPattern count="other">{0} my/imp. g</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Petabaitas</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="many">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="many">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="many">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="many">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="many">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="many">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="many">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="many">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="many">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="few">{0} B</unitPattern>
+				<unitPattern count="many">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bitai</displayName>
+				<unitPattern count="one">{0} b</unitPattern>
+				<unitPattern count="few">{0} b</unitPattern>
+				<unitPattern count="many">{0} b</unitPattern>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>a.</displayName>
@@ -15358,11 +15358,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} a.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dekados</displayName>
+				<unitPattern count="one">{0} dek.</unitPattern>
+				<unitPattern count="few">{0} dek.</unitPattern>
+				<unitPattern count="many">{0} dek.</unitPattern>
+				<unitPattern count="other">{0} dek.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>metai</displayName>
@@ -15373,7 +15373,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/m.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ketv.</displayName>
 				<unitPattern count="one">{0} ketv.</unitPattern>
 				<unitPattern count="few">{0} ketv.</unitPattern>
 				<unitPattern count="many">{0} ketv.</unitPattern>
@@ -15450,207 +15450,207 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="many">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="many">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="many">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="many">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="many">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="many">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="many">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="many">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="few">{0} kWh</unitPattern>
+				<unitPattern count="many">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>JAV terma</displayName>
+				<unitPattern count="one">{0} JAV terma</unitPattern>
+				<unitPattern count="few">{0} JAV termos</unitPattern>
+				<unitPattern count="many">{0} JAV termos</unitPattern>
+				<unitPattern count="other">{0} JAV termų</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="many">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="many">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="many">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="many">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tipografinis emas</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="many">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pikseliai</displayName>
+				<unitPattern count="one">{0} p</unitPattern>
+				<unitPattern count="few">{0} p</unitPattern>
+				<unitPattern count="many">{0} p</unitPattern>
+				<unitPattern count="other">{0} p</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapikseliai</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="many">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pikseliai centimetre</displayName>
+				<unitPattern count="one">{0} p/cm</unitPattern>
+				<unitPattern count="few">{0} p/cm</unitPattern>
+				<unitPattern count="many">{0} p/cm</unitPattern>
+				<unitPattern count="other">{0} p/cm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pikseliai colyje</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>taškai centimetre</displayName>
+				<unitPattern count="one">{0} tšk./cm</unitPattern>
+				<unitPattern count="few">{0} tšk./cm</unitPattern>
+				<unitPattern count="many">{0} tšk./cm</unitPattern>
+				<unitPattern count="other">{0} tšk./cm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>taškai colyje</displayName>
+				<unitPattern count="one">{0} tšk./in</unitPattern>
+				<unitPattern count="few">{0} tšk./in</unitPattern>
+				<unitPattern count="many">{0} tšk./in</unitPattern>
+				<unitPattern count="other">{0} tšk./in</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tšk.</displayName>
+				<unitPattern count="one">{0} tšk.</unitPattern>
+				<unitPattern count="few">{0} tšk.</unitPattern>
+				<unitPattern count="many">{0} tšk.</unitPattern>
+				<unitPattern count="other">{0} tšk.</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -15691,21 +15691,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="many">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="many">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="few">{0} pm</unitPattern>
 				<unitPattern count="many">{0} pm</unitPattern>
@@ -15742,25 +15742,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="many">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>šviesmečiai</displayName>
 				<unitPattern count="one">{0} šm.</unitPattern>
 				<unitPattern count="few">{0} šm.</unitPattern>
 				<unitPattern count="many">{0} šm.</unitPattern>
 				<unitPattern count="other">{0} šm.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>AV</displayName>
+				<unitPattern count="one">{0} AV</unitPattern>
+				<unitPattern count="few">{0} AV</unitPattern>
+				<unitPattern count="many">{0} AV</unitPattern>
+				<unitPattern count="other">{0} AV</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>fur</displayName>
@@ -15777,11 +15777,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M</displayName>
+				<unitPattern count="one">{0} M</unitPattern>
+				<unitPattern count="few">{0} M</unitPattern>
+				<unitPattern count="many">{0} M</unitPattern>
+				<unitPattern count="other">{0} M</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>IM</displayName>
@@ -15791,53 +15791,53 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} IM</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="many">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="many">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mt</displayName>
+				<unitPattern count="one">{0} mt</unitPattern>
+				<unitPattern count="few">{0} mt</unitPattern>
+				<unitPattern count="many">{0} mt</unitPattern>
+				<unitPattern count="other">{0} mt</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
@@ -15856,25 +15856,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="many">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="many">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="many">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>st</displayName>
@@ -15900,84 +15900,84 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ozt</displayName>
+				<unitPattern count="one">{0} ozt</unitPattern>
+				<unitPattern count="few">{0} ozt</unitPattern>
+				<unitPattern count="many">{0} ozt</unitPattern>
+				<unitPattern count="other">{0} ozt</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ct</displayName>
+				<unitPattern count="one">{0} ct</unitPattern>
+				<unitPattern count="few">{0} ct</unitPattern>
+				<unitPattern count="many">{0} ct</unitPattern>
+				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grūdas</displayName>
+				<unitPattern count="one">{0} grūdas</unitPattern>
+				<unitPattern count="few">{0} grūdai</unitPattern>
+				<unitPattern count="many">{0} grūdo</unitPattern>
+				<unitPattern count="other">{0} grūdų</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="few">{0} GW</unitPattern>
+				<unitPattern count="many">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="few">{0} MW</unitPattern>
+				<unitPattern count="many">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="few">{0} kW</unitPattern>
 				<unitPattern count="many">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="few">{0} W</unitPattern>
 				<unitPattern count="many">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="few">{0} mW</unitPattern>
+				<unitPattern count="many">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>AG</displayName>
 				<unitPattern count="one">{0} AG</unitPattern>
 				<unitPattern count="few">{0} AG</unitPattern>
 				<unitPattern count="many">{0} AG</unitPattern>
@@ -16005,11 +16005,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>baras</displayName>
+				<unitPattern count="one">{0} ba</unitPattern>
+				<unitPattern count="few">{0} ba</unitPattern>
+				<unitPattern count="many">{0} ba</unitPattern>
+				<unitPattern count="other">{0} ba</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -16019,18 +16019,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="many">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>paskaliai</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -16040,18 +16040,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -16110,83 +16110,83 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N-m</displayName>
+				<unitPattern count="one">{0} N-m</unitPattern>
+				<unitPattern count="few">{0} N-m</unitPattern>
+				<unitPattern count="many">{0} N-m</unitPattern>
+				<unitPattern count="other">{0} N-m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="few">{0} km³</unitPattern>
 				<unitPattern count="many">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="many">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="many">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="many">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="many">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="many">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="many">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="few">{0} Ml</unitPattern>
+				<unitPattern count="many">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="few">{0} hl</unitPattern>
+				<unitPattern count="many">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litrai</displayName>
@@ -16194,42 +16194,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="many">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="few">{0} dl</unitPattern>
+				<unitPattern count="many">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="few">{0} cl</unitPattern>
+				<unitPattern count="many">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="few">{0} ml</unitPattern>
+				<unitPattern count="many">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="many">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mat. puodelis</displayName>
+				<unitPattern count="one">{0} mat. puodelis</unitPattern>
+				<unitPattern count="few">{0} mat. puodeliai</unitPattern>
+				<unitPattern count="many">{0} mat. puodelio</unitPattern>
+				<unitPattern count="other">{0} mat. puodelių</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>ft akre</displayName>
@@ -16246,125 +16246,125 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="few">{0} gal</unitPattern>
+				<unitPattern count="many">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>imp. galonas</displayName>
+				<unitPattern count="one">{0} imp. galonas</unitPattern>
+				<unitPattern count="few">{0} imp. galonai</unitPattern>
+				<unitPattern count="many">{0} imp. galono</unitPattern>
+				<unitPattern count="other">{0} imp. galonų</unitPattern>
+				<perUnitPattern>{0}/imp. galone</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>kvortos</displayName>
 				<unitPattern count="one">{0} kvorta</unitPattern>
 				<unitPattern count="few">{0} kvortos</unitPattern>
 				<unitPattern count="many">{0} kvortos</unitPattern>
 				<unitPattern count="other">{0} kvortų</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pintos</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="many">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>stikl.</displayName>
+				<unitPattern count="one">{0} stikl.</unitPattern>
+				<unitPattern count="few">{0} stikl.</unitPattern>
+				<unitPattern count="many">{0} stikl.</unitPattern>
+				<unitPattern count="other">{0} stikl.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>skysčio oz</displayName>
 				<unitPattern count="one">{0} fl oz</unitPattern>
 				<unitPattern count="few">{0} fl oz</unitPattern>
 				<unitPattern count="many">{0} fl oz</unitPattern>
 				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp. skysčio uncija</displayName>
+				<unitPattern count="one">{0} imp. fl oz</unitPattern>
+				<unitPattern count="few">{0} imp. fl oz</unitPattern>
+				<unitPattern count="many">{0} imp. fl oz</unitPattern>
+				<unitPattern count="other">{0} imp. fl oz</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>v. š.</displayName>
+				<unitPattern count="one">{0} v. š.</unitPattern>
+				<unitPattern count="few">{0} v. š.</unitPattern>
+				<unitPattern count="many">{0} v. š.</unitPattern>
+				<unitPattern count="other">{0} v. š.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>a. š.</displayName>
+				<unitPattern count="one">{0} a. š.</unitPattern>
+				<unitPattern count="few">{0} a. š.</unitPattern>
+				<unitPattern count="many">{0} a. š.</unitPattern>
+				<unitPattern count="other">{0} a. š.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="many">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>des. š.</displayName>
+				<unitPattern count="one">{0} des. š.</unitPattern>
+				<unitPattern count="few">{0} des. š.</unitPattern>
+				<unitPattern count="many">{0} des. š.</unitPattern>
+				<unitPattern count="other">{0} des. š.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp. des. š.</displayName>
+				<unitPattern count="one">{0} imp. des. š.</unitPattern>
+				<unitPattern count="few">{0} imp. des. š.</unitPattern>
+				<unitPattern count="many">{0} imp. des. š.</unitPattern>
+				<unitPattern count="other">{0} imp. des. š.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>laš.</displayName>
+				<unitPattern count="one">{0} laš.</unitPattern>
+				<unitPattern count="few">{0} laš.</unitPattern>
+				<unitPattern count="many">{0} laš.</unitPattern>
+				<unitPattern count="other">{0} laš.</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sk. drach.</displayName>
+				<unitPattern count="one">{0} sk. drach.</unitPattern>
+				<unitPattern count="few">{0} sk. drach.</unitPattern>
+				<unitPattern count="many">{0} sk. drach.</unitPattern>
+				<unitPattern count="other">{0} sk. drach.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>džigeris</displayName>
+				<unitPattern count="one">{0} džigeris</unitPattern>
+				<unitPattern count="few">{0} džigeriai</unitPattern>
+				<unitPattern count="many">{0} džigerio</unitPattern>
+				<unitPattern count="other">{0} džigerio</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>žiupsn.</displayName>
+				<unitPattern count="one">{0} žiupsn.</unitPattern>
+				<unitPattern count="few">{0} žiupsn.</unitPattern>
+				<unitPattern count="many">{0} žiupsn.</unitPattern>
+				<unitPattern count="other">{0} žiupsn.</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp. kv.</displayName>
+				<unitPattern count="one">{0} imp. kv.</unitPattern>
+				<unitPattern count="few">{0} imp. kv.</unitPattern>
+				<unitPattern count="many">{0} imp. kv.</unitPattern>
+				<unitPattern count="other">{0} imp. kv.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>kryptis</displayName>
@@ -16398,22 +16398,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ar {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ar {1}</listPatternPart>
+			<listPatternPart type="2">{0} ar {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ar {1}</listPatternPart>
+			<listPatternPart type="2">{0} ar {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ir {1}</listPatternPart>
+			<listPatternPart type="2">{0} ir {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -16632,7 +16632,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{credentials} {title} {given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
@@ -16641,25 +16641,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{credentials} {title} {given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{credentials} {title} {given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
 			<namePattern>{given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
@@ -16674,10 +16674,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{title} {surname} {surname2}, {given} {given2}</namePattern>
@@ -16695,7 +16695,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{credentials} {surname} {given} {given2-initial} {generation}</namePattern>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -108,7 +108,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">čiroku</language>
 			<language type="chy">šejenu</language>
 			<language type="ckb">centrālkurdu</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">centrālkurdu</language>
 			<language type="ckb" alt="variant">sorani kurdu</language>
 			<language type="clc">čilkotīnu</language>
 			<language type="co">korsikāņu</language>
@@ -905,7 +905,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">Jaunzēlande</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Jaunzēlande</territory>
 			<territory type="OM">Omāna</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -965,7 +965,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisija</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turcija</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turcija</territory>
 			<territory type="TT">Trinidāda un Tobāgo</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taivāna</territory>
@@ -1440,7 +1440,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1448,7 +1448,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1859,7 +1859,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="noon">pusd.</dayPeriod>
 							<dayPeriod type="pm">pēcpusd.</dayPeriod>
 							<dayPeriod type="morning1">rīts</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
+							<dayPeriod type="afternoon1">pēcpusd.</dayPeriod>
 							<dayPeriod type="evening1">vakars</dayPeriod>
 							<dayPeriod type="night1">nakts</dayPeriod>
 						</dayPeriodWidth>
@@ -1963,7 +1963,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1971,7 +1971,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1979,7 +1979,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1987,7 +1987,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2694,9 +2694,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>d.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">vakar</relative>
+				<relative type="0">šodien</relative>
+				<relative type="1">rīt</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">pēc {0} d.</relativeTimePattern>
 					<relativeTimePattern count="one">pēc {0} d.</relativeTimePattern>
@@ -2710,9 +2710,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>d.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">vakar</relative>
+				<relative type="0">šodien</relative>
+				<relative type="1">rīt</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="zero">pēc {0} d.</relativeTimePattern>
 					<relativeTimePattern count="one">pēc {0} d.</relativeTimePattern>
@@ -6302,9 +6302,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>Lesoto loti</displayName>
-				<displayName count="zero">↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="zero">Lesoto loti</displayName>
+				<displayName count="one">Lesoto loti</displayName>
+				<displayName count="other">Lesoto loti</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -7155,79 +7155,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="zero">kvadrāt{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" case="accusative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" case="dative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" case="genitive">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" case="locative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine" case="accusative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine" case="dative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine" case="genitive">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine" case="locative">kvadrāt{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kvadrāt{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="locative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="dative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="locative">kvadrāt{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kvadrāt{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="dative">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">kvadrāt{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="locative">kvadrāt{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1 count="zero">kubik{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" case="accusative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" case="dative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" case="genitive">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" case="locative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine" case="accusative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine" case="dative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine" case="genitive">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero" gender="feminine" case="locative">kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kubik{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="locative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="dative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="locative">kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kubik{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="dative">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="locative">kubik{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>masculine</gender>
 				<displayName>smagumspēks</displayName>
 				<unitPattern count="zero">{0} smagumspēku</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} smagumspēku</unitPattern>
+				<unitPattern count="zero" case="dative">{0} smagumspēku</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} smagumspēku</unitPattern>
+				<unitPattern count="zero" case="locative">{0} smagumspēku</unitPattern>
 				<unitPattern count="one">{0} smagumspēks</unitPattern>
 				<unitPattern count="one" case="accusative">{0} smagumspēku</unitPattern>
 				<unitPattern count="one" case="dative">{0} smagumspēkam</unitPattern>
@@ -7243,10 +7243,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>metri sekundē kvadrātā</displayName>
 				<unitPattern count="zero">{0} metru sekundē kvadrātā</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} metru sekundē kvadrātā</unitPattern>
+				<unitPattern count="zero" case="dative">{0} metru sekundē kvadrātā</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} metru sekundē kvadrātā</unitPattern>
+				<unitPattern count="zero" case="locative">{0} metru sekundē kvadrātā</unitPattern>
 				<unitPattern count="one">{0} metrs sekundē kvadrātā</unitPattern>
 				<unitPattern count="one" case="accusative">{0} metru sekundē kvadrātā</unitPattern>
 				<unitPattern count="one" case="dative">{0} metram sekundē kvadrātā</unitPattern>
@@ -7262,10 +7262,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>apgrieziens</displayName>
 				<unitPattern count="zero">{0} apgriezienu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} apgriezienu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} apgriezienu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} apgriezienu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} apgriezienu</unitPattern>
 				<unitPattern count="one">{0} apgrieziens</unitPattern>
 				<unitPattern count="one" case="accusative">{0} apgriezienu</unitPattern>
 				<unitPattern count="one" case="dative">{0} apgriezienam</unitPattern>
@@ -7281,10 +7281,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>radiāni</displayName>
 				<unitPattern count="zero">{0} radiānu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} radiānu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} radiānu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} radiānu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} radiānu</unitPattern>
 				<unitPattern count="one">{0} radiāns</unitPattern>
 				<unitPattern count="one" case="accusative">{0} radiānu</unitPattern>
 				<unitPattern count="one" case="dative">{0} radiānam</unitPattern>
@@ -7300,10 +7300,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>grādi</displayName>
 				<unitPattern count="zero">{0} grādu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} grādu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} grādu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} grādu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} grādu</unitPattern>
 				<unitPattern count="one">{0} grāds</unitPattern>
 				<unitPattern count="one" case="accusative">{0} grādu</unitPattern>
 				<unitPattern count="one" case="dative">{0} grādam</unitPattern>
@@ -7319,10 +7319,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>leņķa minūtes</displayName>
 				<unitPattern count="zero">{0} leņķa minūšu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} leņķa minūšu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} leņķa minūšu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} leņķa minūšu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} leņķa minūšu</unitPattern>
 				<unitPattern count="one">{0} leņķa minūte</unitPattern>
 				<unitPattern count="one" case="accusative">{0} leņķa minūti</unitPattern>
 				<unitPattern count="one" case="dative">{0} leņķa minūtei</unitPattern>
@@ -7338,10 +7338,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>leņķa sekundes</displayName>
 				<unitPattern count="zero">{0} leņķa sekunžu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} leņķa sekunžu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} leņķa sekunžu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} leņķa sekunžu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} leņķa sekunžu</unitPattern>
 				<unitPattern count="one">{0} leņķa sekunde</unitPattern>
 				<unitPattern count="one" case="accusative">{0} leņķa sekundi</unitPattern>
 				<unitPattern count="one" case="dative">{0} leņķa sekundei</unitPattern>
@@ -7357,10 +7357,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kvadrātkilometri</displayName>
 				<unitPattern count="zero">{0} kvadrātkilometru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kvadrātkilometru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kvadrātkilometru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kvadrātkilometru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kvadrātkilometru</unitPattern>
 				<unitPattern count="one">{0} kvadrātkilometrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kvadrātkilometru</unitPattern>
 				<unitPattern count="one" case="dative">{0} kvadrātkilometram</unitPattern>
@@ -7378,9 +7378,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>hektāri</displayName>
 				<unitPattern count="zero">{0} hektāru</unitPattern>
 				<unitPattern count="zero" case="accusative">{0} hektāru</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="dative">{0} hektāru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} hektāru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} hektāru</unitPattern>
 				<unitPattern count="one">{0} hektārs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} hektāru</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektāram</unitPattern>
@@ -7396,10 +7396,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kvadrātmetri</displayName>
 				<unitPattern count="zero">{0} kvadrātmetru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kvadrātmetru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kvadrātmetru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kvadrātmetru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kvadrātmetru</unitPattern>
 				<unitPattern count="one">{0} kvadrātmetrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kvadrātmetru</unitPattern>
 				<unitPattern count="one" case="dative">{0} kvadrātmetram</unitPattern>
@@ -7416,10 +7416,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kvadrātcentimetri</displayName>
 				<unitPattern count="zero">{0} kvadrātcentimetru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kvadrātcentimetru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kvadrātcentimetru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kvadrātcentimetru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kvadrātcentimetru</unitPattern>
 				<unitPattern count="one">{0} kvadrātcentimetrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kvadrātcentimetru</unitPattern>
 				<unitPattern count="one" case="dative">{0} kvadrātcentimetram</unitPattern>
@@ -7465,7 +7465,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} uz kvadrātcollu</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>dunami</displayName>
 				<unitPattern count="zero">{0} dunamu</unitPattern>
 				<unitPattern count="one">{0} dunams</unitPattern>
 				<unitPattern count="other">{0} dunami</unitPattern>
@@ -7474,10 +7474,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>karāti</displayName>
 				<unitPattern count="zero">{0} karātu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} karātu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} karātu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} karātu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} karātu</unitPattern>
 				<unitPattern count="one">{0} karāts</unitPattern>
 				<unitPattern count="one" case="accusative">{0} karātu</unitPattern>
 				<unitPattern count="one" case="dative">{0} karātam</unitPattern>
@@ -7499,10 +7499,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>milimoli uz litru</displayName>
 				<unitPattern count="zero">{0} milimolu uz litru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} milimolu uz litru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} milimolu uz litru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} milimolu uz litru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} milimolu uz litru</unitPattern>
 				<unitPattern count="one">{0} milimols uz litru</unitPattern>
 				<unitPattern count="one" case="accusative">{0} milimolu uz litru</unitPattern>
 				<unitPattern count="one" case="dative">{0} milimolam uz litru</unitPattern>
@@ -7518,10 +7518,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>vienumi</displayName>
 				<unitPattern count="zero">{0} vienumu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} vienumu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} vienumu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} vienumu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} vienumu</unitPattern>
 				<unitPattern count="one">{0} vienums</unitPattern>
 				<unitPattern count="one" case="accusative">{0} vienumu</unitPattern>
 				<unitPattern count="one" case="dative">{0} vienumam</unitPattern>
@@ -7537,10 +7537,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>miljonās daļas</displayName>
 				<unitPattern count="zero">{0} miljono daļu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} miljono daļu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} miljono daļu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} miljono daļu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} miljono daļu</unitPattern>
 				<unitPattern count="one">{0} miljonā daļa</unitPattern>
 				<unitPattern count="one" case="accusative">{0} miljono daļu</unitPattern>
 				<unitPattern count="one" case="dative">{0} miljonajai daļai</unitPattern>
@@ -7556,10 +7556,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>procents</displayName>
 				<unitPattern count="zero">{0} procentu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} procentu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} procentu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} procentu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} procentu</unitPattern>
 				<unitPattern count="one">{0} procents</unitPattern>
 				<unitPattern count="one" case="accusative">{0} procentu</unitPattern>
 				<unitPattern count="one" case="dative">{0} procentam</unitPattern>
@@ -7575,10 +7575,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>promile</displayName>
 				<unitPattern count="zero">{0} promiļu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} promiļu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} promiļu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} promiļu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} promiļu</unitPattern>
 				<unitPattern count="one">{0} promile</unitPattern>
 				<unitPattern count="one" case="accusative">{0} promili</unitPattern>
 				<unitPattern count="one" case="dative">{0} promilei</unitPattern>
@@ -7594,10 +7594,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>promiriāde</displayName>
 				<unitPattern count="zero">{0}‱</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="zero" case="dative">{0}‱</unitPattern>
+				<unitPattern count="zero" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="zero" case="locative">{0}‱</unitPattern>
 				<unitPattern count="one">{0} promiriāde</unitPattern>
 				<unitPattern count="one" case="accusative">{0} promiriādi</unitPattern>
 				<unitPattern count="one" case="dative">{0} promiriādei</unitPattern>
@@ -7613,10 +7613,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>moli</displayName>
 				<unitPattern count="zero">{0} molu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} molu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} molu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} molu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} molu</unitPattern>
 				<unitPattern count="one">{0} mols</unitPattern>
 				<unitPattern count="one" case="accusative">{0} molu</unitPattern>
 				<unitPattern count="one" case="dative">{0} molam</unitPattern>
@@ -7632,10 +7632,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>litri uz kilometru</displayName>
 				<unitPattern count="zero">{0} litru uz kilometru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} litru uz kilometru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} litru uz kilometru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} litru uz kilometru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} litru uz kilometru</unitPattern>
 				<unitPattern count="one">{0} litrs uz kilometru</unitPattern>
 				<unitPattern count="one" case="accusative">{0} litru uz kilometru</unitPattern>
 				<unitPattern count="one" case="dative">{0} litram uz kilometru</unitPattern>
@@ -7651,10 +7651,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>litri uz 100 kilometriem</displayName>
 				<unitPattern count="zero">{0} litru uz 100 kilometriem</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} litru uz 100 kilometriem</unitPattern>
+				<unitPattern count="zero" case="dative">{0} litru uz 100 kilometriem</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} litru uz 100 kilometriem</unitPattern>
+				<unitPattern count="zero" case="locative">{0} litru uz 100 kilometriem</unitPattern>
 				<unitPattern count="one">{0} litrs uz 100 kilometriem</unitPattern>
 				<unitPattern count="one" case="accusative">{0} litru uz 100 kilometriem</unitPattern>
 				<unitPattern count="one" case="dative">{0} litram uz 100 kilometriem</unitPattern>
@@ -7682,10 +7682,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>petabaiti</displayName>
 				<unitPattern count="zero">{0} petabaitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} petabaitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} petabaitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} petabaitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} petabaitu</unitPattern>
 				<unitPattern count="one">{0} petabaits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} petabaitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} petabaitam</unitPattern>
@@ -7701,10 +7701,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>terabaiti</displayName>
 				<unitPattern count="zero">{0} terabaitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} terabaitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} terabaitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} terabaitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} terabaitu</unitPattern>
 				<unitPattern count="one">{0} terabaits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} terabaitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} terabaitam</unitPattern>
@@ -7720,10 +7720,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>terabiti</displayName>
 				<unitPattern count="zero">{0} terabitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} terabitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} terabitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} terabitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} terabitu</unitPattern>
 				<unitPattern count="one">{0} terabits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} terabitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} terabitam</unitPattern>
@@ -7739,10 +7739,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>gigabaiti</displayName>
 				<unitPattern count="zero">{0} gigabaitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} gigabaitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} gigabaitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} gigabaitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} gigabaitu</unitPattern>
 				<unitPattern count="one">{0} gigabaits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} gigabaitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigabaitam</unitPattern>
@@ -7758,10 +7758,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>gigabiti</displayName>
 				<unitPattern count="zero">{0} gigabitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} gigabitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} gigabitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} gigabitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} gigabitu</unitPattern>
 				<unitPattern count="one">{0} gigabits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} gigabitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigabitam</unitPattern>
@@ -7777,10 +7777,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>megabaiti</displayName>
 				<unitPattern count="zero">{0} megabaitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} megabaitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} megabaitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} megabaitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} megabaitu</unitPattern>
 				<unitPattern count="one">{0} megabaits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} megabaitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} megabaitam</unitPattern>
@@ -7796,10 +7796,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>megabiti</displayName>
 				<unitPattern count="zero">{0} megabitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} megabitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} megabitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} megabitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} megabitu</unitPattern>
 				<unitPattern count="one">{0} megabits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} megabitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} megabitam</unitPattern>
@@ -7815,10 +7815,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilobaiti</displayName>
 				<unitPattern count="zero">{0} kilobaitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilobaitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilobaitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilobaitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilobaitu</unitPattern>
 				<unitPattern count="one">{0} kilobaits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilobaitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilobaitam</unitPattern>
@@ -7834,10 +7834,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilobiti</displayName>
 				<unitPattern count="zero">{0} kilobitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilobitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilobitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilobitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilobitu</unitPattern>
 				<unitPattern count="one">{0} kilobits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilobitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilobitam</unitPattern>
@@ -7853,10 +7853,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>baiti</displayName>
 				<unitPattern count="zero">{0} baitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} baitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} baitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} baitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} baitu</unitPattern>
 				<unitPattern count="one">{0} baits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} baitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} baitam</unitPattern>
@@ -7872,10 +7872,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>biti</displayName>
 				<unitPattern count="zero">{0} bitu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} bitu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} bitu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} bitu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} bitu</unitPattern>
 				<unitPattern count="one">{0} bits</unitPattern>
 				<unitPattern count="one" case="accusative">{0} bitu</unitPattern>
 				<unitPattern count="one" case="dative">{0} bitam</unitPattern>
@@ -7929,10 +7929,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>gadi</displayName>
 				<unitPattern count="zero">{0} gadu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} gadu</unitPattern>
 				<unitPattern count="zero" case="dative">{0} gadu</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} gadu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} gadu</unitPattern>
 				<unitPattern count="one">{0} gads</unitPattern>
 				<unitPattern count="one" case="accusative">{0} gadu</unitPattern>
 				<unitPattern count="one" case="dative">{0} gadam</unitPattern>
@@ -7969,10 +7969,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>mēneši</displayName>
 				<unitPattern count="zero">{0} mēnešu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} mēnešu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} mēnešu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} mēnešu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} mēnešu</unitPattern>
 				<unitPattern count="one">{0} mēnesis</unitPattern>
 				<unitPattern count="one" case="accusative">{0} mēnesi</unitPattern>
 				<unitPattern count="one" case="dative">{0} mēnesim</unitPattern>
@@ -7989,17 +7989,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>nedēļas</displayName>
 				<unitPattern count="zero">{0} nedēļu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} nedēļu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} nedēļu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} nedēļu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} nedēļu</unitPattern>
 				<unitPattern count="one">{0} nedēļa</unitPattern>
 				<unitPattern count="one" case="accusative">{0} nedēļu</unitPattern>
 				<unitPattern count="one" case="dative">{0} nedēļai</unitPattern>
 				<unitPattern count="one" case="genitive">{0} nedēļas</unitPattern>
 				<unitPattern count="one" case="locative">{0} nedēļā</unitPattern>
 				<unitPattern count="other">{0} nedēļas</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nedēļas</unitPattern>
 				<unitPattern count="other" case="dative">{0} nedēļām</unitPattern>
 				<unitPattern count="other" case="genitive">{0} nedēļu</unitPattern>
 				<unitPattern count="other" case="locative">{0} nedēļās</unitPattern>
@@ -8009,17 +8009,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>dienas</displayName>
 				<unitPattern count="zero">{0} dienu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} dienu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} dienu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} dienu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} dienu</unitPattern>
 				<unitPattern count="one">{0} diena</unitPattern>
 				<unitPattern count="one" case="accusative">{0} dienu</unitPattern>
 				<unitPattern count="one" case="dative">{0} dienai</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dienas</unitPattern>
 				<unitPattern count="one" case="locative">{0} dienā</unitPattern>
 				<unitPattern count="other">{0} dienas</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dienas</unitPattern>
 				<unitPattern count="other" case="dative">{0} dienām</unitPattern>
 				<unitPattern count="other" case="genitive">{0} dienu</unitPattern>
 				<unitPattern count="other" case="locative">{0} dienās</unitPattern>
@@ -8029,17 +8029,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>stundas</displayName>
 				<unitPattern count="zero">{0} stundu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} stundu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} stundu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} stundu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} stundu</unitPattern>
 				<unitPattern count="one">{0} stunda</unitPattern>
 				<unitPattern count="one" case="accusative">{0} stundu</unitPattern>
 				<unitPattern count="one" case="dative">{0} stundai</unitPattern>
 				<unitPattern count="one" case="genitive">{0} stundas</unitPattern>
 				<unitPattern count="one" case="locative">{0} stundā</unitPattern>
 				<unitPattern count="other">{0} stundas</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stundas</unitPattern>
 				<unitPattern count="other" case="dative">{0} stundām</unitPattern>
 				<unitPattern count="other" case="genitive">{0} stundu</unitPattern>
 				<unitPattern count="other" case="locative">{0} stundās</unitPattern>
@@ -8049,17 +8049,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>minūtes</displayName>
 				<unitPattern count="zero">{0} minūšu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} minūšu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} minūšu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} minūšu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} minūšu</unitPattern>
 				<unitPattern count="one">{0} minūte</unitPattern>
 				<unitPattern count="one" case="accusative">{0} minūti</unitPattern>
 				<unitPattern count="one" case="dative">{0} minūtei</unitPattern>
 				<unitPattern count="one" case="genitive">{0} minūtes</unitPattern>
 				<unitPattern count="one" case="locative">{0} minūtē</unitPattern>
 				<unitPattern count="other">{0} minūtes</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} minūtes</unitPattern>
 				<unitPattern count="other" case="dative">{0} minūtēm</unitPattern>
 				<unitPattern count="other" case="genitive">{0} minūšu</unitPattern>
 				<unitPattern count="other" case="locative">{0} minūtēs</unitPattern>
@@ -8069,17 +8069,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>sekundes</displayName>
 				<unitPattern count="zero">{0} sekunžu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} sekunžu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} sekunžu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} sekunžu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} sekunžu</unitPattern>
 				<unitPattern count="one">{0} sekunde</unitPattern>
 				<unitPattern count="one" case="accusative">{0} sekundi</unitPattern>
 				<unitPattern count="one" case="dative">{0} sekundei</unitPattern>
 				<unitPattern count="one" case="genitive">{0} sekundes</unitPattern>
 				<unitPattern count="one" case="locative">{0} sekundē</unitPattern>
 				<unitPattern count="other">{0} sekundes</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sekundes</unitPattern>
 				<unitPattern count="other" case="dative">{0} sekundēm</unitPattern>
 				<unitPattern count="other" case="genitive">{0} sekunžu</unitPattern>
 				<unitPattern count="other" case="locative">{0} sekundēs</unitPattern>
@@ -8089,17 +8089,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>milisekundes</displayName>
 				<unitPattern count="zero">{0} milisekunžu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} milisekunžu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} milisekunžu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} milisekunžu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} milisekunžu</unitPattern>
 				<unitPattern count="one">{0} milisekunde</unitPattern>
 				<unitPattern count="one" case="accusative">{0} milisekundi</unitPattern>
 				<unitPattern count="one" case="dative">{0} milisekundei</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milisekundes</unitPattern>
 				<unitPattern count="one" case="locative">{0} milisekundē</unitPattern>
 				<unitPattern count="other">{0} milisekundes</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milisekundes</unitPattern>
 				<unitPattern count="other" case="dative">{0} milisekundēm</unitPattern>
 				<unitPattern count="other" case="genitive">{0} milisekunžu</unitPattern>
 				<unitPattern count="other" case="locative">{0} milisekundēs</unitPattern>
@@ -8108,17 +8108,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>mikrosekundes</displayName>
 				<unitPattern count="zero">{0} mikrosekunžu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} mikrosekunžu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} mikrosekunžu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} mikrosekunžu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} mikrosekunžu</unitPattern>
 				<unitPattern count="one">{0} mikrosekunde</unitPattern>
 				<unitPattern count="one" case="accusative">{0} mikrosekundi</unitPattern>
 				<unitPattern count="one" case="dative">{0} mikrosekundei</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrosekundes</unitPattern>
 				<unitPattern count="one" case="locative">{0} mikrosekundē</unitPattern>
 				<unitPattern count="other">{0} mikrosekundes</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrosekundes</unitPattern>
 				<unitPattern count="other" case="dative">{0} mikrosekundēm</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mikrosekunžu</unitPattern>
 				<unitPattern count="other" case="locative">{0} mikrosekundēs</unitPattern>
@@ -8127,17 +8127,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>nanosekundes</displayName>
 				<unitPattern count="zero">{0} nanosekunžu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} nanosekunžu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} nanosekunžu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} nanosekunžu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} nanosekunžu</unitPattern>
 				<unitPattern count="one">{0} nanosekunde</unitPattern>
 				<unitPattern count="one" case="accusative">{0} nanosekundi</unitPattern>
 				<unitPattern count="one" case="dative">{0} nanosekundei</unitPattern>
 				<unitPattern count="one" case="genitive">{0} nanosekundes</unitPattern>
 				<unitPattern count="one" case="locative">{0} nanosekundē</unitPattern>
 				<unitPattern count="other">{0} nanosekundes</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanosekundes</unitPattern>
 				<unitPattern count="other" case="dative">{0} nanosekundēm</unitPattern>
 				<unitPattern count="other" case="genitive">{0} nanosekunžu</unitPattern>
 				<unitPattern count="other" case="locative">{0} nanosekundēs</unitPattern>
@@ -8146,10 +8146,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ampēri</displayName>
 				<unitPattern count="zero">{0} ampēru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} ampēru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} ampēru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} ampēru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} ampēru</unitPattern>
 				<unitPattern count="one">{0} ampērs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} ampēru</unitPattern>
 				<unitPattern count="one" case="dative">{0} ampēram</unitPattern>
@@ -8165,10 +8165,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>miliampēri</displayName>
 				<unitPattern count="zero">{0} miliampēru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} miliampēru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} miliampēru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} miliampēru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} miliampēru</unitPattern>
 				<unitPattern count="one">{0} miliampērs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} miliampēru</unitPattern>
 				<unitPattern count="one" case="dative">{0} miliampēram</unitPattern>
@@ -8184,10 +8184,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>omi</displayName>
 				<unitPattern count="zero">{0} omu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} omu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} omu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} omu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} omu</unitPattern>
 				<unitPattern count="one">{0} oms</unitPattern>
 				<unitPattern count="one" case="accusative">{0} omu</unitPattern>
 				<unitPattern count="one" case="dative">{0} omam</unitPattern>
@@ -8203,10 +8203,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>volti</displayName>
 				<unitPattern count="zero">{0} voltu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} voltu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} voltu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} voltu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} voltu</unitPattern>
 				<unitPattern count="one">{0} volts</unitPattern>
 				<unitPattern count="one" case="accusative">{0} voltu</unitPattern>
 				<unitPattern count="one" case="dative">{0} voltam</unitPattern>
@@ -8228,17 +8228,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>kalorijas</displayName>
 				<unitPattern count="zero">{0} kaloriju</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kaloriju</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kaloriju</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kaloriju</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kaloriju</unitPattern>
 				<unitPattern count="one">{0} kalorija</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kaloriju</unitPattern>
 				<unitPattern count="one" case="dative">{0} kalorijai</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kalorijas</unitPattern>
 				<unitPattern count="one" case="locative">{0} kalorijā</unitPattern>
 				<unitPattern count="other">{0} kalorijas</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kalorijas</unitPattern>
 				<unitPattern count="other" case="dative">{0} kalorijām</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kalorijas</unitPattern>
 				<unitPattern count="other" case="locative">{0} kalorijās</unitPattern>
@@ -8253,10 +8253,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilodžouli</displayName>
 				<unitPattern count="zero">{0} kilodžoulu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilodžoulu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilodžoulu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilodžoulu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilodžoulu</unitPattern>
 				<unitPattern count="one">{0} kilodžouls</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilodžoulu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilodžoulam</unitPattern>
@@ -8272,10 +8272,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>džouli</displayName>
 				<unitPattern count="zero">{0} džoulu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} džoulu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} džoulu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} džoulu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} džoulu</unitPattern>
 				<unitPattern count="one">{0} džouls</unitPattern>
 				<unitPattern count="one" case="accusative">{0} džoulu</unitPattern>
 				<unitPattern count="one" case="dative">{0} džoulam</unitPattern>
@@ -8291,10 +8291,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>kilovatstundas</displayName>
 				<unitPattern count="zero">{0} kilovatstundu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilovatstundu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilovatstundu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilovatstundu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilovatstundu</unitPattern>
 				<unitPattern count="one">{0} kilovatstunda</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilovatstundu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilovatstundai</unitPattern>
@@ -8334,10 +8334,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ņūtoni</displayName>
 				<unitPattern count="zero">{0} N</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} N</unitPattern>
+				<unitPattern count="zero" case="dative">{0} N</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} N</unitPattern>
+				<unitPattern count="zero" case="locative">{0} N</unitPattern>
 				<unitPattern count="one">{0} ņūtons</unitPattern>
 				<unitPattern count="one" case="accusative">{0} ņūtonu</unitPattern>
 				<unitPattern count="one" case="dative">{0} ņūtonam</unitPattern>
@@ -8353,10 +8353,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>kilovatstunda uz 100 kilometriem</displayName>
 				<unitPattern count="zero">{0} kilovatstundu uz 100 kilometriem</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilovatstundu uz 100 kilometriem</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilovatstundu uz 100 kilometriem</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilovatstundu uz 100 kilometriem</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilovatstundu uz 100 kilometriem</unitPattern>
 				<unitPattern count="one">{0} kilovatstunda uz 100 kilometriem</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilovatstundu uz 100 kilometriem</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilovatstundai uz 100 kilometriem</unitPattern>
@@ -8372,10 +8372,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>gigaherci</displayName>
 				<unitPattern count="zero">{0} gigahercu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} gigahercu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} gigahercu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} gigahercu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} gigahercu</unitPattern>
 				<unitPattern count="one">{0} gigahercs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} gigaherca</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigahercam</unitPattern>
@@ -8391,10 +8391,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>megaherci</displayName>
 				<unitPattern count="zero">{0} megahercu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} megahercu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} megahercu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} megahercu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} megahercu</unitPattern>
 				<unitPattern count="one">{0} megahercs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} megahercu</unitPattern>
 				<unitPattern count="one" case="dative">{0} megahercam</unitPattern>
@@ -8410,10 +8410,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kiloherci</displayName>
 				<unitPattern count="zero">{0} kilohercu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilohercu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilohercu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilohercu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilohercu</unitPattern>
 				<unitPattern count="one">{0} kilohercs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilohercu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilohercam</unitPattern>
@@ -8429,10 +8429,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>herci</displayName>
 				<unitPattern count="zero">{0} hercu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} hercu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} hercu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} hercu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} hercu</unitPattern>
 				<unitPattern count="one">{0} hercs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} hercu</unitPattern>
 				<unitPattern count="one" case="dative">{0} hercam</unitPattern>
@@ -8446,31 +8446,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<gender>feminine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="zero">{0} em</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} em</unitPattern>
+				<unitPattern count="zero" case="dative">{0} em</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} em</unitPattern>
+				<unitPattern count="zero" case="locative">{0} em</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="accusative">{0} em</unitPattern>
+				<unitPattern count="one" case="dative">{0} em</unitPattern>
+				<unitPattern count="one" case="genitive">{0} em</unitPattern>
+				<unitPattern count="one" case="locative">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="accusative">{0} em</unitPattern>
+				<unitPattern count="other" case="dative">{0} em</unitPattern>
+				<unitPattern count="other" case="genitive">{0} em</unitPattern>
+				<unitPattern count="other" case="locative">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
 				<displayName>pikseļi</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} px</unitPattern>
+				<unitPattern count="zero" case="dative">{0} px</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} px</unitPattern>
+				<unitPattern count="zero" case="locative">{0} px</unitPattern>
 				<unitPattern count="one">{0} pikselis</unitPattern>
 				<unitPattern count="one" case="accusative">{0} pikseli</unitPattern>
 				<unitPattern count="one" case="dative">{0} pikselim</unitPattern>
@@ -8485,11 +8485,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="graphics-megapixel">
 				<gender>masculine</gender>
 				<displayName>megapikseļi</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MP</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} MP</unitPattern>
+				<unitPattern count="zero" case="dative">{0} MP</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} MP</unitPattern>
+				<unitPattern count="zero" case="locative">{0} MP</unitPattern>
 				<unitPattern count="one">{0} megapikselis</unitPattern>
 				<unitPattern count="one" case="accusative">{0} megapikseli</unitPattern>
 				<unitPattern count="one" case="dative">{0} megapikselim</unitPattern>
@@ -8504,11 +8504,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>masculine</gender>
 				<displayName>pikseļi centimetrā</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppcm</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} ppcm</unitPattern>
+				<unitPattern count="zero" case="dative">{0} ppcm</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} ppcm</unitPattern>
+				<unitPattern count="zero" case="locative">{0} ppcm</unitPattern>
 				<unitPattern count="one">{0} pikselis centimetrā</unitPattern>
 				<unitPattern count="one" case="accusative">{0} pikseli centimetrā</unitPattern>
 				<unitPattern count="one" case="dative">{0} pikselim centimetrā</unitPattern>
@@ -8522,7 +8522,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>pikseļi collā</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppi</unitPattern>
 				<unitPattern count="one">{0} pikselis collā</unitPattern>
 				<unitPattern count="other">{0} pikseļi collā</unitPattern>
 			</unit>
@@ -8534,19 +8534,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>punkti collā</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppi</unitPattern>
 				<unitPattern count="one">{0} punkts collā</unitPattern>
 				<unitPattern count="other">{0} punkti collā</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>punkts</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="one">{0} p.</unitPattern>
+				<unitPattern count="other">{0} p.</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>Zemes rādiuss</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} R⊕</unitPattern>
 				<unitPattern count="one">{0} Zemes rādiuss</unitPattern>
 				<unitPattern count="other">{0} Zemes rādiuss</unitPattern>
 			</unit>
@@ -8554,10 +8554,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilometri</displayName>
 				<unitPattern count="zero">{0} kilometru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilometru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilometru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilometru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilometru</unitPattern>
 				<unitPattern count="one">{0} kilometrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilometru</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilometram</unitPattern>
@@ -8574,10 +8574,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>metri</displayName>
 				<unitPattern count="zero">{0} metru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} metru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} metru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} metru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} metru</unitPattern>
 				<unitPattern count="one">{0} metrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} metru</unitPattern>
 				<unitPattern count="one" case="dative">{0} metram</unitPattern>
@@ -8594,10 +8594,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>decimetri</displayName>
 				<unitPattern count="zero">{0} decimetru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} decimetru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} decimetru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} decimetru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} decimetru</unitPattern>
 				<unitPattern count="one">{0} decimetrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} decimetru</unitPattern>
 				<unitPattern count="one" case="dative">{0} decimetram</unitPattern>
@@ -8613,10 +8613,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>centimetri</displayName>
 				<unitPattern count="zero">{0} centimetru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} centimetru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} centimetru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} centimetru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} centimetru</unitPattern>
 				<unitPattern count="one">{0} centimetrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} centimetru</unitPattern>
 				<unitPattern count="one" case="dative">{0} centimetram</unitPattern>
@@ -8633,10 +8633,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>milimetri</displayName>
 				<unitPattern count="zero">{0} milimetru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} milimetru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} milimetru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} milimetru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} milimetru</unitPattern>
 				<unitPattern count="one">{0} milimetrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} milimetru</unitPattern>
 				<unitPattern count="one" case="dative">{0} milimetram</unitPattern>
@@ -8652,10 +8652,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>mikrometri</displayName>
 				<unitPattern count="zero">{0} mikrometru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} mikrometru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} mikrometru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} mikrometru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} mikrometru</unitPattern>
 				<unitPattern count="one">{0} mikrometrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} mikrometru</unitPattern>
 				<unitPattern count="one" case="dative">{0} mikrometram</unitPattern>
@@ -8671,10 +8671,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>nanometri</displayName>
 				<unitPattern count="zero">{0} nanometru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} nanometru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} nanometru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} nanometru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} nanometru</unitPattern>
 				<unitPattern count="one">{0} nanometrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} nanometru</unitPattern>
 				<unitPattern count="one" case="dative">{0} nanometram</unitPattern>
@@ -8690,10 +8690,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>pikometri</displayName>
 				<unitPattern count="zero">{0} pikometru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} pikometru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} pikometru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} pikometru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} pikometru</unitPattern>
 				<unitPattern count="one">{0} pikometrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} pikometru</unitPattern>
 				<unitPattern count="one" case="dative">{0} pikometram</unitPattern>
@@ -8802,10 +8802,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>lukss</displayName>
 				<unitPattern count="zero">{0} luksu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} luksu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} luksu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} luksu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} luksu</unitPattern>
 				<unitPattern count="one">{0} lukss</unitPattern>
 				<unitPattern count="one" case="accusative">{0} luksu</unitPattern>
 				<unitPattern count="one" case="dative">{0} luksam</unitPattern>
@@ -8821,10 +8821,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>kandela</displayName>
 				<unitPattern count="zero">{0} kandelu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kandelu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kandelu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kandelu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kandelu</unitPattern>
 				<unitPattern count="one">{0} kandela</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kandelu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kandelai</unitPattern>
@@ -8840,10 +8840,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>lūmens</displayName>
 				<unitPattern count="zero">{0} lūmenu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} lūmenu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} lūmenu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} lūmenu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} lūmenu</unitPattern>
 				<unitPattern count="one">{0} lūmens</unitPattern>
 				<unitPattern count="one" case="accusative">{0} lūmenu</unitPattern>
 				<unitPattern count="one" case="dative">{0} lūmenam</unitPattern>
@@ -8865,17 +8865,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>metriskās tonnas</displayName>
 				<unitPattern count="zero">{0} metrisko tonnu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} metrisko tonnu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} metrisko tonnu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} metrisko tonnu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} metrisko tonnu</unitPattern>
 				<unitPattern count="one">{0} metriskā tonna</unitPattern>
 				<unitPattern count="one" case="accusative">{0} metrisko tonnu</unitPattern>
 				<unitPattern count="one" case="dative">{0} metriskajai tonnai</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metriskās tonnas</unitPattern>
 				<unitPattern count="one" case="locative">{0} metriskajā tonnā</unitPattern>
 				<unitPattern count="other">{0} metriskās tonnas</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metriskās tonnas</unitPattern>
 				<unitPattern count="other" case="dative">{0} metriskajām tonnām</unitPattern>
 				<unitPattern count="other" case="genitive">{0} metrisko tonnu</unitPattern>
 				<unitPattern count="other" case="locative">{0} metriskajās tonnās</unitPattern>
@@ -8884,10 +8884,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilogrami</displayName>
 				<unitPattern count="zero">{0} kilogramu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilogramu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilogramu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilogramu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilogramu</unitPattern>
 				<unitPattern count="one">{0} kilograms</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilogramu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilogramam</unitPattern>
@@ -8904,10 +8904,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>grami</displayName>
 				<unitPattern count="zero">{0} gramu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} gramu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} gramu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} gramu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} gramu</unitPattern>
 				<unitPattern count="one">{0} grams</unitPattern>
 				<unitPattern count="one" case="accusative">{0} gramu</unitPattern>
 				<unitPattern count="one" case="dative">{0} gramam</unitPattern>
@@ -8924,10 +8924,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>miligrami</displayName>
 				<unitPattern count="zero">{0} miligramu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} miligramu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} miligramu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} miligramu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} miligramu</unitPattern>
 				<unitPattern count="one">{0} miligrams</unitPattern>
 				<unitPattern count="one" case="accusative">{0} miligramu</unitPattern>
 				<unitPattern count="one" case="dative">{0} miligramam</unitPattern>
@@ -8943,10 +8943,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>mikrogrami</displayName>
 				<unitPattern count="zero">{0} mikrogramu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} mikrogramu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} mikrogramu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} mikrogramu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} mikrogramu</unitPattern>
 				<unitPattern count="one">{0} mikrograms</unitPattern>
 				<unitPattern count="one" case="accusative">{0} mikrogramu</unitPattern>
 				<unitPattern count="one" case="dative">{0} mikrogramam</unitPattern>
@@ -8994,10 +8994,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>karāti</displayName>
 				<unitPattern count="zero">{0} karātu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} karātu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} karātu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} karātu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} karātu</unitPattern>
 				<unitPattern count="one">{0} karāts</unitPattern>
 				<unitPattern count="one" case="accusative">{0} karātu</unitPattern>
 				<unitPattern count="one" case="dative">{0} karātam</unitPattern>
@@ -9037,10 +9037,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>gigavati</displayName>
 				<unitPattern count="zero">{0} gigavatu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} gigavatu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} gigavatu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} gigavatu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} gigavatu</unitPattern>
 				<unitPattern count="one">{0} gigavats</unitPattern>
 				<unitPattern count="one" case="accusative">{0} gigavatu</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigavatam</unitPattern>
@@ -9056,10 +9056,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>megavati</displayName>
 				<unitPattern count="zero">{0} megavatu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} megavatu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} megavatu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} megavatu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} megavatu</unitPattern>
 				<unitPattern count="one">{0} megavats</unitPattern>
 				<unitPattern count="one" case="accusative">{0} megavatu</unitPattern>
 				<unitPattern count="one" case="dative">{0} megavatam</unitPattern>
@@ -9075,10 +9075,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilovati</displayName>
 				<unitPattern count="zero">{0} kilovatu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilovatu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilovatu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilovatu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilovatu</unitPattern>
 				<unitPattern count="one">{0} kilovats</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilovatu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilovatam</unitPattern>
@@ -9094,10 +9094,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>vati</displayName>
 				<unitPattern count="zero">{0} vatu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} vatu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} vatu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} vatu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} vatu</unitPattern>
 				<unitPattern count="one">{0} vats</unitPattern>
 				<unitPattern count="one" case="accusative">{0} vatu</unitPattern>
 				<unitPattern count="one" case="dative">{0} vatam</unitPattern>
@@ -9113,10 +9113,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>milivati</displayName>
 				<unitPattern count="zero">{0} milivatu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} milivatu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} milivatu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} milivatu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} milivatu</unitPattern>
 				<unitPattern count="one">{0} milivats</unitPattern>
 				<unitPattern count="one" case="accusative">{0} milivatu</unitPattern>
 				<unitPattern count="one" case="dative">{0} milivatam</unitPattern>
@@ -9156,10 +9156,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>bāri</displayName>
 				<unitPattern count="zero">{0} bāru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} bāru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} bāru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} bāru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} bāru</unitPattern>
 				<unitPattern count="one">{0} bārs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} bāru</unitPattern>
 				<unitPattern count="one" case="dative">{0} bāram</unitPattern>
@@ -9175,10 +9175,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>milibāri</displayName>
 				<unitPattern count="zero">{0} milibāru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} milibāru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} milibāru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} milibāru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} milibāru</unitPattern>
 				<unitPattern count="one">{0} milibārs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} milibāru</unitPattern>
 				<unitPattern count="one" case="dative">{0} milibāram</unitPattern>
@@ -9194,10 +9194,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>atmosfēras</displayName>
 				<unitPattern count="zero">{0} atmosfēras</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} atmosfēras</unitPattern>
+				<unitPattern count="zero" case="dative">{0} atmosfēras</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} atmosfēras</unitPattern>
+				<unitPattern count="zero" case="locative">{0} atmosfēras</unitPattern>
 				<unitPattern count="one">{0} atmosfēra</unitPattern>
 				<unitPattern count="one" case="accusative">{0} atmosfēru</unitPattern>
 				<unitPattern count="one" case="dative">{0} atmosfērai</unitPattern>
@@ -9205,7 +9205,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} atmosfērā</unitPattern>
 				<unitPattern count="other">{0} atmosfēras</unitPattern>
 				<unitPattern count="other" case="accusative">{0} atmosfēras</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="dative">{0} atmosfēras</unitPattern>
 				<unitPattern count="other" case="genitive">{0} atmosfēru</unitPattern>
 				<unitPattern count="other" case="locative">{0} atmosfērās</unitPattern>
 			</unit>
@@ -9213,10 +9213,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>paskāli</displayName>
 				<unitPattern count="zero">{0} paskālu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} paskālu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} paskālu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} paskālu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} paskālu</unitPattern>
 				<unitPattern count="one">{0} paskāls</unitPattern>
 				<unitPattern count="one" case="accusative">{0} paskālu</unitPattern>
 				<unitPattern count="one" case="dative">{0} paskālam</unitPattern>
@@ -9232,10 +9232,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>hektopaskāli</displayName>
 				<unitPattern count="zero">{0} hektopaskālu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} hektopaskālu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} hektopaskālu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} hektopaskālu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} hektopaskālu</unitPattern>
 				<unitPattern count="one">{0} hektopaskāls</unitPattern>
 				<unitPattern count="one" case="accusative">{0} hektopaskālu</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektopaskālam</unitPattern>
@@ -9251,10 +9251,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilopaskāli</displayName>
 				<unitPattern count="zero">{0} kPa</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kPa</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kPa</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kPa</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kPa</unitPattern>
 				<unitPattern count="one">{0} kilopaskāls</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilopaskālu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilopaskālam</unitPattern>
@@ -9270,10 +9270,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>magapaskāli</displayName>
 				<unitPattern count="zero">{0} MPa</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} MPa</unitPattern>
+				<unitPattern count="zero" case="dative">{0} MPa</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} MPa</unitPattern>
+				<unitPattern count="zero" case="locative">{0} MPa</unitPattern>
 				<unitPattern count="one">{0} megapaskāls</unitPattern>
 				<unitPattern count="one" case="accusative">{0} megapaskālu</unitPattern>
 				<unitPattern count="one" case="dative">{0} megapaskālam</unitPattern>
@@ -9289,10 +9289,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilometri stundā</displayName>
 				<unitPattern count="zero">{0} kilometru stundā</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kilometru stundā</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kilometru stundā</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kilometru stundā</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kilometru stundā</unitPattern>
 				<unitPattern count="one">{0} kilometrs stundā</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kilometru stundā</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilometram stundā</unitPattern>
@@ -9308,10 +9308,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>metri sekundē</displayName>
 				<unitPattern count="zero">{0} metru sekundē</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} metru sekundē</unitPattern>
+				<unitPattern count="zero" case="dative">{0} metru sekundē</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} metru sekundē</unitPattern>
+				<unitPattern count="zero" case="locative">{0} metru sekundē</unitPattern>
 				<unitPattern count="one">{0} metrs sekundē</unitPattern>
 				<unitPattern count="one" case="accusative">{0} metru sekundē</unitPattern>
 				<unitPattern count="one" case="dative">{0} metram sekundē</unitPattern>
@@ -9339,10 +9339,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>°</displayName>
 				<unitPattern count="zero">{0}°</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0}°</unitPattern>
+				<unitPattern count="zero" case="dative">{0}°</unitPattern>
+				<unitPattern count="zero" case="genitive">{0}°</unitPattern>
+				<unitPattern count="zero" case="locative">{0}°</unitPattern>
 				<unitPattern count="one">{0} grāds</unitPattern>
 				<unitPattern count="one" case="accusative">{0} grādu</unitPattern>
 				<unitPattern count="one" case="dative">{0} grādam</unitPattern>
@@ -9358,10 +9358,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>Celsija grādi</displayName>
 				<unitPattern count="zero">{0} Celsija grādu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} Celsija grādu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} Celsija grādu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} Celsija grādu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} Celsija grādu</unitPattern>
 				<unitPattern count="one">{0} Celsija grāds</unitPattern>
 				<unitPattern count="one" case="accusative">{0} Celsija grādu</unitPattern>
 				<unitPattern count="one" case="dative">{0} Celsija grādam</unitPattern>
@@ -9383,10 +9383,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kelvini</displayName>
 				<unitPattern count="zero">{0} kelvinu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kelvinu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kelvinu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kelvinu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kelvinu</unitPattern>
 				<unitPattern count="one">{0} kelvins</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kelvinu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kelvinam</unitPattern>
@@ -9408,10 +9408,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ņūtonmetri</displayName>
 				<unitPattern count="zero">{0} ņūtonmetru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} ņūtonmetru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} ņūtonmetru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} ņūtonmetru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} ņūtonmetru</unitPattern>
 				<unitPattern count="one">{0} ņūtonmetrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} ņūtonmetru</unitPattern>
 				<unitPattern count="one" case="dative">{0} ņūtonmetram</unitPattern>
@@ -9427,10 +9427,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kubikkilometri</displayName>
 				<unitPattern count="zero">{0} kubikkilometru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kubikkilometru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kubikkilometru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kubikkilometru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kubikkilometru</unitPattern>
 				<unitPattern count="one">{0} kubikkilometrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kubikkilometru</unitPattern>
 				<unitPattern count="one" case="dative">{0} kubikkilometram</unitPattern>
@@ -9446,10 +9446,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kubikmetri</displayName>
 				<unitPattern count="zero">{0} kubikmetru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kubikmetru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kubikmetru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kubikmetru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kubikmetru</unitPattern>
 				<unitPattern count="one">{0} kubikmetrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kubikmetru</unitPattern>
 				<unitPattern count="one" case="dative">{0} kubikmetram</unitPattern>
@@ -9466,10 +9466,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kubikcentimetri</displayName>
 				<unitPattern count="zero">{0} kubikcentimetru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} kubikcentimetru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} kubikcentimetru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} kubikcentimetru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} kubikcentimetru</unitPattern>
 				<unitPattern count="one">{0} kubikcentimetrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} kubikcentimetru</unitPattern>
 				<unitPattern count="one" case="dative">{0} kubikcentimetram</unitPattern>
@@ -9510,10 +9510,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>megalitri</displayName>
 				<unitPattern count="zero">{0} megalitru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} megalitru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} megalitru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} megalitru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} megalitru</unitPattern>
 				<unitPattern count="one">{0} megalitrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} megalitru</unitPattern>
 				<unitPattern count="one" case="dative">{0} megalitram</unitPattern>
@@ -9529,10 +9529,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>hektolitri</displayName>
 				<unitPattern count="zero">{0} hektolitru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} hektolitru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} hektolitru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} hektolitru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} hektolitru</unitPattern>
 				<unitPattern count="one">{0} hektolitrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} hektolitru</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektolitram</unitPattern>
@@ -9548,17 +9548,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>litri</displayName>
 				<unitPattern count="zero">{0} litru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} litru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} litru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} litru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} litru</unitPattern>
 				<unitPattern count="one">{0} litrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} litru</unitPattern>
 				<unitPattern count="one" case="dative">{0} litram</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra</unitPattern>
 				<unitPattern count="one" case="locative">{0} litrā</unitPattern>
 				<unitPattern count="other">{0} litri</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litri</unitPattern>
 				<unitPattern count="other" case="dative">{0} litriem</unitPattern>
 				<unitPattern count="other" case="genitive">{0} litru</unitPattern>
 				<unitPattern count="other" case="locative">{0} litros</unitPattern>
@@ -9568,10 +9568,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>decilitri</displayName>
 				<unitPattern count="zero">{0} decilitru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} decilitru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} decilitru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} decilitru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} decilitru</unitPattern>
 				<unitPattern count="one">{0} decilitrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} decilitru</unitPattern>
 				<unitPattern count="one" case="dative">{0} decilitram</unitPattern>
@@ -9587,10 +9587,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>centilitri</displayName>
 				<unitPattern count="zero">{0} centilitru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} centilitru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} centilitru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} centilitru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} centilitru</unitPattern>
 				<unitPattern count="one">{0} centilitrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} centilitru</unitPattern>
 				<unitPattern count="one" case="dative">{0} centilitram</unitPattern>
@@ -9606,10 +9606,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>mililitri</displayName>
 				<unitPattern count="zero">{0} mililitru</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} mililitru</unitPattern>
+				<unitPattern count="zero" case="dative">{0} mililitru</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} mililitru</unitPattern>
+				<unitPattern count="zero" case="locative">{0} mililitru</unitPattern>
 				<unitPattern count="one">{0} mililitrs</unitPattern>
 				<unitPattern count="one" case="accusative">{0} mililitru</unitPattern>
 				<unitPattern count="one" case="dative">{0} mililitram</unitPattern>
@@ -9625,10 +9625,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>metriskās pintes</displayName>
 				<unitPattern count="zero">{0} metrisko pinšu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} metrisko pinšu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} metrisko pinšu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} metrisko pinšu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} metrisko pinšu</unitPattern>
 				<unitPattern count="one">{0} metriskā pinte</unitPattern>
 				<unitPattern count="one" case="accusative">{0} metrisko pinti</unitPattern>
 				<unitPattern count="one" case="dative">{0} metriskajai pintei</unitPattern>
@@ -9644,10 +9644,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>metriskā glāze</displayName>
 				<unitPattern count="zero">{0} metrisko glāžu</unitPattern>
-				<unitPattern count="zero" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="zero" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="zero" case="accusative">{0} metrisko glāžu</unitPattern>
+				<unitPattern count="zero" case="dative">{0} metrisko glāžu</unitPattern>
+				<unitPattern count="zero" case="genitive">{0} metrisko glāžu</unitPattern>
+				<unitPattern count="zero" case="locative">{0} metrisko glāžu</unitPattern>
 				<unitPattern count="one">{0} metriskā glāze</unitPattern>
 				<unitPattern count="one" case="accusative">{0} metrisko glāzi</unitPattern>
 				<unitPattern count="one" case="dative">{0} metriskajai glāzei</unitPattern>
@@ -9873,14 +9873,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10193,8 +10193,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-minute">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} min</unitPattern>
+				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -10297,8 +10297,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} US therm</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
@@ -10315,8 +10315,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kWh/100km</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -10345,32 +10345,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} em</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pikseļi</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapikseļi</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MP</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppcm</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ppi</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -10380,21 +10380,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpc</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="zero">{0} ppi</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>punkts</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} px</unitPattern>
 				<unitPattern count="one">{0} p.</unitPattern>
 				<unitPattern count="other">{0} p.</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} R⊕</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10469,8 +10469,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-inch">
 				<displayName>collas</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} in</unitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -10536,14 +10536,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>kandela</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cd</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>lūmens</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} lm</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -10702,8 +10702,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} bar</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -10720,8 +10720,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} Pa</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -10762,8 +10762,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-knot">
 				<displayName>mezgls</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} kn</unitPattern>
+				<unitPattern count="one">{0} kn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
@@ -10903,8 +10903,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} bu</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -11021,106 +11021,106 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
 				<unitPrefixPattern>j{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="zero">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="zero">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>Brīvās krišanas paātrinājums:</displayName>
@@ -11129,135 +11129,135 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metri sekundē kvadrātā</displayName>
+				<unitPattern count="zero">{0} m/s²</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>apgr.</displayName>
+				<unitPattern count="zero">{0} apgr.</unitPattern>
+				<unitPattern count="one">{0} apgr.</unitPattern>
+				<unitPattern count="other">{0} apgr.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>radiāni</displayName>
+				<unitPattern count="zero">{0} rad</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="zero">{0}°</unitPattern>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>leņķa minūtes</displayName>
 				<unitPattern count="zero">{0}′</unitPattern>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>leņķa sekundes</displayName>
 				<unitPattern count="zero">{0}″</unitPattern>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="zero">{0}km²</unitPattern>
 				<unitPattern count="one">{0}km²</unitPattern>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ha</displayName>
 				<unitPattern count="zero">{0}ha</unitPattern>
 				<unitPattern count="one">{0}ha</unitPattern>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="zero">{0}m²</unitPattern>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="zero">{0} cm²</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="zero">{0}mi²</unitPattern>
 				<unitPattern count="one">{0}mi²</unitPattern>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>akri</displayName>
 				<unitPattern count="zero">{0}ac</unitPattern>
 				<unitPattern count="one">{0}ac</unitPattern>
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="zero">{0} yd²</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="zero">{0}ft²</unitPattern>
 				<unitPattern count="one">{0}ft²</unitPattern>
 				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="zero">{0} in²</unitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunami</displayName>
+				<unitPattern count="zero">{0} dunamu</unitPattern>
+				<unitPattern count="one">{0} dunams</unitPattern>
+				<unitPattern count="other">{0} dunami</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="zero">{0} kt</unitPattern>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="zero">{0} mg/dl</unitPattern>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/l</displayName>
+				<unitPattern count="zero">{0} mmol/l</unitPattern>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>vienums</displayName>
 				<unitPattern count="zero">{0} vienuma</unitPattern>
 				<unitPattern count="one">{0} vienums</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} vienumi</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miljonās daļas</displayName>
+				<unitPattern count="zero">{0} ppm</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>procents</displayName>
@@ -11266,28 +11266,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>promile</displayName>
+				<unitPattern count="zero">{0}‰</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>promiriāde</displayName>
+				<unitPattern count="zero">{0}‱</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mols</displayName>
+				<unitPattern count="zero">{0} mol</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="zero">{0} l/km</unitPattern>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -11296,82 +11296,82 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jūdzes uz galonu</displayName>
+				<unitPattern count="zero">{0} mpg</unitPattern>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="zero">{0} mpg Imp.</unitPattern>
+				<unitPattern count="one">{0} mpg Imp.</unitPattern>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="zero">{0} PB</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="zero">{0} TB</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="zero">{0} Tb</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="zero">{0} GB</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="zero">{0} Gb</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="zero">{0} MB</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="zero">{0} Mb</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="zero">{0} kB</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="zero">{0} kb</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="zero">{0} B</unitPattern>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>b</displayName>
+				<unitPattern count="zero">{0} b</unitPattern>
+				<unitPattern count="one">{0} b</unitPattern>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>gs.</displayName>
@@ -11380,7 +11380,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} gs.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>dek</displayName>
 				<unitPattern count="zero">{0} dek</unitPattern>
 				<unitPattern count="one">{0} dek</unitPattern>
 				<unitPattern count="other">{0} dek</unitPattern>
@@ -11415,9 +11415,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-day">
 				<displayName>d.</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} d.</unitPattern>
+				<unitPattern count="one">{0} d.</unitPattern>
+				<unitPattern count="other">{0} d.</unitPattern>
 				<perUnitPattern>{0}/d.</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -11425,7 +11425,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="zero">{0} h</unitPattern>
 				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="other">{0} h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
@@ -11443,243 +11443,243 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} ms</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="zero">{0} μs</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="zero">{0} ns</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="zero">{0} A</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="zero">{0} mA</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>omi</displayName>
+				<unitPattern count="zero">{0} Ω</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volti</displayName>
+				<unitPattern count="zero">{0} V</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="zero">{0} kcal</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="zero">{0} cal</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="zero">{0} cal</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="zero">{0} kJ</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>džouli</displayName>
+				<unitPattern count="zero">{0} J</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="zero">{0} kWh</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>elektronvolts</displayName>
+				<unitPattern count="zero">{0} eV</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="zero">{0} Btu</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="zero">{0} US therm</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jaudas mārciņa</displayName>
+				<unitPattern count="zero">{0} lbf</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ņūtons</displayName>
+				<unitPattern count="zero">{0} N</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="zero">{0} kWh/100km</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="zero">{0} GHz</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="zero">{0} MHz</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="zero">{0} kHz</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="zero">{0} Hz</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="zero">{0} em</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pikseļi</displayName>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} MP</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="zero">{0} ppcm</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="zero">{0} ppi</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpc</displayName>
+				<unitPattern count="zero">{0} dpc</unitPattern>
+				<unitPattern count="one">{0} dpc</unitPattern>
+				<unitPattern count="other">{0} dpc</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="zero">{0} ppi</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>punkts</displayName>
+				<unitPattern count="zero">{0} px</unitPattern>
+				<unitPattern count="one">{0} p.</unitPattern>
+				<unitPattern count="other">{0} p.</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="zero">{0} R⊕</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="zero">{0} km</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="zero">{0} m</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="zero">{0} dm</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} cm</unitPattern>
 				<unitPattern count="one">{0}cm</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} mm</unitPattern>
 				<unitPattern count="one">{0}mm</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="zero">{0} μm</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="zero">{0} nm</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="zero">{0}pm</unitPattern>
 				<unitPattern count="one">{0}pm</unitPattern>
 				<unitPattern count="other">{0}pm</unitPattern>
@@ -11736,9 +11736,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fatomi</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} fatomu</unitPattern>
+				<unitPattern count="one">{0} fatoms</unitPattern>
+				<unitPattern count="other">{0} fatomi</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>j.j.</displayName>
@@ -11760,65 +11760,65 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="zero">{0} R☉</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lukss</displayName>
+				<unitPattern count="zero">{0} lx</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kandela</displayName>
+				<unitPattern count="zero">{0} cd</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lūmens</displayName>
+				<unitPattern count="zero">{0} lm</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Saules starjauda</displayName>
+				<unitPattern count="zero">{0} L☉</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="zero">{0} t</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="zero">{0} kg</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>grams</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="zero">{0} g</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="zero">{0} mg</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="zero">{0} μg</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>tonnas</displayName>
@@ -11847,10 +11847,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/unce</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Trojas unces</displayName>
+				<unitPattern count="zero">{0} Trojas unces</unitPattern>
+				<unitPattern count="one">{0} Trojas unce</unitPattern>
+				<unitPattern count="other">{0} Trojas unces</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>karāti</displayName>
@@ -11859,61 +11859,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>daltoni</displayName>
+				<unitPattern count="zero">{0} Da</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Zemes masas</displayName>
+				<unitPattern count="zero">{0} M⊕</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Saules masas</displayName>
+				<unitPattern count="zero">{0} M☉</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gr.</displayName>
+				<unitPattern count="zero">{0} gr.</unitPattern>
+				<unitPattern count="one">{0} gr.</unitPattern>
+				<unitPattern count="other">{0} gr.</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="zero">{0} GW</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="zero">{0} MW</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="zero">{0}kW</unitPattern>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>vati</displayName>
 				<unitPattern count="zero">{0}W</unitPattern>
 				<unitPattern count="one">{0}W</unitPattern>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="zero">{0} mW</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>ZS</displayName>
 				<unitPattern count="zero">{0} ZS</unitPattern>
 				<unitPattern count="one">{0} ZS</unitPattern>
 				<unitPattern count="other">{0} ZS</unitPattern>
@@ -11925,58 +11925,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="zero">{0} psi</unitPattern>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="zero">{0}inHg</unitPattern>
 				<unitPattern count="one">{0}inHg</unitPattern>
 				<unitPattern count="other">{0}inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="zero">{0} bar</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="zero">{0}mbar</unitPattern>
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="zero">{0} atm</unitPattern>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="zero">{0} Pa</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="zero">{0}hPa</unitPattern>
 				<unitPattern count="one">{0}hPa</unitPattern>
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="zero">{0} kPa</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="zero">{0} MPa</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -11985,7 +11985,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="zero">{0}m/s</unitPattern>
 				<unitPattern count="one">{0}m/s</unitPattern>
 				<unitPattern count="other">{0}m/s</unitPattern>
@@ -12003,10 +12003,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mezgli</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="zero">{0}°</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -12015,237 +12015,237 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="zero">{0}°F</unitPattern>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="zero">{0} K</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mārciņpēda</displayName>
+				<unitPattern count="zero">{0} mārc. pēdu</unitPattern>
+				<unitPattern count="one">{0} mārc. pēda</unitPattern>
+				<unitPattern count="other">{0} mārc. pēdas</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="zero">{0} N⋅m</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="zero">{0}km³</unitPattern>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="zero">{0} m³</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="zero">{0} cm³</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="zero">{0}mi³</unitPattern>
 				<unitPattern count="one">{0}mi³</unitPattern>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="zero">{0} yd³</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="zero">{0} ft³</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="zero">{0} in³</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="zero">{0} ML</unitPattern>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="zero">{0} hl</unitPattern>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="zero">{0} l</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="other">{0} l</unitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="zero">{0} dl</unitPattern>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="zero">{0} cl</unitPattern>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="zero">{0} ml</unitPattern>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="zero">{0} mpt</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metr. gl.</displayName>
+				<unitPattern count="zero">{0} metr. gl.</unitPattern>
+				<unitPattern count="one">{0} metr. gl.</unitPattern>
+				<unitPattern count="other">{0} metr. gl.</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="zero">{0} ac ft</unitPattern>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="zero">{0} bu</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="zero">{0} gal</unitPattern>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>britu galons</displayName>
+				<unitPattern count="zero">{0} britu galonu</unitPattern>
+				<unitPattern count="one">{0} britu galons</unitPattern>
+				<unitPattern count="other">{0} britu galoni</unitPattern>
+				<perUnitPattern>{0}/britu galonu</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="zero">{0} qt</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pintes</displayName>
+				<unitPattern count="zero">{0} pt</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>glāzes</displayName>
+				<unitPattern count="zero">{0} gl.</unitPattern>
+				<unitPattern count="one">{0} gl.</unitPattern>
+				<unitPattern count="other">{0} gl.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="zero">{0} fl oz</unitPattern>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>britu šķidr. unces</displayName>
+				<unitPattern count="zero">{0} britu šķidr. unču</unitPattern>
+				<unitPattern count="one">{0} britu šķidr. unce</unitPattern>
+				<unitPattern count="other">{0} britu šķidr. unces</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ĒK</displayName>
+				<unitPattern count="zero">{0} ĒK</unitPattern>
+				<unitPattern count="one">{0} ĒK</unitPattern>
+				<unitPattern count="other">{0} ĒK</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TK</displayName>
+				<unitPattern count="zero">{0} TK</unitPattern>
+				<unitPattern count="one">{0} TK</unitPattern>
+				<unitPattern count="other">{0} TK</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>barels</displayName>
+				<unitPattern count="zero">{0} bbl</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>des. kar.</displayName>
+				<unitPattern count="zero">{0} des. kar.</unitPattern>
+				<unitPattern count="one">{0} des. kar.</unitPattern>
+				<unitPattern count="other">{0} des. kar.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>britu des. kar.</displayName>
+				<unitPattern count="zero">{0} britu des. kar.</unitPattern>
+				<unitPattern count="one">{0} britu des. kar.</unitPattern>
+				<unitPattern count="other">{0} britu des. kar.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pil.</displayName>
+				<unitPattern count="zero">{0} pil.</unitPattern>
+				<unitPattern count="one">{0} pil.</unitPattern>
+				<unitPattern count="other">{0} pil.</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>šķidruma drahma</displayName>
+				<unitPattern count="zero">{0} šķi. drahmu</unitPattern>
+				<unitPattern count="one">{0} šķ. drahma</unitPattern>
+				<unitPattern count="other">{0} šķ. drahmas</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mērglāzīte</displayName>
+				<unitPattern count="zero">{0} mērgl.</unitPattern>
+				<unitPattern count="one">{0} mērgl.</unitPattern>
+				<unitPattern count="other">{0} mērgl.</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>šķips.</displayName>
+				<unitPattern count="zero">{0} šķips.</unitPattern>
+				<unitPattern count="one">{0} šķips.</unitPattern>
+				<unitPattern count="other">{0} šķips.</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="zero">↑↑↑</unitPattern>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>IQT</displayName>
+				<unitPattern count="zero">{0} IQT</unitPattern>
+				<unitPattern count="one">{0} IQT</unitPattern>
+				<unitPattern count="other">{0} IQT</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>debespuse</displayName>
@@ -12279,22 +12279,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} vai {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} vai {1}</listPatternPart>
+			<listPatternPart type="2">{0} vai {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} vai {1}</listPatternPart>
+			<listPatternPart type="2">{0} vai {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} un {1}</listPatternPart>
+			<listPatternPart type="2">{0} un {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -12521,10 +12521,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{credentials} {given} {given2} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given} {surname}</namePattern>
@@ -12563,10 +12563,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname} {given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -12575,25 +12575,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{credentials} {surname} {given} {given2-initial}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
 			<namePattern>{given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{surname} {given-initial} {given2-initial}</namePattern>
@@ -12602,16 +12602,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname} {given-initial}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
 			<namePattern>{given}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2}</namePattern>
@@ -12620,7 +12620,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}, {given} {given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given}</namePattern>

--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -799,7 +799,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UM">यू॰एस॰ आउटलाइंग द्वीपसमूह</territory>
 			<territory type="UN">संयुक्त राष्ट्र</territory>
 			<territory type="US">संयुक्त राज्य</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">संयुक्त राज्य</territory>
 			<territory type="UY">उरुग्वे</territory>
 			<territory type="UZ">उजबेकिस्तान</territory>
 			<territory type="VA">वेटिकन सिटी</territory>
@@ -979,7 +979,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -987,7 +987,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1258,13 +1258,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">श</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
+							<day type="sun">रवि</day>
+							<day type="mon">सोम</day>
+							<day type="tue">मंगल</day>
+							<day type="wed">बुध</day>
 							<day type="thu">बृहस्पति</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="fri">शुक्र</day>
+							<day type="sat">शनि</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">रवि दिन</day>
@@ -1296,13 +1296,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">श</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">रवि</day>
+							<day type="mon">सोम</day>
+							<day type="tue">मंगल</day>
+							<day type="wed">बुध</day>
+							<day type="thu">बृहस्पति</day>
+							<day type="fri">शुक्र</day>
+							<day type="sat">शनि</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">रवि दिन</day>
@@ -1324,10 +1324,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">ति4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">1</quarter>
+							<quarter type="2">2</quarter>
+							<quarter type="3">3</quarter>
+							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1">पहिल तिमाही</quarter>
@@ -1364,8 +1364,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">सांझ</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">भोर</dayPeriod>
+							<dayPeriod type="pm">सांझ</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">भोर</dayPeriod>
@@ -1378,8 +1378,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">अपराह्न</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">पूर्वाह्न</dayPeriod>
+							<dayPeriod type="pm">अपराह्न</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">पूर्वाह्न</dayPeriod>
@@ -1389,10 +1389,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</dayPeriods>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="0">ईसा-पूर्व</era>
+						<era type="0" alt="variant">ईसवी पूर्व</era>
+						<era type="1">ईसवी</era>
+						<era type="1" alt="variant">ईसवी</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">ईसा-पूर्व</era>
@@ -1475,7 +1475,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1483,7 +1483,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1686,7 +1686,51 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
+							<month type="1">चैत</month>
+							<month type="2">बैशाख</month>
+							<month type="3">जेठ</month>
+							<month type="4">अखाढ़</month>
+							<month type="5">सउन</month>
+							<month type="6">भादो</month>
+							<month type="7">आसिन</month>
+							<month type="8">कातिक</month>
+							<month type="9">अगहन</month>
+							<month type="10">पूस</month>
+							<month type="11">माघ</month>
+							<month type="12">फागुन</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">चैत</month>
+							<month type="2">बैशाख</month>
+							<month type="3">जेठ</month>
+							<month type="4">अखाढ़</month>
+							<month type="5">सउन</month>
+							<month type="6">भादो</month>
+							<month type="7">आसिन</month>
+							<month type="8">कातिक</month>
+							<month type="9">अगहन</month>
+							<month type="10">पूस</month>
+							<month type="11">माघ</month>
+							<month type="12">फागुन</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">चैत</month>
 							<month type="2">बैशाख</month>
 							<month type="3">जेठ</month>
 							<month type="4">अखाढ़</month>
@@ -1728,50 +1772,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">फागुन</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraAbbr>
@@ -1788,7 +1788,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>जुग</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>जुग</displayName>
 			</field>
 			<field type="year">
 				<displayName>वर्ष</displayName>
@@ -1804,19 +1804,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>वर्ष</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल बरख</relative>
+				<relative type="0">एहि बरख</relative>
+				<relative type="1">अगिला बरख</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} बरख मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} बरख पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
 				<displayName>वर्ष</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">बीतल बरख</relative>
 				<relative type="0">एहि बरख</relative>
 				<relative type="1">अगिला बरख</relative>
 				<relativeTime type="future">
@@ -1841,19 +1841,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="quarter-short">
 				<displayName>तिमाही</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} तिमाही मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} तिमाही पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
 				<displayName>तिमाही</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} तिमाही मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} तिमाही पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -1907,38 +1907,38 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>सप्ताह</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल सप्ताह</relative>
+				<relative type="0">एहि सप्ताह</relative>
+				<relative type="1">अगिला सप्ताह</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सप्ताह मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सप्ताह पहिले</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>{0} केर सप्ताह</relativePeriod>
 			</field>
 			<field type="week-narrow">
 				<displayName>सप्ताह</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल सप्ताह</relative>
+				<relative type="0">एहि सप्ताह</relative>
+				<relative type="1">अगिला सप्ताह</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सप्ताह मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सप्ताह पहिले</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>{0} केर सप्ताह</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName>महीना केर सप्ताह</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>महीना केर सप्ताह</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>महीना केर सप्ताह</displayName>
 			</field>
 			<field type="day">
 				<displayName>दिन</displayName>
@@ -1955,10 +1955,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="day-short">
 				<displayName>दिन</displayName>
 				<relative type="-1">बीतल काल्हि</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">आजुक दिन</relative>
 				<relative type="1">आबय वला काल्हि</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} दिन मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0}दिन पहिले</relativeTimePattern>
@@ -1970,7 +1970,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">आजुक दिन</relative>
 				<relative type="1">आबय वला काल्हि</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} दिन मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0}दिन पहिले</relativeTimePattern>
@@ -1980,28 +1980,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>बरखक दिन</displayName>
 			</field>
 			<field type="dayOfYear-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>बरखक दिन</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>बरखक दिन</displayName>
 			</field>
 			<field type="weekday">
 				<displayName>सप्ताहक दिन</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>सप्ताहक दिन</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>सप्ताहक दिन</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>माहक कार्यदिवस</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>माहक कार्यदिवस</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>माहक कार्यदिवस</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1">बीतल रवि</relative>
@@ -2015,25 +2015,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल रवि</relative>
+				<relative type="0">एहि रवि</relative>
+				<relative type="1">अगिला रवि</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} रवि मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} रवि पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल रवि</relative>
+				<relative type="0">एहि रवि</relative>
+				<relative type="1">अगिला रवि</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} रवि मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} रवि पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2048,25 +2048,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="mon-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल सोम</relative>
+				<relative type="0">एहि सोम</relative>
+				<relative type="1">अगिला सोम</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सोम मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सोम पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल सोम</relative>
+				<relative type="0">एहि सोम</relative>
+				<relative type="1">अगिला सोम</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सोम मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सोम पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -2081,25 +2081,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="tue-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल मंगल</relative>
+				<relative type="0">एहि मंगल</relative>
+				<relative type="1">अगिला मंगल</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} मंगल मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} मंगल पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल मंगल</relative>
+				<relative type="0">एहि मंगल</relative>
+				<relative type="1">अगिला मंगल</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} मंगल मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} मंगल पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -2114,25 +2114,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="wed-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">पिछला बुध</relative>
+				<relative type="0">एहि बुध</relative>
+				<relative type="1">अगिला बुध</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} बुध मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} बुध पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">पिछला बुध</relative>
+				<relative type="0">एहि बुध</relative>
+				<relative type="1">अगिला बुध</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} बुध मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} बुध पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -2147,25 +2147,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="thu-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल बृहस्पति</relative>
+				<relative type="0">एहि बृहस्पति</relative>
+				<relative type="1">अगिला बृहस्पति</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} बृहस्पति मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} बृहस्पति पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल बृहस्पति</relative>
+				<relative type="0">एहि बृहस्पति</relative>
+				<relative type="1">अगिला बृहस्पति</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} बृहस्पति मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} बृहस्पति पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -2180,25 +2180,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="fri-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">पिछलका शुक्र</relative>
+				<relative type="0">एहि शुक्र</relative>
+				<relative type="1">अगिला शुक्र</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} शुक्र मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} शुक्र पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">पिछलका शुक्र</relative>
+				<relative type="0">एहि शुक्र</relative>
+				<relative type="1">अगिला शुक्र</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} शुक्र मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} शुक्र पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -2213,35 +2213,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sat-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल शनि</relative>
+				<relative type="0">एहि शनि</relative>
+				<relative type="1">अगिला शनि</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} शनि मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} शनि पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">बीतल शनि</relative>
+				<relative type="0">एहि शनि</relative>
+				<relative type="1">अगिला शनि</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} शनि मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} शनि पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>पूर्वाह्न/अपराह्न</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>पूर्वाह्न/अपराह्न</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>पूर्वाह्न/अपराह्न</displayName>
 			</field>
 			<field type="hour">
 				<displayName>घंटा</displayName>
@@ -2254,21 +2254,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>घंटा</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} घंटा मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} घंटा पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>घंटा</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} घंटा मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} घंटा पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
@@ -2282,21 +2282,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="minute-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>मिनट</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} मिनट मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} मिनट पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>मिनट</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} मिनट मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} मिनट पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -2310,31 +2310,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="second-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>सेकंड</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सेकेंड मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सेकेंड पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>सेकंड</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सेकेंड मे</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} सेकेंड पहिले</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
 				<displayName>समय क्षेत्र</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>समय क्षेत्र</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>समय क्षेत्र</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>

--- a/common/main/mi.xml
+++ b/common/main/mi.xml
@@ -446,9 +446,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="zh">Hainamana</language>
 			<language type="zh" alt="menu">Hainamana Manarini</language>
 			<language type="zh_Hans">Hainamana Māmā</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">Hainamana Māmā</language>
 			<language type="zh_Hant">Hainamana Tukuiho</language>
-			<language type="zh_Hant" alt="long">↑↑↑</language>
+			<language type="zh_Hant" alt="long">Hainamana Tukuiho</language>
 			<language type="zu">Tūru</language>
 			<language type="zun">Tuni</language>
 			<language type="zxx">Wetereo kiko kore</language>
@@ -608,7 +608,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="FR">Wīwī</territory>
 			<territory type="GA">Kāpona</territory>
 			<territory type="GB">Te Hononga o Piritene</territory>
-			<territory type="GB" alt="short">↑↑↑</territory>
+			<territory type="GB" alt="short">Te Hononga o Piritene</territory>
 			<territory type="GD">Kerenāta</territory>
 			<territory type="GF">Kaiana Wīwī</territory>
 			<territory type="GG">Kēni</territory>
@@ -666,7 +666,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NL">Hōrana</territory>
 			<territory type="NO">Nōwei</territory>
 			<territory type="NZ">Aotearoa</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Aotearoa</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
 			<territory type="PM">Hato Piere &amp; Mikarona</territory>
@@ -701,7 +701,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UG">Ukāna</territory>
 			<territory type="UN">Te Kotahitanga o Ngā Iwi o te Ao</territory>
 			<territory type="US">Hononga o Amerika</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">Hononga o Amerika</territory>
 			<territory type="UY">Urukoi</territory>
 			<territory type="VC">Hato Wetene me Keretīni</territory>
 			<territory type="VE">Wenehūera</territory>
@@ -810,7 +810,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -818,7 +818,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -826,7 +826,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -834,7 +834,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1055,14 +1055,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">T</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
+							<month type="1">Hānuere</month>
+							<month type="2">Pēpuere</month>
+							<month type="3">Māehe</month>
+							<month type="4">Āpereira</month>
+							<month type="5">Mei</month>
+							<month type="6">Hune</month>
+							<month type="7">Hūrae</month>
+							<month type="8">Ākuhata</month>
 							<month type="9">Hepetema</month>
 							<month type="10">Oketopa</month>
 							<month type="11">Noema</month>
@@ -1208,7 +1208,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
 							<dayPeriod type="am">AM</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="am">AM</dayPeriod>
@@ -1292,7 +1292,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1300,7 +1300,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1308,7 +1308,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1316,7 +1316,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1524,26 +1524,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>t.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">i tērā tau</relative>
+				<relative type="0">i tēnei tau</relative>
+				<relative type="1">ā tērā tau</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ā te {0} tau</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">i te {0} tau</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
 				<displayName>t</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">i tērā tau</relative>
+				<relative type="0">i tēnei tau</relative>
+				<relative type="1">ā tērā tau</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ā te {0} tau</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">i te {0} tau</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -1561,10 +1561,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="quarter-short">
 				<displayName>hw.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} hwh</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} hwh</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
@@ -1573,7 +1573,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">+{0} Hwh</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} hwh</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -1602,14 +1602,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>m</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">i tērā m.</relative>
+				<relative type="0">i tēnei m.</relative>
+				<relative type="1">ā tērā m.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} m.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} m.</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -1631,25 +1631,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">i tēnei w.</relative>
 				<relative type="1">ā tērā w.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>t w o {0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
 				<displayName>w</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">i tērā w.</relative>
+				<relative type="0">i tēnei w.</relative>
+				<relative type="1">ā tērā w.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} w</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>t w o {0}</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName>wiki o te marama</displayName>
@@ -1674,9 +1674,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>rā.</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">inanahi</relative>
 				<relative type="0">i tēnei rā</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">āpōpō</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} r</relativeTimePattern>
 				</relativeTime>
@@ -1686,9 +1686,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>rā</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">inanahi</relative>
 				<relative type="0">i tēnei rā</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">āpōpō</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} r</relativeTimePattern>
 				</relativeTime>
@@ -1985,10 +1985,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="hour-narrow">
 				<displayName>hr</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} h.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} h.</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
@@ -2039,7 +2039,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>hēk</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} h</relativeTimePattern>
 				</relativeTime>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -1131,7 +1131,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Тунис</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Турција</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Турција</territory>
 			<territory type="TT">Тринидад и Тобаго</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тајван</territory>
@@ -1679,7 +1679,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1687,7 +1687,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1695,7 +1695,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2119,22 +2119,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="am">претпл.</dayPeriod>
 							<dayPeriod type="noon">напл.</dayPeriod>
 							<dayPeriod type="pm">попл.</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
+							<dayPeriod type="morning1">наутро</dayPeriod>
 							<dayPeriod type="morning2">претпл.</dayPeriod>
 							<dayPeriod type="afternoon1">попл.</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
+							<dayPeriod type="evening1">навечер</dayPeriod>
 							<dayPeriod type="night1">ноќе</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="midnight">полноќ</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
+							<dayPeriod type="am">претпл.</dayPeriod>
 							<dayPeriod type="noon">напладне</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">попл.</dayPeriod>
 							<dayPeriod type="morning1">наутро</dayPeriod>
 							<dayPeriod type="morning2">претпладне</dayPeriod>
 							<dayPeriod type="afternoon1">попладне</dayPeriod>
 							<dayPeriod type="evening1">навечер</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
+							<dayPeriod type="night1">ноќе</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
@@ -2161,10 +2161,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="night1">ноќ</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="midnight">↑↑↑</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
+							<dayPeriod type="midnight">полноќ</dayPeriod>
+							<dayPeriod type="am">претпл.</dayPeriod>
 							<dayPeriod type="noon">пладне</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">попл.</dayPeriod>
 							<dayPeriod type="morning1">утро</dayPeriod>
 							<dayPeriod type="morning2">претпладне</dayPeriod>
 							<dayPeriod type="afternoon1">попладне</dayPeriod>
@@ -2187,8 +2187,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<era type="1" alt="variant">н.е.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0">п.н.е.</era>
+						<era type="0" alt="variant">п.н.е.</era>
 						<era type="1">н.е.</era>
 					</eraNarrow>
 				</eras>
@@ -6681,7 +6681,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>Лесотско лоти</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Лесотски лоти</displayName>
 				<displayName count="other">Лесотски лоти</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
@@ -7832,39 +7832,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} херци</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>точка</displayName>
@@ -7977,9 +7977,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} скандинавски милји</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>сончеви радиуси</displayName>
@@ -8859,7 +8859,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -8884,47 +8884,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>тчк.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9044,12 +9044,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -9413,7 +9413,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>dstspn Imp</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -9423,22 +9423,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>драм течност</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>џигер</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pinch</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -9460,90 +9460,90 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
@@ -9551,29 +9551,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>гравитациска сила</displayName>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>m/s²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>rad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>deg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} deg</unitPattern>
+				<unitPattern count="other">{0} deg</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>arcmin</displayName>
@@ -9586,27 +9586,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>хектар</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>метри²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
@@ -9616,13 +9616,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-acre">
 				<displayName>акр</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ft²</displayName>
@@ -9630,30 +9630,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>дунам</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>ставка</displayName>
@@ -9661,9 +9661,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ставки</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9672,23 +9672,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">{0} ‱</unitPattern>
 				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>L/km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -9697,8 +9697,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg UK</displayName>
@@ -9706,9 +9706,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TB</displayName>
@@ -9756,9 +9756,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>в.</displayName>
@@ -9766,9 +9766,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} в.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дец.</displayName>
+				<unitPattern count="one">{0} дец.</unitPattern>
+				<unitPattern count="other">{0} дец.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>г.</displayName>
@@ -9835,138 +9835,138 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amp</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>mA</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>ohm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>volt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kJ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>џули</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>US терм</displayName>
 				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">{0} US therms</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpcm</displayName>
 				<unitPattern count="one">{0} dpcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpi</displayName>
 				<unitPattern count="one">{0} dpi</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>dot</displayName>
@@ -9974,213 +9974,213 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>yd</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>in</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>parsec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>ly</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ly</unitPattern>
+				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>furlong</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fathom</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>лукс</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>грам</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>американски тони</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>стоуни</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>lb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz t</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>карати</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>gr</displayName>
@@ -10188,14 +10188,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>kW</displayName>
@@ -10203,212 +10203,212 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>вати</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="one">{0} hp</unitPattern>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km/h</unitPattern>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>m/s</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>mi/hr</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mph</unitPattern>
+				<unitPattern count="other">{0} mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} °C</unitPattern>
+				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="one">{0} °F</unitPattern>
+				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>yd³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>ft³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>in³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>литар</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} L</unitPattern>
+				<unitPattern count="other">{0} L</unitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>бушел</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
 				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
@@ -10418,22 +10418,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/galIm</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt</displayName>
 				<unitPattern count="one">{0} qt</unitPattern>
 				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>чаша</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz</displayName>
 				<unitPattern count="one">{0} fl oz</unitPattern>
 				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
@@ -10443,19 +10443,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dsp</displayName>
@@ -10478,9 +10478,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>џигер</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>pn</displayName>
@@ -10488,7 +10488,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pn</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt Imp</displayName>
 				<unitPattern count="one">{0} qt-Imp.</unitPattern>
 				<unitPattern count="other">{0} qt-Imp.</unitPattern>
 			</unit>
@@ -10524,21 +10524,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} или {1}</listPatternPart>
+			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} или {1}</listPatternPart>
+			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} и {1}</listPatternPart>
 			<listPatternPart type="2">{0} и {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
@@ -10819,7 +10819,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname-core-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2-initial}</namePattern>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -1020,7 +1020,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ടുണീഷ്യ</territory>
 			<territory type="TO">ടോംഗ</territory>
 			<territory type="TR">തുർക്കിയെ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">തുർക്കിയെ</territory>
 			<territory type="TT">ട്രിനിഡാഡും ടുബാഗോയും</territory>
 			<territory type="TV">ടുവാലു</territory>
 			<territory type="TW">തായ്‌വാൻ</territory>
@@ -1569,7 +1569,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1577,7 +1577,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1585,7 +1585,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1593,7 +1593,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2163,7 +2163,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2171,7 +2171,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2179,7 +2179,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2187,7 +2187,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5800,7 +5800,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -7665,7 +7665,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>ടെറാ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
 				<unitPrefixPattern>എക്സാ{0}</unitPrefixPattern>
@@ -7677,7 +7677,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>യൊറ്റാ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
 				<unitPrefixPattern>mebi{0}</unitPrefixPattern>
@@ -7705,38 +7705,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="one">വർഗ്ഗം {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="sociative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="instrumental">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="locative">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="sociative">വർഗ്ഗം {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">വർഗ്ഗം {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="sociative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">വർഗ്ഗം {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="sociative">വർഗ്ഗം {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1 count="one">ക്യുബിക് {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="sociative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="dative">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="instrumental">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="locative">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="sociative">ക്യുബിക് {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">ക്യുബിക് {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="sociative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">ക്യുബിക് {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="sociative">ക്യുബിക് {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>neuter</gender>
@@ -7747,7 +7747,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} ജി-ഫോഴ്‌സിന്റെ</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ജി-ഫോഴ്‌സിനാൽ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ജി-ഫോഴ്‌സിൽ</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="sociative">{0} ജി-ഫോഴ്‌സ്</unitPattern>
 				<unitPattern count="other">{0} ജി-ഫോഴ്‌സ്</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ജി-ഫോഴ്‌സിനെ</unitPattern>
 				<unitPattern count="other" case="dative">{0} ജി-ഫോഴ്‌സിന്</unitPattern>
@@ -7783,7 +7783,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>റേഡിയൻ</displayName>
 				<unitPattern count="one">{0} റേഡിയൻ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} റേഡിയൻ</unitPattern>
 				<unitPattern count="one" case="dative">{0} റേഡിയന്</unitPattern>
 				<unitPattern count="one" case="genitive">{0} റേഡിയന്റെ</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} റേഡിയനാൽ</unitPattern>
@@ -8008,7 +8008,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>പിരമിഡ്</displayName>
 				<unitPattern count="one">{0} പിരമിഡ്</unitPattern>
 				<unitPattern count="one" case="accusative">{0} പിരമിഡിനെ</unitPattern>
 				<unitPattern count="one" case="dative">{0} പിരമിഡിന്</unitPattern>
@@ -8150,16 +8150,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} നൂറ്റാണ്ടിനെ</unitPattern>
 				<unitPattern count="one" case="dative">{0} നൂറ്റാണ്ടിന്</unitPattern>
 				<unitPattern count="one" case="genitive">{0} നൂറ്റാണ്ടിന്റെ</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} നൂറ്റാണ്ട്</unitPattern>
 				<unitPattern count="one" case="locative">{0} നൂറ്റാണ്ടിൽ</unitPattern>
 				<unitPattern count="one" case="sociative">{0} നൂറ്റാണ്ടിനോട്</unitPattern>
 				<unitPattern count="other">{0} നൂറ്റാണ്ടുകൾ</unitPattern>
 				<unitPattern count="other" case="accusative">{0} നൂറ്റാണ്ടുകളുടെ</unitPattern>
 				<unitPattern count="other" case="dative">{0} നൂറ്റാണ്ടിലെ</unitPattern>
 				<unitPattern count="other" case="genitive">{0} നൂറ്റാണ്ടിന്റെ</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} നൂറ്റാണ്ടുകൾ</unitPattern>
+				<unitPattern count="other" case="locative">{0} നൂറ്റാണ്ടുകൾ</unitPattern>
+				<unitPattern count="other" case="sociative">{0} നൂറ്റാണ്ടുകൾ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>neuter</gender>
@@ -8186,16 +8186,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} വർഷത്തെ</unitPattern>
 				<unitPattern count="one" case="dative">{0} വർഷത്തിന്</unitPattern>
 				<unitPattern count="one" case="genitive">{0} വർഷത്തിന്റെ</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} വർഷം</unitPattern>
+				<unitPattern count="one" case="locative">{0} വർഷം</unitPattern>
+				<unitPattern count="one" case="sociative">{0} വർഷം</unitPattern>
 				<unitPattern count="other">{0} വർഷം</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} വർഷം</unitPattern>
+				<unitPattern count="other" case="dative">{0} വർഷം</unitPattern>
+				<unitPattern count="other" case="genitive">{0} വർഷം</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} വർഷം</unitPattern>
+				<unitPattern count="other" case="locative">{0} വർഷം</unitPattern>
+				<unitPattern count="other" case="sociative">{0} വർഷം</unitPattern>
 				<perUnitPattern>{0} / വർഷം</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -8208,114 +8208,114 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>മാസം</displayName>
 				<unitPattern count="one">{0} മാസം</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} മാസം</unitPattern>
+				<unitPattern count="one" case="dative">{0} മാസം</unitPattern>
+				<unitPattern count="one" case="genitive">{0} മാസം</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} മാസം</unitPattern>
+				<unitPattern count="one" case="locative">{0} മാസം</unitPattern>
+				<unitPattern count="one" case="sociative">{0} മാസം</unitPattern>
 				<unitPattern count="other">{0} മാസം</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} മാസം</unitPattern>
+				<unitPattern count="other" case="dative">{0} മാസം</unitPattern>
+				<unitPattern count="other" case="genitive">{0} മാസം</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} മാസം</unitPattern>
+				<unitPattern count="other" case="locative">{0} മാസം</unitPattern>
+				<unitPattern count="other" case="sociative">{0} മാസം</unitPattern>
 				<perUnitPattern>{0} / മാസം</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<gender>neuter</gender>
 				<displayName>ആഴ്ച</displayName>
 				<unitPattern count="one">{0} ആഴ്ച</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="one" case="dative">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="one" case="genitive">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="one" case="locative">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="one" case="sociative">{0} ആഴ്ച</unitPattern>
 				<unitPattern count="other">{0} ആഴ്ച</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="other" case="dative">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="other" case="locative">{0} ആഴ്ച</unitPattern>
+				<unitPattern count="other" case="sociative">{0} ആഴ്ച</unitPattern>
 				<perUnitPattern>{0} / ആഴ്ച</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<gender>neuter</gender>
 				<displayName>ദിവസം</displayName>
 				<unitPattern count="one">{0} ദിവസം</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ദിവസം</unitPattern>
+				<unitPattern count="one" case="dative">{0} ദിവസം</unitPattern>
+				<unitPattern count="one" case="genitive">{0} ദിവസം</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} ദിവസം</unitPattern>
+				<unitPattern count="one" case="locative">{0} ദിവസം</unitPattern>
+				<unitPattern count="one" case="sociative">{0} ദിവസം</unitPattern>
 				<unitPattern count="other">{0} ദിവസം</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ദിവസം</unitPattern>
+				<unitPattern count="other" case="dative">{0} ദിവസം</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ദിവസം</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ദിവസം</unitPattern>
+				<unitPattern count="other" case="locative">{0} ദിവസം</unitPattern>
+				<unitPattern count="other" case="sociative">{0} ദിവസം</unitPattern>
 				<perUnitPattern>{0} / ദിവസം</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<gender>neuter</gender>
 				<displayName>മണിക്കൂർ</displayName>
 				<unitPattern count="one">{0} മണിക്കൂർ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="one" case="dative">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="one" case="locative">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="one" case="sociative">{0} മണിക്കൂർ</unitPattern>
 				<unitPattern count="other">{0} മണിക്കൂർ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="other" case="dative">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="other" case="locative">{0} മണിക്കൂർ</unitPattern>
+				<unitPattern count="other" case="sociative">{0} മണിക്കൂർ</unitPattern>
 				<perUnitPattern>{0} / മണിക്കൂർ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<gender>neuter</gender>
 				<displayName>മിനിറ്റ്</displayName>
 				<unitPattern count="one">{0} മിനിറ്റ്</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="one" case="dative">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="one" case="genitive">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="one" case="locative">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="one" case="sociative">{0} മിനിറ്റ്</unitPattern>
 				<unitPattern count="other">{0} മിനിറ്റ്</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="other" case="dative">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="other" case="genitive">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="other" case="locative">{0} മിനിറ്റ്</unitPattern>
+				<unitPattern count="other" case="sociative">{0} മിനിറ്റ്</unitPattern>
 				<perUnitPattern>{0} / മിനിറ്റ്</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<gender>neuter</gender>
 				<displayName>സെക്കൻഡ്</displayName>
 				<unitPattern count="one">{0} സെക്കൻഡ്</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="one" case="dative">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="one" case="genitive">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="one" case="locative">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="one" case="sociative">{0} സെക്കൻഡ്</unitPattern>
 				<unitPattern count="other">{0} സെക്കൻഡ്</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="other" case="dative">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="other" case="genitive">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="other" case="locative">{0} സെക്കൻഡ്</unitPattern>
+				<unitPattern count="other" case="sociative">{0} സെക്കൻഡ്</unitPattern>
 				<perUnitPattern>{0} / സെക്കൻഡ്</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
@@ -8449,7 +8449,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} കിലോവാട്ട്/മണിക്കൂർ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ഇലക്ട്രോൺവോൾട്ട്</displayName>
 				<unitPattern count="one">{0} ഇലക്ട്രോൺവോൾട്ട്</unitPattern>
 				<unitPattern count="other">{0} ഇലക്ട്രോൺവോൾട്ട്</unitPattern>
 			</unit>
@@ -8459,7 +8459,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ബ്രിട്ടീഷ് തെർമൽ യൂണിറ്റുകൾ</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>US തേം</displayName>
 				<unitPattern count="one">{0} US തേം</unitPattern>
 				<unitPattern count="other">{0} US തേം</unitPattern>
 			</unit>
@@ -8487,9 +8487,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="sociative">{0} ന്യൂട്ടനോട്</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>ജിഗാഹെർട്സ്</displayName>
@@ -8526,74 +8526,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="accusative">{0} em</unitPattern>
+				<unitPattern count="one" case="dative">{0} em</unitPattern>
+				<unitPattern count="one" case="genitive">{0} em</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="one" case="locative">{0} em</unitPattern>
+				<unitPattern count="one" case="sociative">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="accusative">{0} em</unitPattern>
+				<unitPattern count="other" case="dative">{0} em</unitPattern>
+				<unitPattern count="other" case="genitive">{0} em</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="other" case="locative">{0} em</unitPattern>
+				<unitPattern count="other" case="sociative">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="one" case="accusative">{0} px</unitPattern>
+				<unitPattern count="one" case="dative">{0} px</unitPattern>
+				<unitPattern count="one" case="genitive">{0} px</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} px</unitPattern>
+				<unitPattern count="one" case="locative">{0} px</unitPattern>
+				<unitPattern count="one" case="sociative">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
+				<unitPattern count="other" case="accusative">{0} px</unitPattern>
+				<unitPattern count="other" case="dative">{0} px</unitPattern>
+				<unitPattern count="other" case="genitive">{0} px</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} px</unitPattern>
+				<unitPattern count="other" case="locative">{0} px</unitPattern>
+				<unitPattern count="other" case="sociative">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ഡോട്ട്</displayName>
 				<unitPattern count="one">{0} ഡോട്ട്</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>കിലോമീറ്റർ</displayName>
@@ -8605,19 +8605,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>മീറ്റർ</displayName>
 				<unitPattern count="one">{0} മീറ്റർ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="one" case="dative">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="one" case="locative">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="one" case="sociative">{0} മീറ്റർ</unitPattern>
 				<unitPattern count="other">{0} മീറ്റർ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="other" case="dative">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="other" case="locative">{0} മീറ്റർ</unitPattern>
+				<unitPattern count="other" case="sociative">{0} മീറ്റർ</unitPattern>
 				<perUnitPattern>{0} / മീറ്റർ</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
@@ -8707,19 +8707,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>സ്കാൻഡിനേവിയൻ മൈൽ</displayName>
 				<unitPattern count="one">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="one" case="dative">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="one" case="locative">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="one" case="sociative">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
 				<unitPattern count="other">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="other" case="dative">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="other" case="locative">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
+				<unitPattern count="other" case="sociative">{0} സ്കാൻഡിനേവിയൻ മൈൽ</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>പോയിന്റ്</displayName>
@@ -8727,9 +8727,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} പോയിന്റ്</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<gender>neuter</gender>
@@ -8751,15 +8751,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="one" case="accusative">{0} കാൻഡെലയെ</unitPattern>
 				<unitPattern count="one" case="dative">{0} കാൻഡെലയ്ക്ക്</unitPattern>
 				<unitPattern count="one" case="genitive">{0} കാൻഡെലയുടെ</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} കാൻഡെലയാൽ</unitPattern>
 				<unitPattern count="one" case="locative">{0} കാൻഡെലയിൽ</unitPattern>
 				<unitPattern count="one" case="sociative">{0} കാൻഡെലയോട്</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 				<unitPattern count="other" case="accusative">{0} കാൻഡെലയെ</unitPattern>
 				<unitPattern count="other" case="dative">{0} കാൻഡെലയ്ക്ക്</unitPattern>
 				<unitPattern count="other" case="genitive">{0} കാൻഡെലയുടെ</unitPattern>
@@ -8769,15 +8769,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-lumen">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="one" case="accusative">{0} ലൂമെനെ</unitPattern>
 				<unitPattern count="one" case="dative">{0} ലൂമെന്</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ലൂമെന്റെ</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ലൂമെനാൽ</unitPattern>
 				<unitPattern count="one" case="locative">{0} ലൂമെനിൽ</unitPattern>
 				<unitPattern count="one" case="sociative">{0} ലൂമെനോട്</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ലൂമെനെ</unitPattern>
 				<unitPattern count="other" case="dative">{0} ലൂമെന്</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ലൂമെന്റെ</unitPattern>
@@ -8907,7 +8907,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ഡാൽട്ടണുകൾ</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>ഭൂപിണ്ഡം</displayName>
 				<unitPattern count="one">{0} ഭൂപിണ്ഡം</unitPattern>
 				<unitPattern count="other">{0} ഭൂപിണ്ഡം</unitPattern>
 			</unit>
@@ -8917,7 +8917,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} സൂര്യപിണ്ഡം</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>grain</displayName>
 				<unitPattern count="one">{0} gr</unitPattern>
 				<unitPattern count="other">{0} gr</unitPattern>
 			</unit>
@@ -9193,19 +9193,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>ലിറ്റർ</displayName>
 				<unitPattern count="one">{0} ലിറ്റർ</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="one" case="dative">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="one" case="genitive">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="one" case="locative">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="one" case="sociative">{0} ലിറ്റർ</unitPattern>
 				<unitPattern count="other">{0} ലിറ്റർ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="other" case="dative">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="other" case="locative">{0} ലിറ്റർ</unitPattern>
+				<unitPattern count="other" case="sociative">{0} ലിറ്റർ</unitPattern>
 				<perUnitPattern>{0} / ലിറ്റർ</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
@@ -9227,37 +9227,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>മെട്രിക് പൈന്റ്</displayName>
 				<unitPattern count="one">{0} മെട്രിക് പൈന്റ്</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="one" case="dative">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="one" case="genitive">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="one" case="locative">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="one" case="sociative">{0} മെട്രിക് പൈന്റ്</unitPattern>
 				<unitPattern count="other">{0} മെട്രിക് പൈന്റ്</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="other" case="dative">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="other" case="genitive">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="other" case="locative">{0} മെട്രിക് പൈന്റ്</unitPattern>
+				<unitPattern count="other" case="sociative">{0} മെട്രിക് പൈന്റ്</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>neuter</gender>
 				<displayName>മെട്രിക് കപ്പ്</displayName>
 				<unitPattern count="one">{0} മെട്രിക് കപ്പ്</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="one" case="dative">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="one" case="genitive">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="one" case="locative">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="one" case="sociative">{0} മെട്രിക് കപ്പ്</unitPattern>
 				<unitPattern count="other">{0} മെട്രിക് കപ്പ്</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="sociative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="other" case="dative">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="other" case="genitive">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="other" case="locative">{0} മെട്രിക് കപ്പ്</unitPattern>
+				<unitPattern count="other" case="sociative">{0} മെട്രിക് കപ്പ്</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>ഏക്കർ അടി</displayName>
@@ -9265,9 +9265,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ഏക്കർ അടി</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>ഗാലൻ</displayName>
@@ -9302,9 +9302,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ഫ്ലൂയിഡ് ഔൺസ്</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>ടേബിൾസ്‌പൂൺ</displayName>
@@ -9322,14 +9322,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ബാരൽ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>തുള്ളികൾ</displayName>
@@ -9352,9 +9352,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} നുള്ള്</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>കാർഡിനൽ ദിശ</displayName>
@@ -9454,12 +9454,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -9592,7 +9592,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>പിരമിഡ്</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -9800,12 +9800,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>ഇലക്ട്രോൺവോൾട്ട്</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -9815,17 +9815,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>പൗണ്ട് ഫോഴ്സ്</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>ന്യൂട്ടൻ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -9850,32 +9850,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
@@ -9884,13 +9884,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10000,7 +10000,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -10010,17 +10010,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>സോളാർ ലുമിനോസൈട്സ്</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -10089,12 +10089,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>ഭൂപിണ്ഡം</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>സൂര്യപിണ്ഡം</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -10174,12 +10174,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -10224,12 +10224,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -10317,7 +10317,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -10354,7 +10354,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -10369,27 +10369,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>ബാരൽ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>തുള്ളി</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} തുള്ളി</unitPattern>
 				<unitPattern count="other">{0} തുള്ളി</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
@@ -10404,7 +10404,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -10417,104 +10417,104 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
 				<unitPrefixPattern>പി{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
 				<unitPrefixPattern>യോ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ജി-ഫോഴ്‌സ്</displayName>
@@ -10527,109 +10527,109 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}മീ/സെ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>റെവ.</displayName>
+				<unitPattern count="one">{0} റെവ.</unitPattern>
+				<unitPattern count="other">{0} റെവ.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>റേഡിയൻ</displayName>
+				<unitPattern count="one">{0} റേഡി.</unitPattern>
+				<unitPattern count="other">{0} റേഡി.</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഡിഗ്രി</displayName>
+				<unitPattern count="one">{0} ഡിഗ്രി</unitPattern>
+				<unitPattern count="other">{0} ഡിഗ്രി</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>ആർക്ക്.മി.</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ആർക്ക്.സെ.</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>കി.മീ²</displayName>
 				<unitPattern count="one">{0} ച.കിമീ</unitPattern>
 				<unitPattern count="other">{0} ച.കിമീ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/കി.മീ²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ഹെക്‌ടർ</displayName>
 				<unitPattern count="one">{0} ഹെ</unitPattern>
 				<unitPattern count="other">{0} ഹെ</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>മീറ്റർ²</displayName>
 				<unitPattern count="one">{0} ച.മീ</unitPattern>
 				<unitPattern count="other">{0} ച.മീ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/മീ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>സെ.മീ²</displayName>
+				<unitPattern count="one">{0} സെ.മീ²</unitPattern>
+				<unitPattern count="other">{0} സെ.മീ²</unitPattern>
+				<perUnitPattern>{0}/സെ.മീ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ചതു.മൈൽ</displayName>
 				<unitPattern count="one">{0} ച.മൈ</unitPattern>
 				<unitPattern count="other">{0} ച.മൈ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/മൈ²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ഏക്കർ</displayName>
 				<unitPattern count="one">{0} ഏ</unitPattern>
 				<unitPattern count="other">{0} ഏക്ക</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>വാര²</displayName>
+				<unitPattern count="one">{0} വാ²</unitPattern>
+				<unitPattern count="other">{0} വാ²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ചതു.അടി</displayName>
 				<unitPattern count="one">{0} ച. അടി</unitPattern>
 				<unitPattern count="other">{0} ച.അടി</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ഇഞ്ച്²</displayName>
+				<unitPattern count="one">{0} ഇഞ്ച്²</unitPattern>
+				<unitPattern count="other">{0} ഇഞ്ച്²</unitPattern>
+				<perUnitPattern>{0}/ഇഞ്ച്²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>ദുനം</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ദുനം</unitPattern>
+				<unitPattern count="other">{0} ദുനം</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ക്യാരറ്റ്</displayName>
+				<unitPattern count="one">{0} ക്യാ.</unitPattern>
+				<unitPattern count="other">{0} ക്യാ.</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മി.ഗ്രാം/ഡെ.ലി.</displayName>
+				<unitPattern count="one">{0} മി.ഗ്രാം/ഡെ.ലി.</unitPattern>
+				<unitPattern count="other">{0} മി.ഗ്രാം/ഡെ.ലി.</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മില്ലിമോൾ/ലിറ്റർ</displayName>
+				<unitPattern count="one">{0} മി.മോ/ലി.</unitPattern>
+				<unitPattern count="other">{0} മി.മോ/ലി.</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഇനം</displayName>
+				<unitPattern count="one">{0} ഇനം</unitPattern>
+				<unitPattern count="other">{0} ഇനം</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>പാർട്‌സ്/മില്ല്യൺ</displayName>
+				<unitPattern count="one">{0} പാ.പെ.മി.</unitPattern>
+				<unitPattern count="other">{0} പാ.പെ.മി.</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -10637,24 +10637,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>പിരമിഡ്</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മോൾ</displayName>
+				<unitPattern count="one">{0} മോൾ</unitPattern>
+				<unitPattern count="other">{0} മോൾ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ലിറ്റർ/കി.മീ.</displayName>
+				<unitPattern count="one">{0} ലി/കി.മീ.</unitPattern>
+				<unitPattern count="other">{0} ലി/കി.മീ.</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ലി./100 കി.മീ.</displayName>
@@ -10662,69 +10662,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ലി/100കി.മീ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മൈൽ/ഗാ.</displayName>
+				<unitPattern count="one">{0} മൈ/ഗാ.</unitPattern>
+				<unitPattern count="other">{0} മൈ/ഗാ.</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മൈൽ/ഗാ. ഇംപീ.</displayName>
+				<unitPattern count="one">{0} മൈ.പെ.ഗാ./ഇം‌പീ.</unitPattern>
+				<unitPattern count="other">{0} മൈ.പെ.ഗാ./ഇം‌പീ.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>പെ.ബൈ.</displayName>
+				<unitPattern count="one">{0} പിബി</unitPattern>
+				<unitPattern count="other">{0} പിബി</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>ടിബി</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ടിബി</unitPattern>
+				<unitPattern count="other">{0} ടിബി</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ടെ.ബിറ്റ്</displayName>
+				<unitPattern count="one">{0} ടെ.ബി.</unitPattern>
+				<unitPattern count="other">{0} ടെ.ബി.</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ജി.ബൈറ്റ്</displayName>
+				<unitPattern count="one">{0} ജിബി</unitPattern>
+				<unitPattern count="other">{0} ജിബി</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ജി.ബിറ്റ്</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>എംബി</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} എംബി</unitPattern>
+				<unitPattern count="other">{0} എംബി</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മെ.ബിറ്റ്</displayName>
+				<unitPattern count="one">{0} മെ.ബി.</unitPattern>
+				<unitPattern count="other">{0} മെ.ബി.</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>കി.ബൈറ്റ്</displayName>
+				<unitPattern count="one">{0} കെബി</unitPattern>
+				<unitPattern count="other">{0} കെബി</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>കെബി</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} കി.ബിറ്റ്</unitPattern>
+				<unitPattern count="other">{0} കി.ബിറ്റ്</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ബൈറ്റ്</displayName>
+				<unitPattern count="one">{0} ബൈറ്റ്</unitPattern>
+				<unitPattern count="other">{0} ബൈറ്റ്</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ബിറ്റ്</displayName>
+				<unitPattern count="one">{0} ബിറ്റ്</unitPattern>
+				<unitPattern count="other">{0} ബിറ്റ്</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>നൂ.</displayName>
@@ -10732,7 +10732,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} നൂ.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>ദശാബ്‌ദം</displayName>
 				<unitPattern count="one">{0}ദശാ.</unitPattern>
 				<unitPattern count="other">{0}ദശാ.</unitPattern>
 			</unit>
@@ -10743,10 +10743,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/വ.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>പാദം</displayName>
+				<unitPattern count="one">{0} പാദം</unitPattern>
+				<unitPattern count="other">{0} പാദങ്ങൾ</unitPattern>
+				<perUnitPattern>{0}/പാദം</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>മാസം</displayName>
@@ -10800,64 +10800,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} നാ.സെ.</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ആമ്പിയർ</displayName>
+				<unitPattern count="one">{0} ആ.</unitPattern>
+				<unitPattern count="other">{0} ആ.</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മില്ലിആമ്പിയർ</displayName>
+				<unitPattern count="one">{0} മി.ആ.</unitPattern>
+				<unitPattern count="other">{0} മി.ആ.</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഓം</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>വോൾട്ട്</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>കി.കലോ.</displayName>
+				<unitPattern count="one">{0} കി.കലോ.</unitPattern>
+				<unitPattern count="other">{0} കി.കലോ.</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>കലോ.</displayName>
+				<unitPattern count="one">{0} കലോ.</unitPattern>
+				<unitPattern count="other">{0} കലോ.</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>കലോ.</displayName>
+				<unitPattern count="one">{0} കലോ.</unitPattern>
+				<unitPattern count="other">{0} കലോ.</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>കി.ജൂ.</displayName>
+				<unitPattern count="one">{0} കി.ജൂ.</unitPattern>
+				<unitPattern count="other">{0} കി.ജൂ.</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ജൂൾ</displayName>
+				<unitPattern count="one">{0} ജൂ.</unitPattern>
+				<unitPattern count="other">{0} ജൂ.</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>കി.വാ/മ.</displayName>
+				<unitPattern count="one">{0} കി.വാ/മ.</unitPattern>
+				<unitPattern count="other">{0} കി.വാ/മ.</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഇലക്ട്രോൺവോൾട്ട്</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>US തേം</displayName>
@@ -10865,84 +10865,84 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} US തേം</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>പൗണ്ട് ഫോഴ്സ്</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ന്യൂട്ടൻ</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ജി.ഹെ.</displayName>
+				<unitPattern count="one">{0} ജി.ഹെ.</unitPattern>
+				<unitPattern count="other">{0} ജി.ഹെ.</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മെ.ഹെ.</displayName>
+				<unitPattern count="one">{0} മെ.ഹെ.</unitPattern>
+				<unitPattern count="other">{0} മെ.ഹെ.</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>കി.ഹെ.</displayName>
+				<unitPattern count="one">{0} കി.ഹെ.</unitPattern>
+				<unitPattern count="other">{0} കി.ഹെ.</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഹെ.</displayName>
+				<unitPattern count="one">{0} ഹെ.</unitPattern>
+				<unitPattern count="other">{0} ഹെ.</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="one">{0} ഡോട്ട്</unitPattern>
 				<unitPattern count="other">{0} ഡോട്ട്</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>കി.മീ.</displayName>
@@ -11050,29 +11050,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}പോ.</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ലക്സ്</displayName>
+				<unitPattern count="one">{0} ലക്സ്</unitPattern>
+				<unitPattern count="other">{0} ലക്സ്</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>സോളാർ ലുമിനോസൈട്സ്</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>ട.</displayName>
@@ -11125,8 +11125,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>ട്രോ.ഔ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ട്രോ.ഔ.</unitPattern>
+				<unitPattern count="other">{0} ട്രോ.ഔ.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>ക്യാരറ്റ്</displayName>
@@ -11135,53 +11135,53 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ഡാ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ഡാ</unitPattern>
+				<unitPattern count="other">{0} ഡാ</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഭൂപിണ്ഡം</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>സൂര്യപിണ്ഡം</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} gr</unitPattern>
+				<unitPattern count="other">{0} gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ജി.വാ.</displayName>
+				<unitPattern count="one">{0} ജി.വാ.</unitPattern>
+				<unitPattern count="other">{0} ജി.വാ.</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മെ.വാ.</displayName>
+				<unitPattern count="one">{0} മെ.വാ.</unitPattern>
+				<unitPattern count="other">{0} മെ.വാ.</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>കി.വാ.</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>വാട്ട്</displayName>
 				<unitPattern count="one">{0} വാ</unitPattern>
 				<unitPattern count="other">{0} വാ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മി.വാ.</displayName>
+				<unitPattern count="one">{0} മി.വാ.</unitPattern>
+				<unitPattern count="other">{0} മി.വാ.</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>എച്ച്.പി.</displayName>
+				<unitPattern count="one">{0} എച്ച്.പി.</unitPattern>
+				<unitPattern count="other">{0} എച്ച്.പി.</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>മിമീ.മെ.</displayName>
@@ -11190,8 +11190,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>പിഎസ്ഐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} പിഎസ്ഐ</unitPattern>
+				<unitPattern count="other">{0} പിഎസ്ഐ</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>ഇഞ്ച് മെ.</displayName>
@@ -11199,8 +11199,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>ബാർ</displayName>
+				<unitPattern count="one">{0} ബാർ</unitPattern>
 				<unitPattern count="other">{0}ബാർ</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -11209,14 +11209,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} മിബാ</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>പാ</displayName>
+				<unitPattern count="one">{0} പാ</unitPattern>
+				<unitPattern count="other">{0} പാ</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>ഹെ.പാ.</displayName>
@@ -11224,14 +11224,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>കി.മീ/മ.</displayName>
@@ -11274,162 +11274,162 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>കി.മീ³</displayName>
 				<unitPattern count="one">{0} കിമീ³</unitPattern>
 				<unitPattern count="other">{0} കിമീ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>മീ³</displayName>
+				<unitPattern count="one">{0} മീ³</unitPattern>
+				<unitPattern count="other">{0} മീ³</unitPattern>
+				<perUnitPattern>{0}/മീ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>സെ.മീ³</displayName>
+				<unitPattern count="one">{0} സെ.മീ³</unitPattern>
+				<unitPattern count="other">{0} സെ.മീ³</unitPattern>
+				<perUnitPattern>{0}/സെ.മീ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>മൈ³</displayName>
 				<unitPattern count="one">{0} മൈ³</unitPattern>
 				<unitPattern count="other">{0} മൈ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>വാര³</displayName>
+				<unitPattern count="one">{0} വാ³</unitPattern>
+				<unitPattern count="other">{0} വാ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>അടി³</displayName>
+				<unitPattern count="one">{0} അടി³</unitPattern>
+				<unitPattern count="other">{0} അടി³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഇഞ്ച്³</displayName>
+				<unitPattern count="one">{0} ഇഞ്ച്³</unitPattern>
+				<unitPattern count="other">{0} ഇഞ്ച്³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മെ.ലി.</displayName>
+				<unitPattern count="one">{0} മെ.ലി.</unitPattern>
+				<unitPattern count="other">{0} മെ.ലി.</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഹെ.ലി.</displayName>
+				<unitPattern count="one">{0} ഹെ.ലി.</unitPattern>
+				<unitPattern count="other">{0} ഹെ.ലി.</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ലിറ്റർ</displayName>
 				<unitPattern count="one">{0} ലി.</unitPattern>
 				<unitPattern count="other">{0} ലി.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ലി.</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഡെ.ലി.</displayName>
+				<unitPattern count="one">{0} ഡെ.ലി.</unitPattern>
+				<unitPattern count="other">{0} ഡെ.ലി.</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>സെ.ലി.</displayName>
+				<unitPattern count="one">{0} സെ.ലി.</unitPattern>
+				<unitPattern count="other">{0} സെ.ലി.</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മി.ലി.</displayName>
+				<unitPattern count="one">{0} മി.ലി.</unitPattern>
+				<unitPattern count="other">{0} മി.ലി.</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മെ. പൈ.</displayName>
+				<unitPattern count="one">{0} മെ. പൈ.</unitPattern>
+				<unitPattern count="other">{0} മെ. പൈ.</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>മെ. ക.</displayName>
+				<unitPattern count="one">{0} മെ. ക.</unitPattern>
+				<unitPattern count="other">{0} മെ. ക.</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഏ. അടി</displayName>
+				<unitPattern count="one">{0} ഏ. അടി</unitPattern>
+				<unitPattern count="other">{0} ഏ. അടി</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bu</displayName>
 				<unitPattern count="one">{0} പറ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ഗാ.</displayName>
+				<unitPattern count="one">{0} ഗാ.</unitPattern>
+				<unitPattern count="other">{0} ഗാ.</unitPattern>
+				<perUnitPattern>{0}/ഗാ.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ഇംപീ. ഗാലൻ</displayName>
+				<unitPattern count="one">{0} ഗാ. ഇംപീ.</unitPattern>
+				<unitPattern count="other">{0} ഗാ. ഇംപീ.</unitPattern>
+				<perUnitPattern>{0}/ഗാ. ഇംപീ.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ക്വാ.</displayName>
+				<unitPattern count="one">{0} ക്വാ.</unitPattern>
+				<unitPattern count="other">{0} ക്വാ.</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>പൈ.</displayName>
+				<unitPattern count="one">{0} പൈ.</unitPattern>
+				<unitPattern count="other">{0} പൈ.</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>കപ്പ്</displayName>
+				<unitPattern count="one">{0} കപ്പ്</unitPattern>
+				<unitPattern count="other">{0} കപ്പ്</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ഫ്ലൂ. ഔ.</displayName>
+				<unitPattern count="one">{0} ഫ്ലൂ. ഔ.</unitPattern>
+				<unitPattern count="other">{0} ഫ്ലൂ. ഔ.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ടേ.സ്‌പൂ.</displayName>
+				<unitPattern count="one">{0} ടേ.സ്‌പൂ.</unitPattern>
+				<unitPattern count="other">{0} ടേ.സ്‌പൂ.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ടീ.സ്‌പൂ.</displayName>
+				<unitPattern count="one">{0} ടീ.സ്‌പൂ.</unitPattern>
+				<unitPattern count="other">{0} ടീ.സ്‌പൂ.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ബാരൽ</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstspn Imp</displayName>
 				<unitPattern count="one">{0}dsp-Imp</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
@@ -11439,24 +11439,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}തു</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram fluid</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ജിഗർ</displayName>
+				<unitPattern count="one">{0} ജിഗർ</unitPattern>
+				<unitPattern count="other">{0} ജിഗർ</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>നുള്ള്</displayName>
+				<unitPattern count="one">{0} നുള്ള്</unitPattern>
+				<unitPattern count="other">{0} നുള്ള്</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ദിശ</displayName>
@@ -11490,21 +11490,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} അല്ലെങ്കിൽ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, അല്ലെങ്കിൽ {1}</listPatternPart>
+			<listPatternPart type="2">{0} അല്ലെങ്കിൽ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, അല്ലെങ്കിൽ {1}</listPatternPart>
+			<listPatternPart type="2">{0} അല്ലെങ്കിൽ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1} എന്നിവ</listPatternPart>
 			<listPatternPart type="2">{0}, {1} എന്നിവ</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -934,7 +934,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Тунис</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Турк</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Турк</territory>
 			<territory type="TT">Тринидад ба Тобаго</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тайвань</territory>
@@ -1172,238 +1172,238 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="buddhist">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">BE</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">BE</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G y 'оны' MMMM'ын' d. cccc 'гараг'</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G y 'оны' MM 'сарын' dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>G y 'оны' MMM'ын' d</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>GGGGG y.MM.dd</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">dd. E</dateFormatItem>
+						<dateFormatItem id="Gy">G y</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG y.MM.dd</dateFormatItem>
+						<dateFormatItem id="GyMMM">G y 'оны' MMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G y 'оны' MMM'ын' d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G y 'оны' MMM'ын' d. E</dateFormatItem>
+						<dateFormatItem id="M">LLLLL</dateFormatItem>
+						<dateFormatItem id="Md">MMMMM/dd</dateFormatItem>
+						<dateFormatItem id="MEd">MMMMM/dd. E</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM'ын' d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM'ын' d. E</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM'ын' d</dateFormatItem>
+						<dateFormatItem id="y">G y</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">GGGGG y MMMMM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">GGGGG y.MM.dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">GGGGG y.MM.dd. E</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G y 'оны' MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y 'оны' MMM'ын' d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y 'оны' MMM'ын' d. E</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y 'оны' MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y 'оны' QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y 'оны' QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d – d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMMM – MMMMM 'сар'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMMM/d – MMMMM/d</greatestDifference>
+							<greatestDifference id="M">MMMMM/d – MMMMM/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMMM/d E – MMMMM/d E</greatestDifference>
+							<greatestDifference id="M">MMMMM/d E – MMMMM/d E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMMM – MMMMM 'сар'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMMM/d – d</greatestDifference>
+							<greatestDifference id="M">MMMMM/d – MMMMM/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMMMM/d E – MMMMM/d E</greatestDifference>
+							<greatestDifference id="M">MMMMM/d E – MMMMM/d E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y 'оны' MMMMM–MMMMM 'сар'</greatestDifference>
+							<greatestDifference id="y">GGGGG y 'оны' MMMMM 'сар' – y 'оны' MMMMM 'сар'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y 'оны' MMMMM/dd – MMMMM/dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y 'оны' MMMMM/dd – MMMMM/dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y 'оны' MMMMM/dd – y 'оны' MMMMM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y 'оны' MMMMM/dd E – MMMMM/dd E</greatestDifference>
+							<greatestDifference id="M">GGGGG y 'оны' MMMMM/dd E – MMMMM/dd E</greatestDifference>
+							<greatestDifference id="y">GGGGG y 'оны' MMMMM/dd E – y 'оны' MMMMM/dd E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y 'оны' MMMMM – MMMMM 'сар'</greatestDifference>
+							<greatestDifference id="y">G y 'оны' MMMMM 'сар' – y 'оны' MMMMM 'сар'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y 'оны' MMMMM/dd – dd</greatestDifference>
+							<greatestDifference id="M">G y 'оны' MMMMM/dd – MMMMM/dd</greatestDifference>
+							<greatestDifference id="y">G y 'оны' MMMMM/dd – y 'оны' MMMMM/dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y 'оны' MMMMM/dd E – MMMMM/dd E</greatestDifference>
+							<greatestDifference id="M">G y 'оны' MMMMM/dd E – MMMMM/dd E</greatestDifference>
+							<greatestDifference id="y">G y 'оны' MMMMM/dd E – y 'оны' MMMMM/dd E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y 'оны' MMMMM – MMMMM 'сар'</greatestDifference>
+							<greatestDifference id="y">G y 'оны' MMMMM 'сар' – y 'оны' MMMMM 'сар'</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1412,18 +1412,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1-р сар</month>
+							<month type="2">2-р сар</month>
+							<month type="3">3-р сар</month>
+							<month type="4">4-р сар</month>
+							<month type="5">5-р сар</month>
+							<month type="6">6-р сар</month>
+							<month type="7">7-р сар</month>
+							<month type="8">8-р сар</month>
+							<month type="9">9-р сар</month>
+							<month type="10">10-р сар</month>
+							<month type="11">11-р сар</month>
+							<month type="12">12-р сар</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">1-р сар</month>
+							<month type="2">2-р сар</month>
+							<month type="3">3-р сар</month>
+							<month type="4">4-р сар</month>
+							<month type="5">5-р сар</month>
+							<month type="6">6-р сар</month>
+							<month type="7">7-р сар</month>
+							<month type="8">8-р сар</month>
+							<month type="9">9-р сар</month>
+							<month type="10">10-р сар</month>
+							<month type="11">11-р сар</month>
+							<month type="12">12-р сар</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">1-р сар</month>
+							<month type="2">2-р сар</month>
+							<month type="3">3-р сар</month>
+							<month type="4">4-р сар</month>
+							<month type="5">5-р сар</month>
+							<month type="6">6-р сар</month>
+							<month type="7">7-р сар</month>
+							<month type="8">8-р сар</month>
+							<month type="9">9-р сар</month>
+							<month type="10">10-р сар</month>
+							<month type="11">11-р сар</month>
+							<month type="12">12-р сар</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -1452,50 +1496,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="10">10-р сар</month>
 							<month type="11">11-р сар</month>
 							<month type="12">12-р сар</month>
-						</monthWidth>
-					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1555,7 +1555,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1563,7 +1563,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1571,7 +1571,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1579,7 +1579,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2062,9 +2062,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">МЭӨ</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">НТӨ</era>
 						<era type="1">МЭ</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">НТ</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -2125,7 +2125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2133,7 +2133,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2141,7 +2141,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2149,7 +2149,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2377,9 +2377,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>жил</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">өнгөрсөн жил</relative>
+				<relative type="0">энэ жил</relative>
+				<relative type="1">ирэх жил</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} жилийн дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} жилийн дараа</relativeTimePattern>
@@ -2391,9 +2391,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>жил</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">өнгөрсөн жил</relative>
+				<relative type="0">энэ жил</relative>
+				<relative type="1">ирэх жил</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} жилийн дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} жилийн дараа</relativeTimePattern>
@@ -2419,9 +2419,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-short">
 				<displayName>улирал</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">өнгөрсөн улирал</relative>
+				<relative type="0">энэ улирал</relative>
+				<relative type="1">дараагийн улирал</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} улирлын дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} улирлын дараа</relativeTimePattern>
@@ -2433,9 +2433,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="quarter-narrow">
 				<displayName>улирал</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">өнгөрсөн улирал</relative>
+				<relative type="0">энэ улирал</relative>
+				<relative type="1">дараагийн улирал</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} улирлын дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} улирлын дараа</relativeTimePattern>
@@ -2461,9 +2461,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>сар</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">өнгөрсөн сар</relative>
+				<relative type="0">энэ сар</relative>
+				<relative type="1">ирэх сар</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} сарын дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} сарын дараа</relativeTimePattern>
@@ -2475,9 +2475,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>сар</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">өнгөрсөн сар</relative>
+				<relative type="0">энэ сар</relative>
+				<relative type="1">ирэх сар</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} сарын дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} сарын дараа</relativeTimePattern>
@@ -2559,11 +2559,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>өдөр</displayName>
-				<relative type="-2">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="-2">уржигдар</relative>
+				<relative type="-1">өчигдөр</relative>
+				<relative type="0">өнөөдөр</relative>
+				<relative type="1">маргааш</relative>
+				<relative type="2">нөгөөдөр</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} өдрийн дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} өдрийн дараа</relativeTimePattern>
@@ -2575,11 +2575,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>өдөр</displayName>
-				<relative type="-2">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="-2">уржигдар</relative>
+				<relative type="-1">өчигдөр</relative>
+				<relative type="0">өнөөдөр</relative>
+				<relative type="1">маргааш</relative>
+				<relative type="2">нөгөөдөр</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} өдрийн дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} өдрийн дараа</relativeTimePattern>
@@ -2912,7 +2912,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>ц</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">энэ цаг</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ц дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ц дараа</relativeTimePattern>
@@ -2924,7 +2924,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>ц</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">энэ цаг</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ц дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ц дараа</relativeTimePattern>
@@ -2948,7 +2948,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>мин</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">энэ минут</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} мин дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} мин дараа</relativeTimePattern>
@@ -2960,7 +2960,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>мин</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">энэ минут</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} мин дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} мин дараа</relativeTimePattern>
@@ -2984,7 +2984,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>сек</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">одоо</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} сек дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} сек дараа</relativeTimePattern>
@@ -2996,7 +2996,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>сек</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">одоо</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} сек дараа</relativeTimePattern>
 					<relativeTimePattern count="other">{0} сек дараа</relativeTimePattern>
@@ -5237,154 +5237,154 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arab">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="bali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="beng">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="brah">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cakm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="deva">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="fullwide">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gonm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gujr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="guru">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="hanidec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="java">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="kali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="khmr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="knda">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lana">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lanatham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="laoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -5454,315 +5454,315 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="lepc">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="limb">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mlym">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mtei">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymrshan">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="nkoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="olck">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="orya">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="osma">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="rohg">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="saur">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="shrd">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sora">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sund">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="takr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="talu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tamldec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="telu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="thai">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tibt">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="vaii">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arab">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arabext">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="bali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="beng">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="brah">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cakm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="deva">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="fullwide">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gonm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gujr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="guru">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="hanidec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="java">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="kali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="khmr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="knda">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lana">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lanatham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="laoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -5776,168 +5776,168 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scientificFormats numberSystem="lepc">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="limb">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mlym">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mtei">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymrshan">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="nkoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="olck">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="orya">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="osma">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="rohg">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="saur">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="shrd">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sora">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sund">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="takr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="talu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tamldec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="telu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="thai">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tibt">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="vaii">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -5951,140 +5951,140 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<percentFormats numberSystem="arabext">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="bali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="beng">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="brah">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cakm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="deva">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="fullwide">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gonm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gujr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="guru">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="hanidec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="java">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="kali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="khmr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="knda">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lana">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lanatham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="laoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -6098,178 +6098,178 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<percentFormats numberSystem="lepc">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="limb">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mlym">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mtei">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymrshan">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="nkoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="olck">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="orya">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="osma">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="rohg">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="saur">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="shrd">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sora">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sund">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="takr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="talu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tamldec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="telu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="thai">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tibt">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="vaii">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -6278,310 +6278,310 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -6639,346 +6639,346 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">
@@ -8065,136 +8065,136 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 		</currencies>
 		<miscPatterns numberSystem="adlm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arab">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arabext">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="bali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="beng">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="brah">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cakm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="deva">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="fullwide">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gonm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gujr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="guru">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="hanidec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="java">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="kali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="khmr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="knda">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lana">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lanatham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="laoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="latn">
 			<pattern type="approximately">~{0}</pattern>
@@ -8203,141 +8203,141 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lepc">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="limb">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mlym">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mtei">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymrshan">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="nkoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="olck">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="orya">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="osma">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="rohg">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="saur">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="shrd">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sora">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sund">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="takr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="talu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tamldec">
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="telu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="thai">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tibt">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="vaii">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one">Картанд {0} Х байна. Үүнийг авах уу?</pluralMinimalPairs>
@@ -8445,7 +8445,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">куб {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>жи-хүч</displayName>
@@ -8831,19 +8831,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Герц</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>пиксель/см</displayName>
@@ -8861,9 +8861,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} цэг/см</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>цэг</displayName>
@@ -9181,8 +9181,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-knot">
 				<displayName>зангилаа</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} занг.</unitPattern>
+				<unitPattern count="other">{0} занг.</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
@@ -9298,9 +9298,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} акр-фут</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>галлон</displayName>
@@ -9625,7 +9625,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>арван мянганы хувь</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -9838,7 +9838,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -9848,7 +9848,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>фунт хүч</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
@@ -9883,27 +9883,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -9912,9 +9912,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} цэг/см</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>цэг</displayName>
@@ -9923,7 +9923,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10008,12 +10008,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>фурлонг</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>фатом</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -10033,7 +10033,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>нарны радиус</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -10043,17 +10043,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} lm</unitPattern>
 				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>нарны гэрлийн урсгал</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -10122,12 +10122,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>Дэлхийн масс</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>нарны масс</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -10257,7 +10257,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -10350,7 +10350,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -10547,7 +10547,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>гравитацын тогтмол хүч</displayName>
@@ -10556,103 +10556,103 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>м/с²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} м/с²</unitPattern>
+				<unitPattern count="other">{0} м/с²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>эргэлт</displayName>
+				<unitPattern count="one">{0} эргэлт</unitPattern>
+				<unitPattern count="other">{0} эргэлт</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>радиан</displayName>
+				<unitPattern count="one">{0} рад</unitPattern>
+				<unitPattern count="other">{0} рад</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>хэм</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>аркмин</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>арксек</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>км²</displayName>
 				<unitPattern count="one">{0} км²</unitPattern>
 				<unitPattern count="other">{0} км²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/км²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>гектар</displayName>
 				<unitPattern count="one">{0} га</unitPattern>
 				<unitPattern count="other">{0} га</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>метр²</displayName>
 				<unitPattern count="one">{0} м²</unitPattern>
 				<unitPattern count="other">{0} м²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/м²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>см²</displayName>
+				<unitPattern count="one">{0} см²</unitPattern>
+				<unitPattern count="other">{0} см²</unitPattern>
+				<perUnitPattern>{0}/см²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>миль²</displayName>
 				<unitPattern count="one">{0} миль²</unitPattern>
 				<unitPattern count="other">{0} миль²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/миль²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>акр</displayName>
 				<unitPattern count="one">{0} акр</unitPattern>
 				<unitPattern count="other">{0} акр</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ярд²</displayName>
+				<unitPattern count="one">{0} ярд²</unitPattern>
+				<unitPattern count="other">{0} ярд²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>фут²</displayName>
 				<unitPattern count="one">{0} фт²</unitPattern>
 				<unitPattern count="other">{0} фт²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>инч²</displayName>
+				<unitPattern count="one">{0} инч²</unitPattern>
+				<unitPattern count="other">{0} инч²</unitPattern>
+				<perUnitPattern>{0}/инч²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дунам</displayName>
+				<unitPattern count="one">{0} дунам</unitPattern>
+				<unitPattern count="other">{0} дунам</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>карат</displayName>
+				<unitPattern count="one">{0} кар</unitPattern>
+				<unitPattern count="other">{0} кар</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мг/дл</displayName>
+				<unitPattern count="one">{0} мг/дл</unitPattern>
+				<unitPattern count="other">{0} мг/дл</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>миллимоль/литр</displayName>
+				<unitPattern count="one">{0} ммоль/л</unitPattern>
+				<unitPattern count="other">{0} ммоль/л</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>зүйл</displayName>
@@ -10671,23 +10671,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>моль</displayName>
+				<unitPattern count="one">{0} моль</unitPattern>
+				<unitPattern count="other">{0} моль</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>л/км</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} л/км</unitPattern>
+				<unitPattern count="other">{0} л/км</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>л/100км</displayName>
@@ -10695,9 +10695,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}л/100км</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>миль/гал</displayName>
+				<unitPattern count="one">миль/гал</unitPattern>
+				<unitPattern count="other">{0} ми/гал</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>ми/анг. гал</displayName>
@@ -10705,75 +10705,75 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ми/анг.гал</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ПБайт</displayName>
+				<unitPattern count="one">{0} ПБ</unitPattern>
+				<unitPattern count="other">{0} ПБ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Тбайт</displayName>
+				<unitPattern count="one">{0} ТБ</unitPattern>
+				<unitPattern count="other">{0} ТБ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Тбит</displayName>
+				<unitPattern count="one">{0} Тб</unitPattern>
+				<unitPattern count="other">{0} Тб</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гбайт</displayName>
+				<unitPattern count="one">{0} ГБ</unitPattern>
+				<unitPattern count="other">{0} ГБ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гбит</displayName>
+				<unitPattern count="one">{0} Гб</unitPattern>
+				<unitPattern count="other">{0} Гб</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мбайт</displayName>
+				<unitPattern count="one">{0} МБ</unitPattern>
+				<unitPattern count="other">{0} МБ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мбит</displayName>
+				<unitPattern count="one">{0} Мб</unitPattern>
+				<unitPattern count="other">{0} Мб</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кбайт</displayName>
+				<unitPattern count="one">{0} кБ</unitPattern>
+				<unitPattern count="other">{0} кБ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кбит</displayName>
+				<unitPattern count="one">{0} кб</unitPattern>
+				<unitPattern count="other">{0} кб</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>байт</displayName>
+				<unitPattern count="one">{0} байт</unitPattern>
+				<unitPattern count="other">{0} байт</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бит</displayName>
+				<unitPattern count="one">{0} бит</unitPattern>
+				<unitPattern count="other">{0} бит</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>зуун</displayName>
+				<unitPattern count="one">{0} зуун</unitPattern>
+				<unitPattern count="other">{0} зуун</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>декад</displayName>
+				<unitPattern count="one">{0} декад</unitPattern>
+				<unitPattern count="other">{0} декад</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>жил</displayName>
 				<unitPattern count="one">{0}ж</unitPattern>
 				<unitPattern count="other">{0}ж</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ж</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>улирал</displayName>
@@ -10785,37 +10785,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>сар</displayName>
 				<unitPattern count="one">{0}с</unitPattern>
 				<unitPattern count="other">{0}с</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/сар</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>д.х</displayName>
 				<unitPattern count="one">{0} д.х</unitPattern>
 				<unitPattern count="other">{0} д.х</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/д.х</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>хоног</displayName>
 				<unitPattern count="one">{0} хоног</unitPattern>
 				<unitPattern count="other">{0} хоног</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/хоног</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>цаг</displayName>
 				<unitPattern count="one">{0} ц</unitPattern>
 				<unitPattern count="other">{0} ц</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ц</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>мин</displayName>
 				<unitPattern count="one">{0} мин</unitPattern>
 				<unitPattern count="other">{0} мин</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/мин</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>сек</displayName>
 				<unitPattern count="one">{0} сек</unitPattern>
 				<unitPattern count="other">{0} сек</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/сек</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>мсек</displayName>
@@ -10823,89 +10823,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мс</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μсек</displayName>
+				<unitPattern count="one">{0} μсек</unitPattern>
+				<unitPattern count="other">{0} μсек</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>наносек</displayName>
+				<unitPattern count="one">{0} нс</unitPattern>
+				<unitPattern count="other">{0} нс</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>А</displayName>
+				<unitPattern count="one">{0} А</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мА</displayName>
+				<unitPattern count="one">{0} мА</unitPattern>
+				<unitPattern count="other">{0} мА</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>В</displayName>
+				<unitPattern count="one">{0} В</unitPattern>
+				<unitPattern count="other">{0} В</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ккал</displayName>
+				<unitPattern count="one">{0} ккал</unitPattern>
+				<unitPattern count="other">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кал</displayName>
+				<unitPattern count="one">{0} кал</unitPattern>
+				<unitPattern count="other">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кал</displayName>
+				<unitPattern count="one">{0} кал</unitPattern>
+				<unitPattern count="other">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>килоЖоуль</displayName>
+				<unitPattern count="one">{0} кЖ</unitPattern>
+				<unitPattern count="other">{0} кЖ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Жоуль</displayName>
+				<unitPattern count="one">{0} Ж</unitPattern>
+				<unitPattern count="other">{0} Ж</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кВт-цаг</displayName>
+				<unitPattern count="one">{0} кВтц</unitPattern>
+				<unitPattern count="other">{0} кВтц</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>электрон-Вольт</displayName>
+				<unitPattern count="one">{0} эВ</unitPattern>
+				<unitPattern count="other">{0} эВ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ам.дулаан</displayName>
+				<unitPattern count="one">{0} ам.дулаан</unitPattern>
+				<unitPattern count="other">{0} ам.дулаан</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ньютон</displayName>
+				<unitPattern count="one">{0} Н</unitPattern>
+				<unitPattern count="other">{0} Н</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>кВт.ц/100 км</displayName>
@@ -10913,54 +10913,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}кВт.ц/100км</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ГГц</displayName>
+				<unitPattern count="one">{0} ГГц</unitPattern>
+				<unitPattern count="other">{0} ГГц</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МГц</displayName>
+				<unitPattern count="one">{0} МГц</unitPattern>
+				<unitPattern count="other">{0} МГц</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кГц</displayName>
+				<unitPattern count="one">{0} кГц</unitPattern>
+				<unitPattern count="other">{0} кГц</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гц</displayName>
+				<unitPattern count="one">{0} Гц</unitPattern>
+				<unitPattern count="other">{0} Гц</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>цэг/см</displayName>
+				<unitPattern count="one">{0} цэг/см</unitPattern>
+				<unitPattern count="other">{0} цэг/см</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>цэг/инч</displayName>
@@ -10968,37 +10968,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} цэг/инч</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>цэг</displayName>
 				<unitPattern count="one">{0}цэг</unitPattern>
 				<unitPattern count="other">{0}цэг</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>км</displayName>
 				<unitPattern count="one">{0} км</unitPattern>
 				<unitPattern count="other">{0} км</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/км</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>метр</displayName>
 				<unitPattern count="one">{0} м</unitPattern>
 				<unitPattern count="other">{0} м</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/м</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дм</displayName>
+				<unitPattern count="one">{0} дм</unitPattern>
+				<unitPattern count="other">{0} дм</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>см</displayName>
 				<unitPattern count="one">{0} см</unitPattern>
 				<unitPattern count="other">{0} см</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/см</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>мм</displayName>
@@ -11006,49 +11006,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мм</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μметр</displayName>
+				<unitPattern count="one">{0} μм</unitPattern>
+				<unitPattern count="other">{0} μм</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>нм</displayName>
+				<unitPattern count="one">{0} нм</unitPattern>
+				<unitPattern count="other">{0} нм</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>пм</displayName>
 				<unitPattern count="one">{0} пм</unitPattern>
 				<unitPattern count="other">{0} пм</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>миль</displayName>
 				<unitPattern count="one">{0} миль</unitPattern>
 				<unitPattern count="other">{0} миль</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>ярд</displayName>
 				<unitPattern count="one">{0} ярд</unitPattern>
 				<unitPattern count="other">{0} ярд</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>фут</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/фут</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>инч</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/инч</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>парсек</displayName>
+				<unitPattern count="one">{0} пк</unitPattern>
+				<unitPattern count="other">{0} пк</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>гэрл. жил</displayName>
 				<unitPattern count="one">{0} гэрл.жил</unitPattern>
 				<unitPattern count="other">{0} гэрл.жил</unitPattern>
 			</unit>
@@ -11058,39 +11058,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>фурлонг</displayName>
 				<unitPattern count="one">{0} фурлонг</unitPattern>
 				<unitPattern count="other">{0} фурлонг</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фатом</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дми</displayName>
+				<unitPattern count="one">{0} дми</unitPattern>
+				<unitPattern count="other">{0} дми</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
+				<displayName>скандинавын миль</displayName>
 				<unitPattern count="one">{0} ск.миль</unitPattern>
 				<unitPattern count="other">{0} ск.миль</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>оноо</displayName>
+				<unitPattern count="one">{0} оноо</unitPattern>
+				<unitPattern count="other">{0} оноо</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>люкс</displayName>
+				<unitPattern count="one">{0} люкс</unitPattern>
+				<unitPattern count="other">{0} люкс</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>кандел</displayName>
@@ -11104,140 +11104,140 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>т</displayName>
+				<unitPattern count="one">{0} т</unitPattern>
+				<unitPattern count="other">{0} т</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>кг</displayName>
 				<unitPattern count="one">{0} кг</unitPattern>
 				<unitPattern count="other">{0} кг</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/кг</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>грамм</displayName>
 				<unitPattern count="one">{0} гр</unitPattern>
 				<unitPattern count="other">{0} гр</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/гр</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мг</displayName>
+				<unitPattern count="one">{0} мг</unitPattern>
+				<unitPattern count="other">{0} мг</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μг</displayName>
+				<unitPattern count="one">{0} μг</unitPattern>
+				<unitPattern count="other">{0} μг</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>америк тонн</displayName>
+				<unitPattern count="one">{0} ам. тн</unitPattern>
+				<unitPattern count="other">{0} ам. тн</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>чулуу</displayName>
+				<unitPattern count="one">{0} ч</unitPattern>
+				<unitPattern count="other">{0} ч</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>фунт</displayName>
 				<unitPattern count="one">{0}#</unitPattern>
 				<unitPattern count="other">{0}#</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/фунт</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>унц</displayName>
 				<unitPattern count="one">{0} унц</unitPattern>
 				<unitPattern count="other">{0} унц</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/унц</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>трой унц</displayName>
+				<unitPattern count="one">{0} тр.унц</unitPattern>
+				<unitPattern count="other">{0} тр.унц</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>карат</displayName>
+				<unitPattern count="one">{0} кар</unitPattern>
+				<unitPattern count="other">{0} кар</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дальтон</displayName>
+				<unitPattern count="one">{0} Да</unitPattern>
+				<unitPattern count="other">{0} Да</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Дэлхийн масс</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>нарны масс</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>үр</displayName>
+				<unitPattern count="one">{0} үр</unitPattern>
+				<unitPattern count="other">{0} үр</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ГВт</displayName>
+				<unitPattern count="one">{0} ГВт</unitPattern>
+				<unitPattern count="other">{0} ГВт</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МВт</displayName>
+				<unitPattern count="one">{0} МВт</unitPattern>
+				<unitPattern count="other">{0} МВт</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>кВт</displayName>
 				<unitPattern count="one">{0} кватт</unitPattern>
 				<unitPattern count="other">{0} кватт</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ватт</displayName>
 				<unitPattern count="one">{0} ватт</unitPattern>
 				<unitPattern count="other">{0} ватт</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мВт</displayName>
+				<unitPattern count="one">{0} мВт</unitPattern>
+				<unitPattern count="other">{0} мВт</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>мх</displayName>
 				<unitPattern count="one">{0} м.х.</unitPattern>
 				<unitPattern count="other">{0} м.х.</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мм.муб</displayName>
+				<unitPattern count="one">{0} мм.муб</unitPattern>
+				<unitPattern count="other">{0} мм.муб</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фунт/инч²</displayName>
+				<unitPattern count="one">{0} фунт/инч²</unitPattern>
+				<unitPattern count="other">{0} фунт/инч²</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>инч.муб</displayName>
 				<unitPattern count="one">{0} муб</unitPattern>
 				<unitPattern count="other">{0} муб</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бар</displayName>
+				<unitPattern count="one">{0} бар</unitPattern>
+				<unitPattern count="other">{0} бар</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>мбар</displayName>
 				<unitPattern count="one">{0} милбар</unitPattern>
 				<unitPattern count="other">{0} милбар</unitPattern>
 			</unit>
@@ -11247,24 +11247,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} уур амьсгал</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Па</displayName>
+				<unitPattern count="one">{0} Па</unitPattern>
+				<unitPattern count="other">{0} Па</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>гПа</displayName>
 				<unitPattern count="one">{0} гПа</unitPattern>
 				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кПа</displayName>
+				<unitPattern count="one">{0} кПа</unitPattern>
+				<unitPattern count="other">{0} кПа</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МПа</displayName>
+				<unitPattern count="one">{0} МПа</unitPattern>
+				<unitPattern count="other">{0} МПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/ц</displayName>
@@ -11282,14 +11282,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ми/ц</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>занг.</displayName>
+				<unitPattern count="one">{0} занг.</unitPattern>
+				<unitPattern count="other">{0} занг.</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -11302,112 +11302,112 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="one">{0}K</unitPattern>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Н⋅м</displayName>
+				<unitPattern count="one">{0} Н⋅м</unitPattern>
+				<unitPattern count="other">{0} Н⋅м</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>км³</displayName>
 				<unitPattern count="one">{0} км³</unitPattern>
 				<unitPattern count="other">{0} км³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>м³</displayName>
+				<unitPattern count="one">{0} м³</unitPattern>
+				<unitPattern count="other">{0} м³</unitPattern>
+				<perUnitPattern>{0}/м³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>см³</displayName>
+				<unitPattern count="one">{0} cм³</unitPattern>
+				<unitPattern count="other">{0} cм³</unitPattern>
+				<perUnitPattern>{0}/см³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ми³</displayName>
 				<unitPattern count="one">{0} ми³</unitPattern>
 				<unitPattern count="other">{0} ми³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ярд³</displayName>
+				<unitPattern count="one">{0} ярд³</unitPattern>
+				<unitPattern count="other">{0} ярд³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фут³</displayName>
+				<unitPattern count="one">{0} фут³</unitPattern>
+				<unitPattern count="other">{0} фут³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>инч³</displayName>
+				<unitPattern count="one">{0} инч³</unitPattern>
+				<unitPattern count="other">{0} инч³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мл</displayName>
+				<unitPattern count="one">{0} Мл</unitPattern>
+				<unitPattern count="other">{0} Мл</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>хл</displayName>
+				<unitPattern count="one">{0} хл</unitPattern>
+				<unitPattern count="other">{0} хл</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>литр</displayName>
 				<unitPattern count="one">{0} л</unitPattern>
 				<unitPattern count="other">{0} л</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/л</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дл</displayName>
+				<unitPattern count="one">{0} дл</unitPattern>
+				<unitPattern count="other">{0} дл</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>цл</displayName>
+				<unitPattern count="one">{0} цл</unitPattern>
+				<unitPattern count="other">{0} цл</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мл</displayName>
+				<unitPattern count="one">{0} мл</unitPattern>
+				<unitPattern count="other">{0} мл</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мпт</displayName>
+				<unitPattern count="one">{0} мпт</unitPattern>
+				<unitPattern count="other">{0} мпт</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>м.аяга</displayName>
+				<unitPattern count="one">{0} м.аяга</unitPattern>
+				<unitPattern count="other">{0} м.аяга</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>акр фут</displayName>
+				<unitPattern count="one">{0} акр фут</unitPattern>
+				<unitPattern count="other">{0} акр фут</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>гал</displayName>
+				<unitPattern count="one">{0} гал</unitPattern>
+				<unitPattern count="other">{0} гал</unitPattern>
 				<perUnitPattern>{0} гал</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
@@ -11417,79 +11417,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} анг.гал</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>крц</displayName>
+				<unitPattern count="one">{0} крц</unitPattern>
+				<unitPattern count="other">{0} крц</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пинт</displayName>
+				<unitPattern count="one">{0} пт</unitPattern>
+				<unitPattern count="other">{0} пт</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>аяга</displayName>
 				<unitPattern count="one">{0} аяга</unitPattern>
 				<unitPattern count="other">{0} аяга</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ш.унц</displayName>
+				<unitPattern count="one">{0} ш.унц</unitPattern>
+				<unitPattern count="other">{0} ш.унц</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>анг. ш.унц</displayName>
+				<unitPattern count="one">{0} анг. ш.унц</unitPattern>
+				<unitPattern count="other">{0} анг. ш.унц</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>х.х</displayName>
+				<unitPattern count="one">{0} х.х</unitPattern>
+				<unitPattern count="other">{0} х.х</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ц.х</displayName>
+				<unitPattern count="one">{0} ц.х</unitPattern>
+				<unitPattern count="other">{0} ц.х</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>баррель</displayName>
+				<unitPattern count="one">{0} баррель</unitPattern>
+				<unitPattern count="other">{0} баррель</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>амт.х</displayName>
+				<unitPattern count="one">{0} амт.х</unitPattern>
+				<unitPattern count="other">{0} амт.х</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>том амт.х</displayName>
+				<unitPattern count="one">{0} том амт.х</unitPattern>
+				<unitPattern count="other">{0} том амт.х</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дусал</displayName>
+				<unitPattern count="one">{0} дусал</unitPattern>
+				<unitPattern count="other">{0} дусал</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>драм шингэн</displayName>
+				<unitPattern count="one">{0} драм.ш</unitPattern>
+				<unitPattern count="other">{0} драм.ш</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>джиггер</displayName>
+				<unitPattern count="one">{0} джиггер</unitPattern>
+				<unitPattern count="other">{0} джиггер</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>чимх</displayName>
+				<unitPattern count="one">{0} чимх</unitPattern>
+				<unitPattern count="other">{0} чимх</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>том куарт</displayName>
+				<unitPattern count="one">{0} том куарт</unitPattern>
+				<unitPattern count="other">{0} том куарт</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>зүг</displayName>
@@ -11523,28 +11523,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} эсвэл {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1} зэргийн аль нэг</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} эсвэл {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1} зэргийн аль нэг</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} эсвэл {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0} {1}</listPatternPart>
@@ -11767,7 +11767,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>

--- a/common/main/mni.xml
+++ b/common/main/mni.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -186,8 +186,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">জানুৱারি</month>
+							<month type="2">ফেব্রুৱারি</month>
 							<month type="3">মার্চ</month>
 							<month type="4">এপ্রিল</month>
 							<month type="5">মে</month>
@@ -235,7 +235,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="3">মার</month>
 							<month type="4">এপ্রি</month>
 							<month type="5">মে</month>
-							<month type="6">↑↑↑</month>
+							<month type="6">জুন</month>
 							<month type="7">জুলা</month>
 							<month type="8">আগ</month>
 							<month type="9">সেপ্ট</month>
@@ -260,16 +260,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<monthWidth type="wide">
 							<month type="1">জানুৱারি</month>
 							<month type="2">ফেব্রুৱারি</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
+							<month type="3">মার্চ</month>
+							<month type="4">এপ্রিল</month>
+							<month type="5">মে</month>
+							<month type="6">জুন</month>
+							<month type="7">জুলাই</month>
 							<month type="8">ওগষ্ট</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
+							<month type="9">সেপ্টেম্বর</month>
+							<month type="10">ওক্টোবর</month>
 							<month type="11">নবেম্বর</month>
-							<month type="12">↑↑↑</month>
+							<month type="12">ডিসেম্বর</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -290,8 +290,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="tue">লৈবা</day>
 							<day type="wed">য়ুম</day>
 							<day type="thu">শগো</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="fri">ইরা</day>
+							<day type="sat">থাং</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">নোংমাইজিং</day>
@@ -305,12 +305,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
+							<day type="sun">নোংমাইজিং</day>
+							<day type="mon">নিংথৌকাবা</day>
+							<day type="tue">লৈবাকপোকপা</day>
+							<day type="wed">য়ুমশকৈশা</day>
+							<day type="thu">শগোলশেন</day>
+							<day type="fri">ইরাই</day>
 							<day type="sat">থাংজ</day>
 						</dayWidth>
 						<dayWidth type="narrow">
@@ -323,12 +323,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">থাং</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
+							<day type="sun">নোংমাইজিং</day>
+							<day type="mon">নিংথৌকাবা</day>
+							<day type="tue">লৈবাকপোকপা</day>
+							<day type="wed">য়ুমশকৈশা</day>
+							<day type="thu">শগোলশেন</day>
+							<day type="fri">ইরাই</day>
 							<day type="sat">থাংজ</day>
 						</dayWidth>
 					</dayContext>
@@ -350,16 +350,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">অহানবা মসুং</quarter>
+							<quarter type="2">অনীশুবা মসুং</quarter>
+							<quarter type="3">অহুমশুবা মসুং</quarter>
+							<quarter type="4">মরীশুবা মসুং</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">অহানবা মসুং</quarter>
+							<quarter type="2">অনীশুবা মসুং</quarter>
+							<quarter type="3">অহুমশুবা মসুং</quarter>
+							<quarter type="4">মরীশুবা মসুং</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -526,10 +526,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">মথং চহি</relative>
 			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>চহী</displayName>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>চহী</displayName>
 			</field>
 			<field type="quarter">
 				<displayName>মসুং</displayName>
@@ -544,19 +544,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>থা</displayName>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>থা</displayName>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>থা</displayName>
 			</field>
 			<field type="week">
 				<displayName>চয়োল</displayName>
 			</field>
 			<field type="week-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>চয়োল</displayName>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>চয়োল</displayName>
 			</field>
 			<field type="day">
 				<displayName>নুমিৎ</displayName>
@@ -565,15 +565,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">হয়েং</relative>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>নুমিৎ</displayName>
 				<relative type="-1">ঙরাং</relative>
 				<relative type="0">ঙসি</relative>
 				<relative type="1">হয়েং</relative>
 			</field>
 			<field type="day-narrow">
 				<displayName>নুমিৎ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">ঙরাং</relative>
+				<relative type="0">ঙসি</relative>
 				<relative type="1">হয়েং</relative>
 			</field>
 			<field type="weekday">
@@ -586,10 +586,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>পুং</displayName>
 			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>পুং</displayName>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>পুং</displayName>
 			</field>
 			<field type="minute">
 				<displayName>মিনট</displayName>
@@ -604,10 +604,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>সেকেণ্ড</displayName>
 			</field>
 			<field type="second-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>সেকেণ্ড</displayName>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>সেকেণ্ড</displayName>
 			</field>
 			<field type="zone">
 				<displayName>টাইম জোন</displayName>

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -1005,7 +1005,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ट्यूनिशिया</territory>
 			<territory type="TO">टोंगा</territory>
 			<territory type="TR">तुर्किये</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">तुर्किये</territory>
 			<territory type="TT">त्रिनिदाद आणि टोबॅगो</territory>
 			<territory type="TV">टुवालु</territory>
 			<territory type="TW">तैवान</territory>
@@ -2953,9 +2953,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>दिवस</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">काल</relative>
+				<relative type="0">आज</relative>
+				<relative type="1">उद्या</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} दिवसामध्ये</relativeTimePattern>
 					<relativeTimePattern count="other">येत्या {0} दिवसांमध्ये</relativeTimePattern>
@@ -2967,9 +2967,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>दिवस</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">काल</relative>
+				<relative type="0">आज</relative>
+				<relative type="1">उद्या</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} दिवसामध्ये</relativeTimePattern>
 					<relativeTimePattern count="other">{0} दिवसांमध्ये</relativeTimePattern>
@@ -5690,7 +5690,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -6048,7 +6048,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">बेलारुशियन रुबल</displayName>
 				<displayName count="other">बेलारुशियन रुबल्स</displayName>
 				<symbol>BYN</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<symbol alt="narrow">BYN</symbol>
 			</currency>
 			<currency type="BYR">
 				<displayName>बेलारुशियन रुबल (2000–2016)</displayName>
@@ -6449,8 +6449,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>लेसोटो लोटी</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">लेसोटो लोटी</displayName>
+				<displayName count="other">लेसोटो लोटी</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -7094,23 +7094,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" case="ergative">चौरस {0} ने</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">चौरस {0} चा</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="locative">चौरस {0} शी</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="oblique">चौरस {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">चौरस {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="ablative">चौरस {0} आकृती पासून</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">चौरस {0} आकृतीला</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="dative">चौरस {0} आकृतीला</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="ergative">चौरस {0} आकृतीने</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">चौरस {0} आकृतीचा</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="locative">चौरस {0} आकृतीशी</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">चौरस {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">चौरस {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="ablative">चौरस {0} पासून</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">चौरस {0} ला</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="dative">चौरस {0} ला</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="ergative">चौरस {0} ने</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">चौरस {0} चा</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="locative">चौरस {0} शी</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="oblique">चौरस {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">चौरस {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="ablative">चौरस {0} हून</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="accusative">चौरस {0} ना</compoundUnitPattern1>
@@ -7118,23 +7118,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" case="ergative">चौरस {0} नी</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="genitive">चौरस {0} चे</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="locative">चौरस {0} चा</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="oblique">चौरस {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">चौरस {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="ablative">चौरस {0} आकृतींहून</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">चौरस {0} आकृतींना</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="dative">चौरस {0} आकृतींसाठी</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="ergative">चौरस {0} आकृतींनी</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">चौरस {0} आकृतींचे</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="locative">चौरस {0} आकृत्यांचा</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">चौरस {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">चौरस {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="ablative">चौरस {0} हून</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">चौरस {0} ना</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="dative">चौरस {0} साठी</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="ergative">चौरस {0} नी</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">चौरस {0} चे</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="locative">चौरस {0} चा</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="oblique">चौरस {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>घन{0}</compoundUnitPattern1>
@@ -7146,22 +7146,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" case="genitive">घन {0} चा</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="locative">घन {0} शी</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="oblique">घन {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">घन{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="ablative">घन {0} आकृती पासून</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">घन {0} आकृतीला</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="dative">घन {0} आकृतीला</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="ergative">घन {0} आकृतीने</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">घन {0} आकृतीचा</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="locative">घन {0} आकृतीशी</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">घन {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">घन{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="ablative">घन {0} पासून</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">घन {0} ला</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="dative">घन {0} ला</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="ergative">घन {0} ने</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">घन {0} चा</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="locative">घन {0} शी</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="oblique">घन {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">घन{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="ablative">घन {0} हून</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="accusative">घन {0} ना</compoundUnitPattern1>
@@ -7177,7 +7177,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" gender="feminine" case="ergative">घन {0} आकृतींनी</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">घन {0} आकृतींचे</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="locative">घन {0} आकृत्यांचा</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">घन {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine">घन {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="ablative">घन {0} हून</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">घन {0} ना</compoundUnitPattern1>
@@ -7185,10 +7185,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" gender="masculine" case="ergative">घन {0} नी</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">घन {0} चे</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="locative">घन {0} चा</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="oblique">घन {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>masculine</gender>
@@ -7200,7 +7200,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} जी-फोर्सने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} जी-फोर्सचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} जी-फोर्सशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} जी-फोर्स</unitPattern>
 				<unitPattern count="other">{0} जी-फोर्स</unitPattern>
 				<unitPattern count="other" case="ablative">{0} जी-फोर्सहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} जी-फोर्सना</unitPattern>
@@ -7208,7 +7208,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} जी-फोर्सनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} जी-फोर्सचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} जी-फोर्सचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} जी-फोर्स</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>neuter</gender>
@@ -7238,7 +7238,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} परिभ्रमणाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} परिभ्रमणाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} परिभ्रमणाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} परिभ्रमण</unitPattern>
 				<unitPattern count="other">{0} परिभ्रमणे</unitPattern>
 				<unitPattern count="other" case="ablative">{0} परिभ्रमणांहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} परिभ्रमणांना</unitPattern>
@@ -7246,7 +7246,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} परिभ्रमणांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} परिभ्रमणांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} परिभ्रमणांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} परिभ्रमणे</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>feminine</gender>
@@ -7258,7 +7258,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} रेडियनने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} रेडियनचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} रेडियनशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} रेडियन</unitPattern>
 				<unitPattern count="other">{0} रेडियन</unitPattern>
 				<unitPattern count="other" case="ablative">{0} रेडियनहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} रेडियनना</unitPattern>
@@ -7266,7 +7266,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} रेडियननी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} रेडियनचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} रेडियनचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} रेडियन</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>masculine</gender>
@@ -7278,7 +7278,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} अंशाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} अंशाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} अंशाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} अंश</unitPattern>
 				<unitPattern count="other">{0} अंश</unitPattern>
 				<unitPattern count="other" case="ablative">{0} अंशांहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} अंशांना</unitPattern>
@@ -7286,7 +7286,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} अंशांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} अंशांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} अंशांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} अंश</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>masculine</gender>
@@ -7298,7 +7298,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} आर्कमिनिटाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} आर्कमिनिटाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} आर्कमिनिटाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} आर्कमिनिट</unitPattern>
 				<unitPattern count="other">{0} आर्कमिनिटे</unitPattern>
 				<unitPattern count="other" case="ablative">{0} आर्कमिनिटांहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} आर्कमिनिटांना</unitPattern>
@@ -7306,7 +7306,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} आर्कमिनिटांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} आर्कमिनिटांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} आर्कमिनिटांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} आर्कमिनिटे</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>masculine</gender>
@@ -7318,7 +7318,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} आर्कसेकंदाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} आर्कसेकंदाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} आर्कसेकंदाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} आर्कसेकंद</unitPattern>
 				<unitPattern count="other">{0} आर्कसेकंद</unitPattern>
 				<unitPattern count="other" case="ablative">{0} आर्कसेकंदांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} आर्कसेकंदांना</unitPattern>
@@ -7326,7 +7326,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} आर्कसेकंदांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} आर्कसेकंदांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} आर्कसेकंदांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} आर्कसेकंद</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>neuter</gender>
@@ -7357,7 +7357,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} हेक्टरने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} हेक्टरचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} हेक्टरशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} हेक्टर</unitPattern>
 				<unitPattern count="other">{0} हेक्टर</unitPattern>
 				<unitPattern count="other" case="ablative">{0} हेक्टरहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} हेक्टरना</unitPattern>
@@ -7365,7 +7365,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} हेक्टरनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} हेक्टरचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} हेक्टरचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} हेक्टर</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>neuter</gender>
@@ -7447,7 +7447,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} कॅरेटने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} कॅरेटचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} कॅरेटशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} कॅरेट</unitPattern>
 				<unitPattern count="other">{0} कॅरेट्स</unitPattern>
 				<unitPattern count="other" case="ablative">{0} कॅरेट्सहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} कॅरेट्सना</unitPattern>
@@ -7455,7 +7455,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} कॅरेट्सनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} कॅरेट्सचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} कॅरेट्सचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} कॅरेट्स</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>मिलीग्रामस् पर डेसीलिटर</displayName>
@@ -7508,7 +7508,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} भाग प्रति दशलक्षाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} भाग प्रति दशलक्षाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} भाग प्रति दशलक्षाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} भाग प्रति दशलक्ष</unitPattern>
 				<unitPattern count="other">{0} भाग प्रति दशलक्ष</unitPattern>
 				<unitPattern count="other" case="ablative">{0} भाग प्रति दशलक्षांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} भाग प्रति दशलक्षांना</unitPattern>
@@ -7516,7 +7516,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} भाग प्रति दशलक्षांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} भाग प्रति दशलक्षांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} भाग प्रति दशलक्षांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} भाग प्रति दशलक्ष</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>neuter</gender>
@@ -7528,7 +7528,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} टक्क्याने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} टक्क्याचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} टक्क्याशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} टक्के</unitPattern>
 				<unitPattern count="other">{0} टक्के</unitPattern>
 				<unitPattern count="other" case="ablative">{0} टक्क्यांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} टक्क्यांना</unitPattern>
@@ -7536,7 +7536,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} टक्क्यांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} टक्क्यांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} टक्क्यांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} टक्के</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>masculine</gender>
@@ -7548,7 +7548,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} प्रतिमैलाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} प्रतिमैलाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} प्रतिमैलाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} प्रतिमैल</unitPattern>
 				<unitPattern count="other">{0} प्रतिमैल</unitPattern>
 				<unitPattern count="other" case="ablative">{0} प्रतिमैलांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} प्रतिमैलांना</unitPattern>
@@ -7556,7 +7556,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} प्रतिमैलांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} प्रतिमैलांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} प्रतिमैलांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} प्रतिमैल</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>masculine</gender>
@@ -7568,7 +7568,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} पर्मिरेडने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} पर्मिरेडचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} पर्मिरेडशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} पर्मिरेड</unitPattern>
 				<unitPattern count="other">{0} पर्मिरेड</unitPattern>
 				<unitPattern count="other" case="ablative">{0} पर्मिरेडहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} पर्मिरेडना</unitPattern>
@@ -7576,7 +7576,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} पर्मिरेडनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} पर्मिरेडचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} पर्मिरेडचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} पर्मिरेड</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>masculine</gender>
@@ -7588,7 +7588,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} मोलने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} मोलचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} मोलशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मोल</unitPattern>
 				<unitPattern count="other">{0} मोल</unitPattern>
 				<unitPattern count="other" case="ablative">{0} मोलहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} मोलना</unitPattern>
@@ -7596,7 +7596,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} मोलनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} मोलचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} मोलचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मोल</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>neuter</gender>
@@ -7671,7 +7671,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="dative">{0} टेराबाइटला</unitPattern>
 				<unitPattern count="one" case="ergative">{0} टेराबाइटने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} टेराबाइटचा</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="locative">{0} टेराबाइट</unitPattern>
 				<unitPattern count="other">{0} टेराबाइट्स</unitPattern>
 				<unitPattern count="other" case="ablative">{0} टेराबाइट्सपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} टेराबाइट्सना</unitPattern>
@@ -7816,7 +7816,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} बाइटने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} बाइटचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} बाइटशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} बाइट</unitPattern>
 				<unitPattern count="other">{0} बाइट</unitPattern>
 				<unitPattern count="other" case="ablative">{0} बाइटहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} बाइटना</unitPattern>
@@ -7824,7 +7824,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} बाइटनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} बाइटचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} बाइटचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} बाइट</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>masculine</gender>
@@ -7836,7 +7836,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} बिटने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} बिटचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} बिटशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} बिट</unitPattern>
 				<unitPattern count="other">{0} बिट</unitPattern>
 				<unitPattern count="other" case="ablative">{0} बिटहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} बिटना</unitPattern>
@@ -7844,7 +7844,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} बिटनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} बिटचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} बिटचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} बिट</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>neuter</gender>
@@ -7856,7 +7856,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} शतकाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} शतकाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} शतकाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} शतक</unitPattern>
 				<unitPattern count="other">{0} शतके</unitPattern>
 				<unitPattern count="other" case="ablative">{0} शतकांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} शतकांना</unitPattern>
@@ -7864,7 +7864,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} शतकांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} शतकांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} शतकांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} शतके</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>neuter</gender>
@@ -7876,7 +7876,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} दशकाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} दशकाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} दशकाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} दशक</unitPattern>
 				<unitPattern count="other">{0} दशके</unitPattern>
 				<unitPattern count="other" case="ablative">{0} दशकांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} दशकांना</unitPattern>
@@ -7884,7 +7884,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} दशकांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} दशकांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} दशकांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} दशके</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>neuter</gender>
@@ -7896,7 +7896,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} वर्षाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} वर्षाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} वर्षाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} वर्ष</unitPattern>
 				<unitPattern count="other">{0} वर्षे</unitPattern>
 				<unitPattern count="other" case="ablative">{0} वर्षांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} वर्षांना</unitPattern>
@@ -7904,7 +7904,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} वर्षांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} वर्षांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} वर्षांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} वर्षे</unitPattern>
 				<perUnitPattern>{0} दर वर्षी</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -7936,7 +7936,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} महिन्याने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} महिन्याचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} महिन्याशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} महिना</unitPattern>
 				<unitPattern count="other">{0} महिने</unitPattern>
 				<unitPattern count="other" case="ablative">{0} महिन्यांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} महिन्यांना</unitPattern>
@@ -7944,7 +7944,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} महिन्यांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} महिन्यांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} महिन्यांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} महिने</unitPattern>
 				<perUnitPattern>{0} दर महिना</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
@@ -7957,7 +7957,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} आठवड्याने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} आठवड्याचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} आठवड्याशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} आठवडा</unitPattern>
 				<unitPattern count="other">{0} आठवडे</unitPattern>
 				<unitPattern count="other" case="ablative">{0} आठवड्यांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} आठवड्यांना</unitPattern>
@@ -7965,7 +7965,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} आठवड्यांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} आठवड्यांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} आठवड्यांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} आठवडे</unitPattern>
 				<perUnitPattern>{0} दर आठवडा</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
@@ -7978,7 +7978,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} दिवसाशी</unitPattern>
 				<unitPattern count="one" case="genitive">{0} दिवसाची</unitPattern>
 				<unitPattern count="one" case="locative">{0} दिवसा</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} दिवस</unitPattern>
 				<unitPattern count="other">{0} दिवस</unitPattern>
 				<unitPattern count="other" case="ablative">{0} दिवसांहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} दिवसांनी</unitPattern>
@@ -7986,7 +7986,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} दिवसांशी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} दिवसांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} दिवसांच्या</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} दिवस</unitPattern>
 				<perUnitPattern>{0} दर दिवशी</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -7999,7 +7999,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} तासाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} तासाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} तासाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} तास</unitPattern>
 				<unitPattern count="other">{0} तास</unitPattern>
 				<unitPattern count="other" case="ablative">{0} तासांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} तासांना</unitPattern>
@@ -8007,7 +8007,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} तासांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} तासांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} तासांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} तास</unitPattern>
 				<perUnitPattern>{0} प्रति तास</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -8020,7 +8020,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} मिनिटाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} मिनिटाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} मिनिटाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मिनिट</unitPattern>
 				<unitPattern count="other">{0} मिनिटे</unitPattern>
 				<unitPattern count="other" case="ablative">{0} मिनिटांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} मिनिटांना</unitPattern>
@@ -8028,7 +8028,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} मिनिटांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} मिनिटांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} मिनिटांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मिनिटे</unitPattern>
 				<perUnitPattern>{0} दर मिनिट</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -8041,7 +8041,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} सेकंदाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} सेकंदाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} सेकंदाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} सेकंद</unitPattern>
 				<unitPattern count="other">{0} सेकंद</unitPattern>
 				<unitPattern count="other" case="ablative">{0} सेकंदांपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} सेकंदांना</unitPattern>
@@ -8049,7 +8049,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} सेकंदांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} सेकंदांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} सेकंदांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} सेकंद</unitPattern>
 				<perUnitPattern>{0} प्रति सेकंद</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
@@ -8116,7 +8116,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} अँपियरने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} अँपियरचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} अँपियरशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} अँपियर</unitPattern>
 				<unitPattern count="other">{0} अँपियर</unitPattern>
 				<unitPattern count="other" case="ablative">{0} अँपियरहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} अँपियरना</unitPattern>
@@ -8124,7 +8124,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} अँपियरनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} अँपियरचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} अँपियरचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} अँपियर</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>neuter</gender>
@@ -8154,7 +8154,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} ओहमने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ओहमचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} ओहमशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ओहम</unitPattern>
 				<unitPattern count="other">{0} ओहम</unitPattern>
 				<unitPattern count="other" case="ablative">{0} ओहमहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ओहमना</unitPattern>
@@ -8162,7 +8162,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} ओहमनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ओहमचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} ओहमचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ओहम</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>masculine</gender>
@@ -8174,7 +8174,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} व्होल्टने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} व्होल्टचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} व्होल्टशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} व्होल्ट</unitPattern>
 				<unitPattern count="other">{0} व्होल्ट</unitPattern>
 				<unitPattern count="other" case="ablative">{0} व्होल्टहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} व्होल्टना</unitPattern>
@@ -8182,7 +8182,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} व्होल्टनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} व्होल्टचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} व्होल्टचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} व्होल्ट</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>किलोकॅलोरी</displayName>
@@ -8199,7 +8199,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} कॅलरीने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} कॅलरीचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} कॅलरीशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} कॅलरी</unitPattern>
 				<unitPattern count="other">{0} कॅलरीज</unitPattern>
 				<unitPattern count="other" case="ablative">{0} कॅलरीजहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} कॅलरीजना</unitPattern>
@@ -8207,7 +8207,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} कॅलरीजनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} कॅलरीजचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} कॅलरीजचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} कॅलरीज</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>कॅलरीज</displayName>
@@ -8242,7 +8242,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} ज्यूलने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ज्यूलचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} ज्यूलशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ज्यूल</unitPattern>
 				<unitPattern count="other">{0} ज्यूल</unitPattern>
 				<unitPattern count="other" case="ablative">{0} ज्यूलहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ज्यूलना</unitPattern>
@@ -8250,7 +8250,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} ज्यूलनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ज्यूलचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} ज्यूलचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ज्यूल</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>neuter</gender>
@@ -8281,9 +8281,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ब्रिटिश थर्मल युनिट</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>पाउंड्स ऑफ फोर्स</displayName>
@@ -8300,7 +8300,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} न्यूटनने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} न्यूटनचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} न्यूटनशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} न्यूटन</unitPattern>
 				<unitPattern count="other">{0} न्यूटन्स</unitPattern>
 				<unitPattern count="other" case="ablative">{0} न्यूटनहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} न्यूटनना</unitPattern>
@@ -8392,7 +8392,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} हर्ट्झने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} हर्ट्झचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} हर्ट्झशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} हर्ट्झ</unitPattern>
 				<unitPattern count="other">{0} हर्ट्झ</unitPattern>
 				<unitPattern count="other" case="ablative">{0} हर्ट्झहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} हर्ट्झना</unitPattern>
@@ -8400,19 +8400,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} हर्ट्झनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} हर्ट्झचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} हर्ट्झचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} हर्ट्झ</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>masculine</gender>
 				<displayName>टायपोग्राफिक em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="one" case="ablative">{0} em पासून</unitPattern>
 				<unitPattern count="one" case="accusative">{0} em ला</unitPattern>
 				<unitPattern count="one" case="dative">{0} em ला</unitPattern>
 				<unitPattern count="one" case="ergative">{0} em ने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} em चा</unitPattern>
 				<unitPattern count="one" case="locative">{0} em शी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} em</unitPattern>
 				<unitPattern count="other">{0} ems</unitPattern>
 				<unitPattern count="other" case="ablative">{0} em पासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} em ना</unitPattern>
@@ -8420,7 +8420,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} em नी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} em चे</unitPattern>
 				<unitPattern count="other" case="locative">{0} em चा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ems</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
@@ -8432,7 +8432,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} पिक्सेलने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} पिक्सेलचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} पिक्सेलशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} पिक्सेल</unitPattern>
 				<unitPattern count="other">{0} पिक्सेल्स</unitPattern>
 				<unitPattern count="other" case="ablative">{0} पिक्सेल्सपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} पिक्सेल्सना</unitPattern>
@@ -8440,7 +8440,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} पिक्सेल्सनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} पिक्सेल्सचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} पिक्सेल्सचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} पिक्सेल्स</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>masculine</gender>
@@ -8532,7 +8532,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} मीटरने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} मीटरचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} मीटरशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मीटर</unitPattern>
 				<unitPattern count="other">{0} मीटर</unitPattern>
 				<unitPattern count="other" case="ablative">{0} मीटरपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} मीटरना</unitPattern>
@@ -8540,7 +8540,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} मीटरनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} मीटरचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} मीटरचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मीटर</unitPattern>
 				<perUnitPattern>{0} दर मीटर</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
@@ -8714,7 +8714,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} मैल-स्कॅन्डीनेव्हियनने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} मैल-स्कॅन्डीनेव्हियनचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} मैल-स्कॅन्डीनेव्हियनशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मैल-स्कॅन्डीनेव्हियन</unitPattern>
 				<unitPattern count="other">{0} मैल-स्कॅन्डीनेव्हियन</unitPattern>
 				<unitPattern count="other" case="ablative">{0} मैल-स्कॅन्डीनेव्हियनपासून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} मैल-स्कॅन्डीनेव्हियनना</unitPattern>
@@ -8722,7 +8722,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} मैल-स्कॅन्डीनेव्हियननी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} मैल-स्कॅन्डीनेव्हियनचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} मैल-स्कॅन्डीनेव्हियनचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मैल-स्कॅन्डीनेव्हियन</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>बिंदु</displayName>
@@ -8744,7 +8744,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} लक्सने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} लक्सचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} लक्सशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} लक्स</unitPattern>
 				<unitPattern count="other">{0} लक्स</unitPattern>
 				<unitPattern count="other" case="ablative">{0} लक्सहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} लक्सना</unitPattern>
@@ -8752,7 +8752,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} लक्सनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} लक्सचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} लक्सचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} लक्स</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
@@ -8764,7 +8764,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} कँडेलाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} कँडेलाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} कँडेलाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} कँडेला</unitPattern>
 				<unitPattern count="other">{0} कँडेला</unitPattern>
 				<unitPattern count="other" case="ablative">{0} कँडेलाहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} कँडेलाना</unitPattern>
@@ -8772,7 +8772,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} कँडेलानी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} कँडेलाचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} कँडेलाचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} कँडेला</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>masculine</gender>
@@ -8784,7 +8784,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} लुमेनने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} लुमेनचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} लुमेनशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} लुमेन</unitPattern>
 				<unitPattern count="other">{0} लुमेन</unitPattern>
 				<unitPattern count="other" case="ablative">{0} लुमेनहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} लुमेनना</unitPattern>
@@ -8792,7 +8792,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} लुमेननी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} लुमेनचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} लुमेनचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} लुमेन</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>सौर प्रकाश</displayName>
@@ -8809,7 +8809,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} मेट्रिक टनने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} मेट्रिक टनचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} मेट्रिक टनशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेट्रिक टन</unitPattern>
 				<unitPattern count="other">{0} मेट्रिक टन</unitPattern>
 				<unitPattern count="other" case="ablative">{0} मेट्रिक टनहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} मेट्रिक टनना</unitPattern>
@@ -8817,7 +8817,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} मेट्रिक टनसाठी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} मेट्रिक टननी</unitPattern>
 				<unitPattern count="other" case="locative">{0} मेट्रिक टनचे</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेट्रिक टन</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>masculine</gender>
@@ -8829,7 +8829,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} किलोग्रॅमने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} किलोग्रॅमचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} किलोग्रॅमशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} किलोग्रॅम</unitPattern>
 				<unitPattern count="other">{0} किलोग्रॅम</unitPattern>
 				<unitPattern count="other" case="ablative">{0} किलोग्रॅमहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} किलोग्रॅमना</unitPattern>
@@ -8837,7 +8837,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} किलोग्रॅमनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} किलोग्रॅमचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} किलोग्रॅमचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} किलोग्रॅम</unitPattern>
 				<perUnitPattern>{0} दर किलोग्रॅम</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
@@ -8850,7 +8850,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} ग्रॅमने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ग्रॅमचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} ग्रॅमशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ग्रॅम</unitPattern>
 				<unitPattern count="other">{0} ग्रॅम</unitPattern>
 				<unitPattern count="other" case="ablative">{0} ग्रॅमहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} ग्रॅमना</unitPattern>
@@ -8858,7 +8858,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} ग्रॅमनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ग्रॅमचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} ग्रॅमचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ग्रॅम</unitPattern>
 				<perUnitPattern>{0} दर ग्रॅम</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
@@ -8934,7 +8934,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} कॅरेटने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} कॅरेटचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} कॅरेटशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} कॅरेट</unitPattern>
 				<unitPattern count="other">{0} कॅरेट्स</unitPattern>
 				<unitPattern count="other" case="ablative">{0} कॅरेट्सहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} कॅरेट्सना</unitPattern>
@@ -8942,7 +8942,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} कॅरेट्सनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} कॅरेट्सचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} कॅरेट्सचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} कॅरेट्स</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>डाल्टन</displayName>
@@ -9028,7 +9028,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} वॉटने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} वॉटचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} वॉटशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} वॉट</unitPattern>
 				<unitPattern count="other">{0} वॉट</unitPattern>
 				<unitPattern count="other" case="ablative">{0} वॉटहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} वॉटना</unitPattern>
@@ -9036,7 +9036,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} वॉटनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} वॉटचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} वॉटचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} वॉट</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>neuter</gender>
@@ -9078,7 +9078,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>बार</displayName>
 				<unitPattern count="one">{0} बार</unitPattern>
 				<unitPattern count="one" case="ablative">{0} बारपासून</unitPattern>
 				<unitPattern count="one" case="accusative">{0} बारला</unitPattern>
@@ -9086,7 +9086,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} बारने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} बारचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} बारशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} बार</unitPattern>
 				<unitPattern count="other">{0} बार</unitPattern>
 				<unitPattern count="other" case="ablative">{0} बारहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} बारना</unitPattern>
@@ -9094,7 +9094,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} बारनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} बारचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} बारचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} बार</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>masculine</gender>
@@ -9124,7 +9124,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} वातावरणाने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} वातावरणाचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} वातावरणाशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} वातावरण</unitPattern>
 				<unitPattern count="other">{0} वातावरण</unitPattern>
 				<unitPattern count="other" case="ablative">{0} वातावरणांहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} वातावरणांना</unitPattern>
@@ -9132,7 +9132,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} वातावरणांनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} वातावरणांचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} वातावरणांचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} वातावरण</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>masculine</gender>
@@ -9144,7 +9144,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} पास्कालने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} पास्कालचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} पास्कालशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} पास्काल</unitPattern>
 				<unitPattern count="other">{0} पास्काल</unitPattern>
 				<unitPattern count="other" case="ablative">{0} पास्कालहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} पास्कालना</unitPattern>
@@ -9152,7 +9152,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} पास्कालनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} पास्कालचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} पास्कालचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} पास्काल</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>masculine</gender>
@@ -9284,7 +9284,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} अंश सेल्सिअसने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} अंश सेल्सिअसचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} अंश सेल्सिअसशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} अंश सेल्सिअस</unitPattern>
 				<unitPattern count="other">{0} अंश सेल्सिअस</unitPattern>
 				<unitPattern count="other" case="ablative">{0} अंश सेल्सिअसहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} अंश सेल्सिअसना</unitPattern>
@@ -9292,7 +9292,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} अंश सेल्सिअसनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} अंश सेल्सिअसचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} अंश सेल्सिअसचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} अंश सेल्सिअस</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>अंश फॅरनहाईट</displayName>
@@ -9309,7 +9309,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} केल्व्हिनने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} केल्व्हिनचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} केल्व्हिनशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} केल्व्हिन</unitPattern>
 				<unitPattern count="other">{0} केल्व्हिन</unitPattern>
 				<unitPattern count="other" case="ablative">{0} केल्व्हिनहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} केल्व्हिनना</unitPattern>
@@ -9317,7 +9317,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} केल्व्हिननी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} केल्व्हिनचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} केल्व्हिनचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} केल्व्हिन</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>पाउंड-फूट</displayName>
@@ -9464,7 +9464,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} लीटरने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} लीटरचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} लीटरशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} लीटर</unitPattern>
 				<unitPattern count="other">{0} लीटर</unitPattern>
 				<unitPattern count="other" case="ablative">{0} लीटरहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} लीटरना</unitPattern>
@@ -9472,7 +9472,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} लीटरनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} लीटरचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} लीटरचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} लीटर</unitPattern>
 				<perUnitPattern>{0} दर लीटर</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
@@ -9539,7 +9539,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} मेट्रिक पिंटने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} मेट्रिक पिंटचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} मेट्रिक पिंटशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेट्रिक पिंट</unitPattern>
 				<unitPattern count="other">{0} मेट्रिक पिंट</unitPattern>
 				<unitPattern count="other" case="ablative">{0} मेट्रिक पिंटहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} मेट्रिक पिंटना</unitPattern>
@@ -9547,7 +9547,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} मेट्रिक पिंटनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} मेट्रिक पिंटचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} मेट्रिक पिंटचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेट्रिक पिंट</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>neuter</gender>
@@ -9559,7 +9559,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="ergative">{0} मेट्रिक कपने</unitPattern>
 				<unitPattern count="one" case="genitive">{0} मेट्रिक कपचा</unitPattern>
 				<unitPattern count="one" case="locative">{0} मेट्रिक कपशी</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} मेट्रिक कप</unitPattern>
 				<unitPattern count="other">{0} मेट्रिक कप</unitPattern>
 				<unitPattern count="other" case="ablative">{0} मेट्रिक कपहून</unitPattern>
 				<unitPattern count="other" case="accusative">{0} मेट्रिक कपना</unitPattern>
@@ -9567,7 +9567,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="ergative">{0} मेट्रिक कपनी</unitPattern>
 				<unitPattern count="other" case="genitive">{0} मेट्रिक कपचे</unitPattern>
 				<unitPattern count="other" case="locative">{0} मेट्रिक कपचा</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} मेट्रिक कप</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>एकर-फूट</displayName>
@@ -9872,7 +9872,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>mg/dL</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
 				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
@@ -9902,7 +9902,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>पर्मिरेड</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -10110,7 +10110,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>इलेक्ट्रॉनव्होल्ट</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -10120,17 +10120,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>पाउंड-फोर्स</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>न्यूटन</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -10160,7 +10160,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -10194,13 +10194,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} प्र इं बिं</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>पिक्सेल्स</displayName>
+				<unitPattern count="one">{0} पि</unitPattern>
+				<unitPattern count="other">{0} पि</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>R⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10310,7 +10310,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>सौर त्रिज्या</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -10330,7 +10330,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>सौर प्रकाश</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -10399,12 +10399,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>पृथ्वी द्रव्यमान</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>सौर द्रव्यमान</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -10474,7 +10474,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -10484,12 +10484,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>MPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -10534,12 +10534,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -10627,7 +10627,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>बुशेल</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -10664,7 +10664,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>इम्पे. फ्लु औं</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -10679,7 +10679,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>बॅरल</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -10699,7 +10699,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
@@ -10787,28 +10787,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>यो{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
 				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
@@ -10824,10 +10824,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>जी-फोर्स</displayName>
 				<unitPattern count="one">{0}जी</unitPattern>
 				<unitPattern count="other">{0}जी</unitPattern>
 			</unit>
@@ -10837,51 +10837,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} मी/से²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>परिभ्र.</displayName>
+				<unitPattern count="one">{0} परिभ्र.</unitPattern>
+				<unitPattern count="other">{0} परिभ्र.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>रेडियन</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>अंश</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>आर्कमिनि</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}'</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>आर्कसेक</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}&quot;</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>किमी²</displayName>
 				<unitPattern count="one">{0} किमी²</unitPattern>
 				<unitPattern count="other">{0} किमी²</unitPattern>
 				<perUnitPattern>{0}/किमी²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>हेक्टर</displayName>
 				<unitPattern count="one">{0}हेक्टर</unitPattern>
 				<unitPattern count="other">{0}हेक्टर</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>मीटर²</displayName>
 				<unitPattern count="one">{0} मी²</unitPattern>
 				<unitPattern count="other">{0} मी²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/मी²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>सेंमी²</displayName>
+				<unitPattern count="one">{0} सेंमी²</unitPattern>
+				<unitPattern count="other">{0} सेंमी²</unitPattern>
 				<perUnitPattern>{0}/सेंमी²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -10891,14 +10891,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/मै²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>एकर</displayName>
 				<unitPattern count="one">{0}एकर</unitPattern>
 				<unitPattern count="other">{0}एकर</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>यार्ड²</displayName>
+				<unitPattern count="one">{0} यार्ड²</unitPattern>
+				<unitPattern count="other">{0} यार्ड²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>फूट²</displayName>
@@ -10906,25 +10906,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}फूट²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>इंच²</displayName>
+				<unitPattern count="one">{0} इंच²</unitPattern>
+				<unitPattern count="other">{0} इंच²</unitPattern>
+				<perUnitPattern>{0}/इंच²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>दुनाम</displayName>
+				<unitPattern count="one">{0} दुनाम</unitPattern>
+				<unitPattern count="other">{0} दुनाम</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>कॅरेट्स</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>मिलीमो./लि.</displayName>
@@ -10947,24 +10947,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>प्रतिमैल</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>पर्मिरेड</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मोल</displayName>
+				<unitPattern count="one">{0} मोल</unitPattern>
+				<unitPattern count="other">{0} मोल</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>लीटर/किमी</displayName>
+				<unitPattern count="one">{0} ली/किमी</unitPattern>
+				<unitPattern count="other">{0} ली/किमी</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ली/100किमी</displayName>
@@ -10972,7 +10972,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ली/100किमी</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>मैल/गॅलन</displayName>
 				<unitPattern count="one">{0}mpg</unitPattern>
 				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
@@ -11032,9 +11032,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बिट</displayName>
+				<unitPattern count="one">{0} बिट</unitPattern>
+				<unitPattern count="other">{0} बिट</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>श</displayName>
@@ -11042,9 +11042,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} श</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>द</displayName>
+				<unitPattern count="one">{0} द</unitPattern>
+				<unitPattern count="other">{0} द</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>वर्ष</displayName>
@@ -11110,69 +11110,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} नॅसे</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>अँप्स</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मिलिअँप्स</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ओहम</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>व्होल्ट</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>किलोज्यूल</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ज्यूल</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW-तास</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>इलेक्ट्रॉनव्होल्ट</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>BTU</displayName>
 				<unitPattern count="one">{0}Btu</unitPattern>
 				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
@@ -11181,8 +11181,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100km</displayName>
@@ -11190,69 +11190,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>पिक्सेल्स</displayName>
+				<unitPattern count="one">{0} पि</unitPattern>
+				<unitPattern count="other">{0} पि</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मे पि</displayName>
+				<unitPattern count="one">{0} मे पि</unitPattern>
+				<unitPattern count="other">{0} मे पि</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>पि प्र सेंमी</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>पि प्र इं</displayName>
+				<unitPattern count="one">{0} पि प्र इं</unitPattern>
+				<unitPattern count="other">{0} पि प्र इं</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>प्र सें बिं</displayName>
+				<unitPattern count="one">{0} प्र सें बिं</unitPattern>
+				<unitPattern count="other">{0} प्र सें बिं</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>प्र इं बिं</displayName>
+				<unitPattern count="one">{0} प्र इं बिं</unitPattern>
+				<unitPattern count="other">{0} प्र इं बिं</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>पिक्सेल्स</displayName>
+				<unitPattern count="one">{0} पि</unitPattern>
+				<unitPattern count="other">{0} पि</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>किमी</displayName>
@@ -11330,24 +11330,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}प्रव</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>फर्लांग</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>फॅदम</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>smi</displayName>
@@ -11355,39 +11355,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बिंदु</displayName>
+				<unitPattern count="one">{0} बिंदु</unitPattern>
+				<unitPattern count="other">{0} बिंदु</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>सौर त्रिज्या</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>लक्स</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>किग्रॅ</displayName>
@@ -11407,9 +11407,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} मिग्रॅ</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>टन</displayName>
@@ -11435,61 +11435,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz t</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>कॅरेट्स</displayName>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>डाल्टन</displayName>
+				<unitPattern count="one">{0} डाल्टन</unitPattern>
+				<unitPattern count="other">{0} डाल्टन</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>अल्पांश</displayName>
+				<unitPattern count="one">{0} अल्पांश</unitPattern>
+				<unitPattern count="other">{0} अल्पांश</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>किवॉ</displayName>
 				<unitPattern count="one">{0}किवॉ</unitPattern>
 				<unitPattern count="other">{0}किवॉ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>वॉट</displayName>
 				<unitPattern count="one">{0}वॉ</unitPattern>
 				<unitPattern count="other">{0}वॉ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0} हॉपॉ</unitPattern>
 				<unitPattern count="other">{0}हॉपॉ</unitPattern>
 			</unit>
@@ -11509,9 +11509,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}&quot; हेग्रॅ</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बार</displayName>
+				<unitPattern count="one">{0} बार</unitPattern>
+				<unitPattern count="other">{0} बार</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>मिलिबार</displayName>
@@ -11519,14 +11519,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}मिबा</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -11534,14 +11534,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}हेक्टोपा</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>किमी/तास</displayName>
@@ -11559,9 +11559,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}मैप्रता</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
@@ -11584,169 +11584,169 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>किमी³</displayName>
 				<unitPattern count="one">{0}किमी³</unitPattern>
 				<unitPattern count="other">{0}किमी³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>मी³</displayName>
+				<unitPattern count="one">{0} मी³</unitPattern>
+				<unitPattern count="other">{0} मी³</unitPattern>
+				<perUnitPattern>{0}/मी³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>सेंमी³</displayName>
+				<unitPattern count="one">{0} सेंमी³</unitPattern>
+				<unitPattern count="other">{0} सेंमी³</unitPattern>
+				<perUnitPattern>{0}/सेंमी³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>मै³</displayName>
 				<unitPattern count="one">{0}मै³</unitPattern>
 				<unitPattern count="other">{0}मै³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>यार्ड³</displayName>
+				<unitPattern count="one">{0} यार्ड³</unitPattern>
+				<unitPattern count="other">{0} यार्ड³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>फूट³</displayName>
+				<unitPattern count="one">{0} फूट³</unitPattern>
+				<unitPattern count="other">{0} फूट³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>इंच³</displayName>
+				<unitPattern count="one">{0} इंच³</unitPattern>
+				<unitPattern count="other">{0} इंच³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>लीटर</displayName>
 				<unitPattern count="one">{0}ली</unitPattern>
 				<unitPattern count="other">{0}ली</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ली</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मिली</displayName>
+				<unitPattern count="one">{0} मिली</unitPattern>
+				<unitPattern count="other">{0} मिली</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बुशेल</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/गॅ</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>इम्पि. गॅ.</displayName>
+				<unitPattern count="one">{0} गॅ इम्पि</unitPattern>
+				<unitPattern count="other">{0} गॅ इम्पि</unitPattern>
+				<perUnitPattern>{0}/गॅ इम्पि</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>पिंट</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>कप</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>इम्पे. फ्लु औं</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बॅरल</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstspn Imp</displayName>
 				<unitPattern count="one">{0}dsp-Imp</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>पात</displayName>
+				<unitPattern count="one">{0} पात</unitPattern>
+				<unitPattern count="other">{0} पात</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl.dr.</displayName>
@@ -11754,17 +11754,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>जिगर</displayName>
+				<unitPattern count="one">{0} जिगर</unitPattern>
+				<unitPattern count="other">{0} जिगर</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>आकुंचन</displayName>
+				<unitPattern count="one">{0} आकुंचन</unitPattern>
+				<unitPattern count="other">{0} आकुंचन</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt Imp</displayName>
 				<unitPattern count="one">{0}qt-Imp.</unitPattern>
 				<unitPattern count="other">{0}qt-Imp.</unitPattern>
 			</unit>
@@ -11800,22 +11800,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} किंवा {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} किंवा {1}</listPatternPart>
+			<listPatternPart type="2">{0} किंवा {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} किंवा {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} किंवा {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} आणि {1}</listPatternPart>
+			<listPatternPart type="2">{0} आणि {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -12044,7 +12044,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -12098,7 +12098,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {given-informal}</namePattern>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -1302,217 +1302,217 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">EEEE, d MMMM y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">d MMMM y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">dd/MM/y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">d/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="contributed">GGGGGyMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="contributed">E, d</dateFormatItem>
+						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd" draft="contributed">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
+						<dateFormatItem id="Md" draft="contributed">d/M</dateFormatItem>
+						<dateFormatItem id="MEd" draft="contributed">E, d/M</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E, d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd" draft="contributed">d MMMM</dateFormatItem>
+						<dateFormatItem id="y" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM" draft="contributed">M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd" draft="contributed">d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd" draft="contributed">E, d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd" draft="contributed">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd" draft="contributed">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM" draft="contributed">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ" draft="contributed">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ" draft="contributed">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d/M/y GGGGG – d/M/y GGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d/M/y GGGGG – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM, y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM, y G – d MMM, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM, y – d MMM, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM, y G – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM, y – E, d MMM, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M – d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M – d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M – E, d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M – E, d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M/y – d/M/y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M/y – d/M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d/M/y – d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1626,88 +1626,88 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">zi</cyclicName>
+								<cyclicName type="2" draft="contributed">chou</cyclicName>
+								<cyclicName type="3" draft="contributed">yin</cyclicName>
+								<cyclicName type="4" draft="contributed">mao</cyclicName>
+								<cyclicName type="5" draft="contributed">chen</cyclicName>
+								<cyclicName type="6" draft="contributed">si</cyclicName>
+								<cyclicName type="7" draft="contributed">wu</cyclicName>
+								<cyclicName type="8" draft="contributed">wei</cyclicName>
+								<cyclicName type="9" draft="contributed">shen</cyclicName>
+								<cyclicName type="10" draft="contributed">you</cyclicName>
+								<cyclicName type="11" draft="contributed">xu</cyclicName>
+								<cyclicName type="12" draft="contributed">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">zi</cyclicName>
+								<cyclicName type="2" draft="contributed">chou</cyclicName>
+								<cyclicName type="3" draft="contributed">yin</cyclicName>
+								<cyclicName type="4" draft="contributed">mao</cyclicName>
+								<cyclicName type="5" draft="contributed">chen</cyclicName>
+								<cyclicName type="6" draft="contributed">si</cyclicName>
+								<cyclicName type="7" draft="contributed">wu</cyclicName>
+								<cyclicName type="8" draft="contributed">wei</cyclicName>
+								<cyclicName type="9" draft="contributed">shen</cyclicName>
+								<cyclicName type="10" draft="contributed">you</cyclicName>
+								<cyclicName type="11" draft="contributed">xu</cyclicName>
+								<cyclicName type="12" draft="contributed">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="14" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="15" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="16" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="17" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="18" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="19" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="20" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="21" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="22" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="23" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="24" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="25" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="26" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="27" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="28" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="29" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="30" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="31" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="32" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="33" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="34" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="35" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="36" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="37" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="38" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="39" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="40" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="41" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="42" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="43" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="44" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="45" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="46" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="47" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="48" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="49" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="50" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">jia-zi</cyclicName>
+								<cyclicName type="2" draft="contributed">yi-chou</cyclicName>
+								<cyclicName type="3" draft="contributed">bing-yin</cyclicName>
+								<cyclicName type="4" draft="contributed">ding-mao</cyclicName>
+								<cyclicName type="5" draft="contributed">wu-chen</cyclicName>
+								<cyclicName type="6" draft="contributed">ji-si</cyclicName>
+								<cyclicName type="7" draft="contributed">geng-wu</cyclicName>
+								<cyclicName type="8" draft="contributed">xin-wei</cyclicName>
+								<cyclicName type="9" draft="contributed">ren-shen</cyclicName>
+								<cyclicName type="10" draft="contributed">gui-you</cyclicName>
+								<cyclicName type="11" draft="contributed">jia-xu</cyclicName>
+								<cyclicName type="12" draft="contributed">yi-hai</cyclicName>
+								<cyclicName type="13" draft="contributed">bing-zi</cyclicName>
+								<cyclicName type="14" draft="contributed">ding-chou</cyclicName>
+								<cyclicName type="15" draft="contributed">wu-yin</cyclicName>
+								<cyclicName type="16" draft="contributed">ji-mao</cyclicName>
+								<cyclicName type="17" draft="contributed">geng-chen</cyclicName>
+								<cyclicName type="18" draft="contributed">xin-si</cyclicName>
+								<cyclicName type="19" draft="contributed">ren-wu</cyclicName>
+								<cyclicName type="20" draft="contributed">gui-wei</cyclicName>
+								<cyclicName type="21" draft="contributed">jia-shen</cyclicName>
+								<cyclicName type="22" draft="contributed">yi-you</cyclicName>
+								<cyclicName type="23" draft="contributed">bing-xu</cyclicName>
+								<cyclicName type="24" draft="contributed">ding-hai</cyclicName>
+								<cyclicName type="25" draft="contributed">wu-zi</cyclicName>
+								<cyclicName type="26" draft="contributed">ji-chou</cyclicName>
+								<cyclicName type="27" draft="contributed">geng-yin</cyclicName>
+								<cyclicName type="28" draft="contributed">xin-mao</cyclicName>
+								<cyclicName type="29" draft="contributed">ren-chen</cyclicName>
+								<cyclicName type="30" draft="contributed">gui-si</cyclicName>
+								<cyclicName type="31" draft="contributed">jia-wu</cyclicName>
+								<cyclicName type="32" draft="contributed">yi-wei</cyclicName>
+								<cyclicName type="33" draft="contributed">bing-shen</cyclicName>
+								<cyclicName type="34" draft="contributed">ding-you</cyclicName>
+								<cyclicName type="35" draft="contributed">wu-xu</cyclicName>
+								<cyclicName type="36" draft="contributed">ji-hai</cyclicName>
+								<cyclicName type="37" draft="contributed">geng-zi</cyclicName>
+								<cyclicName type="38" draft="contributed">xin-chou</cyclicName>
+								<cyclicName type="39" draft="contributed">ren-yin</cyclicName>
+								<cyclicName type="40" draft="contributed">gui-mao</cyclicName>
+								<cyclicName type="41" draft="contributed">jia-chen</cyclicName>
+								<cyclicName type="42" draft="contributed">yi-si</cyclicName>
+								<cyclicName type="43" draft="contributed">bing-wu</cyclicName>
+								<cyclicName type="44" draft="contributed">ding-wei</cyclicName>
+								<cyclicName type="45" draft="contributed">wu-shen</cyclicName>
+								<cyclicName type="46" draft="contributed">ji-you</cyclicName>
+								<cyclicName type="47" draft="contributed">geng-xu</cyclicName>
+								<cyclicName type="48" draft="contributed">xin-hai</cyclicName>
+								<cyclicName type="49" draft="contributed">ren-zi</cyclicName>
+								<cyclicName type="50" draft="contributed">gui-chou</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2498,21 +2498,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<eras>
 					<eraNames>
 						<era type="0">S.M.</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">S.M.</era>
 						<era type="1">TM</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">TM</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">S.M.</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">S.M.</era>
 						<era type="1">TM</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">TM</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">S.M.</era>
-						<era type="0" alt="variant" draft="contributed">↑↑↑</era>
+						<era type="0" alt="variant" draft="contributed">S.M.</era>
 						<era type="1">TM</era>
-						<era type="1" alt="variant" draft="contributed">↑↑↑</era>
+						<era type="1" alt="variant" draft="contributed">TM</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -3233,11 +3233,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
+							<month type="1">Muh.</month>
 							<month type="2">Saf.</month>
 							<month type="3">Rab. I</month>
 							<month type="4">Rab. II</month>
-							<month type="5">↑↑↑</month>
+							<month type="5">Jam. I</month>
 							<month type="6">Jam. II</month>
 							<month type="7">Rej.</month>
 							<month type="8">Syaa.</month>
@@ -3261,7 +3261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
+							<month type="1">Muharam</month>
 							<month type="2">Safar</month>
 							<month type="3">Rabiulawal</month>
 							<month type="4">Rabiulakhir</month>
@@ -3270,7 +3270,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="7">Rejab</month>
 							<month type="8">Syaaban</month>
 							<month type="9">Ramadan</month>
-							<month type="10">↑↑↑</month>
+							<month type="10">Syawal</month>
 							<month type="11">Zulkaedah</month>
 							<month type="12">Zulhijah</month>
 						</monthWidth>
@@ -3290,54 +3290,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, d MMMM y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern>d MMMM y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern>d/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="contributed">GGGGGyMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
 						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
@@ -3347,17 +3347,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="Md">d/M</dateFormatItem>
 						<dateFormatItem id="MEd">E, d/M</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
 						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMEd">E, d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
 						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
@@ -3367,11 +3367,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="japanese">
 				<eras>
 					<eraNames>
-						<era type="232" draft="contributed">↑↑↑</era>
-						<era type="233" draft="contributed">↑↑↑</era>
-						<era type="234" draft="contributed">↑↑↑</era>
-						<era type="235" draft="contributed">↑↑↑</era>
-						<era type="236" draft="contributed">↑↑↑</era>
+						<era type="232" draft="contributed">Meiji</era>
+						<era type="233" draft="contributed">Taishō</era>
+						<era type="234" draft="contributed">Shōwa</era>
+						<era type="235" draft="contributed">Heisei</era>
+						<era type="236" draft="contributed">Reiwa</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="232" draft="contributed">↑↑↑</era>
@@ -3417,191 +3417,191 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="contributed">E, d</dateFormatItem>
+						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd" draft="contributed">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
+						<dateFormatItem id="Md" draft="contributed">d/M</dateFormatItem>
+						<dateFormatItem id="MEd" draft="contributed">E, d/M</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E, d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd" draft="contributed">d MMMM</dateFormatItem>
+						<dateFormatItem id="y" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM" draft="contributed">M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd" draft="contributed">d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd" draft="contributed">E, d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd" draft="contributed">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd" draft="contributed">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM" draft="contributed">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ" draft="contributed">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ" draft="contributed">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d/M/y GGGGG – d/M/y GGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d/M/y GGGGG – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM, y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM, y G – d MMM, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM, y – d MMM, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM, y G – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM, y – E, d MMM, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M – d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M – d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M – E, d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M – E, d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d/M/y – d/M/y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M/y – d/M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d/M/y – d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d/M/y – E, d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3909,7 +3909,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-short">
 				<displayName>hari</displayName>
 				<relative type="-2">kelmarin</relative>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">semalam</relative>
 				<relative type="0">hari ini</relative>
 				<relative type="1">esok</relative>
 				<relative type="2">lusa</relative>
@@ -4243,7 +4243,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>min</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">pada minit ini</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">dlm {0} min</relativeTimePattern>
 				</relativeTime>
@@ -4253,7 +4253,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>min</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">pada minit ini</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">dlm {0} min</relativeTimePattern>
 				</relativeTime>
@@ -6585,7 +6585,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<percentSign draft="contributed">↑↑↑</percentSign>
@@ -6599,13 +6599,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<minusSign draft="contributed">↑↑↑</minusSign>
 		</symbols>
 		<symbols numberSystem="bali">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -6623,10 +6623,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="contributed">↑↑↑</decimal>
+			<decimal draft="contributed">.</decimal>
 		</symbols>
 		<symbols numberSystem="sora">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="latn">
 			<decimalFormatLength>
@@ -6954,7 +6954,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="BYR">
 				<displayName>Rubel Belarus (2000–2016)</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rubel Belarus (2000–2016)</displayName>
 				<symbol>BYR</symbol>
 			</currency>
 			<currency type="BZD">
@@ -7388,7 +7388,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>Loti Lesotho</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Loti Lesotho</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -7450,7 +7450,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="MGF">
 				<displayName draft="contributed">Franc Malagasy</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">Franc Malagasy</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MKD">
@@ -7678,7 +7678,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<symbol alt="narrow">₽</symbol>
 			</currency>
 			<currency type="RUR">
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">RUR</symbol>
 			</currency>
 			<currency type="RWF">
 				<displayName>Franc Rwanda</displayName>
@@ -8036,7 +8036,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="ZMK">
 				<displayName>Kwacha Zambia (1968–2012)</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">Kwacha Zambia (1968–2012)</displayName>
 				<symbol>ZMK</symbol>
 			</currency>
 			<currency type="ZMW">
@@ -8177,7 +8177,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0} padu</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>daya g</displayName>
@@ -8249,8 +8249,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} setiap inci persegi</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karat</displayName>
@@ -8265,8 +8265,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} milimol setiap liter</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>bahagian setiap juta</displayName>
@@ -8285,8 +8285,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} permyriad</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>liter sekilometer</displayName>
@@ -8364,7 +8364,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-quarter">
 				<displayName>suku</displayName>
 				<unitPattern count="other">{0} suku</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>bulan</displayName>
@@ -8517,8 +8517,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} bintik seinci</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>radius bumi</displayName>
@@ -8690,8 +8690,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} jisim suria</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>gigawatt</displayName>
@@ -8730,8 +8730,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inci raksa</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>milibar</displayName>
@@ -8895,8 +8895,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} auns cecair</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>sudu besar</displayName>
@@ -8928,7 +8928,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>jigger</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>cubit</displayName>
@@ -9383,8 +9383,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
@@ -9814,162 +9814,162 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>daya g</displayName>
 				<unitPattern count="other">{0} g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>meter/s²</displayName>
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>rad</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>darjah</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>min arka</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>saat arka</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektar</displayName>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>bt²</displayName>
 				<unitPattern count="other">{0} bt²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/bt²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ekar</displayName>
 				<unitPattern count="other">{0} ekar</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ela²</displayName>
+				<unitPattern count="other">{0} ela²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ka²</displayName>
@@ -9977,67 +9977,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>in²</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>per seribu</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mol</displayName>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>liter/km</displayName>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
 				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>batu/gal</displayName>
+				<unitPattern count="other">{0} bpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg UK</displayName>
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>PB</displayName>
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
@@ -10085,8 +10085,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} abad</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dkd</displayName>
+				<unitPattern count="other">{0} dkd</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>thn</displayName>
@@ -10137,127 +10137,127 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>nanosaat</displayName>
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>amp</displayName>
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>miliamp</displayName>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>ohm</displayName>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>volt</displayName>
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kkal</displayName>
 				<unitPattern count="other">{0}kkal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kal</displayName>
 				<unitPattern count="other">{0}kal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kal</displayName>
 				<unitPattern count="other">{0}Kal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kilojoule</displayName>
 				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>joule</displayName>
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh</displayName>
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>eV</displayName>
 				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>utB</displayName>
 				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>terma US</displayName>
 				<unitPattern count="other">{0}terma US</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWj/100km</displayName>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km</displayName>
 				<unitPattern count="other">{0} km</unitPattern>
 				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
@@ -10342,24 +10342,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lux</displayName>
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -10410,43 +10410,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>gr</displayName>
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>watt</displayName>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -10462,7 +10462,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -10470,11 +10470,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm</displayName>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -10482,11 +10482,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -10494,7 +10494,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kmj</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>meter/saat</displayName>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
@@ -10522,108 +10522,108 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nm</displayName>
+				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>bt³</displayName>
 				<unitPattern count="other">{0} bt³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ka³</displayName>
+				<unitPattern count="other">{0} ka³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>liter</displayName>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cawan metrik</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ekar ka</displayName>
+				<unitPattern count="other">{0} ekar ka</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. gal</displayName>
 				<unitPattern count="other">{0}galIm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pain</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cawan</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz</displayName>
 				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
@@ -10639,8 +10639,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dsp</displayName>
@@ -10651,24 +10651,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>titis</displayName>
+				<unitPattern count="other">{0} titis</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>dram fl</displayName>
 				<unitPattern count="other">{0}dr.fl.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cubit</displayName>
+				<unitPattern count="other">{0} cubit</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>arah</displayName>
@@ -10702,20 +10702,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} atau {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, atau {1}</listPatternPart>
+			<listPatternPart type="2">{0} atau {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, atau {1}</listPatternPart>
+			<listPatternPart type="2">{0} atau {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -10931,13 +10931,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
@@ -10946,40 +10946,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
@@ -10997,61 +10997,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2-initial} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">Sulaiman</nameField>

--- a/common/main/mt.xml
+++ b/common/main/mt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1572,9 +1572,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>Sn</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">is-sena l-oħra</relative>
+				<relative type="0" draft="unconfirmed">din is-sena</relative>
+				<relative type="1" draft="unconfirmed">is-sena d-dieħla</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">fi żmien sena</relativeTimePattern>
 					<relativeTimePattern count="two">fi żmien sentejn oħra</relativeTimePattern>
@@ -1592,9 +1592,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>Sena</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">is-sena l-oħra</relative>
+				<relative type="0" draft="unconfirmed">din is-sena</relative>
+				<relative type="1" draft="unconfirmed">is-sena d-dieħla</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">fi żmien sena</relativeTimePattern>
 					<relativeTimePattern count="two">fi żmien sentejn oħra</relativeTimePattern>
@@ -1712,9 +1712,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>Xahar</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">ix-xahar li għadda</relative>
 				<relative type="0" draft="unconfirmed">dan ix-xahar</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="1" draft="unconfirmed">ix-xahar id-dieħel</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">sa xahar ieħor</relativeTimePattern>
 					<relativeTimePattern count="two">sa xahrejn oħra</relativeTimePattern>
@@ -1753,19 +1753,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>ġm</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">il-ġimgħa li għaddiet</relative>
+				<relative type="0" draft="unconfirmed">din il-ġimgħa</relative>
+				<relative type="1" draft="unconfirmed">il-ġimgħa d-dieħla</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="two">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">sa ġimgħa oħra</relativeTimePattern>
+					<relativeTimePattern count="two">sa ġimagħtejn oħra</relativeTimePattern>
+					<relativeTimePattern count="few">sa {0} ġimgħat oħra</relativeTimePattern>
 					<relativeTimePattern count="many">sa {0}-il ġimgħa oħra</relativeTimePattern>
 					<relativeTimePattern count="other">sa {0} ġimgħa oħra</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">ġimgħa ilu</relativeTimePattern>
-					<relativeTimePattern count="two">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="two">ġimagħtejn ilu</relativeTimePattern>
 					<relativeTimePattern count="few">{0} ġimgħat ilu</relativeTimePattern>
 					<relativeTimePattern count="many">{0}-il ġimgħa ilu</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ġimgħa ilu</relativeTimePattern>
@@ -1774,9 +1774,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName draft="provisional">Ġimgħa</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">il-ġimgħa li għaddiet</relative>
+				<relative type="0" draft="unconfirmed">din il-ġimgħa</relative>
+				<relative type="1" draft="unconfirmed">il-ġimgħa d-dieħla</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">sa ġimgħa oħra</relativeTimePattern>
 					<relativeTimePattern count="two">sa ġimagħtejn oħra</relativeTimePattern>
@@ -1824,9 +1824,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>Jum</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">lbieraħ</relative>
+				<relative type="0" draft="unconfirmed">illum</relative>
+				<relative type="1" draft="unconfirmed">għada</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">fi żmien ġurnata</relativeTimePattern>
 					<relativeTimePattern count="two">fi żmien jumejn oħra</relativeTimePattern>
@@ -1997,7 +1997,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-short">
 				<displayName>siegħa</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">din is-siegħa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">fi żmien siegħa oħra</relativeTimePattern>
 					<relativeTimePattern count="two">fi żmien sagħtejn</relativeTimePattern>
@@ -2015,7 +2015,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-narrow">
 				<displayName>siegħa</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">din is-siegħa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">fi żmien siegħa oħra</relativeTimePattern>
 					<relativeTimePattern count="two">fi żmien sagħtejn</relativeTimePattern>
@@ -2051,7 +2051,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-short">
 				<displayName>min.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">din il-minuta</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">sa min. oħra</relativeTimePattern>
 					<relativeTimePattern count="two">sa {0} min. oħra</relativeTimePattern>
@@ -2069,7 +2069,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-narrow">
 				<displayName>m</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">din il-minuta</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">sa min. oħra</relativeTimePattern>
 					<relativeTimePattern count="two">sa {0} min. oħra</relativeTimePattern>
@@ -2105,7 +2105,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="second-short">
 				<displayName>sek.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">issa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">sa sek. oħra</relativeTimePattern>
 					<relativeTimePattern count="two">sa {0} sek. oħra</relativeTimePattern>
@@ -2123,7 +2123,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="second-narrow">
 				<displayName>s</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">issa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">sa sek. oħra</relativeTimePattern>
 					<relativeTimePattern count="two">sa {0} sek. oħra</relativeTimePattern>

--- a/common/main/mus.xml
+++ b/common/main/mus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -80,13 +80,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<days>
 					<dayContext type="format">
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">S</day>
+							<day type="mon">M</day>
+							<day type="tue">T</day>
+							<day type="wed">W</day>
+							<day type="thu">T</day>
+							<day type="fri">F</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">Nettv Cako</day>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -1064,7 +1064,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1072,7 +1072,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1080,7 +1080,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1088,7 +1088,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1629,7 +1629,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1637,7 +1637,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1645,7 +1645,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1653,7 +1653,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1878,9 +1878,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>နှစ်</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ယမန်နှစ်</relative>
+				<relative type="0">ယခုနှစ်</relative>
+				<relative type="1">လာမည့်နှစ်</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} နှစ်အတွင်း</relativeTimePattern>
 				</relativeTime>
@@ -1890,9 +1890,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>နှစ်</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ယမန်နှစ်</relative>
+				<relative type="0">ယခုနှစ်</relative>
+				<relative type="1">လာမည့်နှစ်</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} နှစ်အတွင်း</relativeTimePattern>
 				</relativeTime>
@@ -1950,9 +1950,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>လ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ပြီးခဲ့သည့်လ</relative>
+				<relative type="0">ယခုလ</relative>
+				<relative type="1">လာမည့်လ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} လအတွင်း</relativeTimePattern>
 				</relativeTime>
@@ -1962,9 +1962,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>လ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ပြီးခဲ့သည့်လ</relative>
+				<relative type="0">ယခုလ</relative>
+				<relative type="1">လာမည့်လ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} လအတွင်း</relativeTimePattern>
 				</relativeTime>
@@ -1987,9 +1987,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>ပတ်</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ပြီးခဲ့သည့် သီတင်းပတ်</relative>
+				<relative type="0">ယခု သီတင်းပတ်</relative>
+				<relative type="1">လာမည့် သီတင်းပတ်</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} ပတ်အတွင်း</relativeTimePattern>
 				</relativeTime>
@@ -2000,9 +2000,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>ပတ်</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ပြီးခဲ့သည့် သီတင်းပတ်</relative>
+				<relative type="0">ယခု သီတင်းပတ်</relative>
+				<relative type="1">လာမည့် သီတင်းပတ်</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} ပတ်အတွင်း</relativeTimePattern>
 				</relativeTime>
@@ -2036,9 +2036,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>ရက်</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">မနေ့က</relative>
+				<relative type="0">ယနေ့</relative>
+				<relative type="1">မနက်ဖြန်</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} ရက်အတွင်း</relativeTimePattern>
 				</relativeTime>
@@ -2048,9 +2048,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>ရက်</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">မနေ့က</relative>
+				<relative type="0">ယနေ့</relative>
+				<relative type="1">မနက်ဖြန်</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} ရက်အတွင်း</relativeTimePattern>
 				</relativeTime>
@@ -4656,7 +4656,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -5866,7 +5866,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">ကုဗ{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ဆွဲငင်အား</displayName>
@@ -5954,8 +5954,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">တစ်လီတာရှိ {0} မီလီမိုးလ်</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>တစ်သန်းပုံ တစ်ပုံ</displayName>
@@ -6158,8 +6158,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} နယူတန်</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>ဂီဂါဟတ်ဇ်</displayName>
@@ -6431,8 +6431,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ကမ္ဘာ့လေထု</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>ဟက်တိုပါစကယ်</displayName>
@@ -7506,55 +7506,55 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
 				<unitPrefixPattern>Z{0}</unitPrefixPattern>
@@ -7590,348 +7590,348 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>ဆွဲငင်အား</displayName>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မီတာ/စက္ကန့်နှစ်ထပ်ကိန်း</displayName>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ရေဒီယဲန်း</displayName>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>ဒီဂရီ</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>မိနစ်</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>စက္ကန့်</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>စတုရန်းကီလိုမီတာ</displayName>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ဟက်တာ</displayName>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>စတုရန်းမီတာ</displayName>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>စတုရန်းစင်တီမီတာ</displayName>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>စတုရန်းမိုင်</displayName>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ဧက</displayName>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>စတုရန်းကိုက်</displayName>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>စတုရန်းပေ</displayName>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>စတုရန်းလက်မ</displayName>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunams</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကာရက်</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>တစ်သန်းပုံ တစ်ပုံ</displayName>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ပါမီရိတ်</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>L/km</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
 				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မိုင်/ဂါလန်</displayName>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpg Imp.</displayName>
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ပက်တာဘိုက်</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>တယ်ရာဘိုက်</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>တယ်ရာဘစ်</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဂစ်ဂါဘိုက်</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gb</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မီဂါဘိုက်</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မီဂါဘစ်</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကီလိုဘိုက်</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကီလိုဘစ်</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဘစ်</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ရာစု</displayName>
+				<unitPattern count="other">{0} ရာစု</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဆယ်စု</displayName>
+				<unitPattern count="other">{0} ဆယ်စု</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>နှစ်</displayName>
 				<unitPattern count="other">{0} နှစ်</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ နှစ်</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>qtr</displayName>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>လ</displayName>
 				<unitPattern count="other">{0} လ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ လ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ပတ်</displayName>
 				<unitPattern count="other">{0} ပတ်</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ ပတ်</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ရက်</displayName>
 				<unitPattern count="other">{0} ရက်</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ ရက်</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>နာရီ</displayName>
 				<unitPattern count="other">{0} နာရီ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ နာရီ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>မိနစ်</displayName>
 				<unitPattern count="other">{0} မိနစ်</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ မိနစ်</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>စက္ကန့်</displayName>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>မီလီစက္ကန့်</displayName>
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မိုက်ခရိုစက္ကန့်</displayName>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>နာနိုစက္ကန့်</displayName>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amp</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>အုမ်း</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဗို့</displayName>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကီလိုကယ်လိုရီ</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကယ်လိုရီ</displayName>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကယ်လိုရီ</displayName>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကီလိုဂျူးလ်</displayName>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဂျူးလ်</displayName>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကီလိုဝပ်-နာရီ</displayName>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>အီလက်ထရွန်ဗို့</displayName>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>ယူအက်စ် သာမယ်လ်</displayName>
 				<unitPattern count="other">{0}US therms</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>GHz</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မီဂါဟတ်ဇ်</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ပစ်ဆယ်</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မီဂါပစ်ဆယ်</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
@@ -7948,21 +7948,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -7970,19 +7970,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>μm</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mi</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>yd</displayName>
@@ -7991,40 +7991,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-foot">
 				<displayName>ft</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>in</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ပါစက်ခ်</displayName>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>ly</displayName>
 				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>ဖာလုံ</displayName>
 				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>ဖန်တမ်</displayName>
 				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>nmi</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pts</displayName>
@@ -8032,15 +8032,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>လတ်ခ်</displayName>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>lm</displayName>
@@ -8048,213 +8048,213 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မက်ထရစ်တန်</displayName>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>ကီလိုဂရမ်</displayName>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>ဂရမ်</displayName>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မီလီဂရမ်</displayName>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>တန်</displayName>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>စတုန်</displayName>
+				<unitPattern count="other">{0} စတုန်</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>ပေါင်</displayName>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>အောင်စ</displayName>
 				<unitPattern count="other">{0} oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ထရိုအောင်စ</displayName>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကာရက်</displayName>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဒဲလ်တန်စ်</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကမ္ဘာ့ဒြပ်ထု</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>နေရောင်ခြည် ဒြပ်ထု</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဂရိန်</displayName>
+				<unitPattern count="other">{0} ဂရိန်</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဂစ်ဂါဝပ်</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မီဂါဝပ်</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ကီလိုဝပ်</displayName>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ဝပ်</displayName>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မီလီဝပ်</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>psi</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>″ Hg</displayName>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဘား</displayName>
+				<unitPattern count="other">{0} ဘား</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ကီလိုမီတာ/နာရီ</displayName>
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>မီတာ/စက္ကန့်</displayName>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>မိုင်/နာရီ</displayName>
 				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf.ft</displayName>
+				<unitPattern count="other">{0} lbf.ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N.m</displayName>
+				<unitPattern count="other">{0} N.m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ကုဗကီလိုမီတာ</displayName>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ကုဗမီတာ</displayName>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>cm³</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>yd³</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>ft³</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>in³</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>လီတာ</displayName>
@@ -8262,102 +8262,102 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/လီတာ</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဒက်စီလီတာ</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>စင်တီလီတာ</displayName>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မီလီလီတာ</displayName>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မထ္ထရစ်ပိုင့်</displayName>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>မထ္ထရစ်ခွက်</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဧက-ပေ</displayName>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>၈ ဂါလံဝင်ပုံး</displayName>
+				<unitPattern count="other">၈ ဂါလံဝင်ပုံး {0} ပုံး</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ဂါလံ</displayName>
+				<unitPattern count="other">{0} ဂါလံ</unitPattern>
+				<perUnitPattern>{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ယူကေ ဂါလံ</displayName>
 				<unitPattern count="other">ယူကေ ဂါလံ {0} ဂါလံ</unitPattern>
 				<perUnitPattern>{0}/ယူကေ ဂါလံ</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ကွတ်</displayName>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ပိုင့်</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ခွက်</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>အရည်အောင်စ</displayName>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>ဗြိတိသျှသုံး အရည်အောင်စ</displayName>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>စားပွဲဇွန်း</displayName>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>လက်ဖက်ရည်ဇွန်း</displayName>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>စည်</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>အချိုပွဲဇွန်း</displayName>
+				<unitPattern count="other">အချိုပွဲဇွန်း {0} ဇွန်း</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဗြိတိသျှသုံး အချိုပွဲဇွန်း</displayName>
+				<unitPattern count="other">ဗြိတိသျှသုံးအချိုပွဲဇွန်း {0} ဇွန်း</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>စက်</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} စက်</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဒရမ်</displayName>
+				<unitPattern count="other">{0} ဒရမ်</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ပက်</displayName>
+				<unitPattern count="other">{0} ပက်</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>တစ်ဆိတ်</displayName>
+				<unitPattern count="other">{0} ဆိတ်</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ဗြိတိသျှသုံး ကွတ်</displayName>
+				<unitPattern count="other">ဗြိတိသျှသုံး {0} ကွတ်</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>လမ်းကြောင်း</displayName>
@@ -8393,20 +8393,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<listPattern type="or-narrow">
 			<listPatternPart type="start">{0} - {1}</listPatternPart>
 			<listPatternPart type="middle">{0} - {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} သို့မဟုတ် {1}</listPatternPart>
+			<listPatternPart type="2">{0} သို့မဟုတ် {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
 			<listPatternPart type="start">{0} - {1}</listPatternPart>
 			<listPatternPart type="middle">{0} - {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} သို့မဟုတ် {1}</listPatternPart>
+			<listPatternPart type="2">{0} သို့မဟုတ် {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0} - {1}</listPatternPart>
 			<listPatternPart type="middle">{0} - {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0}နှင့် {1}</listPatternPart>
+			<listPatternPart type="2">{0}နှင့် {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0} - {1}</listPatternPart>
@@ -8619,127 +8619,127 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>{surname-core}၊ {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}၊ {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}၊ {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}၊ {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}၊ {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}၊ {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">ဇင်ဒါယာ</nameField>

--- a/common/main/myv.xml
+++ b/common/main/myv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -26,9 +26,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="en_AU" draft="unconfirmed">Австралиянь англонь кель</language>
 			<language type="en_CA" draft="unconfirmed">Канадань англонь кель</language>
 			<language type="en_GB" draft="unconfirmed">Британиянь англонь кель</language>
-			<language type="en_GB" alt="short" draft="unconfirmed">↑↑↑</language>
+			<language type="en_GB" alt="short" draft="unconfirmed">Британиянь англонь кель</language>
 			<language type="en_US" draft="unconfirmed">Американь англонь кель</language>
-			<language type="en_US" alt="short" draft="unconfirmed">↑↑↑</language>
+			<language type="en_US" alt="short" draft="unconfirmed">Американь англонь кель</language>
 			<language type="es" draft="unconfirmed">испанонь кель</language>
 			<language type="es_ES" draft="unconfirmed">Европань испанонь кель</language>
 			<language type="fr" draft="unconfirmed">французонь кель</language>
@@ -335,9 +335,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName draft="unconfirmed">ие</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">мелят</relative>
+				<relative type="0" draft="unconfirmed">тедиде</relative>
+				<relative type="1" draft="unconfirmed">сы иестэ</relative>
 			</field>
 			<field type="year-narrow">
 				<displayName draft="unconfirmed">ие</displayName>
@@ -346,10 +346,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">нилеце пелькс</displayName>
 			</field>
 			<field type="quarter-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">нилеце пелькс</displayName>
 			</field>
 			<field type="quarter-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">нилеце пелькс</displayName>
 			</field>
 			<field type="month">
 				<displayName draft="unconfirmed">ков</displayName>
@@ -358,10 +358,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1" draft="unconfirmed">сы ковсто</relative>
 			</field>
 			<field type="month-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ков</displayName>
 			</field>
 			<field type="month-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ков</displayName>
 			</field>
 			<field type="week">
 				<displayName draft="unconfirmed">тарго</displayName>
@@ -371,10 +371,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativePeriod draft="unconfirmed">{0} таргостонть</relativePeriod>
 			</field>
 			<field type="week-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">тарго</displayName>
 			</field>
 			<field type="week-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">тарго</displayName>
 			</field>
 			<field type="day">
 				<displayName draft="unconfirmed">чи</displayName>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -123,8 +123,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">चेरोकी</language>
 			<language type="chy">चेयेन्ने</language>
 			<language type="ckb">मध्यवर्ती कुर्दिस</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">मध्यवर्ती कुर्दिस</language>
+			<language type="ckb" alt="variant">मध्यवर्ती कुर्दिस</language>
 			<language type="clc">चिलकोटिन</language>
 			<language type="co">कोर्सिकन</language>
 			<language type="cop">कोप्टिक</language>
@@ -1261,7 +1261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1269,7 +1269,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1464,7 +1464,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<monthWidth type="narrow">
 							<month type="1">जन</month>
 							<month type="2">फेब</month>
-							<month type="3">↑↑↑</month>
+							<month type="3">मार्च</month>
 							<month type="4">अप्र</month>
 							<month type="5">मे</month>
 							<month type="6">जुन</month>
@@ -2148,9 +2148,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>वर्ष</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">गत वर्ष</relative>
+				<relative type="0">यो वर्ष</relative>
+				<relative type="1">आगामी वर्ष</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} वर्षमा</relativeTimePattern>
 					<relativeTimePattern count="other">{0} वर्षमा</relativeTimePattern>
@@ -2162,9 +2162,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>वर्ष</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">गत वर्ष</relative>
+				<relative type="0">यो वर्ष</relative>
+				<relative type="1">आगामी वर्ष</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} वर्षमा</relativeTimePattern>
 					<relativeTimePattern count="other">{0} वर्षमा</relativeTimePattern>
@@ -2226,8 +2226,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>महिना</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">गत महिना</relative>
+				<relative type="0">यो महिना</relative>
 				<relative type="1">आगामी महिना</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} महिनामा</relativeTimePattern>
@@ -2240,8 +2240,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>महिना</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">गत महिना</relative>
+				<relative type="0">यो महिना</relative>
 				<relative type="1">आगामी महिना</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} महिनामा</relativeTimePattern>
@@ -2269,8 +2269,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>हप्ता</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">गत हप्ता</relative>
+				<relative type="0">यो हप्ता</relative>
 				<relative type="1">आगामी हप्ता</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} हप्तामा</relativeTimePattern>
@@ -2284,8 +2284,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>हप्ता</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">गत हप्ता</relative>
+				<relative type="0">यो हप्ता</relative>
 				<relative type="1">आगामी हप्ता</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} हप्तामा</relativeTimePattern>
@@ -2324,9 +2324,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>बार</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">हिजो</relative>
+				<relative type="0">आज</relative>
+				<relative type="1">भोलि</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} दिनमा</relativeTimePattern>
 					<relativeTimePattern count="other">{0} दिनमा</relativeTimePattern>
@@ -2338,9 +2338,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>बार</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">हिजो</relative>
+				<relative type="0">आज</relative>
+				<relative type="1">भोलि</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} दिनमा</relativeTimePattern>
 					<relativeTimePattern count="other">{0} दिनमा</relativeTimePattern>
@@ -2525,7 +2525,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">यो बुधबार</relative>
 				<relative type="1">अर्को बुधबार</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} बुधबारमा</relativeTimePattern>
 					<relativeTimePattern count="other">{0} बुधबारमाहरूमा</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
@@ -4980,7 +4980,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -5553,8 +5553,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="HTG">
 				<displayName>हैटियाली गुर्ड</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">हैटियाली गुर्ड</displayName>
+				<displayName count="other">हैटियाली गुर्ड</displayName>
 				<symbol>HTG</symbol>
 			</currency>
 			<currency type="HUF">
@@ -6134,7 +6134,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="USD">
 				<displayName>अमेरिकी डलर</displayName>
 				<displayName count="one">अमेरिकी डलर</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">अमेरिकी डलर</displayName>
 				<symbol>US$</symbol>
 				<symbol alt="narrow">$</symbol>
 			</currency>
@@ -6352,7 +6352,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">घन {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>गुरूत्वाकर्षण शक्ति</displayName>
@@ -6739,8 +6739,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>टाइपोग्रापिक एम</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>पिक्सेल</displayName>
@@ -7399,7 +7399,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7532,7 +7532,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>पर्माइराइड</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -7790,37 +7790,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>पिक्सेल</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>मेगापिक्सेल</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
@@ -7940,7 +7940,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>सौर्य रेडिआई</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -7960,7 +7960,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>सौर्य प्रकाश</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8029,12 +8029,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>पृथ्वी घन</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>सौर्य घन</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8104,7 +8104,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>Pa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8164,7 +8164,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -8294,7 +8294,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -8449,26 +8449,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>गुरूत्वाकर्षण शक्ति</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}परिक्रमा</unitPattern>
+				<unitPattern count="other">{0}परिक्रमा</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<unitPattern count="one">{0}°</unitPattern>
@@ -8495,37 +8495,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ब.मि.</unitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>वर्ग माइल</displayName>
 				<unitPattern count="one">{0} बर्ग माईल</unitPattern>
 				<unitPattern count="other">{0} बर्ग माईल</unitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>वर्ग गज</displayName>
 				<unitPattern count="one">{0} एकर</unitPattern>
 				<unitPattern count="other">{0} एकर</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>वर्ग यार्ड</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<unitPattern count="one">{0} ब.फु.</unitPattern>
 				<unitPattern count="other">{0} ब.फु.</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>वर्ग इन्च</displayName>
+				<unitPattern count="one">{0}वर्ग इन्च</unitPattern>
+				<unitPattern count="other">{0}वर्ग इन्च</unitPattern>
+				<perUnitPattern>{0}प्रति वर्ग इन्च</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>डुनाम</displayName>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>वस्तु</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} वस्तु</unitPattern>
+				<unitPattern count="other">{0} वस्तु</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>प्रतिशत</displayName>
@@ -8542,12 +8542,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>शताब्दी</displayName>
+				<unitPattern count="one">{0} शताब्दी</unitPattern>
+				<unitPattern count="other">{0} शताब्दी</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>दशाब्दी</displayName>
 				<unitPattern count="one">{0} दशक</unitPattern>
 				<unitPattern count="other">{0} दशक</unitPattern>
 			</unit>
@@ -8574,13 +8574,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>दिन</displayName>
 				<unitPattern count="one">{0} दिन</unitPattern>
 				<unitPattern count="other">{0} दिन</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/दिन</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>घण्टा</displayName>
 				<unitPattern count="one">{0} घण्टा</unitPattern>
 				<unitPattern count="other">{0} घण्टा</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}प्रति घण्टा</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>मिनेट</displayName>
@@ -8598,19 +8598,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}मि.से.</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>माइक्रोसेकेन्ड</displayName>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>पिक्सेल</displayName>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>बिन्‍दु</displayName>
+				<unitPattern count="one">{0} बिन्‍दु</unitPattern>
+				<unitPattern count="other">{0} बिन्‍दु</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>कि.मि.</displayName>
@@ -8657,75 +8657,75 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>फर्लंग</displayName>
+				<unitPattern count="one">{0} फर</unitPattern>
 				<unitPattern count="other">{0}फर</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<unitPattern count="one">{0}L☉</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>किलो</displayName>
 				<unitPattern count="one">{0} किलो</unitPattern>
 				<unitPattern count="other">{0} किलो</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}प्रति किलो</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>ग्राम</displayName>
 				<unitPattern count="one">{0} ग्राम</unitPattern>
 				<unitPattern count="other">{0} ग्राम</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}प्रति ग्राम</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>मिलिग्राम</displayName>
+				<unitPattern count="one">{0}मिलिग्राम</unitPattern>
+				<unitPattern count="other">{0}मिलिग्राम</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>टन</displayName>
+				<unitPattern count="one">{0}टन</unitPattern>
+				<unitPattern count="other">{0}टन</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>स्टोन</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>पाउन्ड</displayName>
 				<unitPattern count="one">{0} पाउण्ड</unitPattern>
 				<unitPattern count="other">{0} पाउण्ड</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}प्रति पाउन्ड</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>आउन्स</displayName>
 				<unitPattern count="one">{0} आऊन्स</unitPattern>
 				<unitPattern count="other">{0} आऊन्स</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}प्रति आउन्स</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ओज ट्रोय</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} डाल्टन</unitPattern>
+				<unitPattern count="other">{0} डाल्टन</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>किलोवाट</displayName>
@@ -8750,8 +8750,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} मिलीबार</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} वायु</unitPattern>
+				<unitPattern count="other">{0} वायु</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<unitPattern count="one">{0} hPa</unitPattern>
@@ -8763,19 +8763,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>मिटर प्रति सेकेण्ड</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>माइल प्रति घण्टा</displayName>
 				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°से</displayName>
@@ -8787,7 +8787,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°फ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>घन किलोमिटर</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
@@ -8796,7 +8796,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} घन माईल</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>घन इन्च</displayName>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>लिटर</displayName>
@@ -8804,73 +8804,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} लि.</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>बुशेल</displayName>
 			</unit>
 			<unit type="volume-gallon">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}ग्यालोन</unitPattern>
+				<unitPattern count="other">{0}ग्यालोन</unitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>क्वार्ट्स</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>पिन्ट</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>कप्स</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ब्यारल</displayName>
+				<unitPattern count="one">{0} ब्यारल</unitPattern>
+				<unitPattern count="other">{0} ब्यारल</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstspn</displayName>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>थोपा</displayName>
 			</unit>
 			<unit type="volume-dram">
 				<unitPattern count="one">{0}fl.dr.</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ड्राम fl</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>चुटकी</displayName>
+				<unitPattern count="one">{0} चुटकी</unitPattern>
+				<unitPattern count="other">{0} चुटकी</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>दिशा</displayName>
@@ -8904,19 +8904,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} वा {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, वा {1}</listPatternPart>
+			<listPatternPart type="2">{0} वा {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, वा {1}</listPatternPart>
+			<listPatternPart type="2">{0} वा {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0},{1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -1169,7 +1169,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunesië</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkije</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkije</territory>
 			<territory type="TT">Trinidad en Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1640,7 +1640,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1648,7 +1648,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1656,7 +1656,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
@@ -1682,54 +1682,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M-y GGGGG – M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M-y – M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M-y – M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d-M-y GGGGG – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d-M-y GGGGG – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -2724,7 +2724,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2732,7 +2732,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2740,7 +2740,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2748,7 +2748,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3065,7 +3065,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -3073,7 +3073,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3081,7 +3081,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">E d</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd" draft="contributed">E d MMM y G</dateFormatItem>
@@ -3107,54 +3107,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M-y GGGGG – M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M-y – M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M-y – M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d-M-y GGGGG – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d-M-y GGGGG – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -4165,7 +4165,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4173,7 +4173,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4184,9 +4184,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="GyMMM" draft="contributed">MMM r (U)</dateFormatItem>
 						<dateFormatItem id="GyMMMd" draft="contributed">d MMM r</dateFormatItem>
 						<dateFormatItem id="GyMMMEd" draft="contributed">E d MMM r (U)</dateFormatItem>
-						<dateFormatItem id="GyMMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMEd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMMMM" draft="contributed">MMMM r(U)</dateFormatItem>
+						<dateFormatItem id="GyMMMMd" draft="contributed">d MMMM r(U)</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd" draft="contributed">E d MMMM r(U)</dateFormatItem>
 						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
 						<dateFormatItem id="Md" draft="contributed">d-M</dateFormatItem>
 						<dateFormatItem id="MEd" draft="contributed">E d-M</dateFormatItem>
@@ -4208,21 +4208,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyMMMd" draft="contributed">d MMM r</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd" draft="contributed">E d MMM r (U)</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM" draft="contributed">MMMM r (U)</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd" draft="contributed">d MMMM r(U)</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd" draft="contributed">E d MMMM r(U)</dateFormatItem>
 						<dateFormatItem id="yyyyQQQ" draft="contributed">QQQ r (U)</dateFormatItem>
 						<dateFormatItem id="yyyyQQQQ" draft="contributed">QQQQ r (U)</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
@@ -4478,7 +4478,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4486,7 +4486,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4494,7 +4494,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
@@ -4520,54 +4520,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M-y GGGGG – M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M-y – M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M-y – M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d-M-y GGGGG – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d-M-y GGGGG – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -5032,9 +5032,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">Z</day>
-							<day type="mon">↑↑↑</day>
+							<day type="mon">M</day>
 							<day type="tue">D</day>
-							<day type="wed">↑↑↑</day>
+							<day type="wed">W</day>
 							<day type="thu">D</day>
 							<day type="fri">V</day>
 							<day type="sat">Z</day>
@@ -5293,7 +5293,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -5301,7 +5301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5511,17 +5511,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<monthWidth type="abbreviated">
 							<month type="1">Tisjrie</month>
 							<month type="2">Chesjwan</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
 							<month type="5">Sjevat</month>
 							<month type="6">Adar A</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">Adar</month>
 							<month type="7" yeartype="leap">Adar B</month>
-							<month type="8">↑↑↑</month>
+							<month type="8">Nisan</month>
 							<month type="9">Ijar</month>
-							<month type="10">↑↑↑</month>
+							<month type="10">Sivan</month>
 							<month type="11">Tammoez</month>
-							<month type="12">↑↑↑</month>
+							<month type="12">Av</month>
 							<month type="13">Elloel</month>
 						</monthWidth>
 						<monthWidth type="narrow">
@@ -5561,17 +5561,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<monthWidth type="abbreviated">
 							<month type="1">Tisjrie</month>
 							<month type="2">Chesjwan</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
 							<month type="5">Sjevat</month>
 							<month type="6">Adar A</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">Adar</month>
 							<month type="7" yeartype="leap">Adar B</month>
-							<month type="8">↑↑↑</month>
+							<month type="8">Nisan</month>
 							<month type="9">Ijar</month>
-							<month type="10">↑↑↑</month>
+							<month type="10">Sivan</month>
 							<month type="11">Tammoez</month>
-							<month type="12">↑↑↑</month>
+							<month type="12">Av</month>
 							<month type="13">Elloel</month>
 						</monthWidth>
 						<monthWidth type="narrow">
@@ -5593,17 +5593,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<monthWidth type="wide">
 							<month type="1">Tisjrie</month>
 							<month type="2">Chesjwan</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
 							<month type="5">Sjevat</month>
 							<month type="6">Adar A</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">Adar</month>
 							<month type="7" yeartype="leap">Adar B</month>
-							<month type="8">↑↑↑</month>
+							<month type="8">Nisan</month>
 							<month type="9">Ijar</month>
-							<month type="10">↑↑↑</month>
+							<month type="10">Sivan</month>
 							<month type="11">Tammoez</month>
-							<month type="12">↑↑↑</month>
+							<month type="12">Av</month>
 							<month type="13">Elloel</month>
 						</monthWidth>
 					</monthContext>
@@ -5667,7 +5667,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -5675,7 +5675,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5683,7 +5683,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">E d</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd" draft="contributed">E d MMM y G</dateFormatItem>
@@ -5709,54 +5709,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M-y GGGGG – M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M-y – M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M-y – M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d-M-y GGGGG – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d-M-y GGGGG – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -6003,7 +6003,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -6011,7 +6011,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -6019,7 +6019,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">E d</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd" draft="contributed">E d MMM y G</dateFormatItem>
@@ -6045,54 +6045,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M-y GGGGG – M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M-y – M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M-y – M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d-M-y GGGGG – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d-M-y GGGGG – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -6238,14 +6238,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
 							<month type="1">Moeh.</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
+							<month type="2">Saf.</month>
+							<month type="3">Rab. I</month>
+							<month type="4">Rab. II</month>
 							<month type="5">Joem. I</month>
 							<month type="6">Joem. II</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">Raj.</month>
 							<month type="8">Sja.</month>
-							<month type="9">↑↑↑</month>
+							<month type="9">Ram.</month>
 							<month type="10">Sjaw.</month>
 							<month type="11">Doe al k.</month>
 							<month type="12">Doe al h.</month>
@@ -6266,14 +6266,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Moeharram</month>
-							<month type="2">↑↑↑</month>
+							<month type="2">Safar</month>
 							<month type="3">Rabiʻa al awal</month>
 							<month type="4">Rabiʻa al thani</month>
 							<month type="5">Joemadʻal awal</month>
 							<month type="6">Joemadʻal thani</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">Rajab</month>
 							<month type="8">Sjaʻaban</month>
-							<month type="9">↑↑↑</month>
+							<month type="9">Ramadan</month>
 							<month type="10">Sjawal</month>
 							<month type="11">Doe al kaʻaba</month>
 							<month type="12">Doe al hizja</month>
@@ -6339,7 +6339,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -6347,7 +6347,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -6355,7 +6355,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
@@ -6381,54 +6381,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M-y GGGGG – M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M-y – M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M-y – M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d-M-y GGGGG – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d-M-y GGGGG – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -6764,7 +6764,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<era type="233" draft="contributed">Taishō</era>
 						<era type="234" draft="contributed">Shōwa</era>
 						<era type="235" draft="contributed">Heisei</era>
-						<era type="236">↑↑↑</era>
+						<era type="236">Reiwa</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="contributed">Taika (645–650)</era>
@@ -7293,7 +7293,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -7301,7 +7301,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -7309,7 +7309,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
@@ -7335,54 +7335,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M-y GGGGG – M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M-y – M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M-y – M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d-M-y GGGGG – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d-M-y GGGGG – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -7629,7 +7629,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -7637,7 +7637,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -7645,7 +7645,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">E d</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd" draft="contributed">E d MMM y G</dateFormatItem>
@@ -7671,54 +7671,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M-y GGGGG – M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M-y – M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M-y – M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d-M-y GGGGG – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d-M-y GGGGG – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -7878,7 +7878,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -7886,7 +7886,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -7894,7 +7894,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">E d</dateFormatItem>
 						<dateFormatItem id="Gy">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
@@ -7920,54 +7920,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M-y GGGGG – M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M-y – M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M-y – M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d-M-y GGGGG – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d-M-y – d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d-M-y GGGGG – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d-M-y – E d-M-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -11078,19 +11078,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">٫</decimal>
@@ -11129,7 +11129,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11144,7 +11144,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11159,7 +11159,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11174,7 +11174,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11189,7 +11189,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11204,7 +11204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11219,7 +11219,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11234,7 +11234,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11249,7 +11249,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11264,7 +11264,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11279,7 +11279,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11294,7 +11294,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11303,19 +11303,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
 			<decimal draft="contributed">,</decimal>
@@ -11324,7 +11324,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11339,7 +11339,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11354,7 +11354,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11369,7 +11369,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11384,7 +11384,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11399,7 +11399,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11414,7 +11414,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11444,7 +11444,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11459,7 +11459,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11474,7 +11474,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11489,7 +11489,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11504,7 +11504,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11519,7 +11519,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11534,7 +11534,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11549,7 +11549,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11564,7 +11564,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11579,7 +11579,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11594,7 +11594,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11609,7 +11609,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11624,7 +11624,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11639,7 +11639,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11654,7 +11654,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11669,7 +11669,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11684,7 +11684,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11699,7 +11699,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11714,7 +11714,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11729,7 +11729,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11744,7 +11744,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11759,7 +11759,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11774,7 +11774,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign draft="contributed">%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
+			<approximatelySign draft="contributed">~</approximatelySign>
 			<exponential draft="contributed">E</exponential>
 			<superscriptingExponent draft="contributed">×</superscriptingExponent>
 			<perMille draft="contributed">‰</perMille>
@@ -11785,7 +11785,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -12163,7 +12163,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -12485,7 +12485,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -12807,17 +12807,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
+			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12827,7 +12827,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">#,##0.00 ¤</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -12835,14 +12835,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12850,14 +12850,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12865,14 +12865,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12880,14 +12880,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12895,14 +12895,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12910,14 +12910,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12925,14 +12925,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12940,14 +12940,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12955,14 +12955,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12970,14 +12970,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -12985,14 +12985,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13000,14 +13000,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13015,14 +13015,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13030,14 +13030,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13045,14 +13045,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13060,14 +13060,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13075,14 +13075,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13090,14 +13090,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13105,14 +13105,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13120,14 +13120,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13178,14 +13178,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13193,14 +13193,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13208,14 +13208,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13223,14 +13223,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13238,14 +13238,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13253,14 +13253,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13268,14 +13268,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13283,14 +13283,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13298,14 +13298,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13313,14 +13313,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13328,14 +13328,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13343,14 +13343,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13358,14 +13358,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13373,14 +13373,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13388,14 +13388,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13403,14 +13403,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13418,14 +13418,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13433,14 +13433,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13448,14 +13448,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13463,14 +13463,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13478,14 +13478,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13493,14 +13493,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -13508,14 +13508,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="contributed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="contributed">↑↑↑</currencyPatternAppendISO>
+			<currencyPatternAppendISO draft="contributed">{0} ¤¤</currencyPatternAppendISO>
 			<unitPattern count="one" draft="contributed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="contributed">{0} {1}</unitPattern>
 		</currencyFormats>
@@ -14952,8 +14952,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="SLE">
 				<displayName>Sierra Leoonse leone</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Sierra Leoonse leone</displayName>
+				<displayName count="other">Sierra Leoonse leone</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="SLL">
@@ -15456,10 +15456,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 		</currencies>
 		<miscPatterns numberSystem="adlm">
-			<pattern type="approximately" draft="contributed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="contributed">↑↑↑</pattern>
-			<pattern type="atMost" draft="contributed">↑↑↑</pattern>
-			<pattern type="range" draft="contributed">↑↑↑</pattern>
+			<pattern type="approximately" draft="contributed">~{0}</pattern>
+			<pattern type="atLeast" draft="contributed">{0}+</pattern>
+			<pattern type="atMost" draft="contributed">≤{0}</pattern>
+			<pattern type="range" draft="contributed">{0}-{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arab">
 			<pattern type="approximately" draft="contributed">~{0}</pattern>
@@ -15831,16 +15831,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>vierkante {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">vierkante {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="common">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="common">vierkante {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">vierkante {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="common">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="common">vierkante {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>kubieke {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kubieke {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="common">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="common">kubieke {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kubieke {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="common">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="common">kubieke {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}{1}</compoundUnitPattern>
@@ -15945,9 +15945,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} per vierkante inch</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<gender>neuter</gender>
@@ -15998,9 +15998,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>common</gender>
@@ -16089,7 +16089,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="digital-bit">
 				<gender>common</gender>
 				<displayName>bit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bit</unitPattern>
 				<unitPattern count="other">{0} bits</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -16583,7 +16583,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="mass-grain">
 				<gender>neuter</gender>
 				<displayName>grein</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grein</unitPattern>
 				<unitPattern count="other">{0} grein</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -16924,7 +16924,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>jigger</displayName>
 				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">{0} jiggers</unitPattern>
 			</unit>
@@ -17038,12 +17038,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -17136,7 +17136,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -17176,12 +17176,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -17384,12 +17384,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -17399,17 +17399,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -17468,13 +17468,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pixels</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -17584,7 +17584,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -17594,17 +17594,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -17668,17 +17668,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -17758,12 +17758,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -17813,7 +17813,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -17943,7 +17943,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -17958,7 +17958,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -17983,7 +17983,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -18006,101 +18006,101 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}{1}</compoundUnitPattern>
@@ -18191,9 +18191,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>K</displayName>
@@ -18231,14 +18231,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>l/km</displayName>
@@ -18312,7 +18312,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-bit">
 				<displayName>bit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bit</unitPattern>
 				<unitPattern count="other">{0} bits</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -18335,7 +18335,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kw.</displayName>
 				<unitPattern count="one">{0} kw.</unitPattern>
 				<unitPattern count="other">{0} kw.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kw.</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>m</displayName>
@@ -18439,32 +18439,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therms</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
@@ -18489,39 +18489,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>dot</displayName>
@@ -18529,9 +18529,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -18639,9 +18639,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lx</displayName>
@@ -18649,19 +18649,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -18723,19 +18723,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>gr</displayName>
@@ -18788,9 +18788,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -18803,9 +18803,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -18813,14 +18813,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/u</displayName>
@@ -18863,14 +18863,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nm</displayName>
+				<unitPattern count="one">{0} Nm</unitPattern>
+				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>km³</displayName>
@@ -18952,8 +18952,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>acre ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>bu</displayName>
@@ -18993,7 +18993,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="one">{0} fl ozIm</unitPattern>
 				<unitPattern count="other">{0} fl ozIm</unitPattern>
 			</unit>
@@ -19008,14 +19008,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} tl</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>des l</displayName>
+				<unitPattern count="one">{0} des l</unitPattern>
+				<unitPattern count="other">{0} des l</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>imp. d l</displayName>
@@ -19033,9 +19033,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl dr</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>sn</displayName>
@@ -19043,9 +19043,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} sn</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp. qt</displayName>
+				<unitPattern count="one">{0} imp. qt</unitPattern>
+				<unitPattern count="other">{0} imp. qt</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>windstreek</displayName>
@@ -19079,22 +19079,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} of {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} of {1}</listPatternPart>
+			<listPatternPart type="2">{0} of {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} of {1}</listPatternPart>
+			<listPatternPart type="2">{0} of {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} en {1}</listPatternPart>
+			<listPatternPart type="2">{0} en {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -126,7 +126,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">cheyenne</language>
 			<language type="ckb">sentralkurdisk</language>
 			<language type="ckb" alt="menu">kurdisk (sentral)</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">sentralkurdisk</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">korsikansk</language>
 			<language type="cop">koptisk</language>
@@ -1139,7 +1139,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Tyrkia</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Tyrkia</territory>
 			<territory type="TT">Trinidad og Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -4288,7 +4288,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4296,7 +4296,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4592,12 +4592,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">lør.</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
+							<day type="sun">S</day>
+							<day type="mon">M</day>
+							<day type="tue">T</day>
 							<day type="wed">O</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
+							<day type="thu">T</day>
+							<day type="fri">F</day>
 							<day type="sat">L</day>
 						</dayWidth>
 						<dayWidth type="short">
@@ -4876,7 +4876,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -14129,35 +14129,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>kvadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kvadrat{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" draft="contributed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive" draft="contributed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" draft="contributed">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive" draft="contributed">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">kvadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kvadrat{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" draft="contributed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive" draft="contributed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" draft="contributed">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive" draft="contributed">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">kvadrat{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>kubikk{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kubikk{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" draft="contributed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive" draft="contributed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">kubikk{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" draft="contributed">kubikk{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive" draft="contributed">kubikk{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">kubikk{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">kubikk{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kubikk{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" draft="contributed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive" draft="contributed">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kubikk{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" draft="contributed">kubikk{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive" draft="contributed">kubikk{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">kubikk{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">kubikk{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>masculine</gender>
@@ -14281,9 +14281,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} per kvadrattomme</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<gender>masculine</gender>
@@ -14308,10 +14308,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="one" case="genitive">{0} items</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 				<unitPattern count="other" case="genitive">{0} items</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -14348,10 +14348,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mols</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mols</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -14665,8 +14665,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>British thermal unit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>therm</displayName>
@@ -14852,9 +14852,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-mile">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miles</displayName>
+				<unitPattern count="one">{0} mile</unitPattern>
+				<unitPattern count="other">{0} miles</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<gender>masculine</gender>
@@ -14953,8 +14953,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="light-solar-luminosity">
 				<gender>masculine</gender>
 				<displayName>solluminositet</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<gender>neuter</gender>
@@ -15055,7 +15055,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-grain">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>grain</displayName>
 				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
@@ -15121,10 +15121,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bars</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 				<unitPattern count="other" case="genitive">{0} bars</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -15571,12 +15571,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -15669,7 +15669,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -15689,7 +15689,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -15714,7 +15714,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -15922,7 +15922,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -15937,7 +15937,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -15972,28 +15972,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piksler</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapiksler</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
@@ -16007,7 +16007,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -16117,7 +16117,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>solradius</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -16137,7 +16137,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>solluminositet</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -16174,7 +16174,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>stone</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -16216,7 +16216,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -16266,7 +16266,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -16281,7 +16281,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -16291,12 +16291,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -16341,7 +16341,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -16600,38 +16600,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -16675,7 +16675,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektar</displayName>
 				<unitPattern count="one">{0}ha</unitPattern>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
@@ -16695,17 +16695,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mi²</displayName>
 				<unitPattern count="one">{0}mi²</unitPattern>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/mile²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>acre</displayName>
 				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>fot²</displayName>
@@ -16719,17 +16719,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg/dl</displayName>
 				<unitPattern count="one">{0}mg/dl</unitPattern>
 				<unitPattern count="other">{0}mg/dl</unitPattern>
 			</unit>
@@ -16739,9 +16739,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
@@ -16755,16 +16755,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0}mol</unitPattern>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
@@ -16779,69 +16779,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>miles/gal</displayName>
 				<unitPattern count="one">{0}mpg</unitPattern>
 				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>miles/brit. gal</displayName>
 				<unitPattern count="one">{0}mpg brit.</unitPattern>
 				<unitPattern count="other">{0}mpg brit.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>PB</displayName>
 				<unitPattern count="one">{0}PB</unitPattern>
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>TB</displayName>
 				<unitPattern count="one">{0}TB</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>Tb</displayName>
 				<unitPattern count="one">{0}Tb</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>GB</displayName>
 				<unitPattern count="one">{0}GB</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gb</displayName>
 				<unitPattern count="one">{0}Gb</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="one">{0}MB</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mb</displayName>
 				<unitPattern count="one">{0}Mb</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>kB</displayName>
 				<unitPattern count="one">{0}kB</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kb</displayName>
 				<unitPattern count="one">{0}kb</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
 				<unitPattern count="one">{0}B</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>bit</displayName>
 				<unitPattern count="one">{0}bit</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>årh.</displayName>
@@ -16849,9 +16849,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} årh.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tiår</displayName>
+				<unitPattern count="one">{0} tiår</unitPattern>
+				<unitPattern count="other">{0} tiår</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>år</displayName>
@@ -16918,68 +16918,68 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>A</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>mA</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kJ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joule</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>therm</displayName>
+				<unitPattern count="one">{0} therm</unitPattern>
+				<unitPattern count="other">{0} therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
@@ -16997,67 +16997,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gefirt</displayName>
+				<unitPattern count="one">{0} gefirt</unitPattern>
+				<unitPattern count="other">{0} gefirt</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dpi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pkt</displayName>
+				<unitPattern count="one">{0} pkt</unitPattern>
+				<unitPattern count="other">{0} pkt</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">{0}R⊕</unitPattern>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
@@ -17065,16 +17065,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>km</displayName>
 				<unitPattern count="one">{0}km</unitPattern>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dm</displayName>
 				<unitPattern count="one">{0}dm</unitPattern>
 				<unitPattern count="other">{0}dm</unitPattern>
 			</unit>
@@ -17082,7 +17082,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0}cm</unitPattern>
 				<unitPattern count="other">{0}cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -17090,17 +17090,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>μm</displayName>
 				<unitPattern count="one">{0}μm</unitPattern>
 				<unitPattern count="other">{0}μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>nm</displayName>
 				<unitPattern count="one">{0}nm</unitPattern>
 				<unitPattern count="other">{0}nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0}pm</unitPattern>
 				<unitPattern count="other">{0}pm</unitPattern>
 			</unit>
@@ -17127,7 +17127,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>parsec</displayName>
 				<unitPattern count="one">{0}pc</unitPattern>
 				<unitPattern count="other">{0}pc</unitPattern>
 			</unit>
@@ -17137,22 +17137,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>AU</displayName>
 				<unitPattern count="one">{0}AU</unitPattern>
 				<unitPattern count="other">{0}AU</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>furlong</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>favner</displayName>
+				<unitPattern count="one">{0} fm</unitPattern>
+				<unitPattern count="other">{0} fm</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>nmi</displayName>
 				<unitPattern count="one">{0}nmi</unitPattern>
 				<unitPattern count="other">{0}nmi</unitPattern>
 			</unit>
@@ -17168,21 +17168,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lux</displayName>
 				<unitPattern count="one">{0}lx</unitPattern>
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
@@ -17200,33 +17200,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gram</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="one">{0}mg</unitPattern>
 				<unitPattern count="other">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>μg</displayName>
 				<unitPattern count="one">{0}μg</unitPattern>
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>am. tonn</displayName>
 				<unitPattern count="one">{0} am. tn.</unitPattern>
 				<unitPattern count="other">{0} am. tn.</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>stone</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>pund</displayName>
@@ -17241,114 +17241,114 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/unse</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz tr</displayName>
+				<unitPattern count="one">{0} oz tr</unitPattern>
+				<unitPattern count="other">{0} oz tr</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>karat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Da</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>watt</displayName>
 				<unitPattern count="one">{0}W</unitPattern>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hk</displayName>
 				<unitPattern count="one">{0}hk</unitPattern>
 				<unitPattern count="other">{0}hk</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>mmHg</displayName>
 				<unitPattern count="one">{0}mmHg</unitPattern>
 				<unitPattern count="other">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 				<unitPattern count="one">{0}psi</unitPattern>
 				<unitPattern count="other">{0}psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0}inHg</unitPattern>
 				<unitPattern count="other">{0}inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0}hPa</unitPattern>
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/t</displayName>
@@ -17366,14 +17366,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mi/t</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kn</displayName>
 				<unitPattern count="one">{0}kn</unitPattern>
 				<unitPattern count="other">{0}kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -17381,38 +17381,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="one">{0}K</unitPattern>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="one">{0}lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Nm</displayName>
 				<unitPattern count="one">{0}Nm</unitPattern>
 				<unitPattern count="other">{0}Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">{0}m³</unitPattern>
 				<unitPattern count="other">{0}m³</unitPattern>
 				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0}cm³</unitPattern>
 				<unitPattern count="other">{0}cm³</unitPattern>
 				<perUnitPattern>{0}/cm³</perUnitPattern>
@@ -17428,7 +17428,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>fot³</displayName>
 				<unitPattern count="one">{0} fot³</unitPattern>
 				<unitPattern count="other">{0} fot³</unitPattern>
 			</unit>
@@ -17438,14 +17438,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
@@ -17454,101 +17454,101 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0}dl</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cl</displayName>
 				<unitPattern count="one">{0}cl</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ml</displayName>
 				<unitPattern count="one">{0}ml</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>m. kopper</displayName>
+				<unitPattern count="one">{0} m. kopp</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre-fot</displayName>
+				<unitPattern count="one">{0} ac-fot</unitPattern>
+				<unitPattern count="other">{0} ac-fot</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bushel</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>brit. gal</displayName>
+				<unitPattern count="one">{0} brit. gal</unitPattern>
+				<unitPattern count="other">{0} brit. gal</unitPattern>
+				<perUnitPattern>{0}/brit. gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>cup</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} k</unitPattern>
+				<unitPattern count="other">{0} k</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>imp. fl oz</displayName>
 				<unitPattern count="one">{0} fl oz Im</unitPattern>
 				<unitPattern count="other">{0} fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ss</displayName>
 				<unitPattern count="one">{0} ss</unitPattern>
 				<unitPattern count="other">{0} ss</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ts</displayName>
 				<unitPattern count="one">{0} ts</unitPattern>
 				<unitPattern count="other">{0} ts</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fat</displayName>
+				<unitPattern count="one">{0} fat</unitPattern>
+				<unitPattern count="other">{0} fat</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bs</displayName>
+				<unitPattern count="one">{0} bs</unitPattern>
+				<unitPattern count="other">{0} bs</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp. bs</displayName>
+				<unitPattern count="one">{0} imp. bs</unitPattern>
+				<unitPattern count="other">{0} imp. bs</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>dr</displayName>
@@ -17557,21 +17557,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>dram fl</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>shot</displayName>
+				<unitPattern count="one">{0} shot</unitPattern>
+				<unitPattern count="other">{0} shot</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">klype</displayName>
+				<unitPattern count="one" draft="contributed">{0} klype</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} klype</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>imp. quart</displayName>
 				<unitPattern count="one">{0} qt. Imp.</unitPattern>
 				<unitPattern count="other">{0} qt. Imp.</unitPattern>
 			</unit>
@@ -17610,26 +17610,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} eller {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} eller {1}</listPatternPart>
+			<listPatternPart type="2">{0} eller {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} eller {1}</listPatternPart>
+			<listPatternPart type="2">{0} eller {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} og {1}</listPatternPart>
+			<listPatternPart type="2">{0} og {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} og {1}</listPatternPart>
 			<listPatternPart type="2">{0} og {1}</listPatternPart>
 		</listPattern>
@@ -17855,7 +17855,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{credentials} {given} {given2} {surname} {generation}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -17957,7 +17957,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/nqo.xml
+++ b/common/main/nqo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -842,7 +842,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="6">ߥߊ߬ߛ</month>
 							<month type="7">ߞߊ߬ߙ</month>
 							<month type="8">ߘߓߊ߬ߓ</month>
-							<month type="9">↑↑↑</month>
+							<month type="9">ߕߎߟߊߝߌ߲</month>
 							<month type="10">ߞߏ߲ߓ</month>
 							<month type="11">ߣߍߣ</month>
 							<month type="12">ߞߏߟ</month>
@@ -859,7 +859,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="9">ߕ</month>
 							<month type="10">ߞ</month>
 							<month type="11">ߣ</month>
-							<month type="12">↑↑↑</month>
+							<month type="12">ߞ</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">ߓߌ߲ߠߊߥߎߟߋ߲</month>
@@ -886,7 +886,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="6">ߥߊ߬ߛ</month>
 							<month type="7">ߞߊ߬ߙ</month>
 							<month type="8">ߘߓߊ߬ߓ</month>
-							<month type="9">↑↑↑</month>
+							<month type="9">ߕߎߟߊߝߌ߲</month>
 							<month type="10">ߞߏ߲ߓ</month>
 							<month type="11">ߣߍߣ</month>
 							<month type="12">ߞߏߟ</month>
@@ -906,18 +906,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">ߞ</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">ߓߌ߲ߠߊߥߎߟߋ߲</month>
+							<month type="2">ߞߏ߲ߞߏߜߍ</month>
+							<month type="3">ߕߙߊߓߊ</month>
+							<month type="4">ߞߏ߲ߞߏߘߌ߬ߓߌ</month>
+							<month type="5">ߘߓߊ߬ߕߊ</month>
+							<month type="6">ߥߊ߬ߛߌ߬ߥߙߊ</month>
+							<month type="7">ߞߊ߬ߙߌߝߐ߭</month>
+							<month type="8">ߘߓߊ߬ߓߌߟߊ</month>
+							<month type="9">ߕߎߟߊߝߌ߲</month>
+							<month type="10">ߞߏ߲ߓߌߕߌ߮</month>
+							<month type="11">ߣߍߣߍߓߊ</month>
+							<month type="12">ߞߏߟߌ߲ߞߏߟߌ߲</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1022,10 +1022,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">ߞߛ߁</quarter>
+							<quarter type="2">ߞߛ߂</quarter>
+							<quarter type="3">ߞߛ߃</quarter>
+							<quarter type="4">ߞߛ߄</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">߁</quarter>
@@ -1034,10 +1034,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">߄</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">ߞߊߙߏߛߓߊ߫ ߁߭</quarter>
+							<quarter type="2">ߞߊߙߏߛߓߊ߫ ߂߲</quarter>
+							<quarter type="3">ߞߊߙߏߛߓߊ߫ ߃߲</quarter>
+							<quarter type="4">ߞߊߙߏߛߓߊ߫ ߄߲</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -1080,9 +1080,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</eraNames>
 					<eraAbbr>
 						<era type="0">ߌߛ. ߡ. ߢߍ߫</era>
-						<era type="0" alt="variant" draft="unconfirmed">↑↑↑</era>
+						<era type="0" alt="variant" draft="unconfirmed">ߌߛ. ߡ. ߢߍ߫</era>
 						<era type="1">ߌߛ. ߡ. ߞߐ߫</era>
-						<era type="1" alt="variant" draft="unconfirmed">↑↑↑</era>
+						<era type="1" alt="variant" draft="unconfirmed">ߌߛ. ߡ. ߞߐ߫</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">ߌߛ. ߢߍ߫</era>

--- a/common/main/oc.xml
+++ b/common/main/oc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -45,8 +45,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ceb" draft="unconfirmed">cebuan</language>
 			<language type="chr" draft="unconfirmed">cheroqui</language>
 			<language type="ckb" draft="unconfirmed">kurd central</language>
-			<language type="ckb" alt="menu" draft="unconfirmed">↑↑↑</language>
-			<language type="ckb" alt="variant" draft="unconfirmed">↑↑↑</language>
+			<language type="ckb" alt="menu" draft="unconfirmed">kurd central</language>
+			<language type="ckb" alt="variant" draft="unconfirmed">kurd central</language>
 			<language type="co" draft="unconfirmed">còrs</language>
 			<language type="cs" draft="unconfirmed">chèc</language>
 			<language type="cu" draft="unconfirmed">eslavon</language>
@@ -192,7 +192,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="yi" draft="unconfirmed">yiddish</language>
 			<language type="yo" draft="unconfirmed">yoruba</language>
 			<language type="yue" draft="unconfirmed">cantonés</language>
-			<language type="yue" alt="menu" draft="unconfirmed">↑↑↑</language>
+			<language type="yue" alt="menu" draft="unconfirmed">cantonés</language>
 			<language type="zh" draft="unconfirmed">chinés (chinés mandarin)</language>
 			<language type="zh" alt="menu" draft="unconfirmed">chinés, mandarin</language>
 			<language type="zh_Hans" draft="unconfirmed">chinés simplificat</language>
@@ -216,9 +216,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Hang" draft="unconfirmed">hangol</script>
 			<script type="Hani" draft="unconfirmed">chinés</script>
 			<script type="Hans" draft="unconfirmed">chinés simplificat</script>
-			<script type="Hans" alt="stand-alone" draft="unconfirmed">↑↑↑</script>
+			<script type="Hans" alt="stand-alone" draft="unconfirmed">chinés simplificat</script>
 			<script type="Hant" draft="unconfirmed">chinés tradicional</script>
-			<script type="Hant" alt="stand-alone" draft="unconfirmed">↑↑↑</script>
+			<script type="Hant" alt="stand-alone" draft="unconfirmed">chinés tradicional</script>
 			<script type="Hebr" draft="unconfirmed">ebrèu</script>
 			<script type="Hira" draft="unconfirmed">hiragana</script>
 			<script type="Hrkt" draft="unconfirmed">sillabaris japoneses</script>
@@ -319,7 +319,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CG" alt="variant" draft="unconfirmed">Republica de Còngo</territory>
 			<territory type="CH" draft="unconfirmed">Soïssa</territory>
 			<territory type="CI" draft="unconfirmed">Còsta d’Evòri</territory>
-			<territory type="CI" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="CI" alt="variant" draft="unconfirmed">Còsta d’Evòri</territory>
 			<territory type="CK" draft="unconfirmed">Illas Cook</territory>
 			<territory type="CL" draft="unconfirmed">Chile</territory>
 			<territory type="CM" draft="unconfirmed">Cameron</territory>
@@ -457,7 +457,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR" draft="unconfirmed">Nauru</territory>
 			<territory type="NU" draft="unconfirmed">Niue</territory>
 			<territory type="NZ" draft="unconfirmed">Nòva Zelanda</territory>
-			<territory type="NZ" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="NZ" alt="variant" draft="unconfirmed">Nòva Zelanda</territory>
 			<territory type="OM" draft="unconfirmed">Òman</territory>
 			<territory type="PA" draft="unconfirmed">Panamà</territory>
 			<territory type="PE" draft="unconfirmed">Peró</territory>
@@ -517,7 +517,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN" draft="unconfirmed">Tunisia</territory>
 			<territory type="TO" draft="unconfirmed">Tònga</territory>
 			<territory type="TR" draft="unconfirmed">Turquia</territory>
-			<territory type="TR" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="TR" alt="variant" draft="unconfirmed">Turquia</territory>
 			<territory type="TT" draft="unconfirmed">Trinidad e Tobago</territory>
 			<territory type="TV" draft="unconfirmed">Tuvalu</territory>
 			<territory type="TW" draft="unconfirmed">Taiwan</territory>
@@ -649,7 +649,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} 'a' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} 'a' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -657,7 +657,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} 'a' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} 'a' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -665,7 +665,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -673,7 +673,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -882,18 +882,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12" draft="unconfirmed">dec.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">G</month>
+							<month type="2" draft="unconfirmed">F</month>
+							<month type="3" draft="unconfirmed">M</month>
+							<month type="4" draft="unconfirmed">A</month>
+							<month type="5" draft="unconfirmed">M</month>
+							<month type="6" draft="unconfirmed">J</month>
+							<month type="7" draft="unconfirmed">J</month>
+							<month type="8" draft="unconfirmed">A</month>
+							<month type="9" draft="unconfirmed">S</month>
+							<month type="10" draft="unconfirmed">O</month>
+							<month type="11" draft="unconfirmed">N</month>
+							<month type="12" draft="unconfirmed">D</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1" draft="unconfirmed">de genièr</month>
@@ -958,13 +958,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">dimenge</day>
+							<day type="mon" draft="unconfirmed">diluns</day>
+							<day type="tue" draft="unconfirmed">dimars</day>
+							<day type="wed" draft="unconfirmed">dimècres</day>
+							<day type="thu" draft="unconfirmed">dijòus</day>
+							<day type="fri" draft="unconfirmed">divendres</day>
+							<day type="sat" draft="unconfirmed">dissabte</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun" draft="unconfirmed">Dg</day>
@@ -996,13 +996,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">dimenge</day>
+							<day type="mon" draft="unconfirmed">diluns</day>
+							<day type="tue" draft="unconfirmed">dimars</day>
+							<day type="wed" draft="unconfirmed">dimècres</day>
+							<day type="thu" draft="unconfirmed">dijòus</day>
+							<day type="fri" draft="unconfirmed">divendres</day>
+							<day type="sat" draft="unconfirmed">dissabte</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun" draft="unconfirmed">Dg</day>
@@ -1023,13 +1023,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat" draft="unconfirmed">ds</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">dimenge</day>
+							<day type="mon" draft="unconfirmed">diluns</day>
+							<day type="tue" draft="unconfirmed">dimars</day>
+							<day type="wed" draft="unconfirmed">dimècres</day>
+							<day type="thu" draft="unconfirmed">dijòus</day>
+							<day type="fri" draft="unconfirmed">divendres</day>
+							<day type="sat" draft="unconfirmed">dissabte</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -1042,10 +1042,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4" draft="unconfirmed">T4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="1" draft="unconfirmed">1</quarter>
+							<quarter type="2" draft="unconfirmed">2</quarter>
+							<quarter type="3" draft="unconfirmed">3</quarter>
+							<quarter type="4" draft="unconfirmed">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1" draft="unconfirmed">1èr trimèstre</quarter>
@@ -1068,10 +1068,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="1" draft="unconfirmed">1èr trimèstre</quarter>
 							<quarter type="2" draft="unconfirmed">2nd trimèstre</quarter>
 							<quarter type="3" draft="unconfirmed">3en trimèstre</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="4" draft="unconfirmed">4en trimèstre</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -1082,26 +1082,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -1109,7 +1109,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<eraNames>
 						<era type="0" draft="unconfirmed">Abans Jèsus-Crist</era>
 						<era type="0" alt="variant" draft="unconfirmed">Abans l’èra nòstra</era>
-						<era type="1" draft="unconfirmed">↑↑↑</era>
+						<era type="1" draft="unconfirmed">CE</era>
 						<era type="1" alt="variant" draft="unconfirmed">L’èra nòstra</era>
 					</eraNames>
 					<eraAbbr>
@@ -1119,10 +1119,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="1" alt="variant" draft="unconfirmed">E.N.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="unconfirmed">↑↑↑</era>
-						<era type="0" alt="variant" draft="unconfirmed">↑↑↑</era>
-						<era type="1" draft="unconfirmed">↑↑↑</era>
-						<era type="1" alt="variant" draft="unconfirmed">↑↑↑</era>
+						<era type="0" draft="unconfirmed">Ab. J.C.</era>
+						<era type="0" alt="variant" draft="unconfirmed">Ab. E.N.</era>
+						<era type="1" draft="unconfirmed">CE</era>
+						<era type="1" alt="variant" draft="unconfirmed">E.N.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -1183,7 +1183,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} 'a' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} 'a' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1191,7 +1191,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} 'a' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} 'a' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1199,7 +1199,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1207,7 +1207,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1412,10 +1412,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">èra</displayName>
 			</field>
 			<field type="era-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">èra</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">èra</displayName>
 			</field>
 			<field type="year">
 				<displayName draft="unconfirmed">annada</displayName>
@@ -1431,26 +1431,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName draft="unconfirmed">an.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">l’an passat</relative>
 				<relative type="0" draft="unconfirmed">ongan</relative>
 				<relative type="1" draft="unconfirmed">l’an que ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} y</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} y</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
 				<displayName draft="unconfirmed">an.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">l’an passat</relative>
+				<relative type="0" draft="unconfirmed">ongan</relative>
 				<relative type="1" draft="unconfirmed">l’an que ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} y</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} y</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -1467,26 +1467,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="quarter-short">
 				<displayName draft="unconfirmed">trim.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last quarter</relative>
+				<relative type="0" draft="unconfirmed">this quarter</relative>
+				<relative type="1" draft="unconfirmed">next quarter</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Q</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Q</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
 				<displayName draft="unconfirmed">trim.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last quarter</relative>
+				<relative type="0" draft="unconfirmed">this quarter</relative>
+				<relative type="1" draft="unconfirmed">next quarter</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Q</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Q</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -1503,26 +1503,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName draft="unconfirmed">mes</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">lo mes passat</relative>
+				<relative type="0" draft="unconfirmed">aqueste mes</relative>
+				<relative type="1" draft="unconfirmed">lo que mes que ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">d’aquí {0} meses</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">fa {0} mese</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
 				<displayName draft="unconfirmed">mes</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">lo mes passat</relative>
+				<relative type="0" draft="unconfirmed">aqueste mes</relative>
 				<relative type="1" draft="unconfirmed">lo mes que ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">d’aquí {0} meses</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">fa {0} mese</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -1540,27 +1540,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName draft="unconfirmed">setm.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">la setmana passada</relative>
+				<relative type="0" draft="unconfirmed">aquesta setmana</relative>
+				<relative type="1" draft="unconfirmed">la setmana que ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod draft="unconfirmed">la setmana del {0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
 				<displayName draft="unconfirmed">setm.</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">la setmana passada</relative>
+				<relative type="0" draft="unconfirmed">aquesta setmana</relative>
+				<relative type="1" draft="unconfirmed">la setmana que ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod draft="unconfirmed">la setmana del {0}</relativePeriod>
 			</field>
@@ -1568,10 +1568,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">↑↑↑</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Week Of Month</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Week Of Month</displayName>
 			</field>
 			<field type="day">
 				<displayName draft="unconfirmed">jorn</displayName>
@@ -1587,54 +1587,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName draft="unconfirmed">jorn</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">ièr</relative>
+				<relative type="0" draft="unconfirmed">uèi</relative>
+				<relative type="1" draft="unconfirmed">deman</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} d</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} d</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
 				<displayName draft="unconfirmed">jorn</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">ièr</relative>
+				<relative type="0" draft="unconfirmed">uèi</relative>
+				<relative type="1" draft="unconfirmed">deman</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} d</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} d</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
 			</field>
 			<field type="dayOfYear-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Day Of Year</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Day Of Year</displayName>
 			</field>
 			<field type="weekday">
 				<displayName draft="unconfirmed">jorn de la setmana</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">jorn de la setmana</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">jorn de la setmana</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Weekday Of Month</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">Weekday Of Month</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1" draft="unconfirmed">dimenge passat</relative>
@@ -1648,25 +1648,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">dimenge passat</relative>
+				<relative type="0" draft="unconfirmed">aqueste dimenge</relative>
+				<relative type="1" draft="unconfirmed">dimenge que ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Sundays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Sundays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">dimenge passat</relative>
+				<relative type="0" draft="unconfirmed">aqueste dimenge</relative>
+				<relative type="1" draft="unconfirmed">dimenge que ven</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Sundays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Sundays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -1681,25 +1681,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="mon-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Monday</relative>
+				<relative type="0" draft="unconfirmed">this Monday</relative>
+				<relative type="1" draft="unconfirmed">next Monday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Mondays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Mondays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Monday</relative>
+				<relative type="0" draft="unconfirmed">this Monday</relative>
+				<relative type="1" draft="unconfirmed">next Monday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Mondays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Mondays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -1714,25 +1714,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="tue-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Tuesday</relative>
+				<relative type="0" draft="unconfirmed">this Tuesday</relative>
+				<relative type="1" draft="unconfirmed">next Tuesday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Tuesday</relative>
+				<relative type="0" draft="unconfirmed">this Tuesday</relative>
+				<relative type="1" draft="unconfirmed">next Tuesday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Tuesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -1747,25 +1747,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="wed-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Wednesday</relative>
+				<relative type="0" draft="unconfirmed">this Wednesday</relative>
+				<relative type="1" draft="unconfirmed">next Wednesday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Wednesday</relative>
+				<relative type="0" draft="unconfirmed">this Wednesday</relative>
+				<relative type="1" draft="unconfirmed">next Wednesday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Wednesdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -1780,25 +1780,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="thu-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Thursday</relative>
+				<relative type="0" draft="unconfirmed">this Thursday</relative>
+				<relative type="1" draft="unconfirmed">next Thursday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Thursday</relative>
+				<relative type="0" draft="unconfirmed">this Thursday</relative>
+				<relative type="1" draft="unconfirmed">next Thursday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Thursdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -1813,25 +1813,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="fri-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Friday</relative>
+				<relative type="0" draft="unconfirmed">this Friday</relative>
+				<relative type="1" draft="unconfirmed">next Friday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Fridays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Fridays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Friday</relative>
+				<relative type="0" draft="unconfirmed">this Friday</relative>
+				<relative type="1" draft="unconfirmed">next Friday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Fridays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Fridays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -1846,29 +1846,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sat-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Saturday</relative>
+				<relative type="0" draft="unconfirmed">this Saturday</relative>
+				<relative type="1" draft="unconfirmed">next Saturday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">last Saturday</relative>
+				<relative type="0" draft="unconfirmed">this Saturday</relative>
+				<relative type="1" draft="unconfirmed">next Saturday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} Saturdays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">del matin/del vèspre</displayName>
 			</field>
 			<!-- <field type="sun">
 				 <relative type="-1" draft="unconfirmed">Dimenge passat</relative>
@@ -1878,7 +1878,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">del matin/del vèspre</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">del matin/del vèspre</displayName>
 			</field>
 			<field type="hour">
 				<displayName draft="unconfirmed">ora</displayName>
@@ -1892,22 +1892,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-short">
 				<displayName draft="unconfirmed">h</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">this hour</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} h</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} h</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
 				<displayName draft="unconfirmed">h</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">this hour</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} h</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} h</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
@@ -1922,22 +1922,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-short">
 				<displayName draft="unconfirmed">min.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">this minute</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} min</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} min</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
 				<displayName draft="unconfirmed">min.</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">this minute</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} min</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} min</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -1954,30 +1954,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">seg.</displayName>
 				<relative type="0" draft="unconfirmed">ara</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} s</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
 				<displayName draft="unconfirmed">seg.</displayName>
 				<relative type="0" draft="unconfirmed">ara</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} s</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
 				<displayName draft="unconfirmed">zòna orària</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">zòna orària</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">zòna orària</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -2866,19 +2866,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</otherNumberingSystems>
 		<minimumGroupingDigits draft="unconfirmed">↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="unconfirmed">↑↑↑</decimal>
@@ -2911,304 +2911,304 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal draft="unconfirmed">,</decimal>
@@ -3226,501 +3226,501 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed"> </group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">'h'</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arab">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="bali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="beng">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="brah">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cakm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="deva">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="fullwide">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gonm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gujr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="guru">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="hanidec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="java">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="kali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="khmr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="knda">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lana">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lanatham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="laoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -3732,18 +3732,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="long">
 				<decimalFormat>
-					<pattern type="1000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
+					<pattern type="1000" count="other" draft="unconfirmed">0K</pattern>
+					<pattern type="10000" count="other" draft="unconfirmed">00K</pattern>
+					<pattern type="100000" count="other" draft="unconfirmed">000K</pattern>
+					<pattern type="1000000" count="other" draft="unconfirmed">0M</pattern>
+					<pattern type="10000000" count="other" draft="unconfirmed">00M</pattern>
+					<pattern type="100000000" count="other" draft="unconfirmed">000M</pattern>
+					<pattern type="1000000000" count="other" draft="unconfirmed">0G</pattern>
+					<pattern type="10000000000" count="other" draft="unconfirmed">00G</pattern>
+					<pattern type="100000000000" count="other" draft="unconfirmed">000G</pattern>
+					<pattern type="1000000000000" count="other" draft="unconfirmed">0T</pattern>
+					<pattern type="10000000000000" count="other" draft="unconfirmed">00T</pattern>
+					<pattern type="100000000000000" count="other" draft="unconfirmed">000T</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
@@ -3766,315 +3766,315 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<decimalFormats numberSystem="lepc">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="limb">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mlym">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mtei">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymrshan">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="nkoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="olck">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="orya">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="osma">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="rohg">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="saur">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="shrd">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sora">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sund">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="takr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="talu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tamldec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="telu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="thai">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tibt">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="vaii">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arab">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arabext">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="bali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="beng">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="brah">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cakm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="deva">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="fullwide">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gonm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gujr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="guru">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="hanidec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="java">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="kali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="khmr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="knda">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lana">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lanatham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="laoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -4088,168 +4088,168 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<scientificFormats numberSystem="lepc">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="limb">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mlym">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mtei">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymrshan">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="nkoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="olck">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="orya">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="osma">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="rohg">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="saur">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="shrd">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sora">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sund">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="takr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="talu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tamldec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="telu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="thai">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tibt">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="vaii">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -4263,140 +4263,140 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="arabext">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="bali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="beng">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="brah">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cakm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="deva">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="fullwide">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gonm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gujr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="guru">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="hanidec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="java">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="kali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="khmr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="knda">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lana">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lanatham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="laoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -4410,177 +4410,177 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="lepc">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="limb">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mlym">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mtei">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymrshan">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="nkoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="olck">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="orya">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="osma">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="rohg">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="saur">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="shrd">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sora">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sund">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="takr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="talu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tamldec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="telu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="thai">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tibt">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="vaii">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0 %</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -4589,290 +4589,290 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -4882,7 +4882,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -4907,324 +4907,324 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<currencyPatternAppendISO draft="unconfirmed">{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">
@@ -6075,136 +6075,136 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 		</currencies>
 		<miscPatterns numberSystem="adlm">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arab">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arabext">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="bali">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="beng">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="brah">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cakm">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cham">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="deva">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="fullwide">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gong">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gonm">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gujr">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="guru">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="hanidec">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="java">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="kali">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="khmr">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="knda">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lana">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lanatham">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="laoo">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="latn">
 			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
@@ -6213,142 +6213,142 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lepc">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="limb">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mlym">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mong">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mtei">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymr">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymrshan">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="nkoo">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="olck">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="orya">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="osma">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="rohg">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="saur">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="shrd">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sora">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sund">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="takr">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="talu">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tamldec">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="telu">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="thai">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tibt">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="vaii">
-			<pattern type="approximately" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atLeast" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="atMost" draft="unconfirmed">↑↑↑</pattern>
-			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
+			<pattern type="approximately" draft="unconfirmed">~ {0}</pattern>
+			<pattern type="atLeast" draft="unconfirmed">≥{0}</pattern>
+			<pattern type="atMost" draft="unconfirmed">≤{0}</pattern>
+			<pattern type="range" draft="unconfirmed">{0}–{1}</pattern>
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="other" draft="unconfirmed">↑↑↑</pluralMinimalPairs>
@@ -6358,34 +6358,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
 				<unitPrefixPattern draft="unconfirmed">mili{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
 				<unitPrefixPattern draft="unconfirmed">deca{0}</unitPrefixPattern>
@@ -6397,52 +6397,52 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern draft="unconfirmed">quilo{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="other" draft="unconfirmed">{0} cairat</compoundUnitPattern1>
@@ -6451,7 +6451,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other" draft="unconfirmed">{0} cubic</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName draft="unconfirmed">G d’acceleracion</displayName>
@@ -6501,34 +6501,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern draft="unconfirmed">{0} per centimètres cairats</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">mi²</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mi²</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">acre</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">yd²</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ft²</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">in²</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} in²</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">dunam</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">kt</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName draft="unconfirmed">miligramas per decilitre</displayName>
@@ -6551,8 +6551,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} de mila</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">‱</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName draft="unconfirmed">mòls</displayName>
@@ -6567,12 +6567,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} litres per 100 quilomètres</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mpg US</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mpg US</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mpg Imp.</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName draft="unconfirmed">petaoctets</displayName>
@@ -6583,40 +6583,40 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} teraoctets</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">Tb</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName draft="unconfirmed">gigaoctets</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} gigaoctets</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">Gb</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName draft="unconfirmed">megaoctets</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} megaoctets</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">Mb</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName draft="unconfirmed">quilooctets</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} quilooctets</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">kb</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName draft="unconfirmed">octets</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} octets</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">bit</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName draft="unconfirmed">sègles</displayName>
@@ -6649,29 +6649,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-hour">
 				<displayName draft="unconfirmed">oras</displayName>
 				<unitPattern count="other">{0} oras</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName draft="unconfirmed">minutas</displayName>
 				<unitPattern count="other">{0} minutas</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName draft="unconfirmed">segondas</displayName>
 				<unitPattern count="other">{0} segondas</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ms</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">μs</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ns</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName draft="unconfirmed">ampèrs</displayName>
@@ -6682,8 +6682,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} miliampèrs</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ohm</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName draft="unconfirmed">vòlts</displayName>
@@ -6718,72 +6718,72 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} electronvòlts</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">Btu</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">US therm</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">lbf</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">N</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} N</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">GHz</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">MHz</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName draft="unconfirmed">quilohertz</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} quilohertz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">Hz</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">em</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">px</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">MP</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ppcm</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ppi</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName draft="unconfirmed">punts per centimètre</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} punts per centimètre</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ppi</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName draft="unconfirmed">punt</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} punt</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">R⊕</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName draft="unconfirmed">quilomètres</displayName>
@@ -6801,7 +6801,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-centimeter">
 				<displayName draft="unconfirmed">centimètres</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} cm</unitPattern>
 				<perUnitPattern draft="unconfirmed">{0} per centimètres</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
@@ -6821,62 +6821,62 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} picomètres</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mi</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">yd</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">ft</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ft</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">in</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} in</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">pc</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ly</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">au</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} au</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">nmi</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">smi</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName draft="unconfirmed">punts</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} punts</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">R☉</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">lx</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">cd</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">lm</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName draft="unconfirmed">luminositats solaras</displayName>
@@ -6909,26 +6909,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} tonas</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">lb</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} lb</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">oz</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} oz</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">oz t</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">CD</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">Da</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName draft="unconfirmed">massas de Tèrra</displayName>
@@ -6943,12 +6943,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} gran</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">GW</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">MW</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName draft="unconfirmed">quilowatts</displayName>
@@ -6959,8 +6959,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} watts</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mW</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName draft="unconfirmed">cavals vapor</displayName>
@@ -6971,16 +6971,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} milimètres de mercuri</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">psi</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">inHg</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">bar</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName draft="unconfirmed">milibars</displayName>
@@ -6991,8 +6991,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} atmosfèras</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">Pa</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName draft="unconfirmed">ectopascals</displayName>
@@ -7003,8 +7003,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} quilopascals</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">MPa</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName draft="unconfirmed">quilomètres per ora</displayName>
@@ -7015,16 +7015,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} mètres per segonda</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mi/h</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName draft="unconfirmed">noses</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} noses</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">°</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName draft="unconfirmed">grases Celsius</displayName>
@@ -7035,12 +7035,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} grases Fahrenheit</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">K</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">lbf⋅ft</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName draft="unconfirmed">newton-mètres</displayName>
@@ -7061,20 +7061,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern draft="unconfirmed">{0} per centimètres cubics</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mi³</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">yd³</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ft³</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">in³</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName draft="unconfirmed">megalitres</displayName>
@@ -7102,58 +7102,58 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} mililitres</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mpt</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mcup</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ac ft</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">US gal</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} gal US</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">Imp. gal</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} gal Imp.</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">qt</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">pt</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">cup</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">US fl oz</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} fl oz US</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">Imp. fl oz</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">tbsp</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">tsp</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">bbl</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName draft="unconfirmed">culhièr de cafè</displayName>
@@ -7168,20 +7168,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} gota</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">dram fluid</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">jigger</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName draft="unconfirmed">pecic</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} pecic</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">qt Imp</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName draft="unconfirmed">direccion cardinala</displayName>
@@ -7533,8 +7533,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">kcal</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
@@ -7609,8 +7609,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ppi</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName draft="unconfirmed">punt</displayName>
@@ -8028,108 +8028,108 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="other" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" draft="unconfirmed">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="other" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" draft="unconfirmed">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="concentr-percent">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">de cent</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}%</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">L/100km</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName draft="unconfirmed">an.</displayName>
@@ -8137,7 +8137,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-month">
 				<displayName draft="unconfirmed">mes</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} m</unitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName draft="unconfirmed">setm.</displayName>
@@ -8145,55 +8145,55 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-day">
 				<displayName draft="unconfirmed">jorn</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} j</unitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName draft="unconfirmed">ora</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} h</unitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">min</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} min</unitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">sec</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} s</unitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ms</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ms</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">km</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} km</unitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName draft="unconfirmed">m</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} m</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">cm</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} cm</unitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mm</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mm</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">kg</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} kg</unitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName draft="unconfirmed">grama</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} g</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">km/h</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} km/h</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">gr. C</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}°C</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName draft="unconfirmed">litres</displayName>
@@ -8201,10 +8201,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<coordinateUnit>
 				<displayName draft="unconfirmed">direccion</displayName>
-				<coordinateUnitPattern type="east" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="east" draft="unconfirmed">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north" draft="unconfirmed">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south" draft="unconfirmed">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west" draft="unconfirmed">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -8231,46 +8231,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0}, o {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0}, o {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}, e {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}, e {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}, e {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}, e {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}, e {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} e {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/oc_ES.xml
+++ b/common/main/oc_ES.xml
@@ -886,8 +886,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm" draft="unconfirmed">p. m.</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">a. m.</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">p. m.</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -99,8 +99,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">ଚେରୋକୀ</language>
 			<language type="chy">ଚେଚେନା</language>
 			<language type="ckb">କେନ୍ଦ୍ରୀୟ କୁରଡିସ୍</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">କେନ୍ଦ୍ରୀୟ କୁରଡିସ୍</language>
+			<language type="ckb" alt="variant">କେନ୍ଦ୍ରୀୟ କୁରଡିସ୍</language>
 			<language type="clc">ଚିଲକୋଟିନ୍</language>
 			<language type="co">କୋର୍ସିକାନ୍</language>
 			<language type="cop">କପ୍ଟିକ୍</language>
@@ -993,7 +993,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ଟ୍ୟୁନିସିଆ</territory>
 			<territory type="TO">ଟୋଙ୍ଗା</territory>
 			<territory type="TR">ତୁର୍କୀ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ତୁର୍କୀ</territory>
 			<territory type="TT">ତ୍ରିନିଦାଦ୍ ଏବଂ ଟୋବାଗୋ</territory>
 			<territory type="TV">ତୁଭାଲୁ</territory>
 			<territory type="TW">ତାଇୱାନ</territory>
@@ -1624,7 +1624,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">AM</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
@@ -1634,11 +1634,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="am">AM</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">ଅପରାହ୍ନ</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">ପୂର୍ବାହ୍ନ</dayPeriod>
+							<dayPeriod type="pm">ଅପରାହ୍ନ</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -1959,18 +1959,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">ଫାଲଗୁନ</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
 							<month type="3">3</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">ଚୈତ୍ର</month>
@@ -1989,14 +1989,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
+							<month type="1">ଚୈତ୍ର</month>
+							<month type="2">ବୈଶାଖ</month>
+							<month type="3">ଜ୍ୟୋଷ୍ଠ</month>
+							<month type="4">ଆଷାଢ଼</month>
+							<month type="5">ଶ୍ରାବଣ</month>
+							<month type="6">ଭାଦ୍ରବ</month>
+							<month type="7">ଆଶ୍ଵିନ</month>
+							<month type="8">କାର୍ତ୍ତିକ</month>
 							<month type="9">ଆଗ୍ରାହୟଣ</month>
 							<month type="10">ପୌଷ</month>
 							<month type="11">ମାଘ</month>
@@ -2065,9 +2065,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>ବ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ଗତ ବର୍ଷ</relative>
+				<relative type="0">ଏହି ବର୍ଷ</relative>
+				<relative type="1">ଆଗାମୀ ବର୍ଷ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ବ. ରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ବ. ରେ</relativeTimePattern>
@@ -2079,9 +2079,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>ବ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ଗତ ବର୍ଷ</relative>
+				<relative type="0">ଏହି ବର୍ଷ</relative>
+				<relative type="1">ଆଗାମୀ ବର୍ଷ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ବ. ରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ବ. ରେ</relativeTimePattern>
@@ -2109,7 +2109,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ତ୍ରୟ.</displayName>
 				<relative type="-1">ଗତ ତିନିମାସ</relative>
 				<relative type="0">ଏହି ତ୍ରୟମାସ</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">ଆଗାମୀ ତ୍ରୟମାସ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ତ୍ରୟ. ରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ତ୍ରୟ. ରେ</relativeTimePattern>
@@ -2149,9 +2149,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>ମା.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ଗତ ମାସ</relative>
+				<relative type="0">ଏହି ମାସ</relative>
+				<relative type="1">ଆଗାମୀ ମାସ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ମା. ରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ମା. ରେ</relativeTimePattern>
@@ -2163,9 +2163,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>ମା.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ଗତ ମାସ</relative>
+				<relative type="0">ଏହି ମାସ</relative>
+				<relative type="1">ଆଗାମୀ ମାସ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ମା. ରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ମା. ରେ</relativeTimePattern>
@@ -2185,16 +2185,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">{0} ସପ୍ତାହରେ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ସପ୍ତାହ ପୂର୍ବେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ସପ୍ତାହ ପୂର୍ବେ</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>{0} ର ସପ୍ତାହ</relativePeriod>
 			</field>
 			<field type="week-short">
 				<displayName>ସ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ଗତ ସପ୍ତାହ</relative>
+				<relative type="0">ଏହି ସପ୍ତାହ</relative>
+				<relative type="1">ଆଗାମୀ ସପ୍ତାହ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ସପ୍ତା. ରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ସପ୍ତା. ରେ</relativeTimePattern>
@@ -2207,9 +2207,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>ସ.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ଗତ ସପ୍ତାହ</relative>
+				<relative type="0">ଏହି ସପ୍ତାହ</relative>
+				<relative type="1">ଆଗାମୀ ସପ୍ତାହ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ସପ୍ତା. ରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ସପ୍ତା. ରେ</relativeTimePattern>
@@ -2245,9 +2245,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>ଦିନ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ଗତକାଲି</relative>
+				<relative type="0">ଆଜି</relative>
+				<relative type="1">ଆସନ୍ତାକାଲି</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ଦିନରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ଦିନରେ</relativeTimePattern>
@@ -2259,9 +2259,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>ଦିନ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ଗତକାଲି</relative>
+				<relative type="0">ଆଜି</relative>
+				<relative type="1">ଆସନ୍ତାକାଲି</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ଦିନରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ଦିନରେ</relativeTimePattern>
@@ -2411,7 +2411,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">{0} ମଙ୍ଗଳ. ରେ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ମଙ୍ଗଳ. ପୂର୍ବେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ମଙ୍ଗଳ. ପୂର୍ବେ</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2424,7 +2424,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">{0} ବୁଧବାରରେ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ବୁଧବାର ପୂର୍ବେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ବୁଧବାର ପୂର୍ବେ</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2446,7 +2446,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">ଏହି ବୁଧ</relative>
 				<relative type="1">ଆସନ୍ତା ବୁଧ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ବୁଧ. ରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ବୁଧ. ରେ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
@@ -2498,7 +2498,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="0">ଏହି ଶୁକ୍ରବାର</relative>
 				<relative type="1">ଆଗାମୀ ଶୁକ୍ରବାର</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ଶୁକ୍ରବାରରେ</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ଶୁକ୍ରବାରରେ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
@@ -4990,7 +4990,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -5168,8 +5168,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -6198,7 +6198,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="XOF">
 				<displayName>ପଶ୍ଚିମ ଆଫ୍ରିକିୟ CFA ଫ୍ରାଙ୍କ୍</displayName>
 				<displayName count="one">ପଶ୍ଚିମ ଆଫ୍ରିକିୟ CFA ଫ୍ରାଙ୍କ୍</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">ପଶ୍ଚିମ ଆଫ୍ରିକିୟ CFA ଫ୍ରାଙ୍କ୍</displayName>
 				<symbol draft="contributed">F CFA</symbol>
 			</currency>
 			<currency type="XPF">
@@ -6308,28 +6308,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>ୟୋଟା{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
 				<unitPrefixPattern>mebi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{1} ପ୍ରତି {0}</compoundUnitPattern>
@@ -6345,7 +6345,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">କ୍ୟୁ {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ଜି-ଫୋର୍ସ୍</displayName>
@@ -6563,9 +6563,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ଶତାବ୍ଦୀ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="one">{0} dec</unitPattern>
+				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ବର୍ଷ</displayName>
@@ -6731,49 +6731,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ହର୍ଜ୍</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ବି.</displayName>
 				<unitPattern count="one">{0} ବିନ୍ଦୁ</unitPattern>
 				<unitPattern count="other">{0} ବି</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>କିଲୋମିଟର୍</displayName>
@@ -6856,14 +6856,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ଖଗୋଲୀୟ ଏକକ</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>ନଟିକାଲ୍ ମାଇଲ୍</displayName>
@@ -6891,14 +6891,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ଲକ୍ସ</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>ସୋଲର ଲ୍ୟୁମିନୋସିଟିସ</displayName>
@@ -7198,9 +7198,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ଏକର-ଫିଟ୍</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>ଗ୍ୟାଲନ୍</displayName>
@@ -7260,34 +7260,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ଡିଜଟ୍ ସ୍ପୁନ୍</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>drop</displayName>
+				<unitPattern count="one">{0} drop</unitPattern>
+				<unitPattern count="other">{0} drop</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram fluid</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="one">{0} pinch</unitPattern>
+				<unitPattern count="other">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ପ୍ରଧାନ ଦିଶା</displayName>
@@ -7387,12 +7387,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7425,12 +7425,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>ଆର୍କମି</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ଆର୍କମି</unitPattern>
 				<unitPattern count="other">{0} ଆର୍କମି</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>ଆର୍କସେ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ଆର୍କସେ</unitPattern>
 				<unitPattern count="other">{0} ଆର୍କସେ</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
@@ -7525,7 +7525,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>ପରମାଇରିଆଡ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -7615,7 +7615,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-decade">
 				<displayName>dec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dec</unitPattern>
 				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -7673,7 +7673,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>μସେକେଣ୍ଡ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
@@ -7733,12 +7733,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>ଇଲେକ୍ଟ୍ରୋନ୍‌ ଭୋଲ୍ଟ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -7748,17 +7748,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>ପାଉଣ୍ଡ-ଫୋର୍ସ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>ନ୍ୟୁଟନ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -7783,47 +7783,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ବି.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7908,12 +7908,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -7933,7 +7933,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>ସୋଲାର ରାଡି</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -7943,17 +7943,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>ସୋଲର ଲ୍ୟୁମିନୋସିଟିସ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -7990,7 +7990,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>ଷ୍ଟୋନସ୍</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ଷ୍ଟ.</unitPattern>
 				<unitPattern count="other">{0} ଷ୍ଟ.</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -8022,12 +8022,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>ଅର୍ଥ ମାସେସ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>ସୋଲର ମାସେସ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8107,12 +8107,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -8157,12 +8157,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -8250,7 +8250,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -8287,7 +8287,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>ଇମ୍ପ. ଏଫଏଲ ଓଜେ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -8302,42 +8302,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>ବାରେଲ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} drop</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pinch</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -8359,7 +8359,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>ମି{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
 				<unitPrefixPattern>ନେ{0}</unitPrefixPattern>
@@ -8410,44 +8410,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>ୟୋ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ମାଧ୍ୟାକର୍ଷଣ –ବଳ</displayName>
@@ -8455,9 +8455,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ମା. ବଳ</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ମିଟର୍/ସେ²</displayName>
+				<unitPattern count="one">{0} ମି/ସେ²</unitPattern>
+				<unitPattern count="other">{0} ମି/ସେ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>ଘୂର୍ଣନ</displayName>
@@ -8465,30 +8465,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ଘୂର୍ଣନ</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>ରେଡିଆନ୍</displayName>
 				<unitPattern count="one">{0} ରେଡିଆନ୍</unitPattern>
 				<unitPattern count="other">{0} ରେଡିଆନ୍</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ଡିଗ୍ରୀ</displayName>
+				<unitPattern count="one">{0} ଡି</unitPattern>
+				<unitPattern count="other">{0} ଡି</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>ଆର୍କ-ମିନିଟ୍</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ଆର୍କମି</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ଆର୍କସେ</displayName>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>ବର୍ଗକିମି</displayName>
 				<perUnitPattern>{0}/ବର୍ଗକିମି</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ହେ</unitPattern>
+				<unitPattern count="other">{0} ହେ</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>ବର୍ଗମି</displayName>
@@ -8502,15 +8502,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} /ବର୍ଗସେମି</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ବର୍ଗ ମାଇଲ୍</displayName>
 				<unitPattern count="one">{0}ବର୍ଗମାଇଲ୍</unitPattern>
 				<unitPattern count="other">{0}ବର୍ଗମାଇଲ୍</unitPattern>
 				<perUnitPattern>{0}/ବର୍ଗମାଇଲ୍</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ଏକର</displayName>
+				<unitPattern count="one">{0} ଏକର</unitPattern>
+				<unitPattern count="other">{0} ଏକର</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>ବର୍ଗଗଜ</displayName>
@@ -8529,7 +8529,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ଡୋନମ୍</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>କ୍ୟାରେଟ୍</displayName>
 				<unitPattern count="one">{0}kt</unitPattern>
 				<unitPattern count="other">{0}kt</unitPattern>
 			</unit>
@@ -8569,14 +8569,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>ମୋଲ</displayName>
 				<unitPattern count="one">{0}ମୋଲ</unitPattern>
 				<unitPattern count="other">{0}ମୋଲ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ଲିଟର୍/କିମି</displayName>
+				<unitPattern count="one">{0} ଲି/କିମି</unitPattern>
+				<unitPattern count="other">{0} ଲି/କିମି</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ଲି/100କିମି</displayName>
@@ -8587,14 +8587,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ମାଇଲ୍/ଗେଲନ୍</displayName>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ବାଇଟ୍</displayName>
+				<unitPattern count="one">{0} ବାଇଟ୍</unitPattern>
+				<unitPattern count="other">{0} ବାଇଟ୍</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ବିଟ୍</displayName>
+				<unitPattern count="one">{0} ବିଟ୍</unitPattern>
+				<unitPattern count="other">{0} ବିଟ୍</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>c</displayName>
@@ -8614,7 +8614,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>କ୍ୱାର୍ଟର୍ସ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} କ୍ୱାର୍ଟର୍ସ</unitPattern>
 				<unitPattern count="other">{0} କ୍ୱାର୍ଟର୍ସ</unitPattern>
 				<perUnitPattern>{0}/କ୍ୱାର୍ଟର୍ସ</perUnitPattern>
 			</unit>
@@ -8622,7 +8622,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ମାସ</displayName>
 				<unitPattern count="one">{0}ମାସ</unitPattern>
 				<unitPattern count="other">{0}ମାସ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ମାସ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ସପ୍ତାହ</displayName>
@@ -8634,7 +8634,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ଦିନ</displayName>
 				<unitPattern count="one">{0}ଦିନ</unitPattern>
 				<unitPattern count="other">{0}ଦିନ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ଦିନ</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ଘଣ୍ଟା</displayName>
@@ -8660,14 +8660,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μସେକେଣ୍ଡ</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>ଏମ୍ପି.</displayName>
@@ -8676,13 +8676,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ଓମ୍</displayName>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ଭୋଲ୍ଟ୍</displayName>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>କିଲୋଜୁଲ୍</displayName>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>ଜୁଲ୍</displayName>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>ୟୁଏସ୍ଥର୍ମ</displayName>
@@ -8695,34 +8695,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ନ୍ୟୁ.</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
@@ -8740,8 +8740,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ବିନ୍ଦୁ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -8773,12 +8773,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ମିମି</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ପିମି</displayName>
 				<unitPattern count="one">{0}ପି.ମି.</unitPattern>
 				<unitPattern count="other">{0}ପି.ମି.</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ମାଇଲ୍</displayName>
 				<unitPattern count="one">{0}ମାଇଲ</unitPattern>
 				<unitPattern count="other">{0}ମାଇଲ</unitPattern>
 			</unit>
@@ -8789,7 +8789,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-inch">
 				<displayName>ଇଞ୍ଚ୍</displayName>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ଇଞ୍ଚ୍</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>ପାର୍ସେ</displayName>
@@ -8808,7 +8808,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ଫେଦମ୍</displayName>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>ଲକ୍ସ</displayName>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>ମେଟ୍ରିକଟନ</displayName>
@@ -8838,15 +8838,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ମା. ଗ୍ରା.</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ଟନ୍</displayName>
+				<unitPattern count="one">{0} ଟନ୍</unitPattern>
+				<unitPattern count="other">{0} ଟନ୍</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ପାଉଣ୍ଡ୍</displayName>
+				<unitPattern count="one">{0} ପାଉଣ୍ଡ୍</unitPattern>
+				<unitPattern count="other">{0} ପାଉଣ୍ଡ୍</unitPattern>
+				<perUnitPattern>{0}/ପାଉଣ୍ଡ୍</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>ଅନ୍ସ</displayName>
@@ -8860,7 +8860,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ଅନ୍ସ-ଟ୍ରାଇ</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>କ୍ୟାରେଟ୍</displayName>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ଡାଲଟନ୍</displayName>
@@ -8871,9 +8871,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ଅର୍ଥ ମାସ୍</displayName>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ୱାଟ୍</displayName>
+				<unitPattern count="one">{0} ୱା</unitPattern>
+				<unitPattern count="other">{0} ୱା</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>ଏଚ୍ପୀ</displayName>
@@ -8881,9 +8881,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ଏଚ୍ପୀ</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ବାର୍‌</displayName>
+				<unitPattern count="one">{0} ବାର୍‌</unitPattern>
+				<unitPattern count="other">{0} ବାର୍‌</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>ପା.</displayName>
@@ -8907,11 +8907,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>ମିଟର/ସେ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ମି/ସେ</unitPattern>
+				<unitPattern count="other">{0} ମି/ସେ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>ମାଇଲ୍/ଘଣ୍ଟା</displayName>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>ଗଣ୍ଠି</displayName>
@@ -8962,7 +8962,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ଲିଟର୍</displayName>
 				<unitPattern count="one">{0}ଲି</unitPattern>
 				<unitPattern count="other">{0}ଲି</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ଲି</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>ଡେ. ଲି.</displayName>
@@ -8985,9 +8985,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ଏକରଫୁଟ</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>ଗେଲନ୍</displayName>
@@ -9002,28 +9002,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/ ଇମ୍ପିଗେଲନ୍</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>କ୍ଵାର୍ଟ୍</displayName>
+				<unitPattern count="one">{0} କ୍ଵାର୍ଟ୍</unitPattern>
+				<unitPattern count="other">{0} କ୍ଵାର୍ଟ୍</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>କପ୍</displayName>
 				<unitPattern count="one">{0} କପ</unitPattern>
 				<unitPattern count="other">{0} କପ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ଫ୍ଲୁ ଓଜ୍</unitPattern>
+				<unitPattern count="other">{0} ଫ୍ଲୁ ଓଜ୍</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ଇମ୍ପ. ଏଫଏଲ ଓଜେ</displayName>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ଖାଇବା ଚାମଚ</displayName>
+				<unitPattern count="one">{0} ଖାଇବା ଚାମଚ</unitPattern>
+				<unitPattern count="other">{0} ଖାଇବା ଚାମଚ</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>ବ୍ୟାରେଲ୍</displayName>
@@ -9070,28 +9070,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} କିମ୍ବା {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} କିମ୍ବା {1}</listPatternPart>
+			<listPatternPart type="2">{0} କିମ୍ବା {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} କିମ୍ବା {1}</listPatternPart>
+			<listPatternPart type="2">{0} କିମ୍ବା {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, ଓ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ଓ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, ଓ {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} ଓ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -9128,7 +9128,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<characterLabelPattern type="miscellaneous">↑↑↑</characterLabelPattern>
 		<characterLabelPattern type="other">{0} — ଅନ୍ୟ</characterLabelPattern>
 		<characterLabelPattern type="scripts">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="strokes" count="one">↑↑↑</characterLabelPattern>
+		<characterLabelPattern type="strokes" count="one">{0} strokes</characterLabelPattern>
 		<characterLabelPattern type="strokes" count="other">↑↑↑</characterLabelPattern>
 		<characterLabelPattern type="subscript">ସବସ୍କ୍ରିପ୍ଟ {0}</characterLabelPattern>
 		<characterLabelPattern type="superscript">ସୁପରସ୍କ୍ରିପ୍ଟ {0}</characterLabelPattern>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -825,7 +825,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ਟਿਊਨੀਸ਼ੀਆ</territory>
 			<territory type="TO">ਟੌਂਗਾ</territory>
 			<territory type="TR">ਤੁਰਕੀ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ਤੁਰਕੀ</territory>
 			<territory type="TT">ਟ੍ਰਿਨੀਡਾਡ ਅਤੇ ਟੋਬਾਗੋ</territory>
 			<territory type="TV">ਟੁਵਾਲੂ</territory>
 			<territory type="TW">ਤਾਇਵਾਨ</territory>
@@ -1324,7 +1324,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1332,7 +1332,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1340,7 +1340,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1348,7 +1348,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1821,13 +1821,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</eraNames>
 					<eraAbbr>
 						<era type="0">ਈ. ਪੂ.</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">ਈ. ਪੂ.</era>
 						<era type="1">ਸੰਨ</era>
 						<era type="1" alt="variant">ਈ. ਸੰ.</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">ਈ.ਪੂ.</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">ਈ. ਪੂ.</era>
 						<era type="1">ਸੰਨ</era>
 						<era type="1" alt="variant">ਈ.ਸੰ.</era>
 					</eraNarrow>
@@ -1890,7 +1890,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1898,7 +1898,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1906,7 +1906,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1914,7 +1914,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2439,55 +2439,55 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, dd MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd/MM/y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d</dateFormatItem>
+						<dateFormatItem id="Gy">G y</dateFormatItem>
+						<dateFormatItem id="GyMd">d/M/GGGGG y</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">d MMM, y G</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E, d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
@@ -5535,9 +5535,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<plusSign draft="contributed">+</plusSign>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
@@ -5557,19 +5557,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">٫</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
 			<decimal>.</decimal>
@@ -5577,55 +5577,55 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
 			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
 		</symbols>
 		<symbols numberSystem="kali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
 		</symbols>
 		<symbols numberSystem="knda">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -5642,18 +5642,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list draft="contributed">↑↑↑</list>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<nan draft="contributed">↑↑↑</nan>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list draft="contributed">;</list>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<nan draft="contributed">NaN</nan>
 		</symbols>
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
@@ -6373,7 +6373,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="ISK">
 				<displayName>ਆਈਸਲੈਂਡੀ ਕਰੋਨਾ</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">ਆਈਸਲੈਂਡੀ ਕਰੋਨਾ</displayName>
 				<displayName count="other">ਆਈਸਲੈਂਡੀ ਕਰੋਨਾ</displayName>
 				<symbol>ISK</symbol>
 				<symbol alt="narrow">kr</symbol>
@@ -6813,7 +6813,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="STN">
 				<displayName>ਸਾਉ ਟੋਮੀ ਐਂਡ ਪ੍ਰਿੰਸਪੀ ਡੋਬਰਾ</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">ਸਾਉ ਟੋਮੀ ਐਂਡ ਪ੍ਰਿੰਸਪੀ ਡੋਬਰਾ</displayName>
 				<displayName count="other">ਸਾਉ ਟੋਮੀ ਐਂਡ ਪ੍ਰਿੰਸਪੀ ਡੋਬਰਾ</displayName>
 				<symbol>STN</symbol>
 				<symbol alt="narrow">Db</symbol>
@@ -7176,117 +7176,117 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>ਵਰਗ{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">ਵਰਗ{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="oblique">ਵਰਗ{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">ਵਰਗ{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">ਵਰਗ{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">ਵਰਗ{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="oblique">ਵਰਗ{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">ਵਰਗ{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">ਵਰਗ{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>ਘਣ{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">ਘਣ{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="oblique">ਘਣ{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">ਘਣ{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="oblique">ਘਣ{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">ਘਣ{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="oblique">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="oblique">ਘਣ{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">ਘਣ{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="oblique">ਘਣ{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>masculine</gender>
 				<displayName>ਗੁਰੂਤਾਕਰਸ਼ਣ ਬਲ</displayName>
 				<unitPattern count="one">{0} ਗੁਰੂਤਾਕਰਸ਼ਣ ਬਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਗੁਰੂਤਾਕਰਸ਼ਣ ਬਲ</unitPattern>
 				<unitPattern count="other">{0} ਗੁਰੂਤਾਕਰਸ਼ਣ ਬਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਗੁਰੂਤਾਕਰਸ਼ਣ ਬਲ</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>masculine</gender>
 				<displayName>ਮੀਟਰ ਪ੍ਰਤੀ ਵਰਗ ਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਮੀਟਰ ਪ੍ਰਤੀ ਵਰਗ ਸਕਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੀਟਰ ਪ੍ਰਤੀ ਵਰਗ ਸਕਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਮੀਟਰ ਪ੍ਰਤੀ ਵਰਗ ਸਕਿੰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੀਟਰ ਪ੍ਰਤੀ ਵਰਗ ਸਕਿੰਟ</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>feminine</gender>
 				<displayName>ਪਰਿਕਰਮਾ</displayName>
 				<unitPattern count="one">{0} ਪਰਿਕਰਮਾ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਪਰਿਕਰਮਾ</unitPattern>
 				<unitPattern count="other">{0} ਪਰਿਕਰਮਾ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਪਰਿਕਰਮਾ</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>masculine</gender>
 				<displayName>ਰੇਡੀਅਨ</displayName>
 				<unitPattern count="one">{0} ਰੇਡੀਅਨ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਰੇਡੀਅਨ</unitPattern>
 				<unitPattern count="other">{0} ਰੇਡੀਅਨ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਰੇਡੀਅਨ</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>feminine</gender>
 				<displayName>ਡਿਗਰੀ</displayName>
 				<unitPattern count="one">{0} ਡਿਗਰੀ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਡਿਗਰੀ</unitPattern>
 				<unitPattern count="other">{0} ਡਿਗਰੀ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਡਿਗਰੀ</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>masculine</gender>
 				<displayName>ਚਾਪ-ਮਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਚਾਪ-ਮਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਚਾਪ-ਮਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਚਾਪ-ਮਿੰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਚਾਪ-ਮਿੰਟ</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>masculine</gender>
 				<displayName>ਚਾਪ-ਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਚਾਪ-ਸਕਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਚਾਪ-ਸਕਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਚਾਪ-ਸਕਿੰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਚਾਪ-ਸਕਿੰਟ</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>masculine</gender>
 				<displayName>ਵਰਗ ਕਿਲੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਵਰਗ ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਵਰਗ ਕਿਲੋਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਵਰਗ ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਵਰਗ ਕਿਲੋਮੀਟਰ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਵਰਗ ਕਿਲੋਮੀਟਰ</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<gender>masculine</gender>
 				<displayName>ਹੈਕਟੇਅਰ</displayName>
 				<unitPattern count="one">{0} ਹੈਕਟੇਅਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਹੈਕਟੇਅਰ</unitPattern>
 				<unitPattern count="other">{0} ਹੈਕਟੇਅਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਹੈਕਟੇਅਰ</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>masculine</gender>
 				<displayName>ਵਰਗ ਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਵਰਗ ਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਵਰਗ ਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਵਰਗ ਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਵਰਗ ਮੀਟਰ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਵਰਗ ਮੀਟਰ</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<gender>masculine</gender>
 				<displayName>ਵਰਗ ਸੈਂਟੀਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਵਰਗ ਸੈਂਟੀਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਵਰਗ ਸੈਂਟੀਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਵਰਗ ਸੈਂਟੀਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਵਰਗ ਸੈਂਟੀਮੀਟਰ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਵਰਗ ਸੈਂਟੀਮੀਟਰ</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -7325,9 +7325,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਕੇਰਟ</displayName>
 				<unitPattern count="one">{0} ਕੇਰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕੇਰਟ</unitPattern>
 				<unitPattern count="other">{0} ਕੇਰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕੇਰਟ</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>ਮਿਲੀਗ੍ਰਾਮ ਪ੍ਰਤੀ ਡੈਸੀਲਿਟਰ</displayName>
@@ -7338,73 +7338,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਮਿਲੀਮੋਲ ਪ੍ਰਤੀ ਲਿਟਰ</displayName>
 				<unitPattern count="one">{0} ਮਿਲੀਮੋਲ ਪ੍ਰਤੀ ਲਿਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਿਲੀਮੋਲ ਪ੍ਰਤੀ ਲਿਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਮਿਲੀਮੋਲ ਪ੍ਰਤੀ ਲਿਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਿਲੀਮੋਲ ਪ੍ਰਤੀ ਲਿਟਰ</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>feminine</gender>
 				<displayName>ਆਈਟਮਾਂ</displayName>
 				<unitPattern count="one">{0} ਆਈਟਮ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਆਈਟਮ</unitPattern>
 				<unitPattern count="other">{0} ਆਈਟਮਾਂ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਆਈਟਮਾਂ</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>masculine</gender>
 				<displayName>ਹਿੱਸੇ ਪ੍ਰਤੀ ਮਿਲੀਅਨ</displayName>
 				<unitPattern count="one">{0} ਹਿੱਸਾ ਪ੍ਰਤੀ ਮਿਲੀਅਨ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਹਿੱਸਾ ਪ੍ਰਤੀ ਮਿਲੀਅਨ</unitPattern>
 				<unitPattern count="other">{0} ਹਿੱਸੇ ਪ੍ਰਤੀ ਮਿਲੀਅਨ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਹਿੱਸੇ ਪ੍ਰਤੀ ਮਿਲੀਅਨ</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>masculine</gender>
 				<displayName>ਪ੍ਰਤੀਸ਼ਤ</displayName>
 				<unitPattern count="one">{0} ਪ੍ਰਤੀਸ਼ਤ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਪ੍ਰਤੀਸ਼ਤ</unitPattern>
 				<unitPattern count="other">{0} ਪ੍ਰਤੀਸ਼ਤ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਪ੍ਰਤੀਸ਼ਤ</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>masculine</gender>
 				<displayName>ਪਰਮਾਈਲ</displayName>
 				<unitPattern count="one">{0} ਪਰਮਾਈਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਪਰਮਾਈਲ</unitPattern>
 				<unitPattern count="other">{0} ਪਰਮਾਈਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਪਰਮਾਈਲ</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>masculine</gender>
 				<displayName>ਪ੍ਰਤੀ ਦਸ ਹਜ਼ਾਰ</displayName>
 				<unitPattern count="one">{0} ਪ੍ਰਤੀ ਦਸ ਹਜ਼ਾਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਪ੍ਰਤੀ ਦਸ ਹਜ਼ਾਰ</unitPattern>
 				<unitPattern count="other">{0} ਪ੍ਰਤੀ ਦਸ ਹਜ਼ਾਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਪ੍ਰਤੀ ਦਸ ਹਜ਼ਾਰ</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>masculine</gender>
 				<displayName>ਮੋਲ</displayName>
 				<unitPattern count="one">{0} ਮੋਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੋਲ</unitPattern>
 				<unitPattern count="other">{0} ਮੋਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੋਲ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>masculine</gender>
 				<displayName>ਲਿਟਰ ਪ੍ਰਤੀ ਕਿਲੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਲਿਟਰ ਪ੍ਰਤੀ ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਲਿਟਰ ਪ੍ਰਤੀ ਕਿਲੋਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਲਿਟਰ ਪ੍ਰਤੀ ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਲਿਟਰ ਪ੍ਰਤੀ ਕਿਲੋਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>masculine</gender>
 				<displayName>ਲਿਟਰ ਪ੍ਰਤੀ 100 ਕਿਲੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਲਿਟਰ ਪ੍ਰਤੀ 100 ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਲਿਟਰ ਪ੍ਰਤੀ 100 ਕਿਲੋਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਲਿਟਰ ਪ੍ਰਤੀ 100 ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਲਿਟਰ ਪ੍ਰਤੀ 100 ਕਿਲੋਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>ਮੀਲ ਪ੍ਰਤੀ ਗੈਲਨ</displayName>
@@ -7420,97 +7420,97 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>ਪੈਟਾਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} ਪੈਟਾਬਾਇਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਪੈਟਾਬਾਇਟ</unitPattern>
 				<unitPattern count="other">{0} ਪੈਟਾਬਾਇਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਪੈਟਾਬਾਇਟ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>feminine</gender>
 				<displayName>ਟੈਰਾਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} ਟੈਰਾਬਾਇਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਟੈਰਾਬਾਇਟ</unitPattern>
 				<unitPattern count="other">{0} ਟੈਰਾਬਾਇਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਟੈਰਾਬਾਇਟ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>feminine</gender>
 				<displayName>ਟੇਰਾਬਿਟ</displayName>
 				<unitPattern count="one">{0} ਟੇਰਾਬਿਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਟੇਰਾਬਿਟ</unitPattern>
 				<unitPattern count="other">{0} ਟੇਰਾਬਿਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਟੇਰਾਬਿਟ</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>feminine</gender>
 				<displayName>ਗੀਗਾਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} ਗੀਗਾਬਾਇਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਗੀਗਾਬਾਇਟ</unitPattern>
 				<unitPattern count="other">{0} ਗੀਗਾਬਾਇਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਗੀਗਾਬਾਇਟ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>feminine</gender>
 				<displayName>ਗੀਗਾਬਿਟ</displayName>
 				<unitPattern count="one">{0} ਗੀਗਾਬਿਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਗੀਗਾਬਿਟ</unitPattern>
 				<unitPattern count="other">{0} ਗੀਗਾਬਿਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਗੀਗਾਬਿਟ</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>feminine</gender>
 				<displayName>ਮੈਗਾਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} ਮੈਗਾਬਾਇਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੈਗਾਬਾਇਟ</unitPattern>
 				<unitPattern count="other">{0} ਮੈਗਾਬਾਇਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੈਗਾਬਾਇਟ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>feminine</gender>
 				<displayName>ਮੈਗਾਬਿਟ</displayName>
 				<unitPattern count="one">{0} ਮੈਗਾਬਿਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੈਗਾਬਿਟ</unitPattern>
 				<unitPattern count="other">{0} ਮੈਗਾਬਿਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੈਗਾਬਿਟ</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>feminine</gender>
 				<displayName>ਕਿਲੋਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} ਕਿਲੋਬਾਇਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿਲੋਬਾਇਟ</unitPattern>
 				<unitPattern count="other">{0} ਕਿਲੋਬਾਇਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿਲੋਬਾਇਟ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>feminine</gender>
 				<displayName>ਕਿਲੋਬਿਟ</displayName>
 				<unitPattern count="one">{0} ਕਿਲੋਬਿਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿਲੋਬਿਟ</unitPattern>
 				<unitPattern count="other">{0} ਕਿਲੋਬਿਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿਲੋਬਿਟ</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>feminine</gender>
 				<displayName>ਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} ਬਾਇਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਬਾਇਟ</unitPattern>
 				<unitPattern count="other">{0} ਬਾਇਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਬਾਇਟ</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>feminine</gender>
 				<displayName>ਬਿਟ</displayName>
 				<unitPattern count="one">{0} ਬਿਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਬਿਟ</unitPattern>
 				<unitPattern count="other">{0} ਬਿਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਬਿਟ</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>feminine</gender>
 				<displayName>ਸਦੀਆਂ</displayName>
 				<unitPattern count="one">{0} ਸਦੀ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਸਦੀ</unitPattern>
 				<unitPattern count="other">{0} ਸਦੀਆਂ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਸਦੀਆਂ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>masculine</gender>
@@ -7524,7 +7524,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਸਾਲ</displayName>
 				<unitPattern count="one">{0} ਸਾਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਸਾਲ</unitPattern>
 				<unitPattern count="other">{0} ਸਾਲ</unitPattern>
 				<unitPattern count="other" case="oblique">{0} ਸਾਲਾਂ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਸਾਲ</perUnitPattern>
@@ -7560,15 +7560,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਦਿਨ</displayName>
 				<unitPattern count="one">{0} ਦਿਨ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਦਿਨ</unitPattern>
 				<unitPattern count="other">{0} ਦਿਨ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਦਿਨ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਦਿਨ</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<gender>masculine</gender>
 				<displayName>ਘੰਟੇ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ਘੰਟਾ</unitPattern>
 				<unitPattern count="one" case="oblique">{0} ਘੰਟੇ</unitPattern>
 				<unitPattern count="other">{0} ਘੰਟੇ</unitPattern>
 				<unitPattern count="other" case="oblique">{0} ਘੰਟਿਆਂ</unitPattern>
@@ -7578,7 +7578,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਮਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਮਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਮਿੰਟ</unitPattern>
 				<unitPattern count="other" case="oblique">{0} ਮਿੰਟਾਂ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਮਿੰਟ</perUnitPattern>
@@ -7587,7 +7587,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਸਕਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਸਕਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਸਕਿੰਟ</unitPattern>
 				<unitPattern count="other" case="oblique">{0} ਸਕਿੰਟਾਂ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਸਕਿੰਟ</perUnitPattern>
@@ -7596,57 +7596,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਮਿਲੀਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਮਿਲੀਸਕਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਿਲੀਸਕਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਮਿਲੀਸਕਿੰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਿਲੀਸਕਿੰਟ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>masculine</gender>
 				<displayName>ਮਾਈਕਰੋਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਮਾਈਕਰੋਸਕਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਾਈਕਰੋਸਕਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਮਾਈਕਰੋਸਕਿੰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਾਈਕਰੋਸਕਿੰਟ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>masculine</gender>
 				<displayName>ਨੈਨੋਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਨੈਨੋਸਕਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਨੈਨੋਸਕਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਨੈਨੋਸਕਿੰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਨੈਨੋਸਕਿੰਟ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>masculine</gender>
 				<displayName>ਐਮਪੀਅਰ</displayName>
 				<unitPattern count="one">{0} ਐਮਪੀਅਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਐਮਪੀਅਰ</unitPattern>
 				<unitPattern count="other">{0} ਐਮਪੀਅਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਐਮਪੀਅਰ</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>masculine</gender>
 				<displayName>ਮਿਲੀਐਮਪੀਅਰ</displayName>
 				<unitPattern count="one">{0} ਮਿਲੀਐਮਪੀਅਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਿਲੀਐਮਪੀਅਰ</unitPattern>
 				<unitPattern count="other">{0} ਮਿਲੀਐਮਪੀਅਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਿਲੀਐਮਪੀਅਰ</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>masculine</gender>
 				<displayName>ਓਹਮ</displayName>
 				<unitPattern count="one">{0} ਓਹਮ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਓਹਮ</unitPattern>
 				<unitPattern count="other">{0} ਓਹਮ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਓਹਮ</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>masculine</gender>
 				<displayName>ਵੋਲਟ</displayName>
 				<unitPattern count="one">{0} ਵੋਲਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਵੋਲਟ</unitPattern>
 				<unitPattern count="other">{0} ਵੋਲਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਵੋਲਟ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>ਕਿਲੋਕੈਲੋਰੀਆਂ</displayName>
@@ -7657,9 +7657,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>ਕੈਲੋਰੀਆਂ</displayName>
 				<unitPattern count="one">{0} ਕੈਲੋਰੀ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕੈਲੋਰੀ</unitPattern>
 				<unitPattern count="other">{0} ਕੈਲੋਰੀਆਂ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕੈਲੋਰੀਆਂ</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>ਕੈਲੋਰੀਆਂ</displayName>
@@ -7670,25 +7670,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਕਿਲੋਜੂਲ</displayName>
 				<unitPattern count="one">{0} ਕਿਲੋਜੂਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿਲੋਜੂਲ</unitPattern>
 				<unitPattern count="other">{0} ਕਿਲੋਜੂਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿਲੋਜੂਲ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>masculine</gender>
 				<displayName>ਜੂਲ</displayName>
 				<unitPattern count="one">{0} ਜੂਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਜੂਲ</unitPattern>
 				<unitPattern count="other">{0} ਜੂਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਜੂਲ</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>masculine</gender>
 				<displayName>ਕਿਲੋਵਾਟ-ਘੰਟੇ</displayName>
 				<unitPattern count="one">{0} ਕਿਲੋਵਾਟ ਘੰਟਾ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿਲੋਵਾਟ ਘੰਟਾ</unitPattern>
 				<unitPattern count="other">{0} ਕਿਲੋਵਾਟ ਘੰਟੇ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿਲੋਵਾਟ ਘੰਟੇ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>ਇਲੈਕਟ੍ਰਾਨਵੋਲਟ</displayName>
@@ -7702,8 +7702,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>US therms</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ਯੂ.ਐਸ. ਥੈਰਮ</unitPattern>
+				<unitPattern count="other">{0} ਯੂ.ਐਸ. ਥੈਰਮ</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>ਪੌਂਡ ਬਲ</displayName>
@@ -7714,81 +7714,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਨਿਊਟਨ</displayName>
 				<unitPattern count="one">{0} ਨਿਊਟਨ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਨਿਊਟਨ</unitPattern>
 				<unitPattern count="other">{0} ਨਿਊਟਨ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਨਿਊਟਨ</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>masculine</gender>
 				<displayName>ਕਿੱਲੋਵਾਟ-ਘੰਟਾ ਪ੍ਰਤੀ 100 ਕਿੱਲੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਕਿੱਲੋਵਾਟ-ਘੰਟਾ ਪ੍ਰਤੀ 100 ਕਿੱਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿੱਲੋਵਾਟ-ਘੰਟਾ ਪ੍ਰਤੀ 100 ਕਿੱਲੋਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਕਿੱਲੋਵਾਟ-ਘੰਟਾ ਪ੍ਰਤੀ 100 ਕਿੱਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿੱਲੋਵਾਟ-ਘੰਟਾ ਪ੍ਰਤੀ 100 ਕਿੱਲੋਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>masculine</gender>
 				<displayName>ਗੀਗਾਹਰਟਜ਼</displayName>
 				<unitPattern count="one">{0} ਗੀਗਾਹਰਟਜ਼</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਗੀਗਾਹਰਟਜ਼</unitPattern>
 				<unitPattern count="other">{0} ਗੀਗਾਹਰਟਜ਼</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਗੀਗਾਹਰਟਜ਼</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>masculine</gender>
 				<displayName>ਮੈਗਾਹਰਟਜ਼</displayName>
 				<unitPattern count="one">{0} ਮੈਗਾਹਰਟਜ਼</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੈਗਾਹਰਟਜ਼</unitPattern>
 				<unitPattern count="other">{0} ਮੈਗਾਹਰਟਜ਼</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੈਗਾਹਰਟਜ਼</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>masculine</gender>
 				<displayName>ਕਿਲੋਹਰਟਜ਼</displayName>
 				<unitPattern count="one">{0} ਕਿਲੋਹਰਟਜ਼</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿਲੋਹਰਟਜ਼</unitPattern>
 				<unitPattern count="other">{0} ਕਿਲੋਹਰਟਜ਼</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿਲੋਹਰਟਜ਼</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>masculine</gender>
 				<displayName>ਹਰਟਜ਼</displayName>
 				<unitPattern count="one">{0} ਹਰਟਜ਼</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਹਰਟਜ਼</unitPattern>
 				<unitPattern count="other">{0} ਹਰਟਜ਼</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਹਰਟਜ਼</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>masculine</gender>
 				<displayName>ਟਾਈਪੋਗ੍ਰਾਫ਼ਿਕ ਐਮ</displayName>
 				<unitPattern count="one">{0} ਟਾਈਪੋਗ੍ਰਾਫ਼ਿਕ ਐਮ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਟਾਈਪੋਗ੍ਰਾਫ਼ਿਕ ਐਮ</unitPattern>
 				<unitPattern count="other">{0} ਟਾਈਪੋਗ੍ਰਾਫ਼ਿਕ ਐਮ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਟਾਈਪੋਗ੍ਰਾਫ਼ਿਕ ਐਮ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
 				<displayName>ਪਿਕਸਲ</displayName>
 				<unitPattern count="one">{0} ਪਿਕਸਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਪਿਕਸਲ</unitPattern>
 				<unitPattern count="other">{0} ਪਿਕਸਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਪਿਕਸਲ</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>masculine</gender>
 				<displayName>ਮੈਗਾਪਿਕਸਲ</displayName>
 				<unitPattern count="one">{0} ਮੈਗਾਪਿਕਸਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੈਗਾਪਿਕਸਲ</unitPattern>
 				<unitPattern count="other">{0} ਮੈਗਾਪਿਕਸਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੈਗਾਪਿਕਸਲ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>masculine</gender>
 				<displayName>ਪਿਕਸਲ ਪ੍ਰਤੀ ਸੈਂਟੀਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਪਿਕਸਲ ਪ੍ਰਤੀ ਸੈਂਟੀਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਪਿਕਸਲ ਪ੍ਰਤੀ ਸੈਂਟੀਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਪਿਕਸਲ ਪ੍ਰਤੀ ਸੈਂਟੀਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਪਿਕਸਲ ਪ੍ਰਤੀ ਸੈਂਟੀਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ਪਿਕਸਲ ਪ੍ਰਤੀ ਇੰਚ</displayName>
@@ -7819,16 +7819,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਕਿਲੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿਲੋਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿਲੋਮੀਟਰ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਕਿਲੋਮੀਟਰ</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<gender>masculine</gender>
 				<displayName>ਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਮੀਟਰ</unitPattern>
 				<unitPattern count="other" case="oblique">{0} ਮੀਟਰਾਂ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਮੀਟਰ</perUnitPattern>
@@ -7837,50 +7837,50 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਡੈਸੀਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਡੈਸੀਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਡੈਸੀਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਡੈਸੀਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਡੈਸੀਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>masculine</gender>
 				<displayName>ਸੈਂਟੀਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਸੈਂਟੀਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਸੈਂਟੀਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਸੈਂਟੀਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਸੈਂਟੀਮੀਟਰ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਸੈਂਟੀਮੀਟਰ</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<gender>masculine</gender>
 				<displayName>ਮਿਲੀਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਮਿਲੀਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਿਲੀਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਮਿਲੀਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਿਲੀਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>masculine</gender>
 				<displayName>ਮਾਈਕਰੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਮਾਈਕਰੋਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਾਈਕਰੋਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਮਾਈਕਰੋਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਾਈਕਰੋਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>masculine</gender>
 				<displayName>ਨੈਨੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਨੈਨੋਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਨੈਨੋਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਨੈਨੋਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਨੈਨੋਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>masculine</gender>
 				<displayName>ਪਿਕੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਪਿਕੋਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਪਿਕੋਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਪਿਕੋਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਪਿਕੋਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>ਮੀਲ</displayName>
@@ -7938,9 +7938,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਮੀਲ-ਸਕੈਂਡਿਨੇਵਿਆਈ</displayName>
 				<unitPattern count="one">{0} ਮੀਲ-ਸਕੈਂਡਿਨੇਵਿਆਈ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੀਲ-ਸਕੈਂਡਿਨੇਵਿਆਈ</unitPattern>
 				<unitPattern count="other">{0} ਮੀਲ-ਸਕੈਂਡਿਨੇਵਿਆਈ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੀਲ-ਸਕੈਂਡਿਨੇਵਿਆਈ</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>ਪੁਆਇੰਟ</displayName>
@@ -7956,25 +7956,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਲਕਸ</displayName>
 				<unitPattern count="one">{0} ਲਕਸ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਲਕਸ</unitPattern>
 				<unitPattern count="other">{0} ਲਕਸ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਲਕਸ</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>masculine</gender>
 				<displayName>ਕੈਂਡੇਲਾ</displayName>
 				<unitPattern count="one">{0} ਕੈਂਡੇਲਾ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕੈਂਡੇਲਾ</unitPattern>
 				<unitPattern count="other">{0} ਕੈਂਡੇਲਾ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕੈਂਡੇਲਾ</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>masculine</gender>
 				<displayName>ਲੁਮੇਨ</displayName>
 				<unitPattern count="one">{0} ਲੁਮੇਨ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਲੁਮੇਨ</unitPattern>
 				<unitPattern count="other">{0} ਲੁਮੇਨ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਲੁਮੇਨ</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>ਸੋਲਰ ਲੂਮਨਾਸਿਟੀ</displayName>
@@ -7985,43 +7985,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਮੀਟਰਿਕ ਟਨ</displayName>
 				<unitPattern count="one">{0} ਮੀਟਰਿਕ ਟਨ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੀਟਰਿਕ ਟਨ</unitPattern>
 				<unitPattern count="other">{0} ਮੀਟਰਿਕ ਟਨ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੀਟਰਿਕ ਟਨ</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>masculine</gender>
 				<displayName>ਕਿਲੋਗ੍ਰਾਮ</displayName>
 				<unitPattern count="one">{0} ਕਿਲੋਗ੍ਰਾਮ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿਲੋਗ੍ਰਾਮ</unitPattern>
 				<unitPattern count="other">{0} ਕਿਲੋਗ੍ਰਾਮ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿਲੋਗ੍ਰਾਮ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਕਿਲੋਗ੍ਰਾਮ</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<gender>masculine</gender>
 				<displayName>ਗ੍ਰਾਮ</displayName>
 				<unitPattern count="one">{0} ਗ੍ਰਾਮ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਗ੍ਰਾਮ</unitPattern>
 				<unitPattern count="other">{0} ਗ੍ਰਾਮ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਗ੍ਰਾਮ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਗ੍ਰਾਮ</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<gender>masculine</gender>
 				<displayName>ਮਿਲੀਗ੍ਰਾਮ</displayName>
 				<unitPattern count="one">{0} ਮਿਲੀਗ੍ਰਾਮ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਿਲੀਗ੍ਰਾਮ</unitPattern>
 				<unitPattern count="other">{0} ਮਿਲੀਗ੍ਰਾਮ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਿਲੀਗ੍ਰਾਮ</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>masculine</gender>
 				<displayName>ਮਾਈਕਰੋਗ੍ਰਾਮ</displayName>
 				<unitPattern count="one">{0} ਮਾਈਕਰੋਗ੍ਰਾਮ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਾਈਕਰੋਗ੍ਰਾਮ</unitPattern>
 				<unitPattern count="other">{0} ਮਾਈਕਰੋਗ੍ਰਾਮ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਾਈਕਰੋਗ੍ਰਾਮ</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>ਅਮਰੀਕੀ ਟਨ</displayName>
@@ -8054,9 +8054,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਕੈਰਟ</displayName>
 				<unitPattern count="one">{0} ਕੈਰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕੈਰਟ</unitPattern>
 				<unitPattern count="other">{0} ਕੈਰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕੈਰਟ</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ਡਾਲਟਨ</displayName>
@@ -8082,41 +8082,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਗੀਗਾਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਗੀਗਾਵਾਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਗੀਗਾਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਗੀਗਾਵਾਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਗੀਗਾਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>masculine</gender>
 				<displayName>ਮੈਗਾਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਮੈਗਾਵਾਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੈਗਾਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਮੈਗਾਵਾਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੈਗਾਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>masculine</gender>
 				<displayName>ਕਿਲੋਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਕਿਲੋਵਾਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿਲੋਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਕਿਲੋਵਾਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿਲੋਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>feminine</gender>
 				<displayName>ਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਵਾਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਵਾਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>masculine</gender>
 				<displayName>ਮਿਲੀਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਮਿਲੀਵਾਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਿਲੀਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਮਿਲੀਵਾਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਿਲੀਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>ਹੌਰਸਪਾਵਰ</displayName>
@@ -8142,73 +8142,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਬਾਰ</displayName>
 				<unitPattern count="one">{0} ਬਾਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਬਾਰ</unitPattern>
+				<unitPattern count="other">{0} ਬਾਰ</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਬਾਰ</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>masculine</gender>
 				<displayName>ਮਿਲੀਬਾਰ</displayName>
 				<unitPattern count="one">{0} ਮਿਲੀਬਾਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਿਲੀਬਾਰ</unitPattern>
 				<unitPattern count="other">{0} ਮਿਲੀਬਾਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਿਲੀਬਾਰ</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>masculine</gender>
 				<displayName>ਵਾਯੂਮੰਡਲ</displayName>
 				<unitPattern count="one">{0} ਵਾਯੂਮੰਡਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਵਾਯੂਮੰਡਲ</unitPattern>
 				<unitPattern count="other">{0} ਵਾਯੂਮੰਡਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਵਾਯੂਮੰਡਲ</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>masculine</gender>
 				<displayName>ਪੈਸਕਲ</displayName>
 				<unitPattern count="one">{0} ਪੈਸਕਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਪੈਸਕਲ</unitPattern>
 				<unitPattern count="other">{0} ਪੈਸਕਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਪੈਸਕਲ</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>masculine</gender>
 				<displayName>ਹੈਕਟੋਪਾਸਕਲ</displayName>
 				<unitPattern count="one">{0} ਹੈਕਟੋਪਾਸਕਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਹੈਕਟੋਪਾਸਕਲ</unitPattern>
 				<unitPattern count="other">{0} ਹੈਕਟੋਪਾਸਕਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਹੈਕਟੋਪਾਸਕਲ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>masculine</gender>
 				<displayName>ਕਿੱਲੋਪਾਸਕਲ</displayName>
 				<unitPattern count="one">{0} ਕਿੱਲੋਪਾਸਕਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿੱਲੋਪਾਸਕਲ</unitPattern>
 				<unitPattern count="other">{0} ਕਿੱਲੋਪਾਸਕਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿੱਲੋਪਾਸਕਲ</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>masculine</gender>
 				<displayName>ਮੈਗਾਪਾਸਕਲ</displayName>
 				<unitPattern count="one">{0} ਮੈਗਾਪਾਸਕਲ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੈਗਾਪਾਸਕਲ</unitPattern>
 				<unitPattern count="other">{0} ਮੈਗਾਪਾਸਕਲ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੈਗਾਪਾਸਕਲ</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>masculine</gender>
 				<displayName>ਕਿਲੋਮੀਟਰ ਪ੍ਰਤੀ ਘੰਟਾ</displayName>
 				<unitPattern count="one">{0} ਕਿਲੋਮੀਟਰ ਪ੍ਰਤੀ ਘੰਟਾ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕਿਲੋਮੀਟਰ ਪ੍ਰਤੀ ਘੰਟਾ</unitPattern>
 				<unitPattern count="other">{0} ਕਿਲੋਮੀਟਰ ਪ੍ਰਤੀ ਘੰਟਾ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕਿਲੋਮੀਟਰ ਪ੍ਰਤੀ ਘੰਟਾ</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>masculine</gender>
 				<displayName>ਮੀਟਰ ਪ੍ਰਤੀ ਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਮੀਟਰ ਪ੍ਰਤੀ ਸਕਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੀਟਰ ਪ੍ਰਤੀ ਸਕਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਮੀਟਰ ਪ੍ਰਤੀ ਸਕਿੰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੀਟਰ ਪ੍ਰਤੀ ਸਕਿੰਟ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>ਮੀਲ ਪ੍ਰਤੀ ਘੰਟਾ</displayName>
@@ -8245,9 +8245,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਕੈਲਵਿਨ</displayName>
 				<unitPattern count="one">{0} ਕੈਲਵਿਨ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਕੈਲਵਿਨ</unitPattern>
 				<unitPattern count="other">{0} ਕੈਲਵਿਨ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਕੈਲਵਿਨ</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>ਪੌਂਡ-ਫੁੱਟ</displayName>
@@ -8258,34 +8258,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਨਿਊਟਨ-ਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਨਿਊਟਨ-ਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਨਿਊਟਨ-ਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਨਿਊਟਨ-ਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਨਿਊਟਨ-ਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>masculine</gender>
 				<displayName>ਘਣ ਕਿਲੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਘਣ ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਘਣ ਕਿਲੋਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਘਣ ਕਿਲੋਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਘਣ ਕਿਲੋਮੀਟਰ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>masculine</gender>
 				<displayName>ਘਣ ਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਘਣ ਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਘਣ ਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਘਣ ਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਘਣ ਮੀਟਰ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਘਣ ਮੀਟਰ</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<gender>masculine</gender>
 				<displayName>ਘਣ ਸੈਂਟੀਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} ਘਣ ਸੈਂਟੀਮੀਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਘਣ ਸੈਂਟੀਮੀਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਘਣ ਸੈਂਟੀਮੀਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਘਣ ਸੈਂਟੀਮੀਟਰ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਘਣ ਸੈਂਟੀਮੀਟਰ</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -8312,66 +8312,66 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ਮੈਗਾਲਿਟਰ</displayName>
 				<unitPattern count="one">{0} ਮੈਗਾਲਿਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੈਗਾਲਿਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਮੈਗਾਲਿਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੈਗਾਲਿਟਰ</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>masculine</gender>
 				<displayName>ਹੈਕਟੋਲਿਟਰ</displayName>
 				<unitPattern count="one">{0} ਹੈਕਟੋਲਿਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਹੈਕਟੋਲਿਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਹੈਕਟੋਲਿਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਹੈਕਟੋਲਿਟਰ</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>masculine</gender>
 				<displayName>ਲਿਟਰ</displayName>
 				<unitPattern count="one">{0} ਲਿਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਲਿਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਲਿਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਲਿਟਰ</unitPattern>
 				<perUnitPattern>{0} ਪ੍ਰਤੀ ਲਿਟਰ</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<gender>masculine</gender>
 				<displayName>ਡੈਸੀਲਿਟਰ</displayName>
 				<unitPattern count="one">{0} ਡੈਸੀਲਿਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਡੈਸੀਲਿਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਡੈਸੀਲਿਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਡੈਸੀਲਿਟਰ</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>masculine</gender>
 				<displayName>ਸੈਂਟੀਲਿਟਰ</displayName>
 				<unitPattern count="one">{0} ਸੈਂਟੀਲਿਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਸੈਂਟੀਲਿਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਸੈਂਟੀਲਿਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਸੈਂਟੀਲਿਟਰ</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>masculine</gender>
 				<displayName>ਮਿਲੀਲਿਟਰ</displayName>
 				<unitPattern count="one">{0} ਮਿਲੀਲਿਟਰ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮਿਲੀਲਿਟਰ</unitPattern>
 				<unitPattern count="other">{0} ਮਿਲੀਲਿਟਰ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮਿਲੀਲਿਟਰ</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>masculine</gender>
 				<displayName>ਮੀਟਰਿਕ ਪਿੰਟ</displayName>
 				<unitPattern count="one">{0} ਮੀਟਰਿਕ ਪਿੰਟ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੀਟਰਿਕ ਪਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਮੀਟਰਿਕ ਪਿੰਟ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੀਟਰਿਕ ਪਿੰਟ</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>masculine</gender>
 				<displayName>ਮੀਟਰਿਕ ਕੱਪ</displayName>
 				<unitPattern count="one">{0} ਮੀਟਰਿਕ ਕੱਪ</unitPattern>
-				<unitPattern count="one" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="one" case="oblique">{0} ਮੀਟਰਿਕ ਕੱਪ</unitPattern>
 				<unitPattern count="other">{0} ਮੀਟਰਿਕ ਕੱਪ</unitPattern>
-				<unitPattern count="other" case="oblique">↑↑↑</unitPattern>
+				<unitPattern count="other" case="oblique">{0} ਮੀਟਰਿਕ ਕੱਪ</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>ਏਕੜ ਫੁੱਟ</displayName>
@@ -8606,7 +8606,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>ਚਾਪ-ਮਿੰਟ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ਚਾਪ-ਮਿੰਟ</unitPattern>
 				<unitPattern count="other">{0} ਚਾਪ-ਮਿੰਟ</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
@@ -8706,7 +8706,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>ਪ੍ਰਤੀ ਦਸ ਹਜ਼ਾਰ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -8914,12 +8914,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>ਇਲੈਕਟ੍ਰਾਨਵੋਲਟ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -8929,7 +8929,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>ਪੌਂਡ-ਬਲ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
@@ -8964,27 +8964,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -8994,7 +8994,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
@@ -9004,7 +9004,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9114,7 +9114,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>ਸੋਲਰ ਰੇਡੀਅਸ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9124,7 +9124,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
@@ -9134,7 +9134,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>ਸੋਲਰ ਲੂਮਨਾਸਿਟੀ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9203,12 +9203,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>ਅਰਥ ਮਾਸ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>ਸੋਲਰ ਮਾਸ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -9278,7 +9278,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>Pa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -9338,7 +9338,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -9518,7 +9518,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>ਇੰਪੀਰੀਅਲ ਚੁਥਾਈ ਗੈਲਨ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ਇੰਪ. ਚੁ. ਗੈ.</unitPattern>
 				<unitPattern count="other">{0} ਇੰਪ. ਚੁ. ਗੈ.</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -9576,7 +9576,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>ਗੀਗਾ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>ਟੈ.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
 				<unitPrefixPattern>ਪੈਟਾ{0}</unitPrefixPattern>
@@ -9628,25 +9628,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਗੁਰੂਤਾਕਰਸ਼ਣ ਬਲ</displayName>
 				<unitPattern count="one">{0}G</unitPattern>
 				<unitPattern count="other">{0}Gs</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੀਟਰ/ਸਕਿੰਟ²</displayName>
 				<unitPattern count="one">{0}ਮੀ/ਸ²</unitPattern>
 				<unitPattern count="other">{0}ਮੀ/ਸ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>ਪਰਿਕਰਮਾ</displayName>
+				<unitPattern count="one" draft="contributed">{0} ਪਰਿਕਰਮਾ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ਪਰਿਕਰਮਾ</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਰੇਡੀਅਨ</displayName>
 				<unitPattern count="one">{0} ਰੇਡੀ.</unitPattern>
 				<unitPattern count="other">{0} ਰੇਡੀ.</unitPattern>
 			</unit>
@@ -9656,84 +9656,84 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਚਾਪ-ਮਿੰਟ</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਚਾਪ-ਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕਿਮੀ²</displayName>
 				<unitPattern count="one">{0} ਕਿਮੀ²</unitPattern>
 				<unitPattern count="other">{0} ਕਿਮੀ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਕਿਮੀ²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਹੈਕਟੇਅਰ</displayName>
+				<unitPattern count="one">{0} ਹੈਕਟ.</unitPattern>
+				<unitPattern count="other">{0} ਹੈਕਟ.</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੀਟਰ²</displayName>
 				<unitPattern count="one">{0} ਮੀ²</unitPattern>
 				<unitPattern count="other">{0} ਮੀ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} ਪ੍ਰਤੀ ਮੀ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਸੈਮੀ²</displayName>
 				<unitPattern count="one">{0}ਸੈਮੀ²</unitPattern>
 				<unitPattern count="other">{0}ਸੈਮੀ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} ਪ੍ਰਤੀ ਸੈਮੀ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਵਰਗ ਮੀਲ</displayName>
 				<unitPattern count="one">{0}ਮੀਲ²</unitPattern>
 				<unitPattern count="other">{0}ਮੀਲ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਮੀਲ²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਏਕੜ</displayName>
 				<unitPattern count="one">{0}ਏਕੜ</unitPattern>
 				<unitPattern count="other">{0}ਏਕੜ</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਗਜ਼²</displayName>
 				<unitPattern count="one">{0} ਗਜ਼²</unitPattern>
 				<unitPattern count="other">{0} ਗਜ਼²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਵ. ਫੁੱਟ</displayName>
 				<unitPattern count="one">{0}ਫੁੱਟ²</unitPattern>
 				<unitPattern count="other">{0}ਫੁੱਟ²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਇੰਚ²</displayName>
 				<unitPattern count="one">{0}ਇੰਚ²</unitPattern>
 				<unitPattern count="other">{0}ਇੰਚ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} ਪ੍ਰਤੀ ਇੰਚ²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਦੁਨਮ</displayName>
+				<unitPattern count="one">{0} ਦੁਨਮ</unitPattern>
+				<unitPattern count="other">{0} ਦੁਨਮ</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕੇਰਟ</displayName>
 				<unitPattern count="one">{0} ਕੇਰਟ</unitPattern>
 				<unitPattern count="other">{0} ਕੇਰਟ</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮਿ.ਗ੍ਰਾ./ਡੈ.ਲਿ.</displayName>
 				<unitPattern count="one">{0}mg/dL</unitPattern>
 				<unitPattern count="other">{0}mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਮਿਲੀਮੋਲ/ਲਿਟਰ</displayName>
+				<unitPattern count="one">{0} ਮਿ.ਮੋ./ਲਿ.</unitPattern>
+				<unitPattern count="other">{0} ਮਿ.ਮੋ./ਲਿ.</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>ਆਈਟਮ</displayName>
@@ -9741,9 +9741,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ਆਈਟਮ</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਹਿੱਸੇ/ਮਿਲੀਅਨ</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>ਪ੍ਰਤੀਸ਼ਤ</displayName>
@@ -9751,57 +9751,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਪਰਮਾਈਲ</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਮੋਲ</displayName>
+				<unitPattern count="one">{0} ਮੋਲ</unitPattern>
+				<unitPattern count="other">{0} ਮੋਲ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਲਿਟਰ/ਕਿ.ਮੀ.</displayName>
 				<unitPattern count="one">{0}ਲਿ./ਕਿ.ਮੀ.</unitPattern>
 				<unitPattern count="other">{0}ਲਿ./ਕਿ.ਮੀ.</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ਲਿ./100ਕਿ.ਮੀ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}ਲਿ/100 ਕਿਮੀ</unitPattern>
+				<unitPattern count="other">{0}ਲਿ/100 ਕਿਮੀ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੀਲ/ਗੈਲਨ</displayName>
 				<unitPattern count="one">{0} ਮੀ.ਪ੍ਰ.ਗੈ.</unitPattern>
 				<unitPattern count="other">{0} ਮੀ.ਪ੍ਰ.ਗੈ.</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੀਲ/ਗੈਲਨ ਇੰਪ.</displayName>
 				<unitPattern count="one">{0}m/gUK</unitPattern>
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਪੈਟਾਬਾਇਟ</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਟੈਰਾਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} TB</unitPattern>
 				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਟੇਰਾਬਿਟ</displayName>
 				<unitPattern count="one">{0} Tb</unitPattern>
 				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਗੀਗਾਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} GB</unitPattern>
 				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
@@ -9811,42 +9811,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੈਗਾਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} MB</unitPattern>
 				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੈਗਾਬਿਟ</displayName>
 				<unitPattern count="one">{0} Mb</unitPattern>
 				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕਿਲੋਬਾਇਟ</displayName>
 				<unitPattern count="one">{0} kB</unitPattern>
 				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕਿਲੋਬਿਟ</displayName>
 				<unitPattern count="one">{0} kb</unitPattern>
 				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਬਾਇਟ</displayName>
 				<unitPattern count="one">{0}ਬਾਇਟ</unitPattern>
 				<unitPattern count="other">{0}ਬਾਇਟ</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਬਿਟ</displayName>
 				<unitPattern count="one">{0}ਬਿਟ</unitPattern>
 				<unitPattern count="other">{0}ਬਿਟ</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਸਦੀ</displayName>
+				<unitPattern count="one">{0} ਸਦੀ</unitPattern>
+				<unitPattern count="other">{0} ਸਦੀ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਦਹਾ</displayName>
 				<unitPattern count="one">{0} ਦਹਾਕਾ</unitPattern>
 				<unitPattern count="other">{0} ਦਹਾਕੇ</unitPattern>
 			</unit>
@@ -9854,7 +9854,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ਸਾਲ</displayName>
 				<unitPattern count="one">{0} ਸਾਲ</unitPattern>
 				<unitPattern count="other">{0} ਸਾਲ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਸਾਲ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>ਤਿਮਾਹੀ</displayName>
@@ -9866,13 +9866,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ਮਹੀਨਾ</displayName>
 				<unitPattern count="one">{0} ਮਹੀਨਾ</unitPattern>
 				<unitPattern count="other">{0} ਮਹੀਨੇ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਮਹੀਨਾ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ਹਫ਼ਤਾ</displayName>
 				<unitPattern count="one">{0} ਹਫ਼ਤਾ</unitPattern>
 				<unitPattern count="other">{0} ਹਫ਼ਤੇ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਹਫ਼ਤਾ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ਦਿਨ</displayName>
@@ -9904,89 +9904,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ਮਿ.ਸ.</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮਾਈਕਰੋਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਨੈਨੋਸਕਿੰਟ</displayName>
 				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਐਮਪੀਅਰ</displayName>
 				<unitPattern count="one">{0}A</unitPattern>
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮਿਲੀਐਮਪੀਅਰ</displayName>
 				<unitPattern count="one">{0}mA</unitPattern>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਓਹਮ</displayName>
 				<unitPattern count="one">{0}Ω</unitPattern>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਵੋਲਟ</displayName>
 				<unitPattern count="one">{0}V</unitPattern>
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕਿ.ਕੈਲੋਰੀ</displayName>
 				<unitPattern count="one">{0}ਕਿ.ਕੈਲੋਰੀਆਂ</unitPattern>
 				<unitPattern count="other">{0}ਕਿ.ਕੈਲੋਰੀਆਂ</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>ਕੈਲੋਰੀ</displayName>
+				<unitPattern count="one">{0} ਕੈਲੋਰੀ</unitPattern>
 				<unitPattern count="other">{0} ਕੈਲੋਰੀਆਂ</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>ਕੈਲੋਰੀ</displayName>
+				<unitPattern count="one">{0} ਕੈਲੋਰੀ</unitPattern>
 				<unitPattern count="other">{0} ਕੈਲੋਰੀਆਂ</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕਿਲੋਜੂਲ</displayName>
 				<unitPattern count="one">{0} ਕਿ.ਜੂਲ</unitPattern>
 				<unitPattern count="other">{0} ਕਿ.ਜੂਲ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਜੂਲ</displayName>
 				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕਿ.ਵਾ.ਘੰ.</displayName>
 				<unitPattern count="one">{0} ਕਿ.ਵਾ.ਘੰ.</unitPattern>
 				<unitPattern count="other">{0} ਕਿ.ਵਾ.ਘੰ.</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਇਲੈਕਟ੍ਰਾਨਵੋਲਟ</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>ਯੂ.ਐਸ. ਥੈਰਮ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ਯੂ.ਐਸ. ਥੈਰਮ</unitPattern>
+				<unitPattern count="other">{0} ਯੂ.ਐਸ. ਥੈਰਮ</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਪੌਂਡ-ਬਲ</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਨਿਊਟਨ</displayName>
+				<unitPattern count="one">{0} ਨਿ</unitPattern>
+				<unitPattern count="other">{0} ਨਿ</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>ਕਿ.ਵ.ਘੰ./100ਕਿ.ਮੀ.</displayName>
@@ -9994,69 +9994,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ਕਿ.ਵ.ਘੰ./100ਕਿ.ਮੀ.</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="one">{0}GHz</unitPattern>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="one">{0}MHz</unitPattern>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="one">{0}kHz</unitPattern>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="one">{0}Hz</unitPattern>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpcm</displayName>
 				<unitPattern count="one">{0} dpcm</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">dpi</displayName>
 				<unitPattern count="one">{0} dpi</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਡਾਟ</displayName>
+				<unitPattern count="one">{0} ਡਾਟ</unitPattern>
+				<unitPattern count="other">{0} ਡਾਟ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ਕਿ.ਮੀ.</displayName>
@@ -10079,7 +10079,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ਸੈਂ.ਮੀ.</displayName>
 				<unitPattern count="one">{0}ਸੈਂ.ਮੀ.</unitPattern>
 				<unitPattern count="other">{0}ਸੈਂ.ਮੀ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਸੈਂ.ਮੀ.</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>ਮਿ.ਮੀ.</displayName>
@@ -10087,7 +10087,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ਮਿ.ਮੀ.</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮਾਈਕਰੋਮੀਟਰ</displayName>
 				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
@@ -10129,12 +10129,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ਪਾਸੈੱਕ</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਪ੍ਰਕਾਸ਼ ਸਾਲ</displayName>
 				<unitPattern count="one">{0} ਪ੍ਰ.ਸ.</unitPattern>
 				<unitPattern count="other">{0} ਪ੍ਰ.ਸ.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>au</displayName>
 				<unitPattern count="one">{0} au</unitPattern>
 				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
@@ -10149,49 +10149,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ਫ਼ੈਦਮ</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਨੋ.ਮੀਲ</displayName>
 				<unitPattern count="one">{0} ਨੋ.ਮੀਲ</unitPattern>
 				<unitPattern count="other">{0} ਨੋ.ਮੀਲ</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">ਸਕੈਂਡ. ਮੀਲ</displayName>
+				<unitPattern count="one">{0} ਸਕੈਂਡ. ਮੀਲ</unitPattern>
+				<unitPattern count="other">{0} ਸਕੈਂਡ. ਮੀਲ</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਪੁਆਇੰਟ</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਲਕਸ</displayName>
 				<unitPattern count="one">{0} ਲਕਸ</unitPattern>
 				<unitPattern count="other">{0} ਲਕਸ</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">cd</displayName>
+				<unitPattern count="one" draft="contributed">{0} cd</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਲੁਮੇਨ</displayName>
+				<unitPattern count="one">{0} ਲੁਮੇਨ</unitPattern>
+				<unitPattern count="other">{0} ਲੁਮੇਨ</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਸੋਲਰ ਲੂਮਨਾਸਿਟੀ</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>ਕਿ ਗ੍ਰਾ</displayName>
@@ -10206,17 +10206,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/ਗ੍ਰਾ.</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਮਿ.ਗ੍ਰਾ.</displayName>
+				<unitPattern count="one">{0} ਮਿ.ਗ੍ਰਾ.</unitPattern>
+				<unitPattern count="other">{0} ਮਿ.ਗ੍ਰਾ.</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਅਮਰੀਕੀ ਟਨ</displayName>
 				<unitPattern count="one">{0}ਟਨ</unitPattern>
 				<unitPattern count="other">{0}ਟਨ</unitPattern>
 			</unit>
@@ -10238,62 +10238,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/ਔਂਸ</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਔਂਸ ਟਰੌਏ</displayName>
 				<unitPattern count="one">{0} ਔਂਸ ਟ.</unitPattern>
 				<unitPattern count="other">{0} ਔਂਸ ਟ.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਕੈਰਟ</displayName>
+				<unitPattern count="one">{0} ਕੈਰਟ</unitPattern>
+				<unitPattern count="other">{0} ਕੈਰਟ</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਡਾਲਟਨ</displayName>
+				<unitPattern count="one">{0} ਡਾ</unitPattern>
+				<unitPattern count="other">{0} ਡਾ</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਅਰਥ ਮਾਸ</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਸੋਲਰ ਮਾਸ</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਗ੍ਰੇਨ</displayName>
+				<unitPattern count="one">{0} ਗ੍ਰੇਨ</unitPattern>
+				<unitPattern count="other">{0} ਗ੍ਰੇਨ</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਗੀ.ਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਗੀ.ਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਗੀ.ਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੈ.ਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਮੈ.ਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਮੈ.ਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕਿ.ਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਕਿ. ਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਕਿ. ਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮਿ.ਵਾਟ</displayName>
 				<unitPattern count="one">{0} ਮਿ.ਵਾਟ</unitPattern>
 				<unitPattern count="other">{0} ਮਿ.ਵਾਟ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
@@ -10313,9 +10313,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}&quot; ਪਾਰਾ</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਬਾਰ</displayName>
+				<unitPattern count="one">{0} ਬਾਰ</unitPattern>
+				<unitPattern count="other">{0} ਬਾਰ</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>ਮਿ.ਬਾਰ</displayName>
@@ -10323,14 +10323,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ਮਿ.ਬਾ.</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਵਾ. ਮੰ.</displayName>
+				<unitPattern count="one">{0} ਵਾ. ਮੰ.</unitPattern>
+				<unitPattern count="other">{0} ਵਾ. ਮੰ.</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>ਹੈ.ਪਾ.</displayName>
@@ -10338,14 +10338,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ਹੈ.ਪਾ.</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਕਿ.ਪਾ</displayName>
+				<unitPattern count="one">{0} ਕਿ.ਪਾ</unitPattern>
+				<unitPattern count="other">{0} ਕਿ.ਪਾ</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਮੈ.ਪਾ</displayName>
+				<unitPattern count="one">{0} ਮੈ.ਪਾ</unitPattern>
+				<unitPattern count="other">{0} ਮੈ.ਪਾ</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ਕਿ.ਮੀ./ਘੰਟਾ</displayName>
@@ -10363,9 +10363,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ਮੀ.ਪ੍ਰ.ਘੰ.</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
@@ -10388,9 +10388,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">lbf⋅ft</displayName>
+				<unitPattern count="one" draft="contributed">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>N⋅m</displayName>
@@ -10398,49 +10398,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕਿਮੀ³</displayName>
 				<unitPattern count="one">{0}ਕਿਮੀ³</unitPattern>
 				<unitPattern count="other">{0}ਕਿਮੀ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੀ³</displayName>
 				<unitPattern count="one">{0}ਮੀ³</unitPattern>
 				<unitPattern count="other">{0}ਮੀ³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਮੀ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਸੈਮੀ³</displayName>
 				<unitPattern count="one">{0}ਸੈਮੀ³</unitPattern>
 				<unitPattern count="other">{0}ਸੈਮੀ³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਸੈਮੀ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੀਲ³</displayName>
 				<unitPattern count="one">{0}ਮੀਲ³</unitPattern>
 				<unitPattern count="other">{0}ਮੀਲ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਗਜ਼³</displayName>
 				<unitPattern count="one">{0}ਗਜ਼³</unitPattern>
 				<unitPattern count="other">{0}ਗਜ਼³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਫੁੱਟ³</displayName>
 				<unitPattern count="one">{0}ਫੁੱਟ³</unitPattern>
 				<unitPattern count="other">{0}ਫੁੱਟ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਇੰਚ³</displayName>
 				<unitPattern count="one">{0}ਇੰਚ³</unitPattern>
 				<unitPattern count="other">{0}ਇੰਚ³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮੈ.ਲਿ.</displayName>
 				<unitPattern count="one">{0} ਮੈ.ਲਿ.</unitPattern>
 				<unitPattern count="other">{0} ਮੈ.ਲਿ.</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਹੈ.ਲਿ.</displayName>
 				<unitPattern count="one">{0} ਹੈ.ਲਿ.</unitPattern>
 				<unitPattern count="other">{0} ਹੈ.ਲਿ.</unitPattern>
 			</unit>
@@ -10448,35 +10448,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ਲਿਟਰ</displayName>
 				<unitPattern count="one">{0} ਲਿ.</unitPattern>
 				<unitPattern count="other">{0} ਲਿ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਲਿ.</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਡੈ.ਲਿ.</displayName>
 				<unitPattern count="one">{0} ਡੈ.ਲਿ.</unitPattern>
 				<unitPattern count="other">{0} ਡੈ.ਲਿ.</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਸੈਂ.ਲਿ.</displayName>
 				<unitPattern count="one">{0} ਸੈਂ.ਲਿ.</unitPattern>
 				<unitPattern count="other">{0} ਸੈਂ.ਲਿ.</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਮਿ.ਲਿ.</displayName>
 				<unitPattern count="one">{0} ਮਿ.ਲਿ.</unitPattern>
 				<unitPattern count="other">{0} ਮਿ.ਲਿ.</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਮੀ ਪਿੰਟ</displayName>
+				<unitPattern count="one">{0} ਮੀ ਪਿੰਟ</unitPattern>
+				<unitPattern count="other">{0} ਮੀ ਪਿੰਟ</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਮੀ ਕੱਪ</displayName>
+				<unitPattern count="one">{0} ਮੀ ਕੱਪ</unitPattern>
+				<unitPattern count="other">{0} ਮੀ ਕੱਪ</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਏਕੜ ਫੁੱਟ</displayName>
 				<unitPattern count="one">{0} ਏ.ਫੁ.</unitPattern>
 				<unitPattern count="other">{0} ਏ.ਫੁ.</unitPattern>
 			</unit>
@@ -10486,89 +10486,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ਬੁਸ਼ਲ</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਗੈਲਨ</displayName>
 				<unitPattern count="one">{0}ਗੈਲਨ</unitPattern>
 				<unitPattern count="other">{0}ਗੈਲਨ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ਗੈਲਨ</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ਇੰਪ. ਗੈਲਨ</displayName>
+				<unitPattern count="one">{0} ਗੈਲਨ ਇੰਪ.</unitPattern>
+				<unitPattern count="other">{0} ਗੈਲਨ ਇੰਪ.</unitPattern>
+				<perUnitPattern>{0}/ਗੈਲਨ ਇੰਪ.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕੁਆਟ</displayName>
 				<unitPattern count="one">{0}ਕੁਆਟ</unitPattern>
 				<unitPattern count="other">{0}ਕੁਆਟ</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਪਿੰਟ</displayName>
 				<unitPattern count="one">{0}ਪਿੰਟ</unitPattern>
 				<unitPattern count="other">{0}ਪਿੰਟ</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਕੱਪ</displayName>
 				<unitPattern count="one">{0}ਕੱਪ</unitPattern>
 				<unitPattern count="other">{0}ਕੱਪ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਤ. ਔਂਸ</displayName>
 				<unitPattern count="one">{0} ਤ. ਔਂਸ</unitPattern>
 				<unitPattern count="other">{0} ਤ. ਔਂਸ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਇੰਪ. ਫਲੂ. ਔ.</displayName>
 				<unitPattern count="one" draft="contributed">{0} ਫ.ਔ.ਇ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ਫ.ਔ.ਇ.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਟੇਬਲ ਸਪੂਨ</displayName>
 				<unitPattern count="one">{0} ਟੇ. ਸ.</unitPattern>
 				<unitPattern count="other">{0} ਟੇ. ਸ.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਟੀ ਸਪੂਨ</displayName>
+				<unitPattern count="one">{0} ਟੀ ਸਪੂਨ</unitPattern>
+				<unitPattern count="other">{0} ਟੀ ਸਪੂਨ</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਬੈਰਲ</displayName>
+				<unitPattern count="one">{0} ਬੈਰਲ</unitPattern>
+				<unitPattern count="other">{0} ਬੈਰਲ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਡੈਜ਼ਰਟ ਸਪੂਨ</displayName>
+				<unitPattern count="one">{0} ਡੈਜ਼ਰਟ ਸਪੂਨ</unitPattern>
+				<unitPattern count="other">{0} ਡੈਜ਼ਰਟ ਸਪੂਨ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਇੰਪੀਰੀਅਲ ਡੈਜ਼ਰਟ ਸਪੂਨ</displayName>
+				<unitPattern count="one">{0} ਇੰਪ. ਡੈ. ਸ.</unitPattern>
+				<unitPattern count="other">{0} ਇੰਪ. ਡੈ. ਸ.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>ਬੂੰਦ</displayName>
+				<unitPattern count="one">{0} ਬੂੰਦ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ਬੂੰਦ</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਚੁਸਕੀ ਭਰ</displayName>
+				<unitPattern count="one">{0} ਚੁਸਕੀ ਭਰ</unitPattern>
+				<unitPattern count="other">{0} ਚੁਸਕੀ ਭਰ</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ਚੱਕਾ</displayName>
+				<unitPattern count="one">{0} ਚੱਕਾ</unitPattern>
+				<unitPattern count="other">{0} ਚੱਕਾ</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ਚੁਟਕੀ</displayName>
+				<unitPattern count="one" draft="contributed">{0} ਚੁਟਕੀ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ਚੁਟਕੀ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ਇੰਪੀਰੀਅਲ ਚੁਥਾਈ ਗੈਲਨ</displayName>
 				<unitPattern count="one">{0} ਇ.ਚੁ.ਗੈ.</unitPattern>
 				<unitPattern count="other">{0} ਇ.ਚੁ.ਗੈ.</unitPattern>
 			</unit>
@@ -10604,16 +10604,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ਜਾਂ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, ਜਾਂ {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} ਜਾਂ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, ਜਾਂ {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} ਜਾਂ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -10842,8 +10842,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
-			<namePattern alt="1">{given-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 			<namePattern>{given-monogram-allCaps}.{given2-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
+			<namePattern alt="1">{given-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
 			<namePattern>{given-informal-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>

--- a/common/main/pap.xml
+++ b/common/main/pap.xml
@@ -26,7 +26,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="AW" draft="unconfirmed">Aruba</territory>
 			<territory type="CW">Kòrsou</territory>
 			<territory type="TR" draft="unconfirmed">Turkia</territory>
-			<territory type="TR" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="TR" alt="variant" draft="unconfirmed">Turkia</territory>
 		</territories>
 		<measurementSystemNames>
 			<measurementSystemName type="metric" draft="unconfirmed">meter</measurementSystemName>
@@ -88,8 +88,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dayPeriods>
 					<dayPeriodContext type="format">
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -737,7 +737,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">Náuru</territory>
 			<territory type="NU">Niúẹ</territory>
 			<territory type="NZ">Niú Zíland</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Niú Zíland</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Pánáma</territory>
 			<territory type="PE">Pẹ́ru</territory>
@@ -1017,7 +1017,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1025,7 +1025,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1402,8 +1402,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">FI</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">FM</dayPeriod>
+							<dayPeriod type="pm">FI</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">Fọ mọ́nin</dayPeriod>
@@ -1513,7 +1513,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1521,7 +1521,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5840,16 +5840,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>Yóta{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Kí{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mím{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gím{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Tím{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
 				<unitPrefixPattern>Pébi{0}</unitPrefixPattern>
@@ -5985,9 +5985,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} Mílimol Fọ Ẹ́vrí Líta</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>Pat-dẹm Fọ Ích Míliọn</displayName>
@@ -6109,7 +6109,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>kwọ́ta</displayName>
 				<unitPattern count="one">{0} kwọ́ta</unitPattern>
 				<unitPattern count="other">{0} kwọ́ta</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kw</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>Mọnt-dẹm</displayName>
@@ -7037,7 +7037,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -7142,7 +7142,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-century">
 				<displayName>Họ́ndrẹ́d-yiẹ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Họ́nd-yiẹ́</unitPattern>
 				<unitPattern count="other">{0} Họ́nd-yiẹ́</unitPattern>
 			</unit>
 			<unit type="duration-decade">
@@ -7290,7 +7290,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -7355,7 +7355,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7982,24 +7982,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>g-Fọs</displayName>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Míta/sẹk²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rẹv</displayName>
+				<unitPattern count="one">{0} rẹv</unitPattern>
+				<unitPattern count="other">{0} rẹv</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Rédians</displayName>
+				<unitPattern count="one">{0}Réd</unitPattern>
+				<unitPattern count="other">{0}Réd</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>Dig</displayName>
@@ -8007,89 +8007,89 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ákmínits</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>Áksẹ́kọns</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hẹ́ktas</displayName>
+				<unitPattern count="one">{0} hẹ</unitPattern>
+				<unitPattern count="other">{0} hẹ</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Mítas²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sm²</displayName>
+				<unitPattern count="one">{0} sm²</unitPattern>
+				<unitPattern count="other">{0} sm²</unitPattern>
+				<perUnitPattern>{0}/sm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Skwiá Mails</displayName>
+				<unitPattern count="one">{0} skw ma</unitPattern>
+				<unitPattern count="other">{0} skw ma</unitPattern>
+				<perUnitPattern>{0}/ma²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ékas</displayName>
+				<unitPattern count="one">{0} ék</unitPattern>
+				<unitPattern count="other">{0} ék</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Yads²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Skw Fut-dẹm</displayName>
+				<unitPattern count="one">{0} Skw ft</unitPattern>
+				<unitPattern count="other">{0} Skw ft</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Ínchis2</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Dúnams</displayName>
+				<unitPattern count="one">{0} Dúnam</unitPattern>
+				<unitPattern count="other">{0} Dúnam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>Karats</displayName>
 				<unitPattern count="one">{0} kárá</unitPattern>
 				<unitPattern count="other">{0} kárá</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mílimol/Líta</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>Pfim</displayName>
@@ -8103,23 +8103,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>L/km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -8128,8 +8128,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>Mfeg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mfeg</unitPattern>
+				<unitPattern count="other">{0} mfeg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mfeg Brít</displayName>
@@ -8138,58 +8138,58 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>PB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>Tb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>GB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Bait</unitPattern>
+				<unitPattern count="other">{0} Bait</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Bit</displayName>
+				<unitPattern count="one">{0} Bit</unitPattern>
+				<unitPattern count="other">{0} Bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>H</displayName>
@@ -8197,57 +8197,57 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}h</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tẹ́n-tẹ́n-yiẹ</displayName>
+				<unitPattern count="one">{0} Tẹ́n-yiẹ</unitPattern>
+				<unitPattern count="other">{0}Tẹ́n-yiẹ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>Yiẹ</displayName>
 				<unitPattern count="one">{0}Yiẹ</unitPattern>
 				<unitPattern count="other">{0}Yiẹ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/Yiẹ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kwt</displayName>
+				<unitPattern count="one">{0} kwt</unitPattern>
+				<unitPattern count="other">{0} kwtd</unitPattern>
+				<perUnitPattern>{0}/kw</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>Mọnt</displayName>
 				<unitPattern count="one">{0}Mọnt</unitPattern>
 				<unitPattern count="other">{0}Mọnt</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/Mt</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>Wik</displayName>
 				<unitPattern count="one">{0}Wik</unitPattern>
 				<unitPattern count="other">{0}Wik</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} Wik</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>Dè</displayName>
 				<unitPattern count="one">{0}Dè</unitPattern>
 				<unitPattern count="other">{0}Dè</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>Áwa</displayName>
 				<unitPattern count="one">{0}Áwa</unitPattern>
 				<unitPattern count="other">{0}Áwa</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/a</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>Mínit</displayName>
 				<unitPattern count="one">{0}Mínit</unitPattern>
 				<unitPattern count="other">{0}Mínit</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>Sẹ́kọn</displayName>
 				<unitPattern count="one">{0}Sẹ́kọn</unitPattern>
 				<unitPattern count="other">{0}Sẹ́kọn</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sẹ́k</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>Mílisẹ́kọns</displayName>
@@ -8255,124 +8255,124 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Maíkrosẹ́kọns</displayName>
+				<unitPattern count="one">{0}Maíksẹ́k</unitPattern>
+				<unitPattern count="other">{0}Maiksẹk</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nánosẹ́kọns</displayName>
+				<unitPattern count="one">{0} Nansẹk</unitPattern>
+				<unitPattern count="other">{0} Nansẹk</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amps</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Míliámps</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Oms</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Volts</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kkal</displayName>
+				<unitPattern count="one">{0} kkal</unitPattern>
+				<unitPattern count="other">{0} kkal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kal</displayName>
+				<unitPattern count="one">{0} kal</unitPattern>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kal</displayName>
+				<unitPattern count="one">{0} Kal</unitPattern>
+				<unitPattern count="other">{0} Kal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kílojul</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Joules</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>KW-áwa</displayName>
+				<unitPattern count="one">{0} kWa</unitPattern>
+				<unitPattern count="other">{0} kWa</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ẹlẹ́ktrọ́nvolt</displayName>
+				<unitPattern count="one">{0} ẹV</unitPattern>
+				<unitPattern count="other">{0} ẹV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTY</displayName>
+				<unitPattern count="one">{0}Bty</unitPattern>
+				<unitPattern count="other">{0}Bty</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US Támál</displayName>
+				<unitPattern count="one">{0} US Támal</unitPattern>
+				<unitPattern count="other">{0} US Támal</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Píksẹls</displayName>
+				<unitPattern count="one">{0} Píksẹl</unitPattern>
+				<unitPattern count="other">{0} Píksẹl</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
@@ -8380,57 +8380,57 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Píksẹls Fọ Ích Sẹntímíta</displayName>
+				<unitPattern count="one">{0} PFS</unitPattern>
+				<unitPattern count="other">{0} PFS</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Píksẹl Fọ Ẹ́vrí Inch</displayName>
+				<unitPattern count="one">{0} PFI</unitPattern>
+				<unitPattern count="other">{0} PFI</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pọints fọ ích sẹntímíta</displayName>
+				<unitPattern count="one">{0} PFIS</unitPattern>
+				<unitPattern count="other">{0} PFIS</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pọints Fọ Ẹ́vrí Inch</displayName>
+				<unitPattern count="one">{0} PFẸI</unitPattern>
+				<unitPattern count="other">{0} PFẸI</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dọt</displayName>
+				<unitPattern count="one">{0} dọt</unitPattern>
+				<unitPattern count="other">{0} dọt</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0}km</unitPattern>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>sm</displayName>
 				<unitPattern count="one">{0}sm</unitPattern>
 				<unitPattern count="other">{0}sm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -8438,49 +8438,49 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μmíta</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mails</displayName>
+				<unitPattern count="one">{0} ma</unitPattern>
+				<unitPattern count="other">{0} ma</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Yads</displayName>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Fut-dẹm</displayName>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Ínchis</displayName>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ích Sẹ́k</displayName>
 				<unitPattern count="one">{0} is</unitPattern>
 				<unitPattern count="other">{0} is</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>Laít Yiẹ</displayName>
 				<unitPattern count="one">{0}ly</unitPattern>
 				<unitPattern count="other">{0}ly</unitPattern>
 			</unit>
@@ -8490,168 +8490,168 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ay</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fọ́lọng</displayName>
 				<unitPattern count="one">{0} fọlọ</unitPattern>
 				<unitPattern count="other">{0} fọlọ</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fátọm</displayName>
 				<unitPattern count="one">{0} fátọ</unitPattern>
 				<unitPattern count="other">{0} fátọ</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>points</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Sólá Rédiọs-Dẹm</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kd</displayName>
+				<unitPattern count="one">{0} kd</unitPattern>
+				<unitPattern count="other">{0} kd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>T</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>Gram</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tọns</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ston</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Paunds</displayName>
+				<unitPattern count="one">{0} lb</unitPattern>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz trọi</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kárats</displayName>
+				<unitPattern count="one">{0} Kt</unitPattern>
+				<unitPattern count="other">{0} Kt</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Dọ́ltons</displayName>
+				<unitPattern count="one">{0} Dọ</unitPattern>
+				<unitPattern count="other">{0} Dọ</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ẹ́t Masís</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Sólá Masís</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gren</displayName>
+				<unitPattern count="one">{0} gren</unitPattern>
+				<unitPattern count="other">{0} gren</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Wats</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="one">{0} hp</unitPattern>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>pfẹsi</displayName>
@@ -8659,19 +8659,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} pfẹsi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Baa</displayName>
+				<unitPattern count="one">{0} Baa</unitPattern>
+				<unitPattern count="other">{0} Baa</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbaa</displayName>
+				<unitPattern count="one">{0} mbaa</unitPattern>
+				<unitPattern count="other">{0} mbaa</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>átmó</displayName>
@@ -8679,24 +8679,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} átmó</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/áw</displayName>
@@ -8704,24 +8704,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} km/á</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mítas/Sẹk</displayName>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mails/Áwa</displayName>
+				<unitPattern count="one">{0} mfẹa</unitPattern>
+				<unitPattern count="other">{0} mfẹa</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nọt</displayName>
+				<unitPattern count="one">{0} Nọt</unitPattern>
+				<unitPattern count="other">{0} Nọt</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -8734,194 +8734,194 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>N⋅m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sm³</displayName>
+				<unitPattern count="one">{0} sm³</unitPattern>
+				<unitPattern count="other">{0} sm³</unitPattern>
+				<perUnitPattern>{0}/sm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ma³</displayName>
+				<unitPattern count="one">{0} ma³</unitPattern>
+				<unitPattern count="other">{0} ma³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Yáds³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Fut³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ínchis³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>Líta</displayName>
 				<unitPattern count="one">{0}L</unitPattern>
 				<unitPattern count="other">{0}L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sl</displayName>
+				<unitPattern count="one">{0} sl</unitPattern>
+				<unitPattern count="other">{0} sl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mkọp</displayName>
+				<unitPattern count="one">{0} mk</unitPattern>
+				<unitPattern count="other">{0} mk</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Éka ft</displayName>
+				<unitPattern count="one">{0} ek ft</unitPattern>
+				<unitPattern count="other">{0} ek ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Búshẹl</displayName>
+				<unitPattern count="one">{0} bú</unitPattern>
+				<unitPattern count="other">{0} bú</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Brít. gal</displayName>
+				<unitPattern count="one">{0} Brít. gal</unitPattern>
+				<unitPattern count="other">{0} Brít. gal</unitPattern>
+				<perUnitPattern>{0} Brít. gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kwts</displayName>
+				<unitPattern count="one">{0} kwt</unitPattern>
+				<unitPattern count="other">{0} kwt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Paints</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kọps</displayName>
+				<unitPattern count="one">{0} Kọp</unitPattern>
+				<unitPattern count="other">{0} Kọp</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Brít. Fl oz</displayName>
+				<unitPattern count="one">{0} fl oz Brit.</unitPattern>
+				<unitPattern count="other">{0} fl oz Brit.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tbsp</displayName>
+				<unitPattern count="one">{0} Tbsp</unitPattern>
+				<unitPattern count="other">{0} Tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tsp</displayName>
+				<unitPattern count="one">{0} Tsp</unitPattern>
+				<unitPattern count="other">{0} Tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Drọm</displayName>
+				<unitPattern count="one">{0}dr</unitPattern>
+				<unitPattern count="other">{0}dr</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Dztspn</displayName>
+				<unitPattern count="one">{0} dztspn</unitPattern>
+				<unitPattern count="other">{0} dztspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dztspn Imp</displayName>
 				<unitPattern count="one">{0}dzp-Imp</unitPattern>
 				<unitPattern count="other">{0}dzp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Drọp</displayName>
+				<unitPattern count="one">{0} Drọp</unitPattern>
+				<unitPattern count="other">{0} Drọp</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Drám Líkwid</displayName>
+				<unitPattern count="one">{0} Dram lí</unitPattern>
+				<unitPattern count="other">{0} Dram lí</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Jigá</displayName>
+				<unitPattern count="one">{0} Jigá</unitPattern>
+				<unitPattern count="other">{0} Jigá</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pinch</displayName>
+				<unitPattern count="one">{0} Pinch</unitPattern>
+				<unitPattern count="other">{0} Pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kt Impẹ́riál</displayName>
+				<unitPattern count="one">{0} Kt Imp</unitPattern>
+				<unitPattern count="other">{0} Kt Imp</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>Pọint</displayName>
@@ -9199,13 +9199,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -9253,13 +9253,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -9277,7 +9277,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname} {given-initial}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -9295,7 +9295,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname}, {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -125,7 +125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">czejeński</language>
 			<language type="ckb">sorani</language>
 			<language type="ckb" alt="menu">kurdyjski sorani</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">sorani</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">korsykański</language>
 			<language type="cop">koptyjski</language>
@@ -1069,7 +1069,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">Nowa Zelandia</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Nowa Zelandia</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -1129,7 +1129,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunezja</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turcja</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turcja</territory>
 			<territory type="TT">Trynidad i Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tajwan</territory>
@@ -1595,7 +1595,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1603,7 +1603,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1611,7 +1611,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1619,7 +1619,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2167,7 +2167,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2175,7 +2175,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2183,7 +2183,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2191,7 +2191,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2429,15 +2429,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="3" draft="contributed">Kislew</month>
 							<month type="4" draft="contributed">Tewet</month>
 							<month type="5" draft="contributed">Szwat</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
+							<month type="6" draft="contributed">Adar I</month>
+							<month type="7" draft="contributed">Adar</month>
+							<month type="7" yeartype="leap" draft="contributed">Adar II</month>
+							<month type="8" draft="contributed">Nisan</month>
 							<month type="9" draft="contributed">Ijar</month>
 							<month type="10" draft="contributed">Siwan</month>
-							<month type="11" draft="contributed">↑↑↑</month>
+							<month type="11" draft="contributed">Tamuz</month>
 							<month type="12" draft="contributed">Aw</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1" draft="contributed">Tiszri</month>
@@ -2463,15 +2463,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="3">Kislew</month>
 							<month type="4">Tewet</month>
 							<month type="5">Szwat</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
 							<month type="9">Ijar</month>
 							<month type="10">Siwan</month>
-							<month type="11">↑↑↑</month>
+							<month type="11">Tamuz</month>
 							<month type="12">Aw</month>
-							<month type="13">↑↑↑</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1" draft="contributed">Tiszri</month>
@@ -2479,15 +2479,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="3" draft="contributed">Kislew</month>
 							<month type="4" draft="contributed">Tewet</month>
 							<month type="5" draft="contributed">Szwat</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
+							<month type="6" draft="contributed">Adar I</month>
+							<month type="7" draft="contributed">Adar</month>
+							<month type="7" yeartype="leap" draft="contributed">Adar II</month>
+							<month type="8" draft="contributed">Nisan</month>
 							<month type="9" draft="contributed">Ijar</month>
 							<month type="10" draft="contributed">Siwan</month>
-							<month type="11" draft="contributed">↑↑↑</month>
+							<month type="11" draft="contributed">Tamuz</month>
 							<month type="12" draft="contributed">Aw</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -3032,9 +3032,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-short">
 				<displayName>dz.</displayName>
 				<relative type="-2" draft="contributed">przedwczoraj</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">wczoraj</relative>
+				<relative type="0">dzisiaj</relative>
+				<relative type="1">jutro</relative>
 				<relative type="2" draft="contributed">pojutrze</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} dzień</relativeTimePattern>
@@ -3054,7 +3054,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="-2" draft="contributed">przedwczoraj</relative>
 				<relative type="-1">wcz.</relative>
 				<relative type="0">dziś</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">jutro</relative>
 				<relative type="2" draft="contributed">pojutrze</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} dzień</relativeTimePattern>
@@ -6408,7 +6408,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="many">rubli białoruskich</displayName>
 				<displayName count="other">rubla białoruskiego</displayName>
 				<symbol>BYN</symbol>
-				<symbol alt="narrow">↑↑↑</symbol>
+				<symbol alt="narrow">BYN</symbol>
 			</currency>
 			<currency type="BYR">
 				<displayName>rubel białoruski (2000–2016)</displayName>
@@ -8210,39 +8210,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" gender="inanimate" case="vocative">{0} sześciennego</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>neuter</gender>
 				<displayName>stała grawitacji</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="one" case="accusative">{0} G</unitPattern>
+				<unitPattern count="one" case="dative">{0} G</unitPattern>
+				<unitPattern count="one" case="genitive">{0} G</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} G</unitPattern>
+				<unitPattern count="one" case="locative">{0} G</unitPattern>
+				<unitPattern count="one" case="vocative">{0} G</unitPattern>
+				<unitPattern count="few">{0} G</unitPattern>
+				<unitPattern count="few" case="accusative">{0} G</unitPattern>
+				<unitPattern count="few" case="dative">{0} G</unitPattern>
+				<unitPattern count="few" case="genitive">{0} G</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} G</unitPattern>
+				<unitPattern count="few" case="locative">{0} G</unitPattern>
+				<unitPattern count="few" case="vocative">{0} G</unitPattern>
+				<unitPattern count="many">{0} G</unitPattern>
+				<unitPattern count="many" case="accusative">{0} G</unitPattern>
+				<unitPattern count="many" case="dative">{0} G</unitPattern>
+				<unitPattern count="many" case="genitive">{0} G</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} G</unitPattern>
+				<unitPattern count="many" case="locative">{0} G</unitPattern>
+				<unitPattern count="many" case="vocative">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
+				<unitPattern count="other" case="accusative">{0} G</unitPattern>
+				<unitPattern count="other" case="dative">{0} G</unitPattern>
+				<unitPattern count="other" case="genitive">{0} G</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} G</unitPattern>
+				<unitPattern count="other" case="locative">{0} G</unitPattern>
+				<unitPattern count="other" case="vocative">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>inanimate</gender>
@@ -8262,67 +8262,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} metrach na sekundę do kwadratu</unitPattern>
 				<unitPattern count="few" case="vocative">{0} metry na sekundę do kwadratu</unitPattern>
 				<unitPattern count="many">{0} metrów na sekundę do kwadratu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metrów na sekundę do kwadratu</unitPattern>
 				<unitPattern count="many" case="dative">{0} metrom na sekundę do kwadratu</unitPattern>
 				<unitPattern count="many" case="genitive">{0} metrów na sekundę do kwadratu</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} metrami na sekundę do kwadratu</unitPattern>
 				<unitPattern count="many" case="locative">{0} metrach na sekundę do kwadratu</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} metrów na sekundę do kwadratu</unitPattern>
 				<unitPattern count="other">{0} metra na sekundę do kwadratu</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metra na sekundę do kwadratu</unitPattern>
+				<unitPattern count="other" case="dative">{0} metra na sekundę do kwadratu</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metra na sekundę do kwadratu</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metra na sekundę do kwadratu</unitPattern>
+				<unitPattern count="other" case="locative">{0} metra na sekundę do kwadratu</unitPattern>
+				<unitPattern count="other" case="vocative">{0} metra na sekundę do kwadratu</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>inanimate</gender>
 				<displayName>obrót</displayName>
 				<unitPattern count="one">{0} obrót</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} obrót</unitPattern>
 				<unitPattern count="one" case="genitive">{0} obrotu</unitPattern>
 				<unitPattern count="few">{0} obroty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} obroty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} obrotów</unitPattern>
 				<unitPattern count="many">{0} obrotów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} obrotów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} obrotów</unitPattern>
 				<unitPattern count="other">{0} obrotu</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} obrotu</unitPattern>
+				<unitPattern count="other" case="genitive">{0} obrotu</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>inanimate</gender>
 				<displayName>radiany</displayName>
 				<unitPattern count="one">{0} radian</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} radian</unitPattern>
 				<unitPattern count="one" case="genitive">{0} radiana</unitPattern>
 				<unitPattern count="few">{0} radiany</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} radiany</unitPattern>
 				<unitPattern count="few" case="genitive">{0} radianów</unitPattern>
 				<unitPattern count="many">{0} radianów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} radianów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} radianów</unitPattern>
 				<unitPattern count="other">{0} radiana</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} radiana</unitPattern>
+				<unitPattern count="other" case="genitive">{0} radiana</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>inanimate</gender>
 				<displayName>stopnie</displayName>
 				<unitPattern count="one">{0} stopień</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} stopień</unitPattern>
 				<unitPattern count="one" case="genitive">{0} stopnia</unitPattern>
 				<unitPattern count="few">{0} stopnie</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stopnie</unitPattern>
 				<unitPattern count="few" case="genitive">{0} stopni</unitPattern>
 				<unitPattern count="many">{0} stopni</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stopni</unitPattern>
+				<unitPattern count="many" case="genitive">{0} stopni</unitPattern>
 				<unitPattern count="other">{0} stopnia</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stopnia</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stopnia</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>feminine</gender>
@@ -8331,14 +8331,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} minutę kątową</unitPattern>
 				<unitPattern count="one" case="genitive">{0} minuty kątowej</unitPattern>
 				<unitPattern count="few">{0} minuty kątowe</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} minuty kątowe</unitPattern>
 				<unitPattern count="few" case="genitive">{0} minut kątkowych</unitPattern>
 				<unitPattern count="many">{0} minut kątowych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} minut kątowych</unitPattern>
+				<unitPattern count="many" case="genitive">{0} minut kątowych</unitPattern>
 				<unitPattern count="other">{0} minuty kątowej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} minuty kątowej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} minuty kątowej</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>feminine</gender>
@@ -8347,14 +8347,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} sekundę kątową</unitPattern>
 				<unitPattern count="one" case="genitive">{0} sekundy kątowej</unitPattern>
 				<unitPattern count="few">{0} sekundy kątowe</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} sekundy kątowe</unitPattern>
 				<unitPattern count="few" case="genitive">{0} sekund kątkowych</unitPattern>
 				<unitPattern count="many">{0} sekund kątowych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} sekund kątowych</unitPattern>
+				<unitPattern count="many" case="genitive">{0} sekund kątowych</unitPattern>
 				<unitPattern count="other">{0} sekundy kątowej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sekundy kątowej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} sekundy kątowej</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>inanimate</gender>
@@ -8374,19 +8374,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} kilometrach kwadratowych</unitPattern>
 				<unitPattern count="few" case="vocative">{0} kilometry kwadratowe</unitPattern>
 				<unitPattern count="many">{0} kilometrów kwadratowych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilometrów kwadratowych</unitPattern>
 				<unitPattern count="many" case="dative">{0} kilometrom kwadratowym</unitPattern>
 				<unitPattern count="many" case="genitive">{0} kilometrów kwadratowych</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} kilometrami kwadratowymi</unitPattern>
 				<unitPattern count="many" case="locative">{0} kilometrach kwadratowych</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} kilometrów kwadratowych</unitPattern>
 				<unitPattern count="other">{0} kilometra kwadratowego</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometra kwadratowego</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilometra kwadratowego</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometra kwadratowego</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilometra kwadratowego</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilometra kwadratowego</unitPattern>
+				<unitPattern count="other" case="vocative">{0} kilometra kwadratowego</unitPattern>
 				<perUnitPattern>{0} na kilometr kwadratowy</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
@@ -8407,35 +8407,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} hektarach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} hektary</unitPattern>
 				<unitPattern count="many">{0} hektarów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hektarów</unitPattern>
 				<unitPattern count="many" case="dative">{0} hektarom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} hektarów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} hektarami</unitPattern>
 				<unitPattern count="many" case="locative">{0} hektarach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} hektarów</unitPattern>
 				<unitPattern count="other">{0} hektara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektara</unitPattern>
+				<unitPattern count="other" case="dative">{0} hektara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektara</unitPattern>
+				<unitPattern count="other" case="locative">{0} hektara</unitPattern>
+				<unitPattern count="other" case="vocative">{0} hektara</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>inanimate</gender>
 				<displayName>metry kwadratowe</displayName>
 				<unitPattern count="one">{0} metr kwadratowy</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} metr kwadratowy</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra kwadratowego</unitPattern>
 				<unitPattern count="few">{0} metry kwadratowe</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metry kwadratowe</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metrów kwadratowych</unitPattern>
 				<unitPattern count="many">{0} metrów kwadratowych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metrów kwadratowych</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metrów kwadratowych</unitPattern>
 				<unitPattern count="other">{0} metra kwadratowego</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metra kwadratowego</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metra kwadratowego</unitPattern>
 				<perUnitPattern>{0} na metr kwadratowy</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
@@ -8456,19 +8456,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} centymetrach kwadratowych</unitPattern>
 				<unitPattern count="few" case="vocative">{0} centymetry kwadratowe</unitPattern>
 				<unitPattern count="many">{0} centymetrów kwadratowych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} centymetrów kwadratowych</unitPattern>
 				<unitPattern count="many" case="dative">{0} centymetrom kwadratowym</unitPattern>
 				<unitPattern count="many" case="genitive">{0} centymetrów kwadratowych</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} centymetrami kwadratowymi</unitPattern>
 				<unitPattern count="many" case="locative">{0} centymetrach kwadratowych</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} centymetrów kwadratowych</unitPattern>
 				<unitPattern count="other">{0} centymetra kwadratowego</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centymetra kwadratowego</unitPattern>
+				<unitPattern count="other" case="dative">{0} centymetra kwadratowego</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centymetra kwadratowego</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centymetra kwadratowego</unitPattern>
+				<unitPattern count="other" case="locative">{0} centymetra kwadratowego</unitPattern>
+				<unitPattern count="other" case="vocative">{0} centymetra kwadratowego</unitPattern>
 				<perUnitPattern>{0} na centymetr kwadratowy</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -8482,26 +8482,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} mili kwadratowej</unitPattern>
 				<unitPattern count="one" case="vocative">{0} milo kwadratowa</unitPattern>
 				<unitPattern count="few">{0} mile kwadratowe</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mile kwadratowe</unitPattern>
 				<unitPattern count="few" case="dative">{0} milom kwadratowym</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mil kwadratowych</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milami kwadratowymi</unitPattern>
 				<unitPattern count="few" case="locative">{0} milach kwadratowych</unitPattern>
 				<unitPattern count="few" case="vocative">{0} mile kwadratowe</unitPattern>
 				<unitPattern count="many">{0} mil kwadratowych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mil kwadratowych</unitPattern>
 				<unitPattern count="many" case="dative">{0} milom kwadratowym</unitPattern>
 				<unitPattern count="many" case="genitive">{0} mil kwadratowych</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} milami kwadratowymi</unitPattern>
 				<unitPattern count="many" case="locative">{0} milach kwadratowych</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} mil kwadratowych</unitPattern>
 				<unitPattern count="other">{0} mili kwadratowej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mili kwadratowej</unitPattern>
+				<unitPattern count="other" case="dative">{0} mili kwadratowej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mili kwadratowej</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mili kwadratowej</unitPattern>
+				<unitPattern count="other" case="locative">{0} mili kwadratowej</unitPattern>
+				<unitPattern count="other" case="vocative">{0} mili kwadratowej</unitPattern>
 				<perUnitPattern>{0} na milę kwadratową</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
@@ -8522,19 +8522,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} akrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} akry</unitPattern>
 				<unitPattern count="many">{0} akrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} akrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} akrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} akrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} akrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} akrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} akrów</unitPattern>
 				<unitPattern count="other">{0} akra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} akra</unitPattern>
+				<unitPattern count="other" case="dative">{0} akra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} akra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} akra</unitPattern>
+				<unitPattern count="other" case="locative">{0} akra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} akra</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>jardy kwadratowe</displayName>
@@ -8554,26 +8554,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} stopie kwadratowej</unitPattern>
 				<unitPattern count="one" case="vocative">{0} stopo kwadratowa</unitPattern>
 				<unitPattern count="few">{0} stopy kwadratowe</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stopy kwadratowe</unitPattern>
 				<unitPattern count="few" case="dative">{0} stopom kwadratowym</unitPattern>
 				<unitPattern count="few" case="genitive">{0} stóp kwadratowych</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} stopami kwadratowymi</unitPattern>
 				<unitPattern count="few" case="locative">{0} stopach kwadratowych</unitPattern>
 				<unitPattern count="few" case="vocative">{0} stopy kwadratowe</unitPattern>
 				<unitPattern count="many">{0} stóp kwadratowych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stóp kwadratowych</unitPattern>
 				<unitPattern count="many" case="dative">{0} stopom kwadratowym</unitPattern>
 				<unitPattern count="many" case="genitive">{0} stóp kwadratowych</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} stopami kwadratowymi</unitPattern>
 				<unitPattern count="many" case="locative">{0} stopach kwadratowych</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} stóp kwadratowych</unitPattern>
 				<unitPattern count="other">{0} stopy kwadratowej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stopy kwadratowej</unitPattern>
+				<unitPattern count="other" case="dative">{0} stopy kwadratowej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stopy kwadratowej</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stopy kwadratowej</unitPattern>
+				<unitPattern count="other" case="locative">{0} stopy kwadratowej</unitPattern>
+				<unitPattern count="other" case="vocative">{0} stopy kwadratowej</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>cale kwadratowe</displayName>
@@ -8594,17 +8594,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>karaty</displayName>
 				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karata</unitPattern>
 				<unitPattern count="few">{0} karaty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} karaty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} karatów</unitPattern>
 				<unitPattern count="many">{0} karatów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} karatów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} karatów</unitPattern>
 				<unitPattern count="other">{0} karata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karata</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>miligramy na decylitr</displayName>
@@ -8617,17 +8617,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>milimole na litr</displayName>
 				<unitPattern count="one">{0} milimol na litr</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milimol na litr</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milimola na litr</unitPattern>
 				<unitPattern count="few">{0} milimole na litr</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milimole na litr</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milimoli na litr</unitPattern>
 				<unitPattern count="many">{0} milimoli na litr</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milimoli na litr</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milimoli na litr</unitPattern>
 				<unitPattern count="other">{0} milimola na litr</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimola na litr</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimola na litr</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>feminine</gender>
@@ -8636,30 +8636,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} sztukę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} sztuki</unitPattern>
 				<unitPattern count="few">{0} sztuki</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} sztuki</unitPattern>
 				<unitPattern count="few" case="genitive">{0} sztuk</unitPattern>
 				<unitPattern count="many">{0} sztuk</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} sztuk</unitPattern>
+				<unitPattern count="many" case="genitive">{0} sztuk</unitPattern>
 				<unitPattern count="other">{0} sztuki</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sztuki</unitPattern>
+				<unitPattern count="other" case="genitive">{0} sztuki</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>feminine</gender>
 				<displayName>części na milion</displayName>
 				<unitPattern count="one">{0} część na milion</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} część na milion</unitPattern>
 				<unitPattern count="one" case="genitive">{0} części na milion</unitPattern>
 				<unitPattern count="few">{0} części na milion</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} części na milion</unitPattern>
+				<unitPattern count="few" case="genitive">{0} części na milion</unitPattern>
 				<unitPattern count="many">{0} części na milion</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} części na milion</unitPattern>
+				<unitPattern count="many" case="genitive">{0} części na milion</unitPattern>
 				<unitPattern count="other">{0} części na milion</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} części na milion</unitPattern>
+				<unitPattern count="other" case="genitive">{0} części na milion</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>inanimate</gender>
@@ -8672,90 +8672,90 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} procencie</unitPattern>
 				<unitPattern count="one" case="vocative">{0} procencie</unitPattern>
 				<unitPattern count="few">{0} procent</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} procent</unitPattern>
 				<unitPattern count="few" case="dative">{0} procentom</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} procent</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} procentami</unitPattern>
 				<unitPattern count="few" case="locative">{0} procentach</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} procent</unitPattern>
 				<unitPattern count="many">{0} procent</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} procent</unitPattern>
 				<unitPattern count="many" case="dative">{0} procentom</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} procent</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} procentami</unitPattern>
 				<unitPattern count="many" case="locative">{0} procentach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} procent</unitPattern>
 				<unitPattern count="other">{0} procent</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} procent</unitPattern>
+				<unitPattern count="other" case="dative">{0} procent</unitPattern>
+				<unitPattern count="other" case="genitive">{0} procent</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} procent</unitPattern>
+				<unitPattern count="other" case="locative">{0} procent</unitPattern>
+				<unitPattern count="other" case="vocative">{0} procent</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>inanimate</gender>
 				<displayName>promil</displayName>
 				<unitPattern count="one">{0} promil</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} promil</unitPattern>
 				<unitPattern count="one" case="genitive">{0} promila</unitPattern>
 				<unitPattern count="few">{0} promile</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} promile</unitPattern>
 				<unitPattern count="few" case="genitive">{0} promili</unitPattern>
 				<unitPattern count="many">{0} promili</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} promili</unitPattern>
+				<unitPattern count="many" case="genitive">{0} promili</unitPattern>
 				<unitPattern count="other">{0} promila</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} promila</unitPattern>
+				<unitPattern count="other" case="genitive">{0} promila</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>inanimate</gender>
 				<displayName>punkt bazowy</displayName>
 				<unitPattern count="one">{0} punkt bazowy</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} punkt bazowy</unitPattern>
 				<unitPattern count="one" case="genitive">{0} punktu bazowego</unitPattern>
 				<unitPattern count="few">{0} punkty bazowe</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} punkty bazowe</unitPattern>
 				<unitPattern count="few" case="genitive">{0} punktów bazowych</unitPattern>
 				<unitPattern count="many">{0} punktów bazowych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} punktów bazowych</unitPattern>
+				<unitPattern count="many" case="genitive">{0} punktów bazowych</unitPattern>
 				<unitPattern count="other">{0} punktu bazowego</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} punktu bazowego</unitPattern>
+				<unitPattern count="other" case="genitive">{0} punktu bazowego</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>inanimate</gender>
 				<displayName>mol</displayName>
 				<unitPattern count="one">{0} mol</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mol</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mola</unitPattern>
 				<unitPattern count="few">{0} mole</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mole</unitPattern>
 				<unitPattern count="few" case="genitive">{0} moli</unitPattern>
 				<unitPattern count="many">{0} moli</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} moli</unitPattern>
+				<unitPattern count="many" case="genitive">{0} moli</unitPattern>
 				<unitPattern count="other">{0} mola</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mola</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mola</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>inanimate</gender>
 				<displayName>litry na kilometr</displayName>
 				<unitPattern count="one">{0} litr na kilometr</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} litr na kilometr</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra na kilometr</unitPattern>
 				<unitPattern count="few">{0} litry na kilometr</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litry na kilometr</unitPattern>
 				<unitPattern count="few" case="genitive">{0} litrów na kilometr</unitPattern>
 				<unitPattern count="many">{0} litrów na kilometr</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} litrów na kilometr</unitPattern>
+				<unitPattern count="many" case="genitive">{0} litrów na kilometr</unitPattern>
 				<unitPattern count="other">{0} litra na kilometr</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litra na kilometr</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litra na kilometr</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>inanimate</gender>
@@ -8775,19 +8775,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} litrach na 100 kilometrów</unitPattern>
 				<unitPattern count="few" case="vocative">{0} litry na 100 kilometrów</unitPattern>
 				<unitPattern count="many">{0} litrów na 100 kilometrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} litrów na 100 kilometrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} litrom na 100 kilometrów</unitPattern>
 				<unitPattern count="many" case="genitive">{0} litrów na 100 kilometrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} litrami na 100 kilometrów</unitPattern>
 				<unitPattern count="many" case="locative">{0} litrach na 100 kilometrów</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} litrów na 100 kilometrów</unitPattern>
 				<unitPattern count="other">{0} litra na 100 kilometrów</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litra na 100 kilometrów</unitPattern>
+				<unitPattern count="other" case="dative">{0} litra na 100 kilometrów</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litra na 100 kilometrów</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litra na 100 kilometrów</unitPattern>
+				<unitPattern count="other" case="locative">{0} litra na 100 kilometrów</unitPattern>
+				<unitPattern count="other" case="vocative">{0} litra na 100 kilometrów</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<gender>feminine</gender>
@@ -8800,7 +8800,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} mili na galon</unitPattern>
 				<unitPattern count="one" case="vocative">{0} milo na galon</unitPattern>
 				<unitPattern count="few">{0} mile na galon</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mile na galon</unitPattern>
 				<unitPattern count="few" case="dative">{0} milom na galon</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mil na galon</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milami na galon</unitPattern>
@@ -8814,12 +8814,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="locative">{0} milach na galon</unitPattern>
 				<unitPattern count="many" case="vocative">{0} mil na galon</unitPattern>
 				<unitPattern count="other">{0} mili na galon</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mili na galon</unitPattern>
+				<unitPattern count="other" case="dative">{0} mili na galon</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mili na galon</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mili na galon</unitPattern>
+				<unitPattern count="other" case="locative">{0} mili na galon</unitPattern>
+				<unitPattern count="other" case="vocative">{0} mili na galon</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<gender>feminine</gender>
@@ -8832,218 +8832,218 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} mili na galon angielski</unitPattern>
 				<unitPattern count="one" case="vocative">{0} milo na galon angielski</unitPattern>
 				<unitPattern count="few">{0} mile na galon angielski</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mile na galon angielski</unitPattern>
 				<unitPattern count="few" case="dative">{0} milom na galon angielski</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mil na galon angielski</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milami na galon angielski</unitPattern>
 				<unitPattern count="few" case="locative">{0} milach na galon angielski</unitPattern>
 				<unitPattern count="few" case="vocative">{0} mile na galon angielski</unitPattern>
 				<unitPattern count="many">{0} mil na galon angielski</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mil na galon angielski</unitPattern>
 				<unitPattern count="many" case="dative">{0} milom na galon angielski</unitPattern>
 				<unitPattern count="many" case="genitive">{0} mil na galon angielski</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} milami na galon angielski</unitPattern>
 				<unitPattern count="many" case="locative">{0} milach na galon angielski</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} mil na galon angielski</unitPattern>
 				<unitPattern count="other">{0} mili na galon angielski</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mili na galon angielski</unitPattern>
+				<unitPattern count="other" case="dative">{0} mili na galon angielski</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mili na galon angielski</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mili na galon angielski</unitPattern>
+				<unitPattern count="other" case="locative">{0} mili na galon angielski</unitPattern>
+				<unitPattern count="other" case="vocative">{0} mili na galon angielski</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<gender>inanimate</gender>
 				<displayName>petabajty</displayName>
 				<unitPattern count="one">{0} petabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} petabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} petabajta</unitPattern>
 				<unitPattern count="few">{0} petabajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} petabajty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} petabajtów</unitPattern>
 				<unitPattern count="many">{0} petabajtów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} petabajtów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} petabajtów</unitPattern>
 				<unitPattern count="other">{0} petabajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} petabajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} petabajta</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>inanimate</gender>
 				<displayName>terabajty</displayName>
 				<unitPattern count="one">{0} terabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabajta</unitPattern>
 				<unitPattern count="few">{0} terabajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} terabajty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} terabajtów</unitPattern>
 				<unitPattern count="many">{0} terabajtów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} terabajtów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} terabajtów</unitPattern>
 				<unitPattern count="other">{0} terabajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabajta</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>inanimate</gender>
 				<displayName>terabity</displayName>
 				<unitPattern count="one">{0} terabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabita</unitPattern>
 				<unitPattern count="few">{0} terabity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} terabity</unitPattern>
 				<unitPattern count="few" case="genitive">{0} terabitów</unitPattern>
 				<unitPattern count="many">{0} terabitów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} terabitów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} terabitów</unitPattern>
 				<unitPattern count="other">{0} terabita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabita</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>inanimate</gender>
 				<displayName>gigabajty</displayName>
 				<unitPattern count="one">{0} gigabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabajta</unitPattern>
 				<unitPattern count="few">{0} gigabajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigabajty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigabajtów</unitPattern>
 				<unitPattern count="many">{0} gigabajtów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigabajtów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigabajtów</unitPattern>
 				<unitPattern count="other">{0} gigabajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabajta</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>inanimate</gender>
 				<displayName>gigabity</displayName>
 				<unitPattern count="one">{0} gigabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabita</unitPattern>
 				<unitPattern count="few">{0} gigabity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigabity</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigabitów</unitPattern>
 				<unitPattern count="many">{0} gigabitów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigabitów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigabitów</unitPattern>
 				<unitPattern count="other">{0} gigabita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabita</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>inanimate</gender>
 				<displayName>megabajty</displayName>
 				<unitPattern count="one">{0} megabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabajta</unitPattern>
 				<unitPattern count="few">{0} megabajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megabajty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megabajtów</unitPattern>
 				<unitPattern count="many">{0} megabajtów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megabajtów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megabajtów</unitPattern>
 				<unitPattern count="other">{0} megabajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabajta</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>inanimate</gender>
 				<displayName>megabity</displayName>
 				<unitPattern count="one">{0} megabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabita</unitPattern>
 				<unitPattern count="few">{0} megabity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megabity</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megabitów</unitPattern>
 				<unitPattern count="many">{0} megabitów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megabitów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megabitów</unitPattern>
 				<unitPattern count="other">{0} megabita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabita</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>inanimate</gender>
 				<displayName>kilobajty</displayName>
 				<unitPattern count="one">{0} kilobajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobajta</unitPattern>
 				<unitPattern count="few">{0} kilobajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilobajty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilobajtów</unitPattern>
 				<unitPattern count="many">{0} kilobajtów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilobajtów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilobajtów</unitPattern>
 				<unitPattern count="other">{0} kilobajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobajta</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>inanimate</gender>
 				<displayName>kilobity</displayName>
 				<unitPattern count="one">{0} kilobit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobita</unitPattern>
 				<unitPattern count="few">{0} kilobity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilobity</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilobitów</unitPattern>
 				<unitPattern count="many">{0} kilobitów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilobitów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilobitów</unitPattern>
 				<unitPattern count="other">{0} kilobita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobita</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>inanimate</gender>
 				<displayName>bajty</displayName>
 				<unitPattern count="one">{0} bajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bajta</unitPattern>
 				<unitPattern count="few">{0} bajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bajty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} bajtów</unitPattern>
 				<unitPattern count="many">{0} bajtów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} bajtów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} bajtów</unitPattern>
 				<unitPattern count="other">{0} bajta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bajta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bajta</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>inanimate</gender>
 				<displayName>bity</displayName>
 				<unitPattern count="one">{0} bit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bita</unitPattern>
 				<unitPattern count="few">{0} bity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bity</unitPattern>
 				<unitPattern count="few" case="genitive">{0} bitów</unitPattern>
 				<unitPattern count="many">{0} bitów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} bitów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} bitów</unitPattern>
 				<unitPattern count="other">{0} bita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bita</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>inanimate</gender>
 				<displayName>wieki</displayName>
 				<unitPattern count="one">{0} wiek</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} wiek</unitPattern>
 				<unitPattern count="one" case="genitive">{0} wieku</unitPattern>
 				<unitPattern count="few">{0} wieki</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} wieki</unitPattern>
 				<unitPattern count="few" case="genitive">{0} wieków</unitPattern>
 				<unitPattern count="many">{0} wieków</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} wieków</unitPattern>
+				<unitPattern count="many" case="genitive">{0} wieków</unitPattern>
 				<unitPattern count="other">{0} wieku</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} wieku</unitPattern>
+				<unitPattern count="other" case="genitive">{0} wieku</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>feminine</gender>
@@ -9052,46 +9052,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} dekadę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dekady</unitPattern>
 				<unitPattern count="few">{0} dekady</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} dekady</unitPattern>
 				<unitPattern count="few" case="genitive">{0} dekad</unitPattern>
 				<unitPattern count="many">{0} dekad</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} dekad</unitPattern>
+				<unitPattern count="many" case="genitive">{0} dekad</unitPattern>
 				<unitPattern count="other">{0} dekady</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dekady</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dekady</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>inanimate</gender>
 				<displayName>lata</displayName>
 				<unitPattern count="one">{0} rok</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} rok</unitPattern>
 				<unitPattern count="one" case="dative">{0} rokowi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} roku</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} rokiem</unitPattern>
 				<unitPattern count="one" case="locative">{0} roku</unitPattern>
 				<unitPattern count="one" case="vocative">{0} roku</unitPattern>
 				<unitPattern count="few">{0} lata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} lata</unitPattern>
 				<unitPattern count="few" case="dative">{0} latom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} lat</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} latami</unitPattern>
 				<unitPattern count="few" case="locative">{0} latach</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} lata</unitPattern>
 				<unitPattern count="many">{0} lat</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} lat</unitPattern>
 				<unitPattern count="many" case="dative">{0} latom</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} lat</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} latami</unitPattern>
 				<unitPattern count="many" case="locative">{0} latach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} lat</unitPattern>
 				<unitPattern count="other">{0} roku</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} roku</unitPattern>
+				<unitPattern count="other" case="dative">{0} roku</unitPattern>
+				<unitPattern count="other" case="genitive">{0} roku</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} roku</unitPattern>
+				<unitPattern count="other" case="locative">{0} roku</unitPattern>
+				<unitPattern count="other" case="vocative">{0} roku</unitPattern>
 				<perUnitPattern>{0} na rok</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -9129,19 +9129,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} miesiącach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} miesiące</unitPattern>
 				<unitPattern count="many">{0} miesięcy</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} miesięcy</unitPattern>
 				<unitPattern count="many" case="dative">{0} miesiącom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} miesięcy</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} miesiącami</unitPattern>
 				<unitPattern count="many" case="locative">{0} miesiącach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} miesięcy</unitPattern>
 				<unitPattern count="other">{0} miesiąca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miesiąca</unitPattern>
+				<unitPattern count="other" case="dative">{0} miesiąca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miesiąca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} miesiąca</unitPattern>
+				<unitPattern count="other" case="locative">{0} miesiąca</unitPattern>
+				<unitPattern count="other" case="vocative">{0} miesiąca</unitPattern>
 				<perUnitPattern>{0} na miesiąc</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
@@ -9162,25 +9162,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} tygodniach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} tygodnie</unitPattern>
 				<unitPattern count="many">{0} tygodni</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} tygodni</unitPattern>
 				<unitPattern count="many" case="dative">{0} tygodniom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} tygodni</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} tygodniami</unitPattern>
 				<unitPattern count="many" case="locative">{0} tygodniach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} tygodni</unitPattern>
 				<unitPattern count="other">{0} tygodnia</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} tygodnia</unitPattern>
+				<unitPattern count="other" case="dative">{0} tygodnia</unitPattern>
+				<unitPattern count="other" case="genitive">{0} tygodnia</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} tygodnia</unitPattern>
+				<unitPattern count="other" case="locative">{0} tygodnia</unitPattern>
+				<unitPattern count="other" case="vocative">{0} tygodnia</unitPattern>
 				<perUnitPattern>{0} na tydzień</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<gender>feminine</gender>
 				<displayName>doby</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} doba</unitPattern>
 				<unitPattern count="one" case="accusative">{0} dobę</unitPattern>
 				<unitPattern count="one" case="dative">{0} dobie</unitPattern>
 				<unitPattern count="one" case="genitive">{0} doby</unitPattern>
@@ -9200,7 +9200,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="genitive">{0} dób</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} dobami</unitPattern>
 				<unitPattern count="many" case="locative">{0} dobach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} dób</unitPattern>
 				<unitPattern count="other">{0} doby</unitPattern>
 				<unitPattern count="other" case="accusative">{0} doby</unitPattern>
 				<unitPattern count="other" case="dative">{0} doby</unitPattern>
@@ -9212,18 +9212,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-day-person">
 				<gender>feminine</gender>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} doba</unitPattern>
 				<unitPattern count="one" case="accusative">{0} dobę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} doby</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} doby</unitPattern>
+				<unitPattern count="few" case="accusative">{0} doby</unitPattern>
 				<unitPattern count="few" case="genitive">{0} dób</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many">{0} dób</unitPattern>
+				<unitPattern count="many" case="accusative">{0} dób</unitPattern>
+				<unitPattern count="many" case="genitive">{0} dób</unitPattern>
+				<unitPattern count="other">{0} doby</unitPattern>
+				<unitPattern count="other" case="accusative">{0} doby</unitPattern>
+				<unitPattern count="other" case="genitive">{0} doby</unitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<gender>feminine</gender>
@@ -9243,19 +9243,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} godzinach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} godziny</unitPattern>
 				<unitPattern count="many">{0} godzin</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} godzin</unitPattern>
 				<unitPattern count="many" case="dative">{0} godzinom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} godzin</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} godzinami</unitPattern>
 				<unitPattern count="many" case="locative">{0} godzinach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} godzin</unitPattern>
 				<unitPattern count="other">{0} godziny</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} godziny</unitPattern>
+				<unitPattern count="other" case="dative">{0} godziny</unitPattern>
+				<unitPattern count="other" case="genitive">{0} godziny</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} godziny</unitPattern>
+				<unitPattern count="other" case="locative">{0} godziny</unitPattern>
+				<unitPattern count="other" case="vocative">{0} godziny</unitPattern>
 				<perUnitPattern>{0} na godzinę</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -9276,19 +9276,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} minutach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} minuty</unitPattern>
 				<unitPattern count="many">{0} minut</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} minut</unitPattern>
 				<unitPattern count="many" case="dative">{0} minutom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} minut</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} minutami</unitPattern>
 				<unitPattern count="many" case="locative">{0} minutach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} minut</unitPattern>
 				<unitPattern count="other">{0} minuty</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} minuty</unitPattern>
+				<unitPattern count="other" case="dative">{0} minuty</unitPattern>
+				<unitPattern count="other" case="genitive">{0} minuty</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} minuty</unitPattern>
+				<unitPattern count="other" case="locative">{0} minuty</unitPattern>
+				<unitPattern count="other" case="vocative">{0} minuty</unitPattern>
 				<perUnitPattern>{0} na minutę</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -9309,19 +9309,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} sekundach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} sekundy</unitPattern>
 				<unitPattern count="many">{0} sekund</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} sekund</unitPattern>
 				<unitPattern count="many" case="dative">{0} sekundom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} sekund</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} sekundami</unitPattern>
 				<unitPattern count="many" case="locative">{0} sekundach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} sekund</unitPattern>
 				<unitPattern count="other">{0} sekundy</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sekundy</unitPattern>
+				<unitPattern count="other" case="dative">{0} sekundy</unitPattern>
+				<unitPattern count="other" case="genitive">{0} sekundy</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} sekundy</unitPattern>
+				<unitPattern count="other" case="locative">{0} sekundy</unitPattern>
+				<unitPattern count="other" case="vocative">{0} sekundy</unitPattern>
 				<perUnitPattern>{0} na sekundę</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
@@ -9331,14 +9331,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} milisekundę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milisekundy</unitPattern>
 				<unitPattern count="few">{0} milisekundy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milisekundy</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milisekund</unitPattern>
 				<unitPattern count="many">{0} milisekund</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milisekund</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milisekund</unitPattern>
 				<unitPattern count="other">{0} milisekundy</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milisekundy</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milisekundy</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>feminine</gender>
@@ -9347,14 +9347,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} mikrosekundę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrosekundy</unitPattern>
 				<unitPattern count="few">{0} mikrosekundy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrosekundy</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mikrosekund</unitPattern>
 				<unitPattern count="many">{0} mikrosekund</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mikrosekund</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mikrosekund</unitPattern>
 				<unitPattern count="other">{0} mikrosekundy</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrosekundy</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrosekundy</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>feminine</gender>
@@ -9363,78 +9363,78 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} nanosekundę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} nanosekundy</unitPattern>
 				<unitPattern count="few">{0} nanosekundy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} nanosekundy</unitPattern>
 				<unitPattern count="few" case="genitive">{0} nanosekund</unitPattern>
 				<unitPattern count="many">{0} nanosekund</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} nanosekund</unitPattern>
+				<unitPattern count="many" case="genitive">{0} nanosekund</unitPattern>
 				<unitPattern count="other">{0} nanosekundy</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanosekundy</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nanosekundy</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>inanimate</gender>
 				<displayName>ampery</displayName>
 				<unitPattern count="one">{0} amper</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} amper</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ampera</unitPattern>
 				<unitPattern count="few">{0} ampery</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ampery</unitPattern>
 				<unitPattern count="few" case="genitive">{0} amperów</unitPattern>
 				<unitPattern count="many">{0} amperów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} amperów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} amperów</unitPattern>
 				<unitPattern count="other">{0} ampera</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ampera</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ampera</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>inanimate</gender>
 				<displayName>miliampery</displayName>
 				<unitPattern count="one">{0} miliamper</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miliamper</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miliampera</unitPattern>
 				<unitPattern count="few">{0} miliampery</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} miliampery</unitPattern>
 				<unitPattern count="few" case="genitive">{0} miliamperów</unitPattern>
 				<unitPattern count="many">{0} miliamperów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} miliamperów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} miliamperów</unitPattern>
 				<unitPattern count="other">{0} miliampera</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miliampera</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miliampera</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>inanimate</gender>
 				<displayName>omy</displayName>
 				<unitPattern count="one">{0} om</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} om</unitPattern>
 				<unitPattern count="one" case="genitive">{0} oma</unitPattern>
 				<unitPattern count="few">{0} omy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} omy</unitPattern>
 				<unitPattern count="few" case="genitive">{0} omów</unitPattern>
 				<unitPattern count="many">{0} omów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} omów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} omów</unitPattern>
 				<unitPattern count="other">{0} oma</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} oma</unitPattern>
+				<unitPattern count="other" case="genitive">{0} oma</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>inanimate</gender>
 				<displayName>wolty</displayName>
 				<unitPattern count="one">{0} wolt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} wolt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} wolta</unitPattern>
 				<unitPattern count="few">{0} wolty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} wolty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} woltów</unitPattern>
 				<unitPattern count="many">{0} woltów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} woltów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} woltów</unitPattern>
 				<unitPattern count="other">{0} wolta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} wolta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} wolta</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<gender>feminine</gender>
@@ -9447,26 +9447,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} kilokalorii</unitPattern>
 				<unitPattern count="one" case="vocative">{0} kilokalorio</unitPattern>
 				<unitPattern count="few">{0} kilokalorie</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilokalorie</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilokaloriom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilokalorii</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilokaloriami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilokaloriach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} kilokalorie</unitPattern>
 				<unitPattern count="many">{0} kilokalorii</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilokalorii</unitPattern>
 				<unitPattern count="many" case="dative">{0} kilokaloriom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} kilokalorii</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} kilokaloriami</unitPattern>
 				<unitPattern count="many" case="locative">{0} kilokaloriach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} kilokalorii</unitPattern>
 				<unitPattern count="other">{0} kilokalorii</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilokalorii</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilokalorii</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilokalorii</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilokalorii</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilokalorii</unitPattern>
+				<unitPattern count="other" case="vocative">{0} kilokalorii</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<gender>feminine</gender>
@@ -9475,14 +9475,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} kalorię</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kalorii</unitPattern>
 				<unitPattern count="few">{0} kalorie</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kalorie</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kalorii</unitPattern>
 				<unitPattern count="many">{0} kalorii</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kalorii</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kalorii</unitPattern>
 				<unitPattern count="other">{0} kalorii</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kalorii</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kalorii</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<gender>feminine</gender>
@@ -9495,58 +9495,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} kalorii</unitPattern>
 				<unitPattern count="one" case="vocative">{0} kalorio</unitPattern>
 				<unitPattern count="few">{0} kalorie</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kalorie</unitPattern>
 				<unitPattern count="few" case="dative">{0} kaloriom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kalorii</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kaloriami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kaloriach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} kalorie</unitPattern>
 				<unitPattern count="many">{0} kalorii</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kalorii</unitPattern>
 				<unitPattern count="many" case="dative">{0} kaloriom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} kalorii</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} kaloriami</unitPattern>
 				<unitPattern count="many" case="locative">{0} kaloriach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} kalorii</unitPattern>
 				<unitPattern count="other">{0} kalorii</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kalorii</unitPattern>
+				<unitPattern count="other" case="dative">{0} kalorii</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kalorii</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kalorii</unitPattern>
+				<unitPattern count="other" case="locative">{0} kalorii</unitPattern>
+				<unitPattern count="other" case="vocative">{0} kalorii</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<gender>inanimate</gender>
 				<displayName>kilodżule</displayName>
 				<unitPattern count="one">{0} kilodżul</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilodżul</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilodżula</unitPattern>
 				<unitPattern count="few">{0} kilodżule</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilodżule</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilodżuli</unitPattern>
 				<unitPattern count="many">{0} kilodżuli</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilodżuli</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilodżuli</unitPattern>
 				<unitPattern count="other">{0} kilodżula</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilodżula</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilodżula</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>inanimate</gender>
 				<displayName>dżule</displayName>
 				<unitPattern count="one">{0} dżul</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} dżul</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dżula</unitPattern>
 				<unitPattern count="few">{0} dżule</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} dżule</unitPattern>
 				<unitPattern count="few" case="genitive">{0} dżuli</unitPattern>
 				<unitPattern count="many">{0} dżuli</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} dżuli</unitPattern>
+				<unitPattern count="many" case="genitive">{0} dżuli</unitPattern>
 				<unitPattern count="other">{0} dżula</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dżula</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dżula</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>feminine</gender>
@@ -9555,14 +9555,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} kilowatogodzinę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilowatogodziny</unitPattern>
 				<unitPattern count="few">{0} kilowatogodziny</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilowatogodziny</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilowatogodzin</unitPattern>
 				<unitPattern count="many">{0} kilowatogodzin</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilowatogodzin</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilowatogodzin</unitPattern>
 				<unitPattern count="other">{0} kilowatogodziny</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilowatogodziny</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilowatogodziny</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronowolty</displayName>
@@ -9596,17 +9596,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>niutony</displayName>
 				<unitPattern count="one">{0} niuton</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} niuton</unitPattern>
 				<unitPattern count="one" case="genitive">{0} niutona</unitPattern>
 				<unitPattern count="few">{0} niutony</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} niutony</unitPattern>
 				<unitPattern count="few" case="genitive">{0} niutonów</unitPattern>
 				<unitPattern count="many">{0} niutonów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} niutonów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} niutonów</unitPattern>
 				<unitPattern count="other">{0} niutona</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} niutona</unitPattern>
+				<unitPattern count="other" case="genitive">{0} niutona</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>feminine</gender>
@@ -9615,170 +9615,170 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} kilowatogodzinę na 100 km</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilowatogodziny na 100 km</unitPattern>
 				<unitPattern count="few">{0} kilowatogodziny na 100 km</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilowatogodziny na 100 km</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilowatogodzin na 100 km</unitPattern>
 				<unitPattern count="many">{0} kilowatogodzin na 100 km</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilowatogodzin na 100 km</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilowatogodzin na 100 km</unitPattern>
 				<unitPattern count="other">{0} kilowatogodziny na 100 km</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilowatogodziny na 100 km</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilowatogodziny na 100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>inanimate</gender>
 				<displayName>gigaherce</displayName>
 				<unitPattern count="one">{0} gigaherc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigaherc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigaherca</unitPattern>
 				<unitPattern count="few">{0} gigaherce</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigaherce</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigaherców</unitPattern>
 				<unitPattern count="many">{0} gigaherców</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigaherców</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigaherców</unitPattern>
 				<unitPattern count="other">{0} gigaherca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigaherca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigaherca</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>inanimate</gender>
 				<displayName>megaherce</displayName>
 				<unitPattern count="one">{0} megaherc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megaherc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megaherca</unitPattern>
 				<unitPattern count="few">{0} megaherce</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megaherce</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megaherców</unitPattern>
 				<unitPattern count="many">{0} megaherców</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megaherców</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megaherców</unitPattern>
 				<unitPattern count="other">{0} megaherca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megaherca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megaherca</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>inanimate</gender>
 				<displayName>kiloherce</displayName>
 				<unitPattern count="one">{0} kiloherc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kiloherc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kiloherca</unitPattern>
 				<unitPattern count="few">{0} kiloherce</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kiloherce</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kiloherców</unitPattern>
 				<unitPattern count="many">{0} kiloherców</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kiloherców</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kiloherców</unitPattern>
 				<unitPattern count="other">{0} kiloherca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kiloherca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kiloherca</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>inanimate</gender>
 				<displayName>herce</displayName>
 				<unitPattern count="one">{0} herc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} herc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} herca</unitPattern>
 				<unitPattern count="few">{0} herce</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} herce</unitPattern>
 				<unitPattern count="few" case="genitive">{0} herców</unitPattern>
 				<unitPattern count="many">{0} herców</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} herców</unitPattern>
+				<unitPattern count="many" case="genitive">{0} herców</unitPattern>
 				<unitPattern count="other">{0} herca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} herca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} herca</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>inanimate</gender>
 				<displayName>firety</displayName>
 				<unitPattern count="one">{0} firet</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} firet</unitPattern>
 				<unitPattern count="one" case="genitive">{0} firetu</unitPattern>
 				<unitPattern count="few">{0} firety</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} firety</unitPattern>
 				<unitPattern count="few" case="genitive">{0} firetów</unitPattern>
 				<unitPattern count="many">{0} firetów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} firetów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} firetów</unitPattern>
 				<unitPattern count="other">{0} firetu</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} firetu</unitPattern>
+				<unitPattern count="other" case="genitive">{0} firetu</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>inanimate</gender>
 				<displayName>piksele</displayName>
 				<unitPattern count="one">{0} piksel</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} piksel</unitPattern>
 				<unitPattern count="one" case="genitive">{0} piksela</unitPattern>
 				<unitPattern count="few">{0} piksele</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} piksele</unitPattern>
 				<unitPattern count="few" case="genitive">{0} pikseli</unitPattern>
 				<unitPattern count="many">{0} pikseli</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pikseli</unitPattern>
+				<unitPattern count="many" case="genitive">{0} pikseli</unitPattern>
 				<unitPattern count="other">{0} piksela</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} piksela</unitPattern>
+				<unitPattern count="other" case="genitive">{0} piksela</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>inanimate</gender>
 				<displayName>megapiksele</displayName>
 				<unitPattern count="one">{0} megapiksel</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapiksel</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megapiksela</unitPattern>
 				<unitPattern count="few">{0} megapiksele</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megapiksele</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megapikseli</unitPattern>
 				<unitPattern count="many">{0} megapikseli</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megapikseli</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megapikseli</unitPattern>
 				<unitPattern count="other">{0} megapiksela</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapiksela</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapiksela</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ppcm</unitPattern>
+				<unitPattern count="one" case="genitive">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ppcm</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ppcm</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ppcm</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>promień Ziemi</displayName>
@@ -9805,19 +9805,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} kilometrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} kilometry</unitPattern>
 				<unitPattern count="many">{0} kilometrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilometrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} kilometrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} kilometrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} kilometrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} kilometrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} kilometrów</unitPattern>
 				<unitPattern count="other">{0} kilometra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometra</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilometra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilometra</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilometra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} kilometra</unitPattern>
 				<perUnitPattern>{0} na kilometr</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
@@ -9838,36 +9838,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} metrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} metry</unitPattern>
 				<unitPattern count="many">{0} metrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} metrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} metrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} metrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} metrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} metrów</unitPattern>
 				<unitPattern count="other">{0} metra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metra</unitPattern>
+				<unitPattern count="other" case="dative">{0} metra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metra</unitPattern>
+				<unitPattern count="other" case="locative">{0} metra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} metra</unitPattern>
 				<perUnitPattern>{0} na metr</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<gender>inanimate</gender>
 				<displayName>decymetry</displayName>
 				<unitPattern count="one">{0} decymetr</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} decymetr</unitPattern>
 				<unitPattern count="one" case="genitive">{0} decymetra</unitPattern>
 				<unitPattern count="few">{0} decymetry</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} decymetry</unitPattern>
 				<unitPattern count="few" case="genitive">{0} decymetrów</unitPattern>
 				<unitPattern count="many">{0} decymetrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} decymetrów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} decymetrów</unitPattern>
 				<unitPattern count="other">{0} decymetra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decymetra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decymetra</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>inanimate</gender>
@@ -9887,19 +9887,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} centymetrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} centymetry</unitPattern>
 				<unitPattern count="many">{0} centymetrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} centymetrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} centymetrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} centymetrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} centymetrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} centymetrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} centymetrów</unitPattern>
 				<unitPattern count="other">{0} centymetra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centymetra</unitPattern>
+				<unitPattern count="other" case="dative">{0} centymetra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centymetra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centymetra</unitPattern>
+				<unitPattern count="other" case="locative">{0} centymetra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} centymetra</unitPattern>
 				<perUnitPattern>{0} na centymetr</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
@@ -9920,51 +9920,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} milimetrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} milimetry</unitPattern>
 				<unitPattern count="many">{0} milimetrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milimetrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} milimetrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} milimetrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} milimetrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} milimetrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} milimetrów</unitPattern>
 				<unitPattern count="other">{0} milimetra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimetra</unitPattern>
+				<unitPattern count="other" case="dative">{0} milimetra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimetra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milimetra</unitPattern>
+				<unitPattern count="other" case="locative">{0} milimetra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} milimetra</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>inanimate</gender>
 				<displayName>mikrometry</displayName>
 				<unitPattern count="one">{0} mikrometr</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrometr</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrometra</unitPattern>
 				<unitPattern count="few">{0} mikrometry</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrometry</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mikrometrów</unitPattern>
 				<unitPattern count="many">{0} mikrometrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mikrometrów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mikrometrów</unitPattern>
 				<unitPattern count="other">{0} mikrometra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrometra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrometra</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>inanimate</gender>
 				<displayName>nanometry</displayName>
 				<unitPattern count="one">{0} nanometr</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} nanometr</unitPattern>
 				<unitPattern count="one" case="genitive">{0} nanometra</unitPattern>
 				<unitPattern count="few">{0} nanometry</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} nanometry</unitPattern>
 				<unitPattern count="few" case="genitive">{0} nanometrów</unitPattern>
 				<unitPattern count="many">{0} nanometrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} nanometrów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} nanometrów</unitPattern>
 				<unitPattern count="other">{0} nanometra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanometra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nanometra</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>inanimate</gender>
@@ -9984,19 +9984,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} pikometrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} pikometry</unitPattern>
 				<unitPattern count="many">{0} pikometrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pikometrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} pikometrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} pikometrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} pikometrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} pikometrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} pikometrów</unitPattern>
 				<unitPattern count="other">{0} pikometra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pikometra</unitPattern>
+				<unitPattern count="other" case="dative">{0} pikometra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pikometra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} pikometra</unitPattern>
+				<unitPattern count="other" case="locative">{0} pikometra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} pikometra</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<gender>feminine</gender>
@@ -10009,26 +10009,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} mili</unitPattern>
 				<unitPattern count="one" case="vocative">{0} milo</unitPattern>
 				<unitPattern count="few">{0} mile</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mile</unitPattern>
 				<unitPattern count="few" case="dative">{0} milom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mil</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milami</unitPattern>
 				<unitPattern count="few" case="locative">{0} milach</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} mile</unitPattern>
 				<unitPattern count="many">{0} mil</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mil</unitPattern>
 				<unitPattern count="many" case="dative">{0} milom</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mil</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} milami</unitPattern>
 				<unitPattern count="many" case="locative">{0} milach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} mil</unitPattern>
 				<unitPattern count="other">{0} mili</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mili</unitPattern>
+				<unitPattern count="other" case="dative">{0} mili</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mili</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mili</unitPattern>
+				<unitPattern count="other" case="locative">{0} mili</unitPattern>
+				<unitPattern count="other" case="vocative">{0} mili</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<gender>inanimate</gender>
@@ -10041,26 +10041,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} jardzie</unitPattern>
 				<unitPattern count="one" case="vocative">{0} jardzie</unitPattern>
 				<unitPattern count="few">{0} jardy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} jardy</unitPattern>
 				<unitPattern count="few" case="dative">{0} jardom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} jardów</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} jardami</unitPattern>
 				<unitPattern count="few" case="locative">{0} jardach</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} jardy</unitPattern>
 				<unitPattern count="many">{0} jardów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} jardów</unitPattern>
 				<unitPattern count="many" case="dative">{0} jardom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} jardów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} jardami</unitPattern>
 				<unitPattern count="many" case="locative">{0} jardach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} jardów</unitPattern>
 				<unitPattern count="other">{0} jarda</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} jarda</unitPattern>
+				<unitPattern count="other" case="dative">{0} jarda</unitPattern>
+				<unitPattern count="other" case="genitive">{0} jarda</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} jarda</unitPattern>
+				<unitPattern count="other" case="locative">{0} jarda</unitPattern>
+				<unitPattern count="other" case="vocative">{0} jarda</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<gender>feminine</gender>
@@ -10080,19 +10080,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} stopach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} stopy</unitPattern>
 				<unitPattern count="many">{0} stóp</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stóp</unitPattern>
 				<unitPattern count="many" case="dative">{0} stopom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} stóp</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} stopami</unitPattern>
 				<unitPattern count="many" case="locative">{0} stopach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} stóp</unitPattern>
 				<unitPattern count="other">{0} stopy</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stopy</unitPattern>
+				<unitPattern count="other" case="dative">{0} stopy</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stopy</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stopy</unitPattern>
+				<unitPattern count="other" case="locative">{0} stopy</unitPattern>
+				<unitPattern count="other" case="vocative">{0} stopy</unitPattern>
 				<perUnitPattern>{0} na stopę</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
@@ -10113,19 +10113,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} calach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} cale</unitPattern>
 				<unitPattern count="many">{0} cali</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} cali</unitPattern>
 				<unitPattern count="many" case="dative">{0} calom</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} cali</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} calami</unitPattern>
 				<unitPattern count="many" case="locative">{0} calach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} cali</unitPattern>
 				<unitPattern count="other">{0} cala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} cala</unitPattern>
+				<unitPattern count="other" case="dative">{0} cala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} cala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} cala</unitPattern>
+				<unitPattern count="other" case="locative">{0} cala</unitPattern>
+				<unitPattern count="other" case="vocative">{0} cala</unitPattern>
 				<perUnitPattern>{0} na cal</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
@@ -10146,19 +10146,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} parsekach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} parseki</unitPattern>
 				<unitPattern count="many">{0} parseków</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} parseków</unitPattern>
 				<unitPattern count="many" case="dative">{0} parsekom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} parseków</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} parsekami</unitPattern>
 				<unitPattern count="many" case="locative">{0} parsekach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} parseków</unitPattern>
 				<unitPattern count="other">{0} parseka</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} parseka</unitPattern>
+				<unitPattern count="other" case="dative">{0} parseka</unitPattern>
+				<unitPattern count="other" case="genitive">{0} parseka</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} parseka</unitPattern>
+				<unitPattern count="other" case="locative">{0} parseka</unitPattern>
+				<unitPattern count="other" case="vocative">{0} parseka</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>lata świetlne</displayName>
@@ -10202,14 +10202,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} milę skandynawską</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mili skandynawskiej</unitPattern>
 				<unitPattern count="few">{0} mile skandynawskie</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mile skandynawskie</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mil skandynawskich</unitPattern>
 				<unitPattern count="many">{0} mil skandynawskich</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mil skandynawskich</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mil skandynawskich</unitPattern>
 				<unitPattern count="other">{0} mili skandynawskiej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mili skandynawskiej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mili skandynawskiej</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>punkty</displayName>
@@ -10236,35 +10236,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} promieniach Słońca</unitPattern>
 				<unitPattern count="few" case="vocative">{0} promienie Słońca</unitPattern>
 				<unitPattern count="many">{0} promieni Słońca</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} promieni Słońca</unitPattern>
 				<unitPattern count="many" case="dative">{0} promieniom Słońca</unitPattern>
 				<unitPattern count="many" case="genitive">{0} promieni Słońca</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} promieniami Słońca</unitPattern>
 				<unitPattern count="many" case="locative">{0} promieniach Słońca</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} promieni Słońca</unitPattern>
 				<unitPattern count="other">{0} promienia Słońca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} promienia Słońca</unitPattern>
+				<unitPattern count="other" case="dative">{0} promienia Słońca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} promienia Słońca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} promienia Słońca</unitPattern>
+				<unitPattern count="other" case="locative">{0} promienia Słońca</unitPattern>
+				<unitPattern count="other" case="vocative">{0} promienia Słońca</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<gender>inanimate</gender>
 				<displayName>luksy</displayName>
 				<unitPattern count="one">{0} luks</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} luks</unitPattern>
 				<unitPattern count="one" case="genitive">{0} luksu</unitPattern>
 				<unitPattern count="few">{0} luksy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} luksy</unitPattern>
 				<unitPattern count="few" case="genitive">{0} luksów</unitPattern>
 				<unitPattern count="many">{0} luksów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} luksów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} luksów</unitPattern>
 				<unitPattern count="other">{0} luksu</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} luksu</unitPattern>
+				<unitPattern count="other" case="genitive">{0} luksu</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
@@ -10273,30 +10273,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} kandelę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kandeli</unitPattern>
 				<unitPattern count="few">{0} kandele</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kandele</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kandeli</unitPattern>
 				<unitPattern count="many">{0} kandeli</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kandeli</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kandeli</unitPattern>
 				<unitPattern count="other">{0} kandeli</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kandeli</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kandeli</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>inanimate</gender>
 				<displayName>lumen</displayName>
 				<unitPattern count="one">{0} lumen</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} lumen</unitPattern>
 				<unitPattern count="one" case="genitive">{0} lumena</unitPattern>
 				<unitPattern count="few">{0} lumeny</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} lumeny</unitPattern>
 				<unitPattern count="few" case="genitive">{0} lumenów</unitPattern>
 				<unitPattern count="many">{0} lumenów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} lumenów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} lumenów</unitPattern>
 				<unitPattern count="other">{0} lumena</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} lumena</unitPattern>
+				<unitPattern count="other" case="genitive">{0} lumena</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<gender>feminine</gender>
@@ -10323,12 +10323,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="locative">{0} jasnościach Słońca</unitPattern>
 				<unitPattern count="many" case="vocative">{0} jasności Słońca</unitPattern>
 				<unitPattern count="other">{0} jasności Słońca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} jasności Słońca</unitPattern>
+				<unitPattern count="other" case="dative">{0} jasności Słońca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} jasności Słońca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} jasności Słońca</unitPattern>
+				<unitPattern count="other" case="locative">{0} jasności Słońca</unitPattern>
+				<unitPattern count="other" case="vocative">{0} jasności Słońca</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<gender>feminine</gender>
@@ -10337,14 +10337,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} tonę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} tony</unitPattern>
 				<unitPattern count="few">{0} tony</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} tony</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ton</unitPattern>
 				<unitPattern count="many">{0} ton</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ton</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ton</unitPattern>
 				<unitPattern count="other">{0} tony</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} tony</unitPattern>
+				<unitPattern count="other" case="genitive">{0} tony</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>inanimate</gender>
@@ -10364,19 +10364,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} kilogramach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} kilogramy</unitPattern>
 				<unitPattern count="many">{0} kilogramów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilogramów</unitPattern>
 				<unitPattern count="many" case="dative">{0} kilogramom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} kilogramów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} kilogramami</unitPattern>
 				<unitPattern count="many" case="locative">{0} kilogramach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} kilogramów</unitPattern>
 				<unitPattern count="other">{0} kilograma</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilograma</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilograma</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilograma</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilograma</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilograma</unitPattern>
+				<unitPattern count="other" case="vocative">{0} kilograma</unitPattern>
 				<perUnitPattern>{0} na kilogram</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
@@ -10397,19 +10397,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} gramach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} gramy</unitPattern>
 				<unitPattern count="many">{0} gramów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gramów</unitPattern>
 				<unitPattern count="many" case="dative">{0} gramom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} gramów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} gramami</unitPattern>
 				<unitPattern count="many" case="locative">{0} gramach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} gramów</unitPattern>
 				<unitPattern count="other">{0} grama</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} grama</unitPattern>
+				<unitPattern count="other" case="dative">{0} grama</unitPattern>
+				<unitPattern count="other" case="genitive">{0} grama</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} grama</unitPattern>
+				<unitPattern count="other" case="locative">{0} grama</unitPattern>
+				<unitPattern count="other" case="vocative">{0} grama</unitPattern>
 				<perUnitPattern>{0} na gram</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
@@ -10430,35 +10430,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} miligramach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} miligramy</unitPattern>
 				<unitPattern count="many">{0} miligramów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} miligramów</unitPattern>
 				<unitPattern count="many" case="dative">{0} miligramom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} miligramów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} miligramami</unitPattern>
 				<unitPattern count="many" case="locative">{0} miligramach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} miligramów</unitPattern>
 				<unitPattern count="other">{0} miligrama</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miligrama</unitPattern>
+				<unitPattern count="other" case="dative">{0} miligrama</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miligrama</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} miligrama</unitPattern>
+				<unitPattern count="other" case="locative">{0} miligrama</unitPattern>
+				<unitPattern count="other" case="vocative">{0} miligrama</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>inanimate</gender>
 				<displayName>mikrogramy</displayName>
 				<unitPattern count="one">{0} mikrogram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrogram</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrograma</unitPattern>
 				<unitPattern count="few">{0} mikrogramy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrogramy</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mikrogramów</unitPattern>
 				<unitPattern count="many">{0} mikrogramów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mikrogramów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mikrogramów</unitPattern>
 				<unitPattern count="other">{0} mikrograma</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrograma</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrograma</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>krótkie tony</displayName>
@@ -10492,19 +10492,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} funtach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} funty</unitPattern>
 				<unitPattern count="many">{0} funtów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} funtów</unitPattern>
 				<unitPattern count="many" case="dative">{0} funtom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} funtów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} funtami</unitPattern>
 				<unitPattern count="many" case="locative">{0} funtach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} funtów</unitPattern>
 				<unitPattern count="other">{0} funta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} funta</unitPattern>
+				<unitPattern count="other" case="dative">{0} funta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} funta</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} funta</unitPattern>
+				<unitPattern count="other" case="locative">{0} funta</unitPattern>
+				<unitPattern count="other" case="vocative">{0} funta</unitPattern>
 				<perUnitPattern>{0} na funt</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
@@ -10518,26 +10518,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} uncji</unitPattern>
 				<unitPattern count="one" case="vocative">{0} uncjo</unitPattern>
 				<unitPattern count="few">{0} uncje</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} uncje</unitPattern>
 				<unitPattern count="few" case="dative">{0} uncjom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} uncji</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} uncjami</unitPattern>
 				<unitPattern count="few" case="locative">{0} uncjach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} uncje</unitPattern>
 				<unitPattern count="many">{0} uncji</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} uncji</unitPattern>
 				<unitPattern count="many" case="dative">{0} uncjom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} uncji</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} uncjami</unitPattern>
 				<unitPattern count="many" case="locative">{0} uncjach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} uncji</unitPattern>
 				<unitPattern count="other">{0} uncji</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} uncji</unitPattern>
+				<unitPattern count="other" case="dative">{0} uncji</unitPattern>
+				<unitPattern count="other" case="genitive">{0} uncji</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} uncji</unitPattern>
+				<unitPattern count="other" case="locative">{0} uncji</unitPattern>
+				<unitPattern count="other" case="vocative">{0} uncji</unitPattern>
 				<perUnitPattern>{0} na uncję</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
@@ -10551,17 +10551,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>karaty</displayName>
 				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karata</unitPattern>
 				<unitPattern count="few">{0} karaty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} karaty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} karatów</unitPattern>
 				<unitPattern count="many">{0} karatów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} karatów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} karatów</unitPattern>
 				<unitPattern count="other">{0} karata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karata</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<gender>feminine</gender>
@@ -10613,12 +10613,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} masach Ziemi</unitPattern>
 				<unitPattern count="few" case="vocative">{0} masy Ziemi</unitPattern>
 				<unitPattern count="many">{0} mas Ziemi</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mas Ziemi</unitPattern>
 				<unitPattern count="many" case="dative">{0} masom Ziemi</unitPattern>
 				<unitPattern count="many" case="genitive">{0} mas Ziemi</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} masami Ziemi</unitPattern>
 				<unitPattern count="many" case="locative">{0} masach Ziemi</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} mas Ziemi</unitPattern>
 				<unitPattern count="other">{0} masy Ziemi</unitPattern>
 				<unitPattern count="other" case="accusative">{0} masy Ziemi</unitPattern>
 				<unitPattern count="other" case="dative">{0} masy Ziemi</unitPattern>
@@ -10645,19 +10645,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} masach Słońca</unitPattern>
 				<unitPattern count="few" case="vocative">{0} masy Słońca</unitPattern>
 				<unitPattern count="many">{0} mas Słońca</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mas Słońca</unitPattern>
 				<unitPattern count="many" case="dative">{0} masom Słońca</unitPattern>
 				<unitPattern count="many" case="genitive">{0} mas Słońca</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} masami Słońca</unitPattern>
 				<unitPattern count="many" case="locative">{0} masach Słońca</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} mas Słońca</unitPattern>
 				<unitPattern count="other">{0} masy Słońca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} masy Słońca</unitPattern>
+				<unitPattern count="other" case="dative">{0} masy Słońca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} masy Słońca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} masy Słońca</unitPattern>
+				<unitPattern count="other" case="locative">{0} masy Słońca</unitPattern>
+				<unitPattern count="other" case="vocative">{0} masy Słońca</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<gender>inanimate</gender>
@@ -10695,81 +10695,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>gigawaty</displayName>
 				<unitPattern count="one">{0} gigawat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigawat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigawata</unitPattern>
 				<unitPattern count="few">{0} gigawaty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigawaty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigawatów</unitPattern>
 				<unitPattern count="many">{0} gigawatów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigawatów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigawatów</unitPattern>
 				<unitPattern count="other">{0} gigawata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigawata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigawata</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>inanimate</gender>
 				<displayName>megawaty</displayName>
 				<unitPattern count="one">{0} megawat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megawat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megawata</unitPattern>
 				<unitPattern count="few">{0} megawaty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megawaty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megawatów</unitPattern>
 				<unitPattern count="many">{0} megawatów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megawatów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megawatów</unitPattern>
 				<unitPattern count="other">{0} megawata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megawata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megawata</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>inanimate</gender>
 				<displayName>kilowaty</displayName>
 				<unitPattern count="one">{0} kilowat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilowat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilowata</unitPattern>
 				<unitPattern count="few">{0} kilowaty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilowaty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilowatów</unitPattern>
 				<unitPattern count="many">{0} kilowatów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilowatów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilowatów</unitPattern>
 				<unitPattern count="other">{0} kilowata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilowata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilowata</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>inanimate</gender>
 				<displayName>waty</displayName>
 				<unitPattern count="one">{0} wat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} wat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} wata</unitPattern>
 				<unitPattern count="few">{0} waty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} waty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} watów</unitPattern>
 				<unitPattern count="many">{0} watów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} watów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} watów</unitPattern>
 				<unitPattern count="other">{0} wata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} wata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} wata</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>inanimate</gender>
 				<displayName>miliwaty</displayName>
 				<unitPattern count="one">{0} miliwat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miliwat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miliwata</unitPattern>
 				<unitPattern count="few">{0} miliwaty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} miliwaty</unitPattern>
 				<unitPattern count="few" case="genitive">{0} miliwatów</unitPattern>
 				<unitPattern count="many">{0} miliwatów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} miliwatów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} miliwatów</unitPattern>
 				<unitPattern count="other">{0} miliwata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miliwata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miliwata</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>konie mechaniczne</displayName>
@@ -10802,34 +10802,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-bar">
 				<gender>inanimate</gender>
 				<displayName>bary</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bara</unitPattern>
 				<unitPattern count="few">{0} bary</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bary</unitPattern>
 				<unitPattern count="few" case="genitive">{0} barów</unitPattern>
 				<unitPattern count="many">{0} barów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} barów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} barów</unitPattern>
 				<unitPattern count="other">{0} bara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bara</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>inanimate</gender>
 				<displayName>milibary</displayName>
 				<unitPattern count="one">{0} millibar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} millibar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milibara</unitPattern>
 				<unitPattern count="few">{0} millibary</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} millibary</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milibarów</unitPattern>
 				<unitPattern count="many">{0} millibarów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} millibarów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} millibarów</unitPattern>
 				<unitPattern count="other">{0} millibara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} millibara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} millibara</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>feminine</gender>
@@ -10838,46 +10838,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} atmosferę</unitPattern>
 				<unitPattern count="one" case="genitive">{0} atmosfery</unitPattern>
 				<unitPattern count="few">{0} atmosfery</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} atmosfery</unitPattern>
 				<unitPattern count="few" case="genitive">{0} atmosfer</unitPattern>
 				<unitPattern count="many">{0} atmosfer</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} atmosfer</unitPattern>
+				<unitPattern count="many" case="genitive">{0} atmosfer</unitPattern>
 				<unitPattern count="other">{0} atmosfery</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} atmosfery</unitPattern>
+				<unitPattern count="other" case="genitive">{0} atmosfery</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>inanimate</gender>
 				<displayName>paskale</displayName>
 				<unitPattern count="one">{0} paskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} paskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} paskala</unitPattern>
 				<unitPattern count="few">{0} paskale</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} paskale</unitPattern>
 				<unitPattern count="few" case="genitive">{0} paskali</unitPattern>
 				<unitPattern count="many">{0} paskali</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} paskali</unitPattern>
+				<unitPattern count="many" case="genitive">{0} paskali</unitPattern>
 				<unitPattern count="other">{0} paskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} paskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} paskala</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>inanimate</gender>
 				<displayName>hektopaskale</displayName>
 				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektopaskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektopaskala</unitPattern>
 				<unitPattern count="few">{0} hektopaskale</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektopaskale</unitPattern>
 				<unitPattern count="few" case="genitive">{0} hektopaskali</unitPattern>
 				<unitPattern count="many">{0} hektopaskali</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hektopaskali</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hektopaskali</unitPattern>
 				<unitPattern count="other">{0} hektopaskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektopaskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>inanimate</gender>
@@ -10897,35 +10897,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} kilopaskalach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} kilopaskale</unitPattern>
 				<unitPattern count="many">{0} kilopaskali</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilopaskali</unitPattern>
 				<unitPattern count="many" case="dative">{0} kilopaskalom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} kilopaskali</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} kilopaskalami</unitPattern>
 				<unitPattern count="many" case="locative">{0} kilopaskalach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} kilopaskali</unitPattern>
 				<unitPattern count="other">{0} kilopaskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilopaskala</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilopaskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilopaskala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilopaskala</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilopaskala</unitPattern>
+				<unitPattern count="other" case="vocative">{0} kilopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>inanimate</gender>
 				<displayName>megapaskale</displayName>
 				<unitPattern count="one">{0} megapaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapaskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megapaskala</unitPattern>
 				<unitPattern count="few">{0} megapaskale</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megapaskale</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megapaskali</unitPattern>
 				<unitPattern count="many">{0} megapaskali</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megapaskali</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megapaskali</unitPattern>
 				<unitPattern count="other">{0} megapaskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapaskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapaskala</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>inanimate</gender>
@@ -10945,19 +10945,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} kilometrach na godzinę</unitPattern>
 				<unitPattern count="few" case="vocative">{0} kilometry na godzinę</unitPattern>
 				<unitPattern count="many">{0} kilometrów na godzinę</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilometrów na godzinę</unitPattern>
 				<unitPattern count="many" case="dative">{0} kilometrom na godzinę</unitPattern>
 				<unitPattern count="many" case="genitive">{0} kilometrów na godzinę</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} kilometrami na godzinę</unitPattern>
 				<unitPattern count="many" case="locative">{0} kilometrach na godzinę</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} kilometrów na godzinę</unitPattern>
 				<unitPattern count="other">{0} kilometra na godzinę</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometra na godzinę</unitPattern>
+				<unitPattern count="other" case="dative">{0} kilometra na godzinę</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometra na godzinę</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilometra na godzinę</unitPattern>
+				<unitPattern count="other" case="locative">{0} kilometra na godzinę</unitPattern>
+				<unitPattern count="other" case="vocative">{0} kilometra na godzinę</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>inanimate</gender>
@@ -10977,19 +10977,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} metrach na sekundę</unitPattern>
 				<unitPattern count="few" case="vocative">{0} metry na sekundę</unitPattern>
 				<unitPattern count="many">{0} metrów na sekundę</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metrów na sekundę</unitPattern>
 				<unitPattern count="many" case="dative">{0} metrom na sekundę</unitPattern>
 				<unitPattern count="many" case="genitive">{0} metrów na sekundę</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} metrami na sekundę</unitPattern>
 				<unitPattern count="many" case="locative">{0} metrach na sekundę</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} metrów na sekundę</unitPattern>
 				<unitPattern count="other">{0} metra na sekundę</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metra na sekundę</unitPattern>
+				<unitPattern count="other" case="dative">{0} metra na sekundę</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metra na sekundę</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metra na sekundę</unitPattern>
+				<unitPattern count="other" case="locative">{0} metra na sekundę</unitPattern>
+				<unitPattern count="other" case="vocative">{0} metra na sekundę</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<gender>feminine</gender>
@@ -11002,26 +11002,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} mili na godzinę</unitPattern>
 				<unitPattern count="one" case="vocative">{0} milo na godzinę</unitPattern>
 				<unitPattern count="few">{0} mile na godzinę</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mile na godzinę</unitPattern>
 				<unitPattern count="few" case="dative">{0} milom na godzinę</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mil na godzinę</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milami na godzinę</unitPattern>
 				<unitPattern count="few" case="locative">{0} milach na godzinę</unitPattern>
 				<unitPattern count="few" case="vocative">{0} mile na godzinę</unitPattern>
 				<unitPattern count="many">{0} mil na godzinę</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mil na godzinę</unitPattern>
 				<unitPattern count="many" case="dative">{0} milom na godzinę</unitPattern>
 				<unitPattern count="many" case="genitive">{0} mil na godzinę</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} milami na godzinę</unitPattern>
 				<unitPattern count="many" case="locative">{0} milach na godzinę</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} mil na godzinę</unitPattern>
 				<unitPattern count="other">{0} mili na godzinę</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mili na godzinę</unitPattern>
+				<unitPattern count="other" case="dative">{0} mili na godzinę</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mili na godzinę</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mili na godzinę</unitPattern>
+				<unitPattern count="other" case="locative">{0} mili na godzinę</unitPattern>
+				<unitPattern count="other" case="vocative">{0} mili na godzinę</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>węzeł</displayName>
@@ -11048,19 +11048,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} stopniach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} stopnie</unitPattern>
 				<unitPattern count="many">{0} stopni</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stopni</unitPattern>
 				<unitPattern count="many" case="dative">{0} stopniom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} stopni</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} stopniami</unitPattern>
 				<unitPattern count="many" case="locative">{0} stopniach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} stopni</unitPattern>
 				<unitPattern count="other">{0} stopnia</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stopnia</unitPattern>
+				<unitPattern count="other" case="dative">{0} stopnia</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stopnia</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stopnia</unitPattern>
+				<unitPattern count="other" case="locative">{0} stopnia</unitPattern>
+				<unitPattern count="other" case="vocative">{0} stopnia</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<gender>inanimate</gender>
@@ -11080,19 +11080,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} stopniach Celsjusza</unitPattern>
 				<unitPattern count="few" case="vocative">{0} stopnie Celsjusza</unitPattern>
 				<unitPattern count="many">{0} stopni Celsjusza</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stopni Celsjusza</unitPattern>
 				<unitPattern count="many" case="dative">{0} stopniom Celsjusza</unitPattern>
 				<unitPattern count="many" case="genitive">{0} stopni Celsjusza</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} stopniami Celsjusza</unitPattern>
 				<unitPattern count="many" case="locative">{0} stopniach Celsjusza</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} stopni Celsjusza</unitPattern>
 				<unitPattern count="other">{0} stopnia Celsjusza</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stopnia Celsjusza</unitPattern>
+				<unitPattern count="other" case="dative">{0} stopnia Celsjusza</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stopnia Celsjusza</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stopnia Celsjusza</unitPattern>
+				<unitPattern count="other" case="locative">{0} stopnia Celsjusza</unitPattern>
+				<unitPattern count="other" case="vocative">{0} stopnia Celsjusza</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<gender>inanimate</gender>
@@ -11112,19 +11112,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} stopniach Fahrenheita</unitPattern>
 				<unitPattern count="few" case="vocative">{0} stopnie Fahrenheita</unitPattern>
 				<unitPattern count="many">{0} stopni Fahrenheita</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stopni Fahrenheita</unitPattern>
 				<unitPattern count="many" case="dative">{0} stopniom Fahrenheita</unitPattern>
 				<unitPattern count="many" case="genitive">{0} stopni Fahrenheita</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} stopniami Fahrenheita</unitPattern>
 				<unitPattern count="many" case="locative">{0} stopniach Fahrenheita</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} stopni Fahrenheita</unitPattern>
 				<unitPattern count="other">{0} stopnia Fahrenheita</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stopnia Fahrenheita</unitPattern>
+				<unitPattern count="other" case="dative">{0} stopnia Fahrenheita</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stopnia Fahrenheita</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stopnia Fahrenheita</unitPattern>
+				<unitPattern count="other" case="locative">{0} stopnia Fahrenheita</unitPattern>
+				<unitPattern count="other" case="vocative">{0} stopnia Fahrenheita</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<gender>inanimate</gender>
@@ -11144,19 +11144,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} kelwinach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} kelwiny</unitPattern>
 				<unitPattern count="many">{0} kelwinów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kelwinów</unitPattern>
 				<unitPattern count="many" case="dative">{0} kelwinom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} kelwinów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} kelwinami</unitPattern>
 				<unitPattern count="many" case="locative">{0} kelwinach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} kelwinów</unitPattern>
 				<unitPattern count="other">{0} kelwina</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kelwina</unitPattern>
+				<unitPattern count="other" case="dative">{0} kelwina</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kelwina</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kelwina</unitPattern>
+				<unitPattern count="other" case="locative">{0} kelwina</unitPattern>
+				<unitPattern count="other" case="vocative">{0} kelwina</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>stopofunty</displayName>
@@ -11169,49 +11169,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>niutonometry</displayName>
 				<unitPattern count="one">{0} niutonometr</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} niutonometr</unitPattern>
 				<unitPattern count="one" case="genitive">{0} niutonometra</unitPattern>
 				<unitPattern count="few">{0} niutonometry</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} niutonometry</unitPattern>
 				<unitPattern count="few" case="genitive">{0} niutonometrów</unitPattern>
 				<unitPattern count="many">{0} niutonometrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} niutonometrów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} niutonometrów</unitPattern>
 				<unitPattern count="other">{0} niutonometra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} niutonometra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} niutonometra</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>inanimate</gender>
 				<displayName>kilometry sześcienne</displayName>
 				<unitPattern count="one">{0} kilometr sześcienny</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilometr sześcienny</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilometra sześciennego</unitPattern>
 				<unitPattern count="few">{0} kilometry sześcienne</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilometry sześcienne</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilometrów sześciennych</unitPattern>
 				<unitPattern count="many">{0} kilometrów sześciennych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilometrów sześciennych</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilometrów sześciennych</unitPattern>
 				<unitPattern count="other">{0} kilometra sześciennego</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometra sześciennego</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometra sześciennego</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>inanimate</gender>
 				<displayName>metry sześcienne</displayName>
 				<unitPattern count="one">{0} metr sześcienny</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} metr sześcienny</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra sześciennego</unitPattern>
 				<unitPattern count="few">{0} metry sześcienne</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metry sześcienne</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metrów sześciennych</unitPattern>
 				<unitPattern count="many">{0} metrów sześciennych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metrów sześciennych</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metrów sześciennych</unitPattern>
 				<unitPattern count="other">{0} metra sześciennego</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metra sześciennego</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metra sześciennego</unitPattern>
 				<perUnitPattern>{0} na metr sześcienny</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
@@ -11232,19 +11232,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} centymetrach sześciennych</unitPattern>
 				<unitPattern count="few" case="vocative">{0} centymetry sześcienne</unitPattern>
 				<unitPattern count="many">{0} centymetrów sześciennych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} centymetrów sześciennych</unitPattern>
 				<unitPattern count="many" case="dative">{0} centymetrom sześciennym</unitPattern>
 				<unitPattern count="many" case="genitive">{0} centymetrów sześciennych</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} centymetrami sześciennymi</unitPattern>
 				<unitPattern count="many" case="locative">{0} centymetrach sześciennych</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} centymetrów sześciennych</unitPattern>
 				<unitPattern count="other">{0} centymetra sześciennego</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centymetra sześciennego</unitPattern>
+				<unitPattern count="other" case="dative">{0} centymetra sześciennego</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centymetra sześciennego</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centymetra sześciennego</unitPattern>
+				<unitPattern count="other" case="locative">{0} centymetra sześciennego</unitPattern>
+				<unitPattern count="other" case="vocative">{0} centymetra sześciennego</unitPattern>
 				<perUnitPattern>{0} na centymetr sześcienny</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -11258,26 +11258,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} mili sześciennej</unitPattern>
 				<unitPattern count="one" case="vocative">{0} milo sześcienna</unitPattern>
 				<unitPattern count="few">{0} mile sześcienne</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mile sześcienne</unitPattern>
 				<unitPattern count="few" case="dative">{0} milom sześciennym</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mil sześciennych</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milami sześciennymi</unitPattern>
 				<unitPattern count="few" case="locative">{0} milach sześciennych</unitPattern>
 				<unitPattern count="few" case="vocative">{0} mile sześcienne</unitPattern>
 				<unitPattern count="many">{0} mil sześciennych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mil sześciennych</unitPattern>
 				<unitPattern count="many" case="dative">{0} milom sześciennym</unitPattern>
 				<unitPattern count="many" case="genitive">{0} mil sześciennych</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} milami sześciennymi</unitPattern>
 				<unitPattern count="many" case="locative">{0} milach sześciennych</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} mil sześciennych</unitPattern>
 				<unitPattern count="other">{0} mili sześciennej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mili sześciennej</unitPattern>
+				<unitPattern count="other" case="dative">{0} mili sześciennej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mili sześciennej</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mili sześciennej</unitPattern>
+				<unitPattern count="other" case="locative">{0} mili sześciennej</unitPattern>
+				<unitPattern count="other" case="vocative">{0} mili sześciennej</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>jardy sześcienne</displayName>
@@ -11297,26 +11297,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} stopie sześciennej</unitPattern>
 				<unitPattern count="one" case="vocative">{0} stopo sześcienna</unitPattern>
 				<unitPattern count="few">{0} stopy sześcienne</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stopy sześcienne</unitPattern>
 				<unitPattern count="few" case="dative">{0} stopom sześciennym</unitPattern>
 				<unitPattern count="few" case="genitive">{0} stóp sześciennych</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} stopami sześciennymi</unitPattern>
 				<unitPattern count="few" case="locative">{0} stopach sześciennych</unitPattern>
 				<unitPattern count="few" case="vocative">{0} stopy sześcienne</unitPattern>
 				<unitPattern count="many">{0} stóp sześciennych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stóp sześciennych</unitPattern>
 				<unitPattern count="many" case="dative">{0} stopom sześciennym</unitPattern>
 				<unitPattern count="many" case="genitive">{0} stóp sześciennych</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} stopami sześciennymi</unitPattern>
 				<unitPattern count="many" case="locative">{0} stopach sześciennych</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} stóp sześciennych</unitPattern>
 				<unitPattern count="other">{0} stopy sześciennej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stopy sześciennej</unitPattern>
+				<unitPattern count="other" case="dative">{0} stopy sześciennej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stopy sześciennej</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stopy sześciennej</unitPattern>
+				<unitPattern count="other" case="locative">{0} stopy sześciennej</unitPattern>
+				<unitPattern count="other" case="vocative">{0} stopy sześciennej</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>cale sześcienne</displayName>
@@ -11329,33 +11329,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>megalitry</displayName>
 				<unitPattern count="one">{0} megalitr</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megalitr</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megalitra</unitPattern>
 				<unitPattern count="few">{0} megalitry</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megalitry</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megalitrów</unitPattern>
 				<unitPattern count="many">{0} megalitrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megalitrów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megalitrów</unitPattern>
 				<unitPattern count="other">{0} megalitra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megalitra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megalitra</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>inanimate</gender>
 				<displayName>hektolitry</displayName>
 				<unitPattern count="one">{0} hektolitr</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektolitr</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektolitra</unitPattern>
 				<unitPattern count="few">{0} hektolitry</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektolitry</unitPattern>
 				<unitPattern count="few" case="genitive">{0} hektolitrów</unitPattern>
 				<unitPattern count="many">{0} hektolitrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hektolitrów</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hektolitrów</unitPattern>
 				<unitPattern count="other">{0} hektolitra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektolitra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektolitra</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>inanimate</gender>
@@ -11375,19 +11375,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} litrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} litry</unitPattern>
 				<unitPattern count="many">{0} litrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} litrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} litrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} litrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} litrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} litrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} litrów</unitPattern>
 				<unitPattern count="other">{0} litra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litra</unitPattern>
+				<unitPattern count="other" case="dative">{0} litra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litra</unitPattern>
+				<unitPattern count="other" case="locative">{0} litra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} litra</unitPattern>
 				<perUnitPattern>{0} na litr</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
@@ -11408,19 +11408,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} decylitrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} decylitry</unitPattern>
 				<unitPattern count="many">{0} decylitrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} decylitrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} decylitrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} decylitrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} decylitrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} decylitrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} decylitrów</unitPattern>
 				<unitPattern count="other">{0} decylitra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decylitra</unitPattern>
+				<unitPattern count="other" case="dative">{0} decylitra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decylitra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} decylitra</unitPattern>
+				<unitPattern count="other" case="locative">{0} decylitra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} decylitra</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>inanimate</gender>
@@ -11440,19 +11440,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} centylitrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} centylitry</unitPattern>
 				<unitPattern count="many">{0} centylitrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} centylitrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} centylitrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} centylitrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} centylitrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} centylitrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} centylitrów</unitPattern>
 				<unitPattern count="other">{0} centylitra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centylitra</unitPattern>
+				<unitPattern count="other" case="dative">{0} centylitra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centylitra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centylitra</unitPattern>
+				<unitPattern count="other" case="locative">{0} centylitra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} centylitra</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>inanimate</gender>
@@ -11472,19 +11472,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} mililitrach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} mililitry</unitPattern>
 				<unitPattern count="many">{0} mililitrów</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mililitrów</unitPattern>
 				<unitPattern count="many" case="dative">{0} mililitrom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} mililitrów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} mililitrami</unitPattern>
 				<unitPattern count="many" case="locative">{0} mililitrach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} mililitrów</unitPattern>
 				<unitPattern count="other">{0} mililitra</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mililitra</unitPattern>
+				<unitPattern count="other" case="dative">{0} mililitra</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mililitra</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mililitra</unitPattern>
+				<unitPattern count="other" case="locative">{0} mililitra</unitPattern>
+				<unitPattern count="other" case="vocative">{0} mililitra</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>feminine</gender>
@@ -11493,14 +11493,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} półkwartę metryczną</unitPattern>
 				<unitPattern count="one" case="genitive">{0} półkwarty metrycznej</unitPattern>
 				<unitPattern count="few">{0} półkwarty metryczne</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} półkwarty metryczne</unitPattern>
 				<unitPattern count="few" case="genitive">{0} półkwart metrycznych</unitPattern>
 				<unitPattern count="many">{0} półkwart metrycznych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} półkwart metrycznych</unitPattern>
+				<unitPattern count="many" case="genitive">{0} półkwart metrycznych</unitPattern>
 				<unitPattern count="other">{0} półkwarty metrycznej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} półkwarty metrycznej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} półkwarty metrycznej</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>feminine</gender>
@@ -11509,14 +11509,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="accusative">{0} ćwierćkwartę metryczną</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ćwierćkwarty metrycznej</unitPattern>
 				<unitPattern count="few">{0} ćwierćkwarty metryczne</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ćwierćkwarty metryczne</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ćwierćkwart metrycznych</unitPattern>
 				<unitPattern count="many">{0} ćwierćkwart metrycznych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ćwierćkwart metrycznych</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ćwierćkwart metrycznych</unitPattern>
 				<unitPattern count="other">{0} ćwierćkwarty metrycznej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ćwierćkwarty metrycznej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ćwierćkwarty metrycznej</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>akrostopy</displayName>
@@ -11569,33 +11569,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>galony angielskie</displayName>
 				<unitPattern count="one">{0} galon angielski</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} galon angielski</unitPattern>
 				<unitPattern count="one" case="dative">{0} galonowi angielskiemu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} galonu angielskiego</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} galonem angielskim</unitPattern>
 				<unitPattern count="one" case="locative">{0} galonie angielskim</unitPattern>
 				<unitPattern count="one" case="vocative">{0} galonie angielski</unitPattern>
 				<unitPattern count="few">{0} galony angielskie</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} galony angielskie</unitPattern>
 				<unitPattern count="few" case="dative">{0} galonom angielskim</unitPattern>
 				<unitPattern count="few" case="genitive">{0} galonów angielskich</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} galonami angielskimi</unitPattern>
 				<unitPattern count="few" case="locative">{0} galonach angielskich</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} galony angielskie</unitPattern>
 				<unitPattern count="many">{0} galonów angielskich</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} galonów angielskich</unitPattern>
 				<unitPattern count="many" case="dative">{0} galonom angielskim</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} galonów angielskich</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} galonami angielskimi</unitPattern>
 				<unitPattern count="many" case="locative">{0} galonach angielskich</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} galonów angielskich</unitPattern>
 				<unitPattern count="other">{0} galona angielskiego</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} galona angielskiego</unitPattern>
+				<unitPattern count="other" case="dative">{0} galona angielskiego</unitPattern>
+				<unitPattern count="other" case="genitive">{0} galona angielskiego</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} galona angielskiego</unitPattern>
+				<unitPattern count="other" case="locative">{0} galona angielskiego</unitPattern>
+				<unitPattern count="other" case="vocative">{0} galona angielskiego</unitPattern>
 				<perUnitPattern>{0} na galon angielski</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
@@ -11769,26 +11769,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} łyżce stołowej</unitPattern>
 				<unitPattern count="one" case="vocative">{0} łyżko stołowa</unitPattern>
 				<unitPattern count="few">{0} łyżki stołowe</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} łyżki stołowe</unitPattern>
 				<unitPattern count="few" case="dative">{0} łyżkom stołowym</unitPattern>
 				<unitPattern count="few" case="genitive">{0} łyżek stołowych</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} łyżkami stołowymi</unitPattern>
 				<unitPattern count="few" case="locative">{0} łyżkach stołowych</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} łyżki stołowe</unitPattern>
 				<unitPattern count="many">{0} łyżek stołowych</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} łyżek stołowych</unitPattern>
 				<unitPattern count="many" case="dative">{0} łyżkom stołowym</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} łyżek stołowych</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} łyżkami stołowymi</unitPattern>
 				<unitPattern count="many" case="locative">{0} łyżkach stołowych</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} łyżek stołowych</unitPattern>
 				<unitPattern count="other">{0} łyżki stołowej</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} łyżki stołowej</unitPattern>
+				<unitPattern count="other" case="dative">{0} łyżki stołowej</unitPattern>
+				<unitPattern count="other" case="genitive">{0} łyżki stołowej</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} łyżki stołowej</unitPattern>
+				<unitPattern count="other" case="locative">{0} łyżki stołowej</unitPattern>
+				<unitPattern count="other" case="vocative">{0} łyżki stołowej</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
 				<gender>feminine</gender>
@@ -11801,26 +11801,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="locative">{0} łyżeczce</unitPattern>
 				<unitPattern count="one" case="vocative">{0} łyżeczko</unitPattern>
 				<unitPattern count="few">{0} łyżeczki</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} łyżeczki</unitPattern>
 				<unitPattern count="few" case="dative">{0} łyżeczkom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} lyżeczek</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} łyżeczkami</unitPattern>
 				<unitPattern count="few" case="locative">{0} łyżeczkach</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} łyżeczki</unitPattern>
 				<unitPattern count="many">{0} łyżeczek</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} łyżeczek</unitPattern>
 				<unitPattern count="many" case="dative">{0} łyżeczkom</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} łyżeczek</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} łyżeczkami</unitPattern>
 				<unitPattern count="many" case="locative">{0} łyżeczkach</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} łyżeczek</unitPattern>
 				<unitPattern count="other">{0} łyżeczki</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} łyżeczki</unitPattern>
+				<unitPattern count="other" case="dative">{0} łyżeczki</unitPattern>
+				<unitPattern count="other" case="genitive">{0} łyżeczki</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} łyżeczki</unitPattern>
+				<unitPattern count="other" case="locative">{0} łyżeczki</unitPattern>
+				<unitPattern count="other" case="vocative">{0} łyżeczki</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>baryłki</displayName>
@@ -11941,7 +11941,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="genitive">{0} drachm płynu</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} drachmami płynu</unitPattern>
 				<unitPattern count="few" case="locative">{0} drachmach płynu</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} drachmy płynu</unitPattern>
 				<unitPattern count="many">{0} drachm płynu</unitPattern>
 				<unitPattern count="many" case="accusative">{0} drachm płynu</unitPattern>
 				<unitPattern count="many" case="dative">{0} drachmom płynu</unitPattern>
@@ -11974,14 +11974,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} jiggerami</unitPattern>
 				<unitPattern count="few" case="locative">{0} jiggerach</unitPattern>
 				<unitPattern count="few" case="vocative">{0} jiggery</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="many">{0} jiggerów</unitPattern>
 				<unitPattern count="many" case="accusative">{0} jiggerów</unitPattern>
 				<unitPattern count="many" case="dative">{0} jiggerom</unitPattern>
 				<unitPattern count="many" case="genitive">{0} jiggerów</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} jiggerami</unitPattern>
 				<unitPattern count="many" case="locative">{0} jiggerach</unitPattern>
 				<unitPattern count="many" case="vocative">{0} jiggerów</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} jiggera</unitPattern>
 				<unitPattern count="other" case="accusative">{0} jiggera</unitPattern>
 				<unitPattern count="other" case="dative">{0} jiggera</unitPattern>
 				<unitPattern count="other" case="genitive">{0} jiggera</unitPattern>
@@ -12014,12 +12014,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="locative">{0} szczyptach</unitPattern>
 				<unitPattern count="many" case="vocative">{0} szczypt</unitPattern>
 				<unitPattern count="other">{0} szczypty</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} szczypty</unitPattern>
+				<unitPattern count="other" case="dative">{0} szczypty</unitPattern>
+				<unitPattern count="other" case="genitive">{0} szczypty</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} szczypty</unitPattern>
+				<unitPattern count="other" case="locative">{0} szczypty</unitPattern>
+				<unitPattern count="other" case="vocative">{0} szczypty</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<gender>feminine</gender>
@@ -12151,16 +12151,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -12168,16 +12168,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="few">{0} G</unitPattern>
+				<unitPattern count="many">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="few">{0} m/s²</unitPattern>
+				<unitPattern count="many">{0} m/s²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
@@ -12189,60 +12189,60 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-radian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="many">{0} rad</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>stopnie</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="many">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>minuty</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}′</unitPattern>
+				<unitPattern count="few">{0}′</unitPattern>
+				<unitPattern count="many">{0}′</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>sekundy</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}″</unitPattern>
+				<unitPattern count="few">{0}″</unitPattern>
+				<unitPattern count="many">{0}″</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="few">{0} km²</unitPattern>
+				<unitPattern count="many">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ha</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="few">{0} ha</unitPattern>
+				<unitPattern count="many">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="few">{0} m²</unitPattern>
+				<unitPattern count="many">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="many">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -12292,9 +12292,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karaty</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="many">{0} kt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
@@ -12320,23 +12320,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="many">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
+				<unitPattern count="few">{0}%</unitPattern>
+				<unitPattern count="many">{0}%</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="few">{0}‰</unitPattern>
+				<unitPattern count="many">{0}‰</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
@@ -12383,65 +12383,65 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="many">{0} PB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="many">{0} TB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="many">{0} Tb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="many">{0} GB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="many">{0} Gb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="many">{0} MB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="many">{0} Mb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="many">{0} kB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="many">{0} kb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-byte">
@@ -12522,9 +12522,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-minute">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} min</unitPattern>
+				<unitPattern count="few">{0} min</unitPattern>
+				<unitPattern count="many">{0} min</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -12538,65 +12538,65 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="few">{0} ms</unitPattern>
+				<unitPattern count="many">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="many">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="many">{0} ns</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>A</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="many">{0} A</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="many">{0} mA</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>Ω</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="many">{0} Ω</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>V</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="many">{0} V</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="many">{0} cal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
@@ -12608,23 +12608,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="many">{0} kJ</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>J</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="many">{0} J</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="few">{0} kWh</unitPattern>
+				<unitPattern count="many">{0} kWh</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
@@ -12664,37 +12664,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="many">{0} GHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="many">{0} MHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="many">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="many">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
@@ -12706,117 +12706,117 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="many">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="few">{0} km</unitPattern>
+				<unitPattern count="many">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="few">{0} m</unitPattern>
+				<unitPattern count="many">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="many">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="few">{0} cm</unitPattern>
+				<unitPattern count="many">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="few">{0} mm</unitPattern>
+				<unitPattern count="many">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="many">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="many">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="few">{0} pm</unitPattern>
+				<unitPattern count="many">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
@@ -12851,16 +12851,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-parsec">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="many">{0} pc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ly</unitPattern>
+				<unitPattern count="few">{0} ly</unitPattern>
+				<unitPattern count="many">{0} ly</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
@@ -12872,9 +12872,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="many">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
@@ -12893,9 +12893,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="many">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
@@ -12914,9 +12914,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-lux">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="many">{0} lx</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-candela">
@@ -12942,39 +12942,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="many">{0} t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
+				<unitPattern count="few">{0} kg</unitPattern>
+				<unitPattern count="many">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="few">{0} g</unitPattern>
+				<unitPattern count="many">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="many">{0} mg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="many">{0} μg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
@@ -13001,17 +13001,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="few">{0} oz</unitPattern>
+				<unitPattern count="many">{0} oz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="few">{0} oz t</unitPattern>
+				<unitPattern count="many">{0} oz t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-carat">
@@ -13051,37 +13051,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="few">{0} GW</unitPattern>
+				<unitPattern count="many">{0} GW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="few">{0} MW</unitPattern>
+				<unitPattern count="many">{0} MW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="few">{0} kW</unitPattern>
+				<unitPattern count="many">{0} kW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>waty</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="few">{0} W</unitPattern>
+				<unitPattern count="many">{0} W</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="few">{0} mW</unitPattern>
+				<unitPattern count="many">{0} mW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
@@ -13100,51 +13100,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="few">{0} psi</unitPattern>
+				<unitPattern count="many">{0} psi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="few">{0} inHg</unitPattern>
+				<unitPattern count="many">{0} inHg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="many">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="few">{0} mbar</unitPattern>
+				<unitPattern count="many">{0} mbar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="many">{0} atm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
@@ -13170,9 +13170,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="few">{0} m/s</unitPattern>
+				<unitPattern count="many">{0} m/s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
@@ -13191,9 +13191,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="many">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
@@ -13205,16 +13205,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°F</unitPattern>
+				<unitPattern count="few">{0}°F</unitPattern>
+				<unitPattern count="many">{0}°F</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="few">{0} K</unitPattern>
+				<unitPattern count="many">{0} K</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
@@ -13233,24 +13233,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="few">{0} km³</unitPattern>
+				<unitPattern count="many">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="many">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="many">{0} cm³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -13298,9 +13298,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litry</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="few">{0} l</unitPattern>
+				<unitPattern count="many">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -13348,9 +13348,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="many">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -13484,67 +13484,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
 				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
@@ -13568,104 +13568,104 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>G</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="few">{0} G</unitPattern>
 				<unitPattern count="many">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="few">{0} m/s²</unitPattern>
+				<unitPattern count="many">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>obr.</displayName>
+				<unitPattern count="one">{0} obr.</unitPattern>
+				<unitPattern count="few">{0} obr.</unitPattern>
+				<unitPattern count="many">{0} obr.</unitPattern>
+				<unitPattern count="other">{0} obr.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="many">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>stopnie</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="many">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>minuty</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="many">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>sekundy</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="many">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="few">{0} km²</unitPattern>
+				<unitPattern count="many">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ha</displayName>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="few">{0} ha</unitPattern>
+				<unitPattern count="many">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="few">{0} m²</unitPattern>
+				<unitPattern count="many">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="many">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
@@ -13676,11 +13676,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>akry</displayName>
+				<unitPattern count="one">{0} akr</unitPattern>
+				<unitPattern count="few">{0} akry</unitPattern>
+				<unitPattern count="many">{0} akrów</unitPattern>
+				<unitPattern count="other">{0} akra</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
@@ -13705,32 +13705,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunamy</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="few">{0} dunamy</unitPattern>
+				<unitPattern count="many">{0} dunamów</unitPattern>
+				<unitPattern count="other">{0} dunama</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karaty</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="many">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="few">{0} mg/dl</unitPattern>
+				<unitPattern count="many">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/l</displayName>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="few">{0} mmol/l</unitPattern>
+				<unitPattern count="many">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>szt.</displayName>
@@ -13740,46 +13740,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} szt.</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="many">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
+				<unitPattern count="few">{0}%</unitPattern>
+				<unitPattern count="many">{0}%</unitPattern>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="few">{0}‰</unitPattern>
+				<unitPattern count="many">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mole</unitPattern>
+				<unitPattern count="many">{0} moli</unitPattern>
+				<unitPattern count="other">{0} mola</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="few">{0} l/km</unitPattern>
+				<unitPattern count="many">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -13789,109 +13789,109 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="few">{0} mpg</unitPattern>
+				<unitPattern count="many">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mile/gal ang.</displayName>
+				<unitPattern count="one">{0} mi/gal ang.</unitPattern>
+				<unitPattern count="few">{0} mi/gal ang.</unitPattern>
+				<unitPattern count="many">{0} mi/gal ang.</unitPattern>
+				<unitPattern count="other">{0} mi/gal ang.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="many">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="many">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="many">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="many">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="many">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="many">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="many">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="many">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="many">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="few">{0} B</unitPattern>
+				<unitPattern count="many">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>b</displayName>
+				<unitPattern count="one">{0} b</unitPattern>
+				<unitPattern count="few">{0} b</unitPattern>
+				<unitPattern count="many">{0} b</unitPattern>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>w.</displayName>
+				<unitPattern count="one">{0} w.</unitPattern>
+				<unitPattern count="few">{0} w.</unitPattern>
+				<unitPattern count="many">{0} w.</unitPattern>
+				<unitPattern count="other">{0} w.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dek</displayName>
+				<unitPattern count="one">{0} dek</unitPattern>
+				<unitPattern count="few">{0} dek</unitPattern>
+				<unitPattern count="many">{0} dek</unitPattern>
+				<unitPattern count="other">{0} dek</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>r.</displayName>
@@ -13899,7 +13899,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} l.</unitPattern>
 				<unitPattern count="many">{0} l.</unitPattern>
 				<unitPattern count="other">{0} r.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/rok</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>kw.</displayName>
@@ -13943,11 +13943,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} min</unitPattern>
+				<unitPattern count="few">{0} min</unitPattern>
+				<unitPattern count="many">{0} min</unitPattern>
+				<unitPattern count="other">{0} min</unitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
@@ -13955,312 +13955,312 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} s</unitPattern>
 				<unitPattern count="many">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="few">{0} ms</unitPattern>
+				<unitPattern count="many">{0} ms</unitPattern>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="many">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="many">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="many">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="many">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="many">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="many">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="many">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="many">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="many">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="few">{0} kWh</unitPattern>
+				<unitPattern count="many">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="many">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thermy amer.</displayName>
+				<unitPattern count="one">{0} therm amer.</unitPattern>
+				<unitPattern count="few">{0} thermy amer.</unitPattern>
+				<unitPattern count="many">{0} thermów amer.</unitPattern>
+				<unitPattern count="other">{0} therma amer.</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="many">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="many">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="many">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="many">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>firet</displayName>
+				<unitPattern count="one">{0} firet</unitPattern>
+				<unitPattern count="few">{0} firety</unitPattern>
+				<unitPattern count="many">{0} firetów</unitPattern>
+				<unitPattern count="other">{0} firetu</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="many">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="few">{0} km</unitPattern>
+				<unitPattern count="many">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="few">{0} m</unitPattern>
+				<unitPattern count="many">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="many">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="few">{0} cm</unitPattern>
+				<unitPattern count="many">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="few">{0} mm</unitPattern>
+				<unitPattern count="many">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="many">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="many">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="few">{0} pm</unitPattern>
+				<unitPattern count="many">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mile</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mila</unitPattern>
+				<unitPattern count="few">{0} mile</unitPattern>
+				<unitPattern count="many">{0} mil</unitPattern>
+				<unitPattern count="other">{0} mili</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd</displayName>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="few">{0} yd</unitPattern>
+				<unitPattern count="many">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>ft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="few">{0} ft</unitPattern>
+				<unitPattern count="many">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>cale</displayName>
@@ -14271,330 +14271,330 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/cal</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="many">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ly</displayName>
+				<unitPattern count="one">{0} ly</unitPattern>
+				<unitPattern count="few">{0} ly</unitPattern>
+				<unitPattern count="many">{0} ly</unitPattern>
+				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>j.a.</displayName>
+				<unitPattern count="one">{0} j.a.</unitPattern>
+				<unitPattern count="few">{0} j.a.</unitPattern>
+				<unitPattern count="many">{0} j.a.</unitPattern>
+				<unitPattern count="other">{0} j.a.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="many">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fm</unitPattern>
+				<unitPattern count="few">{0} fm</unitPattern>
+				<unitPattern count="many">{0} fm</unitPattern>
+				<unitPattern count="other">{0} fm</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mm</displayName>
+				<unitPattern count="one">{0} Mm</unitPattern>
+				<unitPattern count="few">{0} Mm</unitPattern>
+				<unitPattern count="many">{0} Mm</unitPattern>
+				<unitPattern count="other">{0} Mm</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="many">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pkt.</displayName>
+				<unitPattern count="one">{0} pkt.</unitPattern>
+				<unitPattern count="few">{0} pkt.</unitPattern>
+				<unitPattern count="many">{0} pkt.</unitPattern>
+				<unitPattern count="other">{0} pkt.</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="many">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="many">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="one">{0} kg</unitPattern>
+				<unitPattern count="few">{0} kg</unitPattern>
+				<unitPattern count="many">{0} kg</unitPattern>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>g</displayName>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="few">{0} g</unitPattern>
+				<unitPattern count="many">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="many">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="many">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>krótkie tony</displayName>
+				<unitPattern count="one">{0} krótka tona</unitPattern>
+				<unitPattern count="few">{0} krótkie tony</unitPattern>
+				<unitPattern count="many">{0} krótkich ton</unitPattern>
+				<unitPattern count="other">{0} krótkiej tony</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
+				<unitPattern count="many">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>lb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} funt</unitPattern>
+				<unitPattern count="few">{0} funty</unitPattern>
+				<unitPattern count="many">{0} funtów</unitPattern>
+				<unitPattern count="other">{0} funta</unitPattern>
+				<perUnitPattern>{0}/funt</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="few">{0} oz</unitPattern>
+				<unitPattern count="many">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="few">{0} oz t</unitPattern>
+				<unitPattern count="many">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>kt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="many">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>Da</displayName>
 				<unitPattern count="one">{0} u</unitPattern>
 				<unitPattern count="few">{0} u</unitPattern>
 				<unitPattern count="many">{0} u</unitPattern>
 				<unitPattern count="other">{0} u</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gr</displayName>
+				<unitPattern count="one">{0} gr</unitPattern>
+				<unitPattern count="few">{0} gr</unitPattern>
+				<unitPattern count="many">{0} gr</unitPattern>
+				<unitPattern count="other">{0} gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="few">{0} GW</unitPattern>
+				<unitPattern count="many">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="few">{0} MW</unitPattern>
+				<unitPattern count="many">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="few">{0} kW</unitPattern>
+				<unitPattern count="many">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>waty</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="few">{0} W</unitPattern>
+				<unitPattern count="many">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="few">{0} mW</unitPattern>
+				<unitPattern count="many">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>KM</displayName>
 				<unitPattern count="one">{0} KM</unitPattern>
 				<unitPattern count="few">{0} KM</unitPattern>
 				<unitPattern count="many">{0} KM</unitPattern>
 				<unitPattern count="other">{0} KM</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="few">{0} mmHg</unitPattern>
+				<unitPattern count="many">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="few">{0} psi</unitPattern>
+				<unitPattern count="many">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="few">{0} inHg</unitPattern>
+				<unitPattern count="many">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="many">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="few">{0} mbar</unitPattern>
+				<unitPattern count="many">{0} mbar</unitPattern>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="many">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="few">{0} hPa</unitPattern>
+				<unitPattern count="many">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/godz.</displayName>
+				<unitPattern count="one">{0} km/godz.</unitPattern>
+				<unitPattern count="few">{0} km/godz.</unitPattern>
+				<unitPattern count="many">{0} km/godz.</unitPattern>
+				<unitPattern count="other">{0} km/godz.</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="few">{0} m/s</unitPattern>
+				<unitPattern count="many">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>mph</displayName>
@@ -14604,18 +14604,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>w.</displayName>
+				<unitPattern count="one">{0} w.</unitPattern>
+				<unitPattern count="few">{0} w.</unitPattern>
+				<unitPattern count="many">{0} w.</unitPattern>
+				<unitPattern count="other">{0} w.</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="many">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -14625,55 +14625,55 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="one">{0}°F</unitPattern>
+				<unitPattern count="few">{0}°F</unitPattern>
+				<unitPattern count="many">{0}°F</unitPattern>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="few">{0} K</unitPattern>
+				<unitPattern count="many">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
+				<unitPattern count="many">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="few">{0} km³</unitPattern>
+				<unitPattern count="many">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="many">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="many">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>mi³</displayName>
@@ -14704,203 +14704,203 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="few">{0} Ml</unitPattern>
+				<unitPattern count="many">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="few">{0} hl</unitPattern>
+				<unitPattern count="many">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="few">{0} l</unitPattern>
+				<unitPattern count="many">{0} l</unitPattern>
+				<unitPattern count="other">{0} l</unitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="few">{0} dl</unitPattern>
+				<unitPattern count="many">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="few">{0} cl</unitPattern>
+				<unitPattern count="many">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="few">{0} ml</unitPattern>
+				<unitPattern count="many">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>półkwarty metr.</displayName>
+				<unitPattern count="one">{0} półkwarta metr.</unitPattern>
+				<unitPattern count="few">{0} półkwarty metr.</unitPattern>
+				<unitPattern count="many">{0} półkwart metr.</unitPattern>
+				<unitPattern count="other">{0} półkwarty metr.</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ćwierćkwarty metr.</displayName>
+				<unitPattern count="one">{0} ćwierćkwarta metr.</unitPattern>
+				<unitPattern count="few">{0} ćwierćkwarty metr.</unitPattern>
+				<unitPattern count="many">{0} ćwierćkwart metr.</unitPattern>
+				<unitPattern count="other">{0} ćwierćkwarty metr.</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>akrostopy</displayName>
+				<unitPattern count="one">{0} akrostopa</unitPattern>
+				<unitPattern count="few">{0} akrostopy</unitPattern>
+				<unitPattern count="many">{0} akrostóp</unitPattern>
+				<unitPattern count="other">{0} akrostopy</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="many">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal am.</displayName>
+				<unitPattern count="one">{0} gal am.</unitPattern>
+				<unitPattern count="few">{0} gal am.</unitPattern>
+				<unitPattern count="many">{0} gal am.</unitPattern>
+				<unitPattern count="other">{0} gal am.</unitPattern>
+				<perUnitPattern>{0}/gal am.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal ang.</displayName>
+				<unitPattern count="one">{0} gal ang.</unitPattern>
+				<unitPattern count="few">{0} gal ang.</unitPattern>
+				<unitPattern count="many">{0} gal ang.</unitPattern>
+				<unitPattern count="other">{0} gal ang.</unitPattern>
+				<perUnitPattern>{0}/gal ang.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kwarty am.</displayName>
+				<unitPattern count="one">{0} kwarta am.</unitPattern>
+				<unitPattern count="few">{0} kwarty am.</unitPattern>
+				<unitPattern count="many">{0} kwart am.</unitPattern>
+				<unitPattern count="other">{0} kwarty am.</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>półkwarty am.</displayName>
+				<unitPattern count="one">{0} półkwarta am.</unitPattern>
+				<unitPattern count="few">{0} półkwarty am.</unitPattern>
+				<unitPattern count="many">{0} półkwart am.</unitPattern>
+				<unitPattern count="other">{0} półkwarty am.</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ćwierćkwarty am.</displayName>
+				<unitPattern count="one">{0} ćwierćkwarta am.</unitPattern>
+				<unitPattern count="few">{0} ćwierćkwarty am.</unitPattern>
+				<unitPattern count="many">{0} ćwierćkwart am.</unitPattern>
+				<unitPattern count="other">{0} ćwierćkwarty am.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz am.</displayName>
+				<unitPattern count="one">{0} fl oz am.</unitPattern>
+				<unitPattern count="few">{0} fl oz am.</unitPattern>
+				<unitPattern count="many">{0} fl oz am.</unitPattern>
+				<unitPattern count="other">{0} fl oz am.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz ang.</displayName>
+				<unitPattern count="one">{0} fl oz ang.</unitPattern>
+				<unitPattern count="few">{0} fl oz ang.</unitPattern>
+				<unitPattern count="many">{0} fl oz ang.</unitPattern>
+				<unitPattern count="other">{0} fl oz ang.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ł. stoł.</displayName>
+				<unitPattern count="one">{0} ł. stoł.</unitPattern>
+				<unitPattern count="few">{0} ł. stoł.</unitPattern>
+				<unitPattern count="many">{0} ł. stoł.</unitPattern>
+				<unitPattern count="other">{0} ł. stoł.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>łyżeczki</displayName>
+				<unitPattern count="one">{0} łyżeczka</unitPattern>
+				<unitPattern count="few">{0} łyżeczki</unitPattern>
+				<unitPattern count="many">{0} łyżeczek</unitPattern>
+				<unitPattern count="other">{0} łyżeczki</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>bbl</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="many">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ł. deser.</displayName>
+				<unitPattern count="one">{0} ł. deser.</unitPattern>
+				<unitPattern count="few">{0} ł. deser.</unitPattern>
+				<unitPattern count="many">{0} ł. deser.</unitPattern>
+				<unitPattern count="other">{0} ł. deser.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ł. deser. ang.</displayName>
+				<unitPattern count="one">{0} ł. deser. ang.</unitPattern>
+				<unitPattern count="few">{0} ł. deser. ang.</unitPattern>
+				<unitPattern count="many">{0} ł. deser. ang.</unitPattern>
+				<unitPattern count="other">{0} ł. deser. ang.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>krople</displayName>
+				<unitPattern count="one">{0} kropla</unitPattern>
+				<unitPattern count="few">{0} krople</unitPattern>
+				<unitPattern count="many">{0} kropli</unitPattern>
+				<unitPattern count="other">{0} kropli</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>drachmy</displayName>
+				<unitPattern count="one">{0} drachma</unitPattern>
+				<unitPattern count="few">{0} drachmy</unitPattern>
+				<unitPattern count="many">{0} drachm</unitPattern>
+				<unitPattern count="other">{0} drachmy</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jiggery</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="few">{0} jiggery</unitPattern>
+				<unitPattern count="many">{0} jiggerów</unitPattern>
+				<unitPattern count="other">{0} jiggera</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>szcz.</displayName>
+				<unitPattern count="one">{0} szcz.</unitPattern>
+				<unitPattern count="few">{0} szcz.</unitPattern>
+				<unitPattern count="many">{0} szcz.</unitPattern>
+				<unitPattern count="other">{0} szcz.</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kwarty ang.</displayName>
+				<unitPattern count="one">{0} kwarta ang.</unitPattern>
+				<unitPattern count="few">{0} kwarty ang.</unitPattern>
+				<unitPattern count="many">{0} kwart ang.</unitPattern>
+				<unitPattern count="other">{0} kwarty ang.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>kierunek</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="east">{0}°E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0}°N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0}°S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0}°W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -14927,16 +14927,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} lub {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} lub {1}</listPatternPart>
+			<listPatternPart type="2">{0} lub {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} lub {1}</listPatternPart>
+			<listPatternPart type="2">{0} lub {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -14951,20 +14951,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} i {1}</listPatternPart>
 			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} i {1}</listPatternPart>
 			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} i {1}</listPatternPart>
 			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -80,8 +80,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">چېروکي</language>
 			<language type="chy">شيني</language>
 			<language type="ckb">منځنۍ کوردي</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">منځنۍ کوردي</language>
+			<language type="ckb" alt="variant">منځنۍ کوردي</language>
 			<language type="clc">چیلکوټین</language>
 			<language type="co">کورسيکاني</language>
 			<language type="crg">mc</language>
@@ -1023,7 +1023,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1031,7 +1031,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1039,7 +1039,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1047,7 +1047,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1315,7 +1315,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon">M</day>
 							<day type="tue">T</day>
 							<day type="wed">W</day>
-							<day type="thu">↑↑↑</day>
+							<day type="thu">T</day>
 							<day type="fri">F</day>
 							<day type="sat">S</day>
 						</dayWidth>
@@ -1458,7 +1458,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</eraNames>
 					<eraAbbr>
 						<era type="0">له میلاد وړاندې</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">له میلاد وړاندې</era>
 						<era type="1">م.</era>
 						<era type="1" alt="variant">ع.پ</era>
 					</eraAbbr>
@@ -1524,7 +1524,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1532,7 +1532,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1540,7 +1540,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1548,7 +1548,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1906,7 +1906,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="4">ربيع II</month>
 							<month type="5">جماعه</month>
 							<month type="6">جمادي ۲</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">رجب</month>
 							<month type="8">شعبان</month>
 							<month type="9">رمضان</month>
 							<month type="10">شوال</month>
@@ -4982,7 +4982,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -4994,7 +4994,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="long">
 				<decimalFormat>
-					<pattern type="1000" count="one">↑↑↑</pattern>
+					<pattern type="1000" count="one">0K</pattern>
 					<pattern type="1000" count="other">0K</pattern>
 					<pattern type="10000" count="one">00K</pattern>
 					<pattern type="10000" count="other">00K</pattern>
@@ -5052,7 +5052,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<scientificFormats numberSystem="arabext">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -5066,7 +5066,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="arabext">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -5080,8 +5080,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5093,8 +5093,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -5116,8 +5116,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000000000" count="one">00G ¤</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="10000000000" count="other">¤00B</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤00B</pattern>
+					<pattern type="100000000000" count="one">¤000B</pattern>
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="100000000000" count="other">¤000B</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
@@ -5166,7 +5166,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="ANG">
 				<displayName>هالېنډي انټيليايي ګيلډر</displayName>
 				<displayName count="one">هالېنډې انټيليايي ګيلډر</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">هالېنډي انټيليايي ګيلډر</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="AOA">
@@ -5554,7 +5554,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="INR">
 				<displayName>هندي روپۍ</displayName>
 				<displayName count="one">هندي روپۍ</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">هندي روپۍ</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5980,8 +5980,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="SSP">
 				<displayName>جنوب سوډاني پونډ</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">جنوب سوډاني پونډ</displayName>
+				<displayName count="other">جنوب سوډاني پونډ</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5995,7 +5995,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="SYP">
 				<displayName>سوريايي پونډ</displayName>
 				<displayName count="one">سوريايي پونډ</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">سوريايي پونډ</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -6008,7 +6008,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="THB">
 				<displayName>تهايي بات</displayName>
 				<displayName count="one">تهايي بات</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">تهايي بات</displayName>
 				<symbol draft="contributed">THB</symbol>
 				<symbol alt="narrow" draft="contributed">฿</symbol>
 			</currency>
@@ -6106,8 +6106,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="VND">
 				<displayName>ويتنامي ډونګ</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">ويتنامي ډونګ</displayName>
+				<displayName count="other">ويتنامي ډونګ</displayName>
 				<symbol draft="contributed">₫</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -6249,28 +6249,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>یوټا {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}في {1}</compoundUnitPattern>
@@ -6284,7 +6284,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">{0}معکب</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>د جاذبې قوه</displayName>
@@ -6514,9 +6514,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>ربعه</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} q</unitPattern>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>مياشتې</displayName>
@@ -6537,27 +6537,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} په هره ورځ کې</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ساعتونه</displayName>
+				<unitPattern count="one">{0} h</unitPattern>
+				<unitPattern count="other">{0} h</unitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>دقيقې</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} min</unitPattern>
+				<unitPattern count="other">{0} min</unitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ثانيې</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} s</unitPattern>
+				<unitPattern count="other">{0} s</unitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ms</displayName>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>مايکرو ثانيې</displayName>
@@ -6631,8 +6631,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>متحده ایالاتو ترمامونه</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>د قوې پاونډز</displayName>
@@ -6645,9 +6645,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} نيوټنز</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>ګيګا هرټز</displayName>
@@ -6671,48 +6671,48 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>ټايپو ګرافيک em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>ميګا فکسلسز</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>کيلو ميتره</displayName>
@@ -6795,8 +6795,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} فلکي احدې</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>فرلانګونه</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">{0} فرلانګونه</unitPattern>
 			</unit>
 			<unit type="length-fathom">
@@ -6826,18 +6826,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-lux">
 				<displayName>لکس</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>لمريز ځلښتونه</displayName>
@@ -6877,9 +6877,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ټنز</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>پاونډز</displayName>
@@ -6919,9 +6919,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} لمريز حجم</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>ګيګا واټس</displayName>
@@ -6959,7 +6959,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} د پارې ملي مترز</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 				<unitPattern count="one">{0} پاونډ في مربع انچ</unitPattern>
 				<unitPattern count="other">{0} پاونډز في مربع انچ</unitPattern>
 			</unit>
@@ -6969,9 +6969,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} د پارې انچې</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>ملي بارز</displayName>
@@ -6985,8 +6985,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>پاسکیلز</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>هيکټو پاسکیلز</displayName>
@@ -7025,8 +7025,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>درجې سيلسيس</displayName>
@@ -7122,14 +7122,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ملي ليټرز</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>اکړ فټ</displayName>
@@ -7137,8 +7137,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} اکړ فټ</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>بوشیل</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">{0} بوشیل</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -7148,10 +7148,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} في ګيلن</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="one">{0} gal Imp.</unitPattern>
+				<unitPattern count="other">{0} gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>څلورمه</displayName>
@@ -7159,9 +7159,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} څلورمه</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pints</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>پيالې</displayName>
@@ -7169,9 +7169,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} پيالې</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>امپيريل مايع اونس</displayName>
@@ -7180,8 +7180,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>د ميز کاچوغه</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
 				<displayName>د ميز کاچوغې</displayName>
@@ -7199,12 +7199,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} مچ چمچ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>څاڅک</displayName>
 				<unitPattern count="one">{0} څاڅک</unitPattern>
 				<unitPattern count="other">{0} څاڅک</unitPattern>
 			</unit>
@@ -7214,9 +7214,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ډرام</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} جګر</unitPattern>
+				<unitPattern count="other">{0} جګر</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>چنه</displayName>
@@ -7224,7 +7224,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} چنه</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt Imp</displayName>
 				<unitPattern count="one">{0} Imp. quart</unitPattern>
 				<unitPattern count="other">{0} Imp. quart</unitPattern>
 			</unit>
@@ -7464,7 +7464,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>زرمه</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -7565,7 +7565,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>qtr</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} q</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -7612,7 +7612,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
@@ -7672,7 +7672,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>اليکټران وولټ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -7682,22 +7682,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>US تهرم</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>پاونډ قوه</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>نيوټن</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -7722,47 +7722,47 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7872,7 +7872,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>لمريزې وړانګې</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -7882,17 +7882,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>لمريز ځلښتونه</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -7929,7 +7929,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -7956,22 +7956,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ډالټنز</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>د زمکې حجمونه</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>لمريز حجم</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -8021,7 +8021,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>bar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -8036,7 +8036,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8046,17 +8046,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hour</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kph</unitPattern>
 				<unitPattern count="other">{0} kph</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
@@ -8096,12 +8096,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -8189,7 +8189,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>بوشیل</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -8226,7 +8226,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>امپيريل مايع اونس</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -8241,7 +8241,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>بېرل</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -8251,7 +8251,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>dstspn Imp</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -8266,7 +8266,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} جګر</unitPattern>
 				<unitPattern count="other">{0} جګر</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -8349,25 +8349,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
@@ -8375,55 +8375,55 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">مربع {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>رادیان</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>درجې</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcmins</displayName>
+				<unitPattern count="one">{0}′</unitPattern>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>آرکسیکس</displayName>
+				<unitPattern count="one">{0}″</unitPattern>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قيراط</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملي مول/ليټر</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>توکی</displayName>
@@ -8431,9 +8431,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} توکی</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پارټس/مليون</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>سلنه</displayName>
@@ -8441,24 +8441,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>في ميل</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>زرمه</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مول</displayName>
+				<unitPattern count="one">{0} مول</unitPattern>
+				<unitPattern count="other">{0} مول</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -8466,18 +8466,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg US</displayName>
+				<unitPattern count="one">{0} mpg US</unitPattern>
+				<unitPattern count="other">{0} mpg US</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg UK</displayName>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>c</displayName>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>لسيزه</displayName>
 				<unitPattern count="one">{0} لسیز</unitPattern>
 				<unitPattern count="other">{0} لسیز</unitPattern>
 			</unit>
@@ -8488,9 +8488,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>qtr</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} q</unitPattern>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>مياشت</displayName>
@@ -8529,24 +8529,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پاونډ قوه</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نيوټن</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -8569,22 +8569,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>لمريز ځلښتونه</displayName>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
@@ -8597,47 +8597,47 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}g</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>
@@ -8645,9 +8645,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kph</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -8655,24 +8655,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>deg. F</displayName>
+				<unitPattern count="one">{0}°F</unitPattern>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>لیټر</displayName>
@@ -8723,28 +8723,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, یا {1}</listPatternPart>
+			<listPatternPart type="2">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, یا {1}</listPatternPart>
+			<listPatternPart type="2">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}، {1}</listPatternPart>
+			<listPatternPart type="middle">{0}، {1}</listPatternPart>
+			<listPatternPart type="end">{0}، او {1}</listPatternPart>
 			<listPatternPart type="2">{0}، {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}، {1}</listPatternPart>
+			<listPatternPart type="middle">{0}، {1}</listPatternPart>
+			<listPatternPart type="end">{0}، او {1}</listPatternPart>
+			<listPatternPart type="2">{0} او {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -8952,127 +8952,127 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">سنباد</nameField>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -108,7 +108,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cheroqui</language>
 			<language type="chy">cheiene</language>
 			<language type="ckb">curdo central</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">curdo central</language>
 			<language type="ckb" alt="variant">curdo sorâni</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">corso</language>
@@ -1024,7 +1024,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunísia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turquia</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turquia</territory>
 			<territory type="TT">Trinidad e Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1797,18 +1797,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">jan.</month>
+							<month type="2">fev.</month>
+							<month type="3">mar.</month>
+							<month type="4">abr.</month>
+							<month type="5">mai.</month>
+							<month type="6">jun.</month>
+							<month type="7">jul.</month>
+							<month type="8">ago.</month>
+							<month type="9">set.</month>
+							<month type="10">out.</month>
+							<month type="11">nov.</month>
+							<month type="12">dez.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">J</month>
@@ -1854,20 +1854,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dayWidth type="narrow">
 							<day type="sun">D</day>
 							<day type="mon">S</day>
-							<day type="tue">↑↑↑</day>
+							<day type="tue">T</day>
 							<day type="wed">Q</day>
 							<day type="thu">Q</day>
 							<day type="fri">S</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">dom.</day>
+							<day type="mon">seg.</day>
+							<day type="tue">ter.</day>
+							<day type="wed">qua.</day>
+							<day type="thu">qui.</day>
+							<day type="fri">sex.</day>
+							<day type="sat">sáb.</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">domingo</day>
@@ -1881,13 +1881,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">dom.</day>
+							<day type="mon">seg.</day>
+							<day type="tue">ter.</day>
+							<day type="wed">qua.</day>
+							<day type="thu">qui.</day>
+							<day type="fri">sex.</day>
+							<day type="sat">sáb.</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">D</day>
@@ -1899,13 +1899,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">dom.</day>
+							<day type="mon">seg.</day>
+							<day type="tue">ter.</day>
+							<day type="wed">qua.</day>
+							<day type="thu">qui.</day>
+							<day type="fri">sex.</day>
+							<day type="sat">sáb.</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">domingo</day>
@@ -2422,7 +2422,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">há {0} ano</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">há {0} anos</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -2582,9 +2582,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-short">
 				<displayName>dia</displayName>
 				<relative type="-2" draft="contributed">anteontem</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ontem</relative>
+				<relative type="0">hoje</relative>
+				<relative type="1">amanhã</relative>
 				<relative type="2" draft="contributed">depois de amanhã</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">em {0} dia</relativeTimePattern>
@@ -2598,9 +2598,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-narrow">
 				<displayName>dia</displayName>
 				<relative type="-2" draft="contributed">anteontem</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ontem</relative>
+				<relative type="0">hoje</relative>
+				<relative type="1">amanhã</relative>
 				<relative type="2" draft="contributed">depois de amanhã</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">em {0} dia</relativeTimePattern>
@@ -7441,7 +7441,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunans</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">{0} dunans</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -7487,14 +7487,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>ponto base</displayName>
 				<unitPattern count="one">{0} ponto base</unitPattern>
 				<unitPattern count="other">{0} pontos base</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>masculine</gender>
 				<displayName>mols</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">{0} mols</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7795,7 +7795,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="graphics-em">
 				<gender>masculine</gender>
 				<displayName>em tipográfico</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} ems</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -7832,9 +7832,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pontos por polegada</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ponto</displayName>
 				<unitPattern count="one">{0} ponto</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} pts</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>raio terrestre</displayName>
@@ -8065,7 +8065,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<gender>feminine</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>massas terrestres</displayName>
 				<unitPattern count="one">{0} massa terrestre</unitPattern>
 				<unitPattern count="other">{0} massas terrestres</unitPattern>
 			</unit>
@@ -8134,7 +8134,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-bar">
 				<gender>masculine</gender>
 				<displayName>bars</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bars</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -8198,9 +8198,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-generic">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<gender>masculine</gender>
@@ -8533,12 +8533,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8546,27 +8546,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>força g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>metros/seg²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rev</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>radianos</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>graus</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
@@ -8581,46 +8581,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hectares</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>metros²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>milhas²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>acres</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>jardas²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>pés²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
@@ -8651,12 +8651,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} itens</unitPattern>
 				<unitPattern count="other">{0} itens</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>partes/milhão</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
@@ -8671,12 +8671,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>ponto base</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -8706,52 +8706,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TByte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>Tbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>GByte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MByte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kByte</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bytes</unitPattern>
 				<unitPattern count="other">{0} bytes</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bits</unitPattern>
 				<unitPattern count="other">{0} bits</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -8796,13 +8796,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-hour">
 				<displayName>horas</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -8814,47 +8814,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>milissegundos</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amps</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>miliamps</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>ohms</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>volts</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
@@ -8864,22 +8864,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>quilojoule</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>joules</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kW-hora</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elétron-volt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -8894,73 +8894,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>libra-força</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pixels</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapixels</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ponto</displayName>
@@ -8969,60 +8969,60 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>milhas</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>jardas</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
@@ -9039,7 +9039,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-parsec">
 				<displayName>parsecs</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
@@ -9054,7 +9054,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>furlongs</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
@@ -9069,37 +9069,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pontos</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>raios solares</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lux</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>luminosidades solares</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9109,24 +9109,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gramas</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
@@ -9136,24 +9136,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>stones</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>libras</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz troy</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-carat">
@@ -9163,17 +9163,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>daltons</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>massas terrestres</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>massas solares</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -9183,27 +9183,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>watts</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
@@ -9218,12 +9218,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} psi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
@@ -9233,7 +9233,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
@@ -9243,32 +9243,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>metros/seg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
@@ -9283,7 +9283,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
@@ -9298,49 +9298,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>jardas³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>pés³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
@@ -9360,7 +9360,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litros</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -9396,7 +9396,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>bushels</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -9413,12 +9413,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qts</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pints</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup">
@@ -9433,7 +9433,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -9448,7 +9448,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>barril</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -9468,7 +9468,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>dracma líquido</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
@@ -9496,64 +9496,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -9580,45 +9580,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>força g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>m/s²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>rad</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>graus</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>arcmin</displayName>
@@ -9631,33 +9631,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hectare</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>metros²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>acre</displayName>
@@ -9666,49 +9666,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ft²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>pol²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pol²</unitPattern>
+				<unitPattern count="other">{0} pol²</unitPattern>
 				<perUnitPattern>{0}/pol²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunans</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilates</displayName>
+				<unitPattern count="one">{0} k</unitPattern>
+				<unitPattern count="other">{0} k</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/l</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} itens</unitPattern>
 				<unitPattern count="other">{0} itens</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9717,23 +9717,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>l/km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -9742,58 +9742,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milhas/gal. imp.</displayName>
+				<unitPattern count="one">{0} mpg imp.</unitPattern>
+				<unitPattern count="other">{0} mpg imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>PB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>Tb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>GB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kB</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
@@ -9801,9 +9801,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>bit</displayName>
 				<unitPattern count="one">{0} bit</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} bits</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>séc.</displayName>
@@ -9811,9 +9811,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} sécs.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>déc.</displayName>
+				<unitPattern count="one">{0} déc.</unitPattern>
+				<unitPattern count="other">{0} déc.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ano</displayName>
@@ -9847,234 +9847,234 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-hour">
 				<displayName>hora</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} h</unitPattern>
+				<unitPattern count="other">{0} h</unitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>min</displayName>
+				<unitPattern count="one">{0} min</unitPattern>
+				<unitPattern count="other">{0} min</unitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amp</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>mA</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>ohm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>volt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kJ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>joule</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kWh</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} BTU</unitPattern>
+				<unitPattern count="other">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thm EUA</displayName>
+				<unitPattern count="one">{0} thm EUA</unitPattern>
+				<unitPattern count="other">{0} thm EUA</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ponto</displayName>
+				<unitPattern count="one">{0} p</unitPattern>
+				<unitPattern count="other">{0} pts</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>yd</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>pés</displayName>
@@ -10090,8 +10090,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-parsec">
 				<displayName>parsec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>anos-luz</displayName>
@@ -10105,8 +10105,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>furlong</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>braça</displayName>
@@ -10119,93 +10119,93 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mn</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
+				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>grama</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>ton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>stone</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>lb</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz t</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>quilate</displayName>
@@ -10214,51 +10214,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Da</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grão</displayName>
+				<unitPattern count="one">{0} grão</unitPattern>
+				<unitPattern count="other">{0} grãos</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>watt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>cv</displayName>
 				<unitPattern count="one">{0} cv</unitPattern>
 				<unitPattern count="other">{0} cv</unitPattern>
 			</unit>
@@ -10268,64 +10268,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bars</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mb</unitPattern>
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>km/h</displayName>
 				<unitPattern count="one">{0}km/h</unitPattern>
 				<unitPattern count="other">{0}km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>m/s</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>mph</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mph</unitPattern>
+				<unitPattern count="other">{0} mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>nó</displayName>
@@ -10333,9 +10333,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} nós</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -10344,138 +10344,138 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>°F</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} °F</unitPattern>
+				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>yd³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>ft³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>pol³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pol³</unitPattern>
+				<unitPattern count="other">{0} pol³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litro</displayName>
 				<unitPattern count="one">{0}l</unitPattern>
 				<unitPattern count="other">{0}l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ptm</displayName>
+				<unitPattern count="one">{0} ptm</unitPattern>
+				<unitPattern count="other">{0} ptm</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>xícm</displayName>
+				<unitPattern count="one">{0} xícm</unitPattern>
+				<unitPattern count="other">{0} xícm</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre-pés</displayName>
+				<unitPattern count="one">{0} acre-pé</unitPattern>
+				<unitPattern count="other">{0} acre-pés</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>bushel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal. imp.</displayName>
+				<unitPattern count="one">{0} gal. imp.</unitPattern>
+				<unitPattern count="other">{0} gal. imp.</unitPattern>
+				<perUnitPattern>{0}/gal. imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>xícara</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} xíc.</unitPattern>
+				<unitPattern count="other">{0} xíc.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<displayName>fl. oz.</displayName>
@@ -10483,65 +10483,65 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl. oz.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c. sopa</displayName>
+				<unitPattern count="one">{0} c. sopa</unitPattern>
+				<unitPattern count="other">{0} c. sopa</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c. chá</displayName>
+				<unitPattern count="one">{0} c. chá</unitPattern>
+				<unitPattern count="other">{0} c. chá</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>barril</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>csb</displayName>
+				<unitPattern count="one">{0} csb</unitPattern>
+				<unitPattern count="other">{0} csb</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>csb imp</displayName>
+				<unitPattern count="one">{0} csb imp</unitPattern>
+				<unitPattern count="other">{0} csb imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gota</displayName>
+				<unitPattern count="one">{0} gota</unitPattern>
+				<unitPattern count="other">{0} gotas</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dracma líquido</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>dosador</displayName>
+				<unitPattern count="one">{0} dosador</unitPattern>
 				<unitPattern count="other">{0} dosador</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pitada</displayName>
+				<unitPattern count="one">{0} pitada</unitPattern>
+				<unitPattern count="other">{0} pitadas</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>impqt</displayName>
+				<unitPattern count="one">{0} impqt</unitPattern>
+				<unitPattern count="other">{0} impqt</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>direção</displayName>
 				<coordinateUnitPattern type="east">{0}L</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0} S</coordinateUnitPattern>
 				<coordinateUnitPattern type="west">{0}O</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
@@ -10569,20 +10569,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ou {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ou {1}</listPatternPart>
+			<listPatternPart type="2">{0} ou {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ou {1}</listPatternPart>
+			<listPatternPart type="2">{0} ou {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -10593,8 +10593,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} e {1}</listPatternPart>
 			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
@@ -10605,8 +10605,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} e {1}</listPatternPart>
 			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -801,7 +801,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Túnez</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turquía</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turquía</territory>
 			<territory type="TT">Trinidad y Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwán</territory>
@@ -1019,7 +1019,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1758,9 +1758,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>Year</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">qayna wata</relative>
+				<relative type="0">kunan wata</relative>
+				<relative type="1">hamuq wata</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} y</relativeTimePattern>
 				</relativeTime>
@@ -1770,9 +1770,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>Year</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">qayna wata</relative>
+				<relative type="0">kunan wata</relative>
+				<relative type="1">hamuq wata</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} y</relativeTimePattern>
 				</relativeTime>
@@ -1824,9 +1824,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName>Month</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">qayna killa</relative>
+				<relative type="0">kunan killa</relative>
+				<relative type="1">hamuq killa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} m</relativeTimePattern>
 				</relativeTime>
@@ -1836,9 +1836,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>Month</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">qayna killa</relative>
+				<relative type="0">kunan killa</relative>
+				<relative type="1">hamuq killa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} m</relativeTimePattern>
 				</relativeTime>
@@ -1861,9 +1861,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>Week</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">qayna semana</relative>
+				<relative type="0">kunan semana</relative>
+				<relative type="1">hamuq semana</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} w</relativeTimePattern>
 				</relativeTime>
@@ -1874,9 +1874,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>Week</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">qayna semana</relative>
+				<relative type="0">kunan semana</relative>
+				<relative type="1">hamuq semana</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} w</relativeTimePattern>
 				</relativeTime>
@@ -1908,9 +1908,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>Day</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">qayna punchaw</relative>
+				<relative type="0">kunan punchaw</relative>
+				<relative type="1">paqarin</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} d</relativeTimePattern>
 				</relativeTime>
@@ -1920,9 +1920,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>Day</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">qayna punchaw</relative>
+				<relative type="0">kunan punchaw</relative>
+				<relative type="1">paqarin</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">+{0} d</relativeTimePattern>
 				</relativeTime>
@@ -4727,7 +4727,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Nuevo Rublo Bielorruso</displayName>
 				<displayName count="other">Nuevo rublo bielorruso</displayName>
 				<symbol draft="contributed">BYN</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">BYN</symbol>
 			</currency>
 			<currency type="BZD">
 				<displayName>Dólar Beliceño</displayName>
@@ -4849,7 +4849,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="FJD">
 				<displayName>Dólar Fiyiano</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dólar Fiyiano</displayName>
 				<symbol draft="contributed">FJD</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5582,35 +5582,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">{0} metro cubico</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>g-force</displayName>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>metros por segundo cuadrado</displayName>
 				<unitPattern count="other">{0} metros por segundo cuadrado</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>deg</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcmin</displayName>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcsec</displayName>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>kilómetro cuadrado</displayName>
@@ -5658,16 +5658,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>imakuna</displayName>
@@ -5678,80 +5678,80 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} partes por millon</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>litros por 100 kilometros</displayName>
 				<unitPattern count="other">{0} litros por 100 kilometros</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg US</displayName>
+				<unitPattern count="other">{0} mpg US</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>byte</displayName>
+				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>siglos</displayName>
@@ -5768,8 +5768,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>sapa kimsa killa</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>killa</displayName>
@@ -5814,84 +5814,84 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} nanosegundo</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joule</displayName>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kilowatt-ura sapa 100 kilometrokuna</displayName>
 				<unitPattern count="other">{0} kilowatt-ura sapa 100 kilometrokuna</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipográfico em</displayName>
@@ -6019,8 +6019,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} radiación solar</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>candela</displayName>
@@ -6031,96 +6031,96 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} lumen</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gram</displayName>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>catorce libras</displayName>
 				<unitPattern count="other">{0} catorce libras</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>lb</displayName>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>CD</displayName>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>grano</displayName>
 				<unitPattern count="other">{0} grano</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>watt</displayName>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>milimetros de mercurio</displayName>
@@ -6135,72 +6135,72 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} pulgadas por mercurio</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/h</displayName>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°C</displayName>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>libras-pies</displayName>
 				<unitPattern count="other">{0} libras-pies</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>kilómetro cúbico</displayName>
@@ -6344,11 +6344,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} Imp. cuarta</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>direction</displayName>
+				<coordinateUnitPattern type="east">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<unitLength type="short">
@@ -6702,8 +6702,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>↑↑↑</displayName>
@@ -6778,12 +6778,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>punto</displayName>
@@ -7220,37 +7220,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>{0} dL</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
 				<unitPrefixPattern>{0} km</unitPrefixPattern>
@@ -7259,7 +7259,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>{0} byte MB</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
 				<unitPrefixPattern>{0} TB</unitPrefixPattern>
@@ -7268,65 +7268,65 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>{0} byte PB</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/100 km</displayName>
+				<unitPattern count="other">{0} L/100 km</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>wata</displayName>
 				<unitPattern count="other">{0} w</unitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>qtr</displayName>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>killa</displayName>
@@ -7345,8 +7345,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} h</unitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>min</displayName>
+				<unitPattern count="other">{0} min</unitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>segundo</displayName>
@@ -7373,31 +7373,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="other">{0} kg</unitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gram</displayName>
+				<unitPattern count="other">{0} g</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°C</displayName>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litro</displayName>
 				<unitPattern count="other">{0} litro</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>direction</displayName>
+				<coordinateUnitPattern type="east">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -7424,46 +7424,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} utaq {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, utaq {1}</listPatternPart>
 			<listPatternPart type="2">{0} utaq {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, utaq {1}</listPatternPart>
 			<listPatternPart type="2">{0} utaq {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/rhg.xml
+++ b/common/main/rhg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -62,10 +62,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>𐴎𐴡𐴁𐴝𐴕𐴝</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴎𐴡𐴁𐴝𐴕𐴝</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴎𐴡𐴁𐴝𐴕𐴝</displayName>
 			</field>
 			<field type="year">
 				<displayName>𐴁𐴡𐴏𐴥𐴡𐴌</displayName>
@@ -80,27 +80,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>𐴁𐴡𐴏𐴥𐴡𐴌</displayName>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴁𐴡𐴏𐴥𐴡𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴁𐴡𐴏𐴥𐴡𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴁𐴡𐴏𐴥𐴡𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴁𐴡𐴏𐴥𐴡𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴁𐴡𐴏𐴥𐴡𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>𐴁𐴡𐴏𐴥𐴡𐴌</displayName>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴁𐴡𐴏𐴥𐴡𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴁𐴡𐴏𐴥𐴡𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴁𐴡𐴏𐴥𐴡𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴁𐴡𐴏𐴥𐴡𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴁𐴡𐴏𐴥𐴡𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -116,21 +116,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴉𐴝𐴁𐴝</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴉𐴝𐴁𐴝</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴉𐴝𐴁𐴝 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴉𐴝𐴁𐴝</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴉𐴝𐴁𐴝</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴉𐴝𐴁𐴝 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -146,27 +146,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>𐴔𐴝𐴐𐴢</displayName>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴔𐴥𐴝𐴐𐴢</relative>
+				<relative type="0">𐴀𐴠 𐴔𐴥𐴝𐴐𐴢</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴔𐴥𐴝𐴐𐴢</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴔𐴥𐴝𐴐𐴢</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴔𐴝𐴐𐴢 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>𐴔𐴝𐴐𐴢</displayName>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴔𐴥𐴝𐴐𐴢</relative>
+				<relative type="0">𐴀𐴠 𐴔𐴥𐴝𐴐𐴢</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴔𐴥𐴝𐴐𐴢</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴔𐴥𐴝𐴐𐴢</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴔𐴝𐴐𐴢 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -183,39 +183,39 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativePeriod>𐴇𐴥𐴉𐴃𐴤𐴝𐴌 {0}</relativePeriod>
 			</field>
 			<field type="week-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>𐴇𐴥𐴝𐴉𐴃𐴝</displayName>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴇𐴥𐴝𐴉𐴃𐴝</relative>
+				<relative type="0">𐴀𐴠 𐴇𐴥𐴝𐴉𐴃𐴝</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴇𐴥𐴝𐴉𐴃𐴝</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴇𐴥𐴝𐴉𐴃𐴝</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴇𐴥𐴝𐴉𐴃𐴝 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>𐴇𐴥𐴉𐴃𐴤𐴝𐴌 {0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>𐴇𐴥𐴝𐴉𐴃𐴝</displayName>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴇𐴥𐴝𐴉𐴃𐴝</relative>
+				<relative type="0">𐴀𐴠 𐴇𐴥𐴝𐴉𐴃𐴝</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴇𐴥𐴝𐴉𐴃𐴝</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴇𐴥𐴝𐴉𐴃𐴝</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴇𐴥𐴝𐴉𐴃𐴝 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>𐴇𐴥𐴉𐴃𐴤𐴝𐴌 {0}</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName>𐴔𐴝𐴐𐴤𐴡𐴌 𐴇𐴥𐴝𐴉𐴃𐴝</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴔𐴝𐴐𐴤𐴡𐴌 𐴇𐴥𐴝𐴉𐴃𐴝</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴔𐴝𐴐𐴤𐴡𐴌 𐴇𐴥𐴝𐴉𐴃𐴝</displayName>
 			</field>
 			<field type="day">
 				<displayName>𐴊𐴞𐴕</displayName>
@@ -230,55 +230,55 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>𐴊𐴞𐴕</displayName>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴈𐴝𐴙𐴓𐴧𐴝</relative>
+				<relative type="0">𐴀𐴝𐴙𐴅𐴧𐴙𐴝</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴈𐴝𐴙𐴓𐴧𐴝</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴊𐴞𐴕</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴊𐴞𐴕 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>𐴊𐴞𐴕</displayName>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴈𐴝𐴙𐴓𐴧𐴝</relative>
+				<relative type="0">𐴀𐴝𐴙𐴅𐴧𐴙𐴝</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴈𐴝𐴙𐴓𐴧𐴝</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴊𐴞𐴕</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴊𐴞𐴕 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
 				<displayName>𐴁𐴡𐴏𐴥𐴡𐴌𐴡𐴌 𐴊𐴞𐴕</displayName>
 			</field>
 			<field type="dayOfYear-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴁𐴡𐴏𐴥𐴡𐴌𐴡𐴌 𐴊𐴞𐴕</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴁𐴡𐴏𐴥𐴡𐴌𐴡𐴌 𐴊𐴞𐴕</displayName>
 			</field>
 			<field type="weekday">
 				<displayName>𐴇𐴥𐴝𐴉𐴃𐴝𐴌 𐴊𐴞𐴕</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴇𐴥𐴝𐴉𐴃𐴝𐴌 𐴊𐴞𐴕</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴇𐴥𐴝𐴉𐴃𐴝𐴌 𐴊𐴞𐴕</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>𐴔𐴝𐴐𐴤𐴡𐴌 𐴇𐴥𐴝𐴉𐴃𐴝𐴌 𐴊𐴞𐴕</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴔𐴝𐴐𐴤𐴡𐴌 𐴇𐴥𐴝𐴉𐴃𐴝𐴌 𐴊𐴞𐴕</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴔𐴝𐴐𐴤𐴡𐴌 𐴇𐴥𐴝𐴉𐴃𐴝𐴌 𐴊𐴞𐴕</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌</relative>
@@ -292,25 +292,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴌𐴦𐴡𐴘 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -325,25 +325,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="mon-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴐𐴤𐴡𐴔 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -358,25 +358,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="tue-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴝 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴝 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴔𐴡𐴚𐴒𐴡𐴓 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -391,25 +391,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="wed-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴁𐴟𐴙𐴃 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -424,25 +424,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="thu-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴁𐴞𐴐𐴤𐴞𐴃 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -457,25 +457,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="fri-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴠 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴠 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴐𐴤𐴟𐴑𐴧𐴟𐴌 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -490,35 +490,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sat-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">𐴒𐴠𐴓𐴊𐴠 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌</relative>
+				<relative type="0">𐴀𐴠 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌</relative>
+				<relative type="1">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴐𐴤𐴡𐴕𐴞 𐴁𐴝𐴌 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴊𐴞𐴕 / 𐴌𐴝𐴙𐴃𐴢</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>𐴊𐴞𐴕 / 𐴌𐴝𐴙𐴃𐴢</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴊𐴞𐴕 / 𐴌𐴝𐴙𐴃𐴢</displayName>
 			</field>
 			<field type="hour">
 				<displayName>𐴒𐴤𐴡𐴕𐴄𐴤𐴝</displayName>
@@ -531,21 +531,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴒𐴤𐴡𐴕𐴄𐴤𐴝</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴒𐴤𐴡𐴕𐴄𐴤𐴝</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴒𐴤𐴡𐴕𐴄𐴤𐴝 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴒𐴤𐴡𐴕𐴄𐴤𐴝</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴒𐴤𐴡𐴕𐴄𐴤𐴝</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴒𐴤𐴡𐴕𐴄𐴤𐴝 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
@@ -559,21 +559,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="minute-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴔𐴞𐴕𐴥𐴡𐴄𐴢</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴔𐴞𐴕𐴥𐴡𐴄</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴔𐴞𐴕𐴥𐴡𐴄 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴔𐴞𐴕𐴥𐴡𐴄𐴢</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴔𐴞𐴕𐴥𐴡𐴄</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴔𐴞𐴕𐴥𐴡𐴄 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -587,31 +587,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="second-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴏𐴠𐴑𐴤𐴠𐴕</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴏𐴠𐴑𐴤𐴠𐴕</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴏𐴠𐴑𐴤𐴠𐴕 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴏𐴠𐴑𐴤𐴠𐴕</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">𐴀𐴝𐴘𐴧𐴥𐴠𐴌𐴊𐴧𐴠 {0} 𐴏𐴠𐴑𐴤𐴠𐴕</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} 𐴏𐴠𐴑𐴤𐴠𐴕 𐴀𐴝𐴒𐴠</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
 				<displayName>𐴀𐴠𐴓𐴝𐴑𐴝𐴀𐴞 𐴄𐴝𐴙𐴔</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴀𐴠𐴓𐴝𐴑𐴝𐴀𐴞 𐴄𐴝𐴙𐴔</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>𐴀𐴠𐴓𐴝𐴑𐴝𐴀𐴞 𐴄𐴝𐴙𐴔</displayName>
 			</field>
 		</fields>
 	</dates>

--- a/common/main/rif.xml
+++ b/common/main/rif.xml
@@ -26,7 +26,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territories>
 			<territory type="MA" draft="unconfirmed">Lmuɣrib</territory>
 			<territory type="TR" draft="unconfirmed">Ṭurkya</territory>
-			<territory type="TR" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="TR" alt="variant" draft="unconfirmed">Ṭurkya</territory>
 		</territories>
 		<measurementSystemNames>
 			<measurementSystemName type="metric" draft="unconfirmed">amitrik</measurementSystemName>
@@ -89,8 +89,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dayPeriods>
 					<dayPeriodContext type="format">
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -49,7 +49,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="awa" draft="contributed">awadhi</language>
 			<language type="ay" draft="contributed">aymara</language>
 			<language type="az" draft="contributed">aserbeidschanic</language>
-			<language type="az" alt="short">↑↑↑</language>
+			<language type="az" alt="short">aserbeidschanic</language>
 			<language type="ba" draft="contributed">baschkir</language>
 			<language type="bal" draft="contributed">belutschi</language>
 			<language type="ban" draft="contributed">balinais</language>
@@ -1836,10 +1836,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">l’onn proxim</relative>
 			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>onn</displayName>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>onn</displayName>
 			</field>
 			<field type="quarter">
 				<displayName>quartal</displayName>
@@ -1854,19 +1854,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="contributed">mais</displayName>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>mais</displayName>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>mais</displayName>
 			</field>
 			<field type="week">
 				<displayName draft="contributed">emna</displayName>
 			</field>
 			<field type="week-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>emna</displayName>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>emna</displayName>
 			</field>
 			<field type="day">
 				<displayName>di</displayName>
@@ -1878,15 +1878,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>di</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ier</relative>
+				<relative type="0">oz</relative>
+				<relative type="1">damaun</relative>
 			</field>
 			<field type="day-narrow">
 				<displayName>d</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ier</relative>
+				<relative type="0">oz</relative>
+				<relative type="1">damaun</relative>
 			</field>
 			<field type="weekday">
 				<displayName>di da l’emna</displayName>
@@ -1904,10 +1904,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ura</displayName>
 			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ura</displayName>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ura</displayName>
 			</field>
 			<field type="minute">
 				<displayName>minuta</displayName>
@@ -2703,7 +2703,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="ARS">
 				<displayName>peso argentin</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">pesos argentins</displayName>
 				<displayName count="other">pesos argentins</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -2723,7 +2723,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="AWG">
 				<displayName>flurin da l’Aruba</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">flurins da l’Aruba</displayName>
 				<displayName count="other">flurins da l’Aruba</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -2761,7 +2761,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BBD">
 				<displayName>dollar da Barbados</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">dollars da Barbados</displayName>
 				<displayName count="other">dollars da Barbados</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -2829,7 +2829,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BMD">
 				<displayName>dollar da las Bermudas</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">dollars da las Bermudas</displayName>
 				<displayName count="other">dollars da las Bermudas</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -2884,7 +2884,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BSD">
 				<displayName>dollar da las Bahamas</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">dollars da las Bahamas</displayName>
 				<displayName count="other">dollars da las Bahamas</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -2919,7 +2919,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="one">rubel bieloruss</displayName>
 				<displayName count="other">rubels bieloruss</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">BYN</symbol>
 			</currency>
 			<currency type="BYR">
 				<displayName>rubel bieloruss (2000–2016)</displayName>
@@ -2929,7 +2929,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BZD">
 				<displayName>dollar dal Belize</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">dollars dal Belize</displayName>
 				<displayName count="other">dollars dal Belize</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -2973,7 +2973,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CLP">
 				<displayName>peso chilen</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">pesos chilens</displayName>
 				<displayName count="other">pesos chilens</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -3009,7 +3009,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CRC">
 				<displayName>colon da la Costa Rica</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">colons da la Costa Rica</displayName>
 				<displayName count="other">colons da la Costa Rica</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -3035,7 +3035,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CUP">
 				<displayName>peso cuban</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">pesos cubans</displayName>
 				<displayName count="other">pesos cubans</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -3086,7 +3086,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="DOP">
 				<displayName>peso dominican</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">pesos dominicans</displayName>
 				<displayName count="other">pesos dominicans</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -3169,7 +3169,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="FKP">
 				<displayName>glivra dal Falkland</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">glivras dal Falkland</displayName>
 				<displayName count="other">glivras dal Falkland</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -3235,13 +3235,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="GNS">
 				<displayName draft="contributed">syli da la Guinea</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">sylis da la Guinea</displayName>
 				<displayName count="other" draft="unconfirmed">sylis da la Guinea</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
 			<currency type="GQE">
 				<displayName draft="contributed">ekwele da la Guinea Equatoriala</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">ekweles da la Guinea Equatoriala</displayName>
 				<displayName count="other" draft="unconfirmed">ekweles da la Guinea Equatoriala</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
@@ -3253,14 +3253,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="GTQ">
 				<displayName>quetzal da la Guatemala</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">quetzals da la Guatemala</displayName>
 				<displayName count="other">quetzals da la Guatemala</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GWE">
 				<displayName draft="contributed">escudo da la Guinea Portugaisa</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">escudos da la Guinea Portugaisa</displayName>
 				<displayName count="other" draft="unconfirmed">escudos da la Guinea Portugaisa</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
@@ -3272,7 +3272,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="GYD">
 				<displayName>dollar da la Guyana</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">dollars da la Guyana</displayName>
 				<displayName count="other">dollars da la Guyana</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -3306,7 +3306,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="HTG">
 				<displayName>gourde haitian</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">gourdes haitians</displayName>
 				<displayName count="other">gourdes haitians</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -3515,7 +3515,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="LTL">
 				<displayName draft="contributed">litas lituan</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">litas lituans</displayName>
 				<displayName count="other" draft="unconfirmed">litas lituans</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="unconfirmed">↑↑↑</symbol>
@@ -3528,7 +3528,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="LUC">
 				<displayName draft="contributed">franc convertibel luxemburgais</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">francs convertibels luxemburgais</displayName>
 				<displayName count="other" draft="unconfirmed">francs convertibels luxemburgais</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
@@ -3790,7 +3790,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="PAB">
 				<displayName>balboa dal Panama</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">balboas dal Panama</displayName>
 				<displayName count="other">balboas dal Panama</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -3799,7 +3799,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="PEN">
 				<displayName>sol peruan</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">soles peruans</displayName>
 				<displayName count="other">soles peruans</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -3847,7 +3847,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="PYG">
 				<displayName>guarani paraguaian</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">guaranis paraguaians</displayName>
 				<displayName count="other">guaranis paraguaians</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -3860,7 +3860,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="RHD">
 				<displayName draft="contributed">dollar rodesian</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">dollars rodesians</displayName>
 				<displayName count="other" draft="unconfirmed">dollars rodesians</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
@@ -3889,14 +3889,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="other">rubels russ</displayName>
 				<symbol draft="contributed">RUB</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
-				<symbol alt="variant" draft="contributed">↑↑↑</symbol>
+				<symbol alt="variant" draft="contributed">RUB</symbol>
 			</currency>
 			<currency type="RUR">
 				<displayName draft="contributed">rubel russ (vegl)</displayName>
 				<displayName count="one" draft="contributed">rubel russ (vegl)</displayName>
 				<displayName count="other" draft="contributed">rubel russ (vegl)</displayName>
 				<symbol draft="contributed">RUR</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">RUR</symbol>
 			</currency>
 			<currency type="RWF">
 				<displayName>franc ruandais</displayName>
@@ -3989,7 +3989,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="SRD">
 				<displayName>dollar surinam</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">dollars surinams</displayName>
 				<displayName count="other">dollars surinams</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -4105,7 +4105,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="TTD">
 				<displayName>dollar da Trinidad e Tobago</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">dollars da Trinidad e Tobago</displayName>
 				<displayName count="other">dollars da Trinidad e Tobago</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -4234,7 +4234,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="XBA">
 				<displayName draft="contributed">unitad europeica cumponida</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">unitads europeicas cumponidas</displayName>
 				<displayName count="other" draft="unconfirmed">unitads europeicas cumponidas</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
@@ -4246,7 +4246,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="XBD">
 				<displayName draft="contributed">unitad dal quint europeica (XBD)</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">unitads dal quint europeicas (XBD)</displayName>
 				<displayName count="other" draft="unconfirmed">unitads dal quint europeicas (XBD)</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
@@ -4260,7 +4260,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="XDR">
 				<displayName draft="contributed">dretgs da prelevaziun spezials</displayName>
 				<displayName count="one" draft="unconfirmed">dretg da prelevaziun spezial</displayName>
-				<displayName count="other" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="other" draft="unconfirmed">dretgs da prelevaziun spezials</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
 			<currency type="XEU">
@@ -4271,13 +4271,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="XFO">
 				<displayName draft="contributed">franc d’aur franzos</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">francs d’aur franzos</displayName>
 				<displayName count="other" draft="unconfirmed">francs d’aur franzos</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
 			<currency type="XFU">
 				<displayName draft="contributed">franc UIC franzos</displayName>
-				<displayName count="one" draft="unconfirmed">↑↑↑</displayName>
+				<displayName count="one" draft="unconfirmed">francs UIC franzos</displayName>
 				<displayName count="other" draft="unconfirmed">francs UIC franzos</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
 			</currency>
@@ -4437,7 +4437,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0} per {1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="digital-petabyte">
 				<displayName>petabytes</displayName>
@@ -4649,7 +4649,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-byte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} byte</unitPattern>
 				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
@@ -4759,10 +4759,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="duration-year">
 				<displayName>onn</displayName>
@@ -4868,7 +4868,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<coordinateUnit>
 				<displayName>direcziun</displayName>
 				<coordinateUnitPattern type="east">{0}O</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} N</coordinateUnitPattern>
 				<coordinateUnitPattern type="south">{0}S</coordinateUnitPattern>
 				<coordinateUnitPattern type="west">{0}V</coordinateUnitPattern>
 			</coordinateUnit>
@@ -4897,34 +4897,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} u {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} u {1}</listPatternPart>
 			<listPatternPart type="2">{0} u {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} u {1}</listPatternPart>
 			<listPatternPart type="2">{0} u {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} e {1}</listPatternPart>
+			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} e {1}</listPatternPart>
+			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} e {1}</listPatternPart>
+			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
 			<listPatternPart type="start">{0} {1}</listPatternPart>
@@ -4933,10 +4933,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} e {1}</listPatternPart>
+			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -107,7 +107,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cherokee</language>
 			<language type="chy">cheyenne</language>
 			<language type="ckb">kurdă centrală</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">kurdă centrală</language>
 			<language type="ckb" alt="variant">kurdă sorani</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">corsicană</language>
@@ -1522,7 +1522,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1530,7 +1530,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1538,7 +1538,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">E d</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="contributed">dd.MM.y G</dateFormatItem>
 						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd" draft="contributed">E, d MMM y G</dateFormatItem>
@@ -1565,54 +1565,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MM.y GGGGG – MM.y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MM.y – MM.y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MM.y – MM.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd.MM.y – dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd.MM.y GGGGG – dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd.MM.y – dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd.MM.y – dd.MM.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd.MM.y – E, dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd.MM.y GGGGG – E, dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd.MM.y – E, dd.MM.y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd.MM.y – E, dd.MM.y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
@@ -1886,7 +1886,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap" draft="contributed">↑↑↑</monthPattern>
+							<monthPattern type="leap" draft="contributed">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 				</monthPatterns>
@@ -1894,112 +1894,112 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<cyclicNameSet type="years">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="14" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="15" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="16" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="17" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="18" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="19" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="20" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="21" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="22" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="23" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="24" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="25" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="26" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="27" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="28" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="29" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="30" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="31" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="32" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="33" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="34" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="35" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="36" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="37" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="38" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="39" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="40" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="41" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="42" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="43" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="44" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="45" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="46" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="47" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="48" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="49" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="50" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="51" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="52" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="53" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="54" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="55" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="56" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="57" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="58" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="59" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="60" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">jia-zi</cyclicName>
+								<cyclicName type="2" draft="contributed">yi-chou</cyclicName>
+								<cyclicName type="3" draft="contributed">bing-yin</cyclicName>
+								<cyclicName type="4" draft="contributed">ding-mao</cyclicName>
+								<cyclicName type="5" draft="contributed">wu-chen</cyclicName>
+								<cyclicName type="6" draft="contributed">ji-si</cyclicName>
+								<cyclicName type="7" draft="contributed">geng-wu</cyclicName>
+								<cyclicName type="8" draft="contributed">xin-wei</cyclicName>
+								<cyclicName type="9" draft="contributed">ren-shen</cyclicName>
+								<cyclicName type="10" draft="contributed">gui-you</cyclicName>
+								<cyclicName type="11" draft="contributed">jia-xu</cyclicName>
+								<cyclicName type="12" draft="contributed">yi-hai</cyclicName>
+								<cyclicName type="13" draft="contributed">bing-zi</cyclicName>
+								<cyclicName type="14" draft="contributed">ding-chou</cyclicName>
+								<cyclicName type="15" draft="contributed">wu-yin</cyclicName>
+								<cyclicName type="16" draft="contributed">ji-mao</cyclicName>
+								<cyclicName type="17" draft="contributed">geng-chen</cyclicName>
+								<cyclicName type="18" draft="contributed">xin-si</cyclicName>
+								<cyclicName type="19" draft="contributed">ren-wu</cyclicName>
+								<cyclicName type="20" draft="contributed">gui-wei</cyclicName>
+								<cyclicName type="21" draft="contributed">jia-shen</cyclicName>
+								<cyclicName type="22" draft="contributed">yi-you</cyclicName>
+								<cyclicName type="23" draft="contributed">bing-xu</cyclicName>
+								<cyclicName type="24" draft="contributed">ding-hai</cyclicName>
+								<cyclicName type="25" draft="contributed">wu-zi</cyclicName>
+								<cyclicName type="26" draft="contributed">ji-chou</cyclicName>
+								<cyclicName type="27" draft="contributed">geng-yin</cyclicName>
+								<cyclicName type="28" draft="contributed">xin-mao</cyclicName>
+								<cyclicName type="29" draft="contributed">ren-chen</cyclicName>
+								<cyclicName type="30" draft="contributed">gui-si</cyclicName>
+								<cyclicName type="31" draft="contributed">jia-wu</cyclicName>
+								<cyclicName type="32" draft="contributed">yi-wei</cyclicName>
+								<cyclicName type="33" draft="contributed">bing-shen</cyclicName>
+								<cyclicName type="34" draft="contributed">ding-you</cyclicName>
+								<cyclicName type="35" draft="contributed">wu-xu</cyclicName>
+								<cyclicName type="36" draft="contributed">ji-hai</cyclicName>
+								<cyclicName type="37" draft="contributed">geng-zi</cyclicName>
+								<cyclicName type="38" draft="contributed">xin-chou</cyclicName>
+								<cyclicName type="39" draft="contributed">ren-yin</cyclicName>
+								<cyclicName type="40" draft="contributed">gui-mao</cyclicName>
+								<cyclicName type="41" draft="contributed">jia-chen</cyclicName>
+								<cyclicName type="42" draft="contributed">yi-si</cyclicName>
+								<cyclicName type="43" draft="contributed">bing-wu</cyclicName>
+								<cyclicName type="44" draft="contributed">ding-wei</cyclicName>
+								<cyclicName type="45" draft="contributed">wu-shen</cyclicName>
+								<cyclicName type="46" draft="contributed">ji-you</cyclicName>
+								<cyclicName type="47" draft="contributed">geng-xu</cyclicName>
+								<cyclicName type="48" draft="contributed">xin-hai</cyclicName>
+								<cyclicName type="49" draft="contributed">ren-zi</cyclicName>
+								<cyclicName type="50" draft="contributed">gui-chou</cyclicName>
+								<cyclicName type="51" draft="contributed">jia-yin</cyclicName>
+								<cyclicName type="52" draft="contributed">yi-mao</cyclicName>
+								<cyclicName type="53" draft="contributed">bing-chen</cyclicName>
+								<cyclicName type="54" draft="contributed">ding-si</cyclicName>
+								<cyclicName type="55" draft="contributed">wu-wu</cyclicName>
+								<cyclicName type="56" draft="contributed">ji-wei</cyclicName>
+								<cyclicName type="57" draft="contributed">geng-shen</cyclicName>
+								<cyclicName type="58" draft="contributed">xin-you</cyclicName>
+								<cyclicName type="59" draft="contributed">ren-xu</cyclicName>
+								<cyclicName type="60" draft="contributed">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="zodiacs">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">zi</cyclicName>
+								<cyclicName type="2" draft="contributed">chou</cyclicName>
+								<cyclicName type="3" draft="contributed">yin</cyclicName>
+								<cyclicName type="4" draft="contributed">mao</cyclicName>
+								<cyclicName type="5" draft="contributed">chen</cyclicName>
+								<cyclicName type="6" draft="contributed">si</cyclicName>
+								<cyclicName type="7" draft="contributed">wu</cyclicName>
+								<cyclicName type="8" draft="contributed">wei</cyclicName>
+								<cyclicName type="9" draft="contributed">shen</cyclicName>
+								<cyclicName type="10" draft="contributed">you</cyclicName>
+								<cyclicName type="11" draft="contributed">xu</cyclicName>
+								<cyclicName type="12" draft="contributed">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">zi</cyclicName>
+								<cyclicName type="2" draft="contributed">chou</cyclicName>
+								<cyclicName type="3" draft="contributed">yin</cyclicName>
+								<cyclicName type="4" draft="contributed">mao</cyclicName>
+								<cyclicName type="5" draft="contributed">chen</cyclicName>
+								<cyclicName type="6" draft="contributed">si</cyclicName>
+								<cyclicName type="7" draft="contributed">wu</cyclicName>
+								<cyclicName type="8" draft="contributed">wei</cyclicName>
+								<cyclicName type="9" draft="contributed">shen</cyclicName>
+								<cyclicName type="10" draft="contributed">you</cyclicName>
+								<cyclicName type="11" draft="contributed">xu</cyclicName>
+								<cyclicName type="12" draft="contributed">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">zi</cyclicName>
+								<cyclicName type="2" draft="contributed">chou</cyclicName>
+								<cyclicName type="3" draft="contributed">yin</cyclicName>
+								<cyclicName type="4" draft="contributed">mao</cyclicName>
+								<cyclicName type="5" draft="contributed">chen</cyclicName>
+								<cyclicName type="6" draft="contributed">si</cyclicName>
+								<cyclicName type="7" draft="contributed">wu</cyclicName>
+								<cyclicName type="8" draft="contributed">wei</cyclicName>
+								<cyclicName type="9" draft="contributed">shen</cyclicName>
+								<cyclicName type="10" draft="contributed">you</cyclicName>
+								<cyclicName type="11" draft="contributed">xu</cyclicName>
+								<cyclicName type="12" draft="contributed">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2166,7 +2166,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2174,7 +2174,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2475,7 +2475,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="wed">M</day>
 							<day type="thu">J</day>
 							<day type="fri">V</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">du.</day>
@@ -2592,7 +2592,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">miezul nopții</dayPeriod>
 							<dayPeriod type="am">a.m.</dayPeriod>
-							<dayPeriod type="noon">↑↑↑</dayPeriod>
+							<dayPeriod type="noon">amiază</dayPeriod>
 							<dayPeriod type="pm">p.m.</dayPeriod>
 							<dayPeriod type="morning1">dimineața</dayPeriod>
 							<dayPeriod type="afternoon1">după-amiaza</dayPeriod>
@@ -2737,7 +2737,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2745,7 +2745,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2957,18 +2957,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<monthWidth type="abbreviated">
 							<month type="1" draft="contributed">Tișrei</month>
 							<month type="2" draft="contributed">Heșvan</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
+							<month type="3" draft="contributed">Kislev</month>
+							<month type="4" draft="contributed">Tevet</month>
 							<month type="5" draft="contributed">Șevat</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
+							<month type="6" draft="contributed">Adar I</month>
+							<month type="7" draft="contributed">Adar</month>
+							<month type="7" yeartype="leap" draft="contributed">Adar II</month>
+							<month type="8" draft="contributed">Nisan</month>
+							<month type="9" draft="contributed">Iyar</month>
+							<month type="10" draft="contributed">Sivan</month>
 							<month type="11" draft="contributed">Tammuz</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="12" draft="contributed">Av</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="contributed">1</month>
@@ -3007,18 +3007,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<monthWidth type="abbreviated">
 							<month type="1" draft="contributed">Tișrei</month>
 							<month type="2" draft="contributed">Heșvan</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
+							<month type="3" draft="contributed">Kislev</month>
+							<month type="4" draft="contributed">Tevet</month>
 							<month type="5" draft="contributed">Șevat</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
+							<month type="6" draft="contributed">Adar I</month>
+							<month type="7" draft="contributed">Adar</month>
+							<month type="7" yeartype="leap" draft="contributed">Adar II</month>
+							<month type="8" draft="contributed">Nisan</month>
+							<month type="9" draft="contributed">Iyar</month>
+							<month type="10" draft="contributed">Sivan</month>
 							<month type="11" draft="contributed">Tammuz</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="12" draft="contributed">Av</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="contributed">1</month>
@@ -3039,18 +3039,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<monthWidth type="wide">
 							<month type="1" draft="contributed">Tișrei</month>
 							<month type="2" draft="contributed">Heșvan</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
+							<month type="3" draft="contributed">Kislev</month>
+							<month type="4" draft="contributed">Tevet</month>
 							<month type="5" draft="contributed">Șevat</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
+							<month type="6" draft="contributed">Adar I</month>
+							<month type="7" draft="contributed">Adar</month>
+							<month type="7" yeartype="leap" draft="contributed">Adar II</month>
+							<month type="8" draft="contributed">Nisan</month>
+							<month type="9" draft="contributed">Iyar</month>
+							<month type="10" draft="contributed">Sivan</month>
 							<month type="11" draft="contributed">Tammuz</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="12" draft="contributed">Av</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -3580,7 +3580,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="week-narrow">
 				<displayName>săpt.</displayName>
 				<relative type="-1">săpt. trecută</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">săpt. aceasta</relative>
 				<relative type="1">săpt. viitoare</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">+{0} săpt.</relativeTimePattern>
@@ -7387,7 +7387,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>loti lesothian</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">maloti leshotieni</displayName>
 				<displayName count="few">maloti leshotieni</displayName>
 				<displayName count="other">maloti leshotieni</displayName>
 				<symbol>↑↑↑</symbol>
@@ -8401,11 +8401,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1 count="one">{0} cub</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">{0} cub</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine">{0} cubică</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">{0} cubică</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">{0} cub</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">{0} cub</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">{0} cubice</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="genitive">{0} cubice</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine">{0} cubice</compoundUnitPattern1>
@@ -8426,11 +8426,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>forță g</displayName>
 				<unitPattern count="one">{0} forță g</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} forță g</unitPattern>
 				<unitPattern count="few">{0} forță g</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} forță g</unitPattern>
 				<unitPattern count="other">{0} forță g</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} forță g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>masculine</gender>
@@ -8438,9 +8438,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} metru pe secundă la pătrat</unitPattern>
 				<unitPattern count="one" case="genitive">unui metru pe secundă la pătrat</unitPattern>
 				<unitPattern count="few">{0} metri pe secundă la pătrat</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metri pe secundă la pătrat</unitPattern>
 				<unitPattern count="other">{0} de metri pe secundă la pătrat</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de metri pe secundă la pătrat</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>feminine</gender>
@@ -8458,9 +8458,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} radian</unitPattern>
 				<unitPattern count="one" case="genitive">unui radian</unitPattern>
 				<unitPattern count="few">{0} radiani</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} radiani</unitPattern>
 				<unitPattern count="other">{0} de radiani</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de radiani</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>neuter</gender>
@@ -8468,9 +8468,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} grad</unitPattern>
 				<unitPattern count="one" case="genitive">unui grad</unitPattern>
 				<unitPattern count="few">{0} grade</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} grade</unitPattern>
 				<unitPattern count="other">{0} de grade</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de grade</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>neuter</gender>
@@ -8478,9 +8478,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} minut de arc</unitPattern>
 				<unitPattern count="one" case="genitive">unui minut de arc</unitPattern>
 				<unitPattern count="few">{0} minute de arc</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} minute de arc</unitPattern>
 				<unitPattern count="other">{0} de minute de arc</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de minute de arc</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>feminine</gender>
@@ -8498,9 +8498,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilometru pătrat</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilometru pătrat</unitPattern>
 				<unitPattern count="few">{0} kilometri pătrați</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilometri pătrați</unitPattern>
 				<unitPattern count="other">{0} de kilometri pătrați</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilometri pătrați</unitPattern>
 				<perUnitPattern>{0} pe kilometru pătrat</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
@@ -8509,9 +8509,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hectar</unitPattern>
 				<unitPattern count="one" case="genitive">unui hectar</unitPattern>
 				<unitPattern count="few">{0} hectare</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hectare</unitPattern>
 				<unitPattern count="other">{0} de hectare</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de hectare</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>masculine</gender>
@@ -8519,9 +8519,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} metru pătrat</unitPattern>
 				<unitPattern count="one" case="genitive">unui metru pătrat</unitPattern>
 				<unitPattern count="few">{0} metri pătrați</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metri pătrați</unitPattern>
 				<unitPattern count="other">{0} de metri pătrați</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de metri pătrați</unitPattern>
 				<perUnitPattern>{0} pe metru pătrat</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
@@ -8530,9 +8530,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} centimetru pătrat</unitPattern>
 				<unitPattern count="one" case="genitive">unui centimetru pătrat</unitPattern>
 				<unitPattern count="few">{0} centimetri pătrați</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} centimetri pătrați</unitPattern>
 				<unitPattern count="other">{0} de centimetri pătrați</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de centimetri pătrați</unitPattern>
 				<perUnitPattern>{0} pe centimetru pătrat</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -8569,7 +8569,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunami</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="few">{0} dunami</unitPattern>
 				<unitPattern count="other">{0} de dunami</unitPattern>
 			</unit>
@@ -8595,18 +8595,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} milimol pe litru</unitPattern>
 				<unitPattern count="one" case="genitive">unui milimol pe litru</unitPattern>
 				<unitPattern count="few">{0} milimoli pe litru</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milimoli pe litru</unitPattern>
 				<unitPattern count="other">{0} de milimoli pe litru</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de milimoli pe litru</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} de itemi</unitPattern>
 				<unitPattern count="one" case="genitive">unui item</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} itemi</unitPattern>
+				<unitPattern count="few" case="genitive">{0} itemi</unitPattern>
+				<unitPattern count="other">{0} de itemi</unitPattern>
 				<unitPattern count="other" case="genitive">{0} de itemi</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -8625,9 +8625,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} procent</unitPattern>
 				<unitPattern count="one" case="genitive">unui procent</unitPattern>
 				<unitPattern count="few">{0} procente</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} procente</unitPattern>
 				<unitPattern count="other">{0} de procente</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de procente</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>feminine</gender>
@@ -8635,13 +8635,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} promilă</unitPattern>
 				<unitPattern count="one" case="genitive">unei promile</unitPattern>
 				<unitPattern count="few">{0} promile</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} promile</unitPattern>
 				<unitPattern count="other">{0} de promile</unitPattern>
 				<unitPattern count="other" case="genitive">{0} de promile</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>feminine</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">{0} la zece mii</unitPattern>
 				<unitPattern count="one" case="genitive">unei părți la zece mii</unitPattern>
 				<unitPattern count="few">{0} la zece mii</unitPattern>
@@ -8652,12 +8652,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="concentr-mole">
 				<gender>masculine</gender>
 				<displayName>moli</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="one" case="genitive">unui mol</unitPattern>
 				<unitPattern count="few">{0} moli</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} moli</unitPattern>
 				<unitPattern count="other">{0} de moli</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de moli</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>masculine</gender>
@@ -8665,9 +8665,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} litru pe kilometru</unitPattern>
 				<unitPattern count="one" case="genitive">unui litru pe kilometru</unitPattern>
 				<unitPattern count="few">{0} litri pe kilometru</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} litri pe kilometru</unitPattern>
 				<unitPattern count="other">{0} de litri pe kilometru</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de litri pe kilometru</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>masculine</gender>
@@ -8675,9 +8675,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} litru la suta de kilometri</unitPattern>
 				<unitPattern count="one" case="genitive">unui litru la suta de kilometri</unitPattern>
 				<unitPattern count="few">{0} litri la suta de kilometri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} litri la suta de kilometri</unitPattern>
 				<unitPattern count="other">{0} de litri la suta de kilometri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de litri la suta de kilometri</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mile pe galon</displayName>
@@ -8697,9 +8697,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} petabyte</unitPattern>
 				<unitPattern count="one" case="genitive">unui petabyte</unitPattern>
 				<unitPattern count="few">{0} petabyți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} petabyți</unitPattern>
 				<unitPattern count="other">{0} de petabyți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de petabyți</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>masculine</gender>
@@ -8707,9 +8707,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} terabyte</unitPattern>
 				<unitPattern count="one" case="genitive">unui terabyte</unitPattern>
 				<unitPattern count="few">{0} terabyți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} terabyți</unitPattern>
 				<unitPattern count="other">{0} de terabyți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de terabyți</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>masculine</gender>
@@ -8717,9 +8717,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} terabit</unitPattern>
 				<unitPattern count="one" case="genitive">unui terabit</unitPattern>
 				<unitPattern count="few">{0} terabiți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} terabiți</unitPattern>
 				<unitPattern count="other">{0} de terabiți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de terabiți</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>masculine</gender>
@@ -8727,9 +8727,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} gigabyte</unitPattern>
 				<unitPattern count="one" case="genitive">unui gigabyte</unitPattern>
 				<unitPattern count="few">{0} gigabyți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigabyți</unitPattern>
 				<unitPattern count="other">{0} de gigabyți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de gigabyți</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>masculine</gender>
@@ -8737,9 +8737,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} gigabit</unitPattern>
 				<unitPattern count="one" case="genitive">unui gigabit</unitPattern>
 				<unitPattern count="few">{0} gigabiți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigabiți</unitPattern>
 				<unitPattern count="other">{0} de gigabiți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de gigabiți</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>masculine</gender>
@@ -8747,9 +8747,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} megabyte</unitPattern>
 				<unitPattern count="one" case="genitive">unui megabyte</unitPattern>
 				<unitPattern count="few">{0} megabyți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megabyți</unitPattern>
 				<unitPattern count="other">{0} de megabyți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de megabyți</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>masculine</gender>
@@ -8757,9 +8757,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} megabit</unitPattern>
 				<unitPattern count="one" case="genitive">unui megabit</unitPattern>
 				<unitPattern count="few">{0} megabiți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megabiți</unitPattern>
 				<unitPattern count="other">{0} de megabiți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de megabiți</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>masculine</gender>
@@ -8767,9 +8767,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilobyte</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilobyte</unitPattern>
 				<unitPattern count="few">{0} kilobyți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilobyți</unitPattern>
 				<unitPattern count="other">{0} de kilobyți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilobyți</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>masculine</gender>
@@ -8777,9 +8777,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilobit</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilobit</unitPattern>
 				<unitPattern count="few">{0} kilobiți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilobiți</unitPattern>
 				<unitPattern count="other">{0} de kilobiți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilobiți</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>masculine</gender>
@@ -8787,9 +8787,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} byte</unitPattern>
 				<unitPattern count="one" case="genitive">unui byte</unitPattern>
 				<unitPattern count="few">{0} byți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} byți</unitPattern>
 				<unitPattern count="other">{0} de byți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de byți</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>masculine</gender>
@@ -8797,9 +8797,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} bit</unitPattern>
 				<unitPattern count="one" case="genitive">unui bit</unitPattern>
 				<unitPattern count="few">{0} biți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} biți</unitPattern>
 				<unitPattern count="other">{0} de biți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de biți</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>neuter</gender>
@@ -8807,9 +8807,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} secol</unitPattern>
 				<unitPattern count="one" case="genitive">unui secol</unitPattern>
 				<unitPattern count="few">{0} secole</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} secole</unitPattern>
 				<unitPattern count="other">{0} de secole</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de secole</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>neuter</gender>
@@ -8817,9 +8817,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} deceniu</unitPattern>
 				<unitPattern count="one" case="genitive">unui deceniu</unitPattern>
 				<unitPattern count="few">{0} decenii</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} decenii</unitPattern>
 				<unitPattern count="other">{0} de decenii</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de decenii</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>masculine</gender>
@@ -8827,9 +8827,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} an</unitPattern>
 				<unitPattern count="one" case="genitive">unui an</unitPattern>
 				<unitPattern count="few">{0} ani</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ani</unitPattern>
 				<unitPattern count="other">{0} de ani</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de ani</unitPattern>
 				<perUnitPattern>{0} pe an</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -8838,7 +8838,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} trimestru</unitPattern>
 				<unitPattern count="one" case="genitive">unui trimestru</unitPattern>
 				<unitPattern count="few">{0} trimestre</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} trimestre</unitPattern>
 				<unitPattern count="other">{0} de trimestre</unitPattern>
 				<unitPattern count="other" case="genitive">{0} de trimestre</unitPattern>
 				<perUnitPattern>{0}/trim.</perUnitPattern>
@@ -8893,9 +8893,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} minut</unitPattern>
 				<unitPattern count="one" case="genitive">unui minut</unitPattern>
 				<unitPattern count="few">{0} minute</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} minute</unitPattern>
 				<unitPattern count="other">{0} de minute</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de minute</unitPattern>
 				<perUnitPattern>{0} pe minut</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -8915,9 +8915,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} milisecundă</unitPattern>
 				<unitPattern count="one" case="genitive">unei milisecunde</unitPattern>
 				<unitPattern count="few">{0} milisecunde</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milisecunde</unitPattern>
 				<unitPattern count="other">{0} de milisecunde</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de milisecunde</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>feminine</gender>
@@ -8925,9 +8925,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} microsecundă</unitPattern>
 				<unitPattern count="one" case="genitive">unei microsecunde</unitPattern>
 				<unitPattern count="few">{0} microsecunde</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} microsecunde</unitPattern>
 				<unitPattern count="other">{0} de microsecunde</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de microsecunde</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>feminine</gender>
@@ -8935,9 +8935,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} nanosecundă</unitPattern>
 				<unitPattern count="one" case="genitive">unei nanosecunde</unitPattern>
 				<unitPattern count="few">{0} nanosecunde</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} nanosecunde</unitPattern>
 				<unitPattern count="other">{0} de nanosecunde</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de nanosecunde</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>masculine</gender>
@@ -8945,9 +8945,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} amper</unitPattern>
 				<unitPattern count="one" case="genitive">unui amper</unitPattern>
 				<unitPattern count="few">{0} amperi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} amperi</unitPattern>
 				<unitPattern count="other">{0} de amperi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de amperi</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>masculine</gender>
@@ -8955,9 +8955,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} miliamper</unitPattern>
 				<unitPattern count="one" case="genitive">unui miliamper</unitPattern>
 				<unitPattern count="few">{0} miliamperi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} miliamperi</unitPattern>
 				<unitPattern count="other">{0} de miliamperi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de miliamperi</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>masculine</gender>
@@ -8965,9 +8965,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ohm</unitPattern>
 				<unitPattern count="one" case="genitive">unui ohm</unitPattern>
 				<unitPattern count="few">{0} ohmi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ohmi</unitPattern>
 				<unitPattern count="other">{0} de ohmi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de ohmi</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>masculine</gender>
@@ -8975,9 +8975,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} volt</unitPattern>
 				<unitPattern count="one" case="genitive">unui volt</unitPattern>
 				<unitPattern count="few">{0} volți</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} volți</unitPattern>
 				<unitPattern count="other">{0} de volți</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de volți</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>kilocalorii</displayName>
@@ -9007,9 +9007,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilojoule</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilojoule</unitPattern>
 				<unitPattern count="few">{0} kilojouli</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilojouli</unitPattern>
 				<unitPattern count="other">{0} de kilojouli</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilojouli</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>masculine</gender>
@@ -9017,9 +9017,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} joule</unitPattern>
 				<unitPattern count="one" case="genitive">unui joule</unitPattern>
 				<unitPattern count="few">{0} jouli</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} jouli</unitPattern>
 				<unitPattern count="other">{0} de jouli</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de jouli</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>masculine</gender>
@@ -9027,9 +9027,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">kilowatt-oră</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilowatt-oră</unitPattern>
 				<unitPattern count="few">{0} kilowați-oră</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilowați-oră</unitPattern>
 				<unitPattern count="other">{0} de kilowați-oră</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilowați-oră</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>electronvolți</displayName>
@@ -9061,9 +9061,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} newton</unitPattern>
 				<unitPattern count="one" case="genitive">unui newton</unitPattern>
 				<unitPattern count="few">{0} newtoni</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} newtoni</unitPattern>
 				<unitPattern count="other">{0} de newtoni</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de newtoni</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>masculine</gender>
@@ -9071,7 +9071,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilowatt-oră per 100 kilometri</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilowatt-oră per 100 de kilometri</unitPattern>
 				<unitPattern count="few">{0} kilowați-oră per 100 kilometri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilowați-oră per 100 kilometri</unitPattern>
 				<unitPattern count="other">{0} kilowați-oră per 100 kilometri</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilowați-oră per 100 kilometri</unitPattern>
 			</unit>
@@ -9081,9 +9081,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} gigahertz</unitPattern>
 				<unitPattern count="one" case="genitive">unui gigahertz</unitPattern>
 				<unitPattern count="few">{0} gigahertzi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigahertzi</unitPattern>
 				<unitPattern count="other">{0} de gigahertzi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de gigahertzi</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>masculine</gender>
@@ -9091,9 +9091,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} megahertz</unitPattern>
 				<unitPattern count="one" case="genitive">unui megahertz</unitPattern>
 				<unitPattern count="few">{0} megahertzi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megahertzi</unitPattern>
 				<unitPattern count="other">{0} de megahertzi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de megahertzi</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>masculine</gender>
@@ -9101,9 +9101,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilohertz</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilohertz</unitPattern>
 				<unitPattern count="few">{0} kilohertzi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilohertzi</unitPattern>
 				<unitPattern count="other">{0} de kilohertzi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilohertzi</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>masculine</gender>
@@ -9111,19 +9111,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hertz</unitPattern>
 				<unitPattern count="one" case="genitive">unui hertz</unitPattern>
 				<unitPattern count="few">{0} hertzi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hertzi</unitPattern>
 				<unitPattern count="other">{0} de hertzi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de hertzi</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>masculine</gender>
 				<displayName>em tipografic</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="genitive">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="few" case="genitive">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="genitive">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
@@ -9131,9 +9131,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} pixel</unitPattern>
 				<unitPattern count="one" case="genitive">unui pixel</unitPattern>
 				<unitPattern count="few">{0} pixeli</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} pixeli</unitPattern>
 				<unitPattern count="other">{0} de pixeli</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de pixeli</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>masculine</gender>
@@ -9141,7 +9141,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} megapixel</unitPattern>
 				<unitPattern count="one" case="genitive">unui megapixel</unitPattern>
 				<unitPattern count="few">{0} megapixeli</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megapixeli</unitPattern>
 				<unitPattern count="other">{0} de megapixeli</unitPattern>
 				<unitPattern count="other" case="genitive">{0} de megapixeli</unitPattern>
 			</unit>
@@ -9151,9 +9151,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} pixel pe centimetru</unitPattern>
 				<unitPattern count="one" case="genitive">unui pixel pe centimetru</unitPattern>
 				<unitPattern count="few">{0} pixeli pe centimetru</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} pixeli pe centimetru</unitPattern>
 				<unitPattern count="other">{0} de pixeli pe centimetru</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de pixeli pe centimetru</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>pixeli pe inch</displayName>
@@ -9191,9 +9191,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilometru</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilometru</unitPattern>
 				<unitPattern count="few">{0} kilometri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilometri</unitPattern>
 				<unitPattern count="other">{0} de kilometri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilometri</unitPattern>
 				<perUnitPattern>{0} pe kilometru</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
@@ -9202,9 +9202,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} metru</unitPattern>
 				<unitPattern count="one" case="genitive">unui metru</unitPattern>
 				<unitPattern count="few">{0} metri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metri</unitPattern>
 				<unitPattern count="other">{0} de metri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de metri</unitPattern>
 				<perUnitPattern>{0} pe metru</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
@@ -9213,9 +9213,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} decimetru</unitPattern>
 				<unitPattern count="one" case="genitive">unui decimetru</unitPattern>
 				<unitPattern count="few">{0} decimetri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} decimetri</unitPattern>
 				<unitPattern count="other">{0} de decimetri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de decimetri</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>masculine</gender>
@@ -9223,9 +9223,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} centimetru</unitPattern>
 				<unitPattern count="one" case="genitive">unui centimetru</unitPattern>
 				<unitPattern count="few">{0} centimetri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} centimetri</unitPattern>
 				<unitPattern count="other">{0} de centimetri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de centimetri</unitPattern>
 				<perUnitPattern>{0} pe centimetru</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
@@ -9234,9 +9234,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} milimetru</unitPattern>
 				<unitPattern count="one" case="genitive">unui milimetru</unitPattern>
 				<unitPattern count="few">{0} milimetri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milimetri</unitPattern>
 				<unitPattern count="other">{0} de milimetri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de milimetri</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>masculine</gender>
@@ -9244,9 +9244,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} micrometru</unitPattern>
 				<unitPattern count="one" case="genitive">unui micrometru</unitPattern>
 				<unitPattern count="few">{0} micrometri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} micrometri</unitPattern>
 				<unitPattern count="other">{0} de micrometri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de micrometri</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>masculine</gender>
@@ -9254,9 +9254,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} nanometru</unitPattern>
 				<unitPattern count="one" case="genitive">unui nanometru</unitPattern>
 				<unitPattern count="few">{0} nanometri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} nanometri</unitPattern>
 				<unitPattern count="other">{0} de nanometri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de nanometri</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>masculine</gender>
@@ -9264,9 +9264,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} picometru</unitPattern>
 				<unitPattern count="one" case="genitive">unui picometru</unitPattern>
 				<unitPattern count="few">{0} picometri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} picometri</unitPattern>
 				<unitPattern count="other">{0} de picometri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de picometri</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mile</displayName>
@@ -9358,9 +9358,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} lux</unitPattern>
 				<unitPattern count="one" case="genitive">unui lux</unitPattern>
 				<unitPattern count="few">{0} lucși</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} lucși</unitPattern>
 				<unitPattern count="other">{0} de lucși</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de lucși</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
@@ -9368,9 +9368,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} candelă</unitPattern>
 				<unitPattern count="one" case="genitive">unei candele</unitPattern>
 				<unitPattern count="few">{0} candele</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} candele</unitPattern>
 				<unitPattern count="other">{0} de candele</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de candele</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>masculine</gender>
@@ -9378,9 +9378,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} lumen</unitPattern>
 				<unitPattern count="one" case="genitive">unui lumen</unitPattern>
 				<unitPattern count="few">{0} lumeni</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} lumeni</unitPattern>
 				<unitPattern count="other">{0} de lumeni</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de lumeni</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>luminozități solare</displayName>
@@ -9392,32 +9392,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>tone</displayName>
 				<unitPattern count="one">{0} tonă</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} tonă</unitPattern>
 				<unitPattern count="few">{0} tone</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} tone</unitPattern>
 				<unitPattern count="other">{0} de tone</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de tone</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>neuter</gender>
 				<displayName>kilograme</displayName>
 				<unitPattern count="one">{0} kilogram</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} kilogram</unitPattern>
 				<unitPattern count="few">{0} kilograme</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilograme</unitPattern>
 				<unitPattern count="other">{0} de kilograme</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilograme</unitPattern>
 				<perUnitPattern>{0} per kilogram</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<gender>neuter</gender>
 				<displayName>grame</displayName>
 				<unitPattern count="one">{0} gram</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} gram</unitPattern>
 				<unitPattern count="few">{0} grame</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} grame</unitPattern>
 				<unitPattern count="other">{0} de grame</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de grame</unitPattern>
 				<perUnitPattern>{0} per gram</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
@@ -9426,9 +9426,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} miligram</unitPattern>
 				<unitPattern count="one" case="genitive">unui miligram</unitPattern>
 				<unitPattern count="few">{0} miligrame</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} miligrame</unitPattern>
 				<unitPattern count="other">{0} de miligrame</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de miligrame</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>neuter</gender>
@@ -9436,9 +9436,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} microgram</unitPattern>
 				<unitPattern count="one" case="genitive">unui microgram</unitPattern>
 				<unitPattern count="few">{0} micrograme</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} micrograme</unitPattern>
 				<unitPattern count="other">{0} de micrograme</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de micrograme</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>tone scurte</displayName>
@@ -9476,11 +9476,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>carate</displayName>
 				<unitPattern count="one">{0} carat</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} carat</unitPattern>
 				<unitPattern count="few">{0} carate</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} carate</unitPattern>
 				<unitPattern count="other">{0} de carate</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de carate</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>daltoni</displayName>
@@ -9512,9 +9512,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} gigawatt</unitPattern>
 				<unitPattern count="one" case="genitive">unui gigawatt</unitPattern>
 				<unitPattern count="few">{0} gigawați</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigawați</unitPattern>
 				<unitPattern count="other">{0} de gigawați</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de gigawați</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>masculine</gender>
@@ -9522,9 +9522,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} megawatt</unitPattern>
 				<unitPattern count="one" case="genitive">unui megawatt</unitPattern>
 				<unitPattern count="few">{0} megawați</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megawați</unitPattern>
 				<unitPattern count="other">{0} de megawați</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de megawați</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>masculine</gender>
@@ -9532,9 +9532,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilowatt</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilowatt</unitPattern>
 				<unitPattern count="few">{0} kilowați</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilowați</unitPattern>
 				<unitPattern count="other">{0} de kilowați</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilowați</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>masculine</gender>
@@ -9542,9 +9542,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} watt</unitPattern>
 				<unitPattern count="one" case="genitive">unui watt</unitPattern>
 				<unitPattern count="few">{0} wați</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} wați</unitPattern>
 				<unitPattern count="other">{0} de wați</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de wați</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>masculine</gender>
@@ -9552,9 +9552,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} miliwatt</unitPattern>
 				<unitPattern count="one" case="genitive">unui miliwatt</unitPattern>
 				<unitPattern count="few">{0} miliwați</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} miliwați</unitPattern>
 				<unitPattern count="other">{0} de miliwați</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de miliwați</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>cai putere</displayName>
@@ -9586,9 +9586,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="one" case="genitive">unui bar</unitPattern>
 				<unitPattern count="few">{0} bari</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} bari</unitPattern>
 				<unitPattern count="other">{0} de bari</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de bari</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>masculine</gender>
@@ -9596,9 +9596,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} milibar</unitPattern>
 				<unitPattern count="one" case="genitive">unui milibar</unitPattern>
 				<unitPattern count="few">{0} milibari</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milibari</unitPattern>
 				<unitPattern count="other">{0} de milibari</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de milibari</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>feminine</gender>
@@ -9616,9 +9616,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} pascal</unitPattern>
 				<unitPattern count="one" case="genitive">unui pascal</unitPattern>
 				<unitPattern count="few">{0} pascali</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} pascali</unitPattern>
 				<unitPattern count="other">{0} de pascali</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de pascali</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>masculine</gender>
@@ -9626,9 +9626,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hectopascal</unitPattern>
 				<unitPattern count="one" case="genitive">unui hectopascal</unitPattern>
 				<unitPattern count="few">{0} hectopascali</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hectopascali</unitPattern>
 				<unitPattern count="other">{0} de hectopascali</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de hectopascali</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>masculine</gender>
@@ -9636,9 +9636,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilopascal</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilopascal</unitPattern>
 				<unitPattern count="few">{0} kilopascali</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilopascali</unitPattern>
 				<unitPattern count="other">{0} de kilopascali</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilopascali</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>masculine</gender>
@@ -9646,9 +9646,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} megapascal</unitPattern>
 				<unitPattern count="one" case="genitive">unui megapascal</unitPattern>
 				<unitPattern count="few">{0} megapascali</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megapascali</unitPattern>
 				<unitPattern count="other">{0} de megapascali</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de megapascali</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>masculine</gender>
@@ -9656,9 +9656,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilometru pe oră</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilometru pe oră</unitPattern>
 				<unitPattern count="few">{0} kilometri pe oră</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilometri pe oră</unitPattern>
 				<unitPattern count="other">{0} de kilometri pe oră</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilometri pe oră</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>masculine</gender>
@@ -9666,9 +9666,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} metru pe secundă</unitPattern>
 				<unitPattern count="one" case="genitive">unui metru pe secundă</unitPattern>
 				<unitPattern count="few">{0} metri pe secundă</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metri pe secundă</unitPattern>
 				<unitPattern count="other">{0} de metri pe secundă</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de metri pe secundă</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>mile pe oră</displayName>
@@ -9688,7 +9688,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} grad</unitPattern>
 				<unitPattern count="one" case="genitive">unui grad</unitPattern>
 				<unitPattern count="few">{0} grade</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} grade</unitPattern>
 				<unitPattern count="other">{0} de grade</unitPattern>
 				<unitPattern count="other" case="genitive">{0} de grade</unitPattern>
 			</unit>
@@ -9698,9 +9698,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} grad Celsius</unitPattern>
 				<unitPattern count="one" case="genitive">unui grad Celsius</unitPattern>
 				<unitPattern count="few">{0} grade Celsius</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} grade Celsius</unitPattern>
 				<unitPattern count="other">{0} de grade Celsius</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de grade Celsius</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>grade Fahrenheit</displayName>
@@ -9714,9 +9714,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kelvin</unitPattern>
 				<unitPattern count="one" case="genitive">unui kelvin</unitPattern>
 				<unitPattern count="few">{0} kelvini</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kelvini</unitPattern>
 				<unitPattern count="other">{0} de kelvini</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kelvini</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>livră-forță picioare</displayName>
@@ -9730,9 +9730,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} newton metru</unitPattern>
 				<unitPattern count="one" case="genitive">unui newton metru</unitPattern>
 				<unitPattern count="few">{0} newton metri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} newton metri</unitPattern>
 				<unitPattern count="other">{0} de newton metri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de newton metri</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>masculine</gender>
@@ -9740,9 +9740,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} kilometru cub</unitPattern>
 				<unitPattern count="one" case="genitive">unui kilometru cub</unitPattern>
 				<unitPattern count="few">{0} kilometri cubi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilometri cubi</unitPattern>
 				<unitPattern count="other">{0} de kilometri cubi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de kilometri cubi</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>masculine</gender>
@@ -9750,9 +9750,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} metru cub</unitPattern>
 				<unitPattern count="one" case="genitive">unui metru cub</unitPattern>
 				<unitPattern count="few">{0} metri cubi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metri cubi</unitPattern>
 				<unitPattern count="other">{0} de metri cubi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de metri cubi</unitPattern>
 				<perUnitPattern>{0} pe metru cub</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
@@ -9761,9 +9761,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} centimetru cub</unitPattern>
 				<unitPattern count="one" case="genitive">unui centimetru cub</unitPattern>
 				<unitPattern count="few">{0} centimetri cubi</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} centimetri cubi</unitPattern>
 				<unitPattern count="other">{0} de centimetri cubi</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de centimetri cubi</unitPattern>
 				<perUnitPattern>{0} pe centimetru cub</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -9796,9 +9796,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} megalitru</unitPattern>
 				<unitPattern count="one" case="genitive">unui megalitru</unitPattern>
 				<unitPattern count="few">{0} megalitri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megalitri</unitPattern>
 				<unitPattern count="other">{0} de megalitri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de megalitri</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>masculine</gender>
@@ -9806,9 +9806,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} hectolitru</unitPattern>
 				<unitPattern count="one" case="genitive">unui hectolitru</unitPattern>
 				<unitPattern count="few">{0} hectolitri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hectolitri</unitPattern>
 				<unitPattern count="other">{0} de hectolitri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de hectolitri</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>masculine</gender>
@@ -9816,9 +9816,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} litru</unitPattern>
 				<unitPattern count="one" case="genitive">unui litru</unitPattern>
 				<unitPattern count="few">{0} litri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} litri</unitPattern>
 				<unitPattern count="other">{0} de litri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de litri</unitPattern>
 				<perUnitPattern>{0} pe litru</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
@@ -9827,9 +9827,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} decilitru</unitPattern>
 				<unitPattern count="one" case="genitive">unui decilitru</unitPattern>
 				<unitPattern count="few">{0} decilitri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} decilitri</unitPattern>
 				<unitPattern count="other">{0} de decilitri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de decilitri</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>masculine</gender>
@@ -9837,9 +9837,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} centilitru</unitPattern>
 				<unitPattern count="one" case="genitive">unui centilitru</unitPattern>
 				<unitPattern count="few">{0} centilitri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} centilitri</unitPattern>
 				<unitPattern count="other">{0} de centilitri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de centilitri</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>masculine</gender>
@@ -9847,9 +9847,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} mililitru</unitPattern>
 				<unitPattern count="one" case="genitive">unui mililitru</unitPattern>
 				<unitPattern count="few">{0} mililitri</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mililitri</unitPattern>
 				<unitPattern count="other">{0} de mililitri</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} de mililitri</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>feminine</gender>
@@ -10085,14 +10085,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10225,7 +10225,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} de itemi</unitPattern>
 				<unitPattern count="few">{0} itemi</unitPattern>
 				<unitPattern count="other">{0} de itemi</unitPattern>
 			</unit>
@@ -10249,8 +10249,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -10515,8 +10515,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>livră-forță</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
@@ -10557,20 +10557,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pixeli</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
@@ -10581,8 +10581,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -10605,8 +10605,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10706,14 +10706,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>furlongi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fathomi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="few">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -10736,8 +10736,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -10748,14 +10748,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -10804,8 +10804,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -10914,8 +10914,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>bar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -10932,8 +10932,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -11004,8 +11004,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>livră-forță picior</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -11115,8 +11115,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>banițe</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -11177,20 +11177,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>baril</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="few">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -11201,14 +11201,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>dram lichid</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="few">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>jigger</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="few">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -11293,49 +11293,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0} {1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>forță g</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="few">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
@@ -11347,16 +11347,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev.</displayName>
+				<unitPattern count="one">{0} rev.</unitPattern>
+				<unitPattern count="few">{0} rev.</unitPattern>
+				<unitPattern count="other">{0} rev.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>grad</displayName>
@@ -11365,23 +11365,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcmin</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcsec</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hectar</displayName>
@@ -11390,25 +11390,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
 				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
 				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="few">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>acru</displayName>
@@ -11417,59 +11417,59 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ac.</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="few">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="few">{0} dunami</unitPattern>
+				<unitPattern count="other">{0} dunami</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>carat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="few">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/l</displayName>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="few">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>item</displayName>
 				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="few">{0} itemi</unitPattern>
 				<unitPattern count="other">{0} itemi</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -11478,28 +11478,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>‰</displayName>
 				<unitPattern count="one">{0} ‰</unitPattern>
 				<unitPattern count="few">{0} ‰</unitPattern>
 				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">{0} ‱</unitPattern>
 				<unitPattern count="few">{0} ‱</unitPattern>
 				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mol</displayName>
+				<unitPattern count="one" draft="contributed">{0} mol</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} moli</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} moli</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">l/km</displayName>
+				<unitPattern count="one" draft="contributed">{0} l/km</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} l/km</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -11514,76 +11514,76 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} mi/gal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">mi/gal imp.</displayName>
+				<unitPattern count="one" draft="contributed">{0} mi/gal imp.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} mi/gal imp.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} mi/gal imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="few">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>b</displayName>
+				<unitPattern count="one">{0} b</unitPattern>
+				<unitPattern count="few">{0} b</unitPattern>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>sec.</displayName>
@@ -11592,10 +11592,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} sec.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec.</displayName>
+				<unitPattern count="one">{0} dec.</unitPattern>
+				<unitPattern count="few">{0} dec.</unitPattern>
+				<unitPattern count="other">{0} dec.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>a</displayName>
@@ -11605,7 +11605,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/an</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>trim.</displayName>
 				<unitPattern count="one">{0} trim.</unitPattern>
 				<unitPattern count="few">{0} trim.</unitPattern>
 				<unitPattern count="other">{0} trim.</unitPattern>
@@ -11672,94 +11672,94 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="few">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} BTU</unitPattern>
+				<unitPattern count="few">{0} BTU</unitPattern>
+				<unitPattern count="other">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thm</displayName>
+				<unitPattern count="one">{0} thm</unitPattern>
+				<unitPattern count="few">{0} thm</unitPattern>
+				<unitPattern count="other">{0} thm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName draft="contributed">lbf</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} lbf</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} lbf</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100 km</displayName>
@@ -11768,64 +11768,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kWh/100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppc</displayName>
+				<unitPattern count="one">{0} ppc</unitPattern>
+				<unitPattern count="few">{0} ppc</unitPattern>
+				<unitPattern count="other">{0} ppc</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpc</displayName>
+				<unitPattern count="one">{0} dpc</unitPattern>
+				<unitPattern count="few">{0} dpc</unitPattern>
+				<unitPattern count="other">{0} dpc</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
@@ -11834,16 +11834,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pct.</displayName>
+				<unitPattern count="one">{0} pct</unitPattern>
+				<unitPattern count="few">{0} pct.</unitPattern>
+				<unitPattern count="other">{0} de pct.</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -11942,15 +11942,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>furlong</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fathom</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="few">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>mn</displayName>
@@ -11971,34 +11971,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -12071,61 +12071,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>boabă</displayName>
+				<unitPattern count="one">{0} boabă</unitPattern>
+				<unitPattern count="few">{0} boabe</unitPattern>
+				<unitPattern count="other">{0} boabe</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="few">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="few">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="few">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="few">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="few">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>CP</displayName>
 				<unitPattern count="one">{0} CP</unitPattern>
 				<unitPattern count="few">{0} CP</unitPattern>
 				<unitPattern count="other">{0} CP</unitPattern>
@@ -12144,15 +12144,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>in Hg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in Hg</unitPattern>
+				<unitPattern count="few">{0} in Hg</unitPattern>
+				<unitPattern count="other">{0} in Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -12161,16 +12161,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -12179,16 +12179,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -12228,9 +12228,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>°F</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} °F</unitPattern>
+				<unitPattern count="few">{0} °F</unitPattern>
+				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>K</displayName>
@@ -12240,188 +12240,188 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName draft="contributed">lbf⋅ft</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">N⋅m</displayName>
+				<unitPattern count="one" draft="contributed">{0} N⋅m</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} N⋅m</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="few">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="few">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="few">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="few">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="few">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="few">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="few">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="few">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>baniță</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="few">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal imp.</displayName>
 				<unitPattern count="one">{0} gal im</unitPattern>
 				<unitPattern count="few">{0} gal im</unitPattern>
 				<unitPattern count="other">{0} gal im</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} gal imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="few">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pintă</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>cană</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="few">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="few">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz imp.</displayName>
 				<unitPattern count="one">{0} fl oz im</unitPattern>
 				<unitPattern count="few">{0} fl oz im</unitPattern>
 				<unitPattern count="other">{0} fl oz im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="few">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="few">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>baril</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>dsp im</displayName>
@@ -12430,7 +12430,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dsp im</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>picătură</displayName>
 				<unitPattern count="one">{0} pic.</unitPattern>
 				<unitPattern count="few">{0} pic.</unitPattern>
 				<unitPattern count="other">{0} pic.</unitPattern>
@@ -12442,10 +12442,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dr fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="few">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>vf.</displayName>
@@ -12491,20 +12491,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} sau {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} sau {1}</listPatternPart>
+			<listPatternPart type="2">{0} sau {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} sau {1}</listPatternPart>
+			<listPatternPart type="2">{0} sau {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -109,7 +109,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">шайенский</language>
 			<language type="ckb">центральнокурдский</language>
 			<language type="ckb" alt="menu">курдский (сорани)</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">центральнокурдский</language>
 			<language type="clc">чилкотин</language>
 			<language type="co">корсиканский</language>
 			<language type="cop">коптский</language>
@@ -583,7 +583,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="yo">йоруба</language>
 			<language type="yrl">ньенгату</language>
 			<language type="yue">кантонский</language>
-			<language type="yue" alt="menu">↑↑↑</language>
+			<language type="yue" alt="menu">кантонский</language>
 			<language type="za">чжуань</language>
 			<language type="zap">сапотекский</language>
 			<language type="zbl">блиссимволика</language>
@@ -849,7 +849,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="CG" alt="variant">Республика Конго</territory>
 			<territory type="CH">Швейцария</territory>
 			<territory type="CI">Кот-д’Ивуар</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
+			<territory type="CI" alt="variant">Кот-д’Ивуар</territory>
 			<territory type="CK">о-ва Кука</territory>
 			<territory type="CL">Чили</territory>
 			<territory type="CM">Камерун</territory>
@@ -1048,7 +1048,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Тунис</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Турция</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Турция</territory>
 			<territory type="TT">Тринидад и Тобаго</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тайвань</territory>
@@ -2098,13 +2098,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">сб</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">В</day>
+							<day type="mon">П</day>
+							<day type="tue">В</day>
+							<day type="wed">С</day>
+							<day type="thu">Ч</day>
+							<day type="fri">П</day>
+							<day type="sat">С</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">вс</day>
@@ -3529,7 +3529,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>дн.</displayName>
 				<relative type="-2" draft="contributed">позавчера</relative>
 				<relative type="-1">вчера</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">сегодня</relative>
 				<relative type="1">завтра</relative>
 				<relative type="2" draft="contributed">послезавтра</relative>
 				<relativeTime type="future">
@@ -3549,7 +3549,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>дн.</displayName>
 				<relative type="-2" draft="contributed">позавчера</relative>
 				<relative type="-1">вчера</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">сегодня</relative>
 				<relative type="1">завтра</relative>
 				<relative type="2" draft="contributed">послезавтра</relative>
 				<relativeTime type="future">
@@ -8516,41 +8516,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" gender="feminine" case="locative">квадратной {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="prepositional">квадратной {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="vocative">квадратная {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">квадратный {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">квадратный {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="dative">квадратному {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="instrumental">квадратным {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="prepositional">квадратном {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">квадратных {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="dative">квадратным {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="instrumental">квадратными {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="prepositional">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="vocative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="locative">квадратных {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="prepositional">квадратных {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="vocative">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine">квадратные {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">квадратные {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="dative">квадратным {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">квадратными {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="locative">квадратных {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="prepositional">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="vocative">квадратные {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="accusative">квадратных {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine" case="dative">квадратным {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="genitive">квадратных {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine" case="instrumental">квадратными {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine" case="prepositional">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="accusative">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="dative">квадратным {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="genitive">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="instrumental">квадратными {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="locative">квадратных {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="prepositional">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="vocative">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">квадратных {0}</compoundUnitPattern1>
@@ -8558,21 +8558,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">квадратными {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="locative">квадратных {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="prepositional">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="vocative">квадратных {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine">квадратных {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="accusative">квадратных {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="dative">квадратным {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="genitive">квадратных {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="instrumental">квадратными {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="prepositional">квадратных {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="accusative">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="dative">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="genitive">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="instrumental">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="locative">квадратного {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="prepositional">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="vocative">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine">квадратной {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">квадратной {0}</compoundUnitPattern1>
@@ -8582,12 +8582,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" gender="feminine" case="locative">квадратной {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="prepositional">квадратной {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="vocative">квадратной {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="dative">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="prepositional">квадратного {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>куб. {0}</compoundUnitPattern1>
@@ -8607,41 +8607,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" gender="feminine" case="locative">кубической {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="prepositional">кубической {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="vocative">кубическая {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">кубический {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">кубический {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="dative">кубическому {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">кубического {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="instrumental">кубическим {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="prepositional">кубическом {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">кубических {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="dative">кубическим {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="instrumental">кубическими {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="prepositional">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="vocative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="locative">кубических {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="prepositional">кубических {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="vocative">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine">кубические {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">кубические {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="dative">кубическим {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">кубическими {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="locative">кубических {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="prepositional">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="vocative">кубические {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="accusative">кубических {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine" case="dative">кубическим {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="genitive">кубических {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine" case="instrumental">кубическими {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine" case="prepositional">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="accusative">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="dative">кубическим {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="genitive">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="instrumental">кубическими {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="locative">кубических {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="prepositional">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="vocative">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">кубических {0}</compoundUnitPattern1>
@@ -8649,21 +8649,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">кубическими {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="locative">кубических {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="prepositional">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="vocative">кубических {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine">кубических {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="accusative">кубических {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="dative">кубическим {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="genitive">кубических {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="instrumental">кубическими {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="prepositional">кубических {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">кубического {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="accusative">кубического {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="dative">кубического {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="genitive">кубического {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="instrumental">кубического {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="locative">кубического {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="prepositional">кубического {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="vocative">кубического {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine">кубической {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">кубической {0}</compoundUnitPattern1>
@@ -8673,15 +8673,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" gender="feminine" case="locative">кубической {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="prepositional">кубической {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="vocative">кубической {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="prepositional">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">кубического {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">кубического {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="dative">кубического {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">кубического {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">кубического {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="prepositional">кубического {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>masculine</gender>
@@ -8711,13 +8711,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="prepositional">{0} g</unitPattern>
 				<unitPattern count="many" case="vocative">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} g</unitPattern>
+				<unitPattern count="other" case="dative">{0} g</unitPattern>
+				<unitPattern count="other" case="genitive">{0} g</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} g</unitPattern>
+				<unitPattern count="other" case="locative">{0} g</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} g</unitPattern>
+				<unitPattern count="other" case="vocative">{0} g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>masculine</gender>
@@ -8752,92 +8752,92 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="genitive">{0} метра на секунду в квадрате</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} метра на секунду в квадрате</unitPattern>
 				<unitPattern count="other" case="locative">{0} метра на секунду в квадрате</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} метра на секунду в квадрате</unitPattern>
 				<unitPattern count="other" case="vocative">{0} метра на секунду в квадрате</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>masculine</gender>
 				<displayName>оборот</displayName>
 				<unitPattern count="one">{0} оборот</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} оборот</unitPattern>
 				<unitPattern count="one" case="dative">{0} обороту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} оборота</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} оборотом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} обороте</unitPattern>
 				<unitPattern count="few">{0} оборота</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} оборота</unitPattern>
 				<unitPattern count="few" case="dative">{0} оборотам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} оборотов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} оборотами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} оборотах</unitPattern>
 				<unitPattern count="many">{0} оборотов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} оборотов</unitPattern>
 				<unitPattern count="many" case="dative">{0} оборотам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} оборотов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} оборотами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} оборотах</unitPattern>
 				<unitPattern count="other">{0} оборота</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} оборота</unitPattern>
+				<unitPattern count="other" case="dative">{0} оборота</unitPattern>
+				<unitPattern count="other" case="genitive">{0} оборота</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} оборота</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} оборота</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>masculine</gender>
 				<displayName>радианы</displayName>
 				<unitPattern count="one">{0} радиан</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} радиан</unitPattern>
 				<unitPattern count="one" case="dative">{0} радиану</unitPattern>
 				<unitPattern count="one" case="genitive">{0} радиана</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} радианом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} радиане</unitPattern>
 				<unitPattern count="few">{0} радиана</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} радиана</unitPattern>
 				<unitPattern count="few" case="dative">{0} радианам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} радиан</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} радианами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} радианах</unitPattern>
 				<unitPattern count="many">{0} радиан</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} радиан</unitPattern>
 				<unitPattern count="many" case="dative">{0} радианам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} радиан</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} радианами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} радианах</unitPattern>
 				<unitPattern count="other">{0} радиана</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} радиана</unitPattern>
+				<unitPattern count="other" case="dative">{0} радиана</unitPattern>
+				<unitPattern count="other" case="genitive">{0} радиана</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} радиана</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} радиана</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>masculine</gender>
 				<displayName>градусы</displayName>
 				<unitPattern count="one">{0} градус</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} градус</unitPattern>
 				<unitPattern count="one" case="dative">{0} градусу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} градуса</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} градусом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} градусе</unitPattern>
 				<unitPattern count="few">{0} градуса</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} градуса</unitPattern>
 				<unitPattern count="few" case="dative">{0} градусам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} градусов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} градусами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} градусах</unitPattern>
 				<unitPattern count="many">{0} градусов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} градусов</unitPattern>
 				<unitPattern count="many" case="dative">{0} градусам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} градусов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} градусами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} градусах</unitPattern>
 				<unitPattern count="other">{0} градуса</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} градуса</unitPattern>
+				<unitPattern count="other" case="dative">{0} градуса</unitPattern>
+				<unitPattern count="other" case="genitive">{0} градуса</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} градуса</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} градуса</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>feminine</gender>
@@ -8849,23 +8849,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} минутой</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} минуте</unitPattern>
 				<unitPattern count="few">{0} минуты</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} минуты</unitPattern>
 				<unitPattern count="few" case="dative">{0} минутам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} минут</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} минутами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} минутах</unitPattern>
 				<unitPattern count="many">{0} минут</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} минут</unitPattern>
 				<unitPattern count="many" case="dative">{0} минутам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} минут</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} минутами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} минутах</unitPattern>
 				<unitPattern count="other">{0} минуты</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} минуты</unitPattern>
+				<unitPattern count="other" case="dative">{0} минуты</unitPattern>
+				<unitPattern count="other" case="genitive">{0} минуты</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} минуты</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} минуты</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>feminine</gender>
@@ -8877,23 +8877,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} секундой</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} секунде</unitPattern>
 				<unitPattern count="few">{0} секунды</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} секунды</unitPattern>
 				<unitPattern count="few" case="dative">{0} секундам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} секунд</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} секундами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} секундах</unitPattern>
 				<unitPattern count="many">{0} секунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} секунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} секундам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} секунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} секундами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} секундах</unitPattern>
 				<unitPattern count="other">{0} секунды</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} секунды</unitPattern>
+				<unitPattern count="other" case="dative">{0} секунды</unitPattern>
+				<unitPattern count="other" case="genitive">{0} секунды</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} секунды</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} секунды</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>masculine</gender>
@@ -8907,29 +8907,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} квадратном километре</unitPattern>
 				<unitPattern count="one" case="vocative">{0} квадратный километр</unitPattern>
 				<unitPattern count="few">{0} квадратных километра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратных километра</unitPattern>
 				<unitPattern count="few" case="dative">{0} квадратным километрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} квадратных километров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} квадратными километрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} квадратных километрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} квадратных километрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} квадратных километра</unitPattern>
 				<unitPattern count="many">{0} квадратных километров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} квадратных километров</unitPattern>
 				<unitPattern count="many" case="dative">{0} квадратным километрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} квадратных километров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} квадратными километрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} квадратных километрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} квадратных километрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} квадратных километров</unitPattern>
 				<unitPattern count="other">{0} квадратного километра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратного километра</unitPattern>
+				<unitPattern count="other" case="dative">{0} квадратного километра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратного километра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратного километра</unitPattern>
+				<unitPattern count="other" case="locative">{0} квадратного километра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} квадратного километра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} квадратного километра</unitPattern>
 				<perUnitPattern>{0} на квадратный километр</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
@@ -8950,51 +8950,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} гектарами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гектарах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} гектарах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} гектара</unitPattern>
 				<unitPattern count="many">{0} гектаров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гектаров</unitPattern>
 				<unitPattern count="many" case="dative">{0} гектарам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} гектаров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гектарами</unitPattern>
 				<unitPattern count="many" case="locative">{0} гектарах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} гектарах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} гектаров</unitPattern>
 				<unitPattern count="other">{0} гектара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гектара</unitPattern>
+				<unitPattern count="other" case="dative">{0} гектара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гектара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гектара</unitPattern>
+				<unitPattern count="other" case="locative">{0} гектара</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} гектара</unitPattern>
+				<unitPattern count="other" case="vocative">{0} гектара</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>masculine</gender>
 				<displayName>квадратные метры</displayName>
 				<unitPattern count="one">{0} квадратный метр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} квадратный метр</unitPattern>
 				<unitPattern count="one" case="dative">{0} квадратному метру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} квадратного метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} квадратным метром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} квадратном метре</unitPattern>
 				<unitPattern count="few">{0} квадратных метра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратных метра</unitPattern>
 				<unitPattern count="few" case="dative">{0} квадратным метрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} квадратных метров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} квадратными метрами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} квадратных метрах</unitPattern>
 				<unitPattern count="many">{0} квадратных метров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} квадратных метров</unitPattern>
 				<unitPattern count="many" case="dative">{0} квадратным метрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} квадратных метров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} квадратными метрами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} квадратных метрах</unitPattern>
 				<unitPattern count="other">{0} квадратного метра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратного метра</unitPattern>
+				<unitPattern count="other" case="dative">{0} квадратного метра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратного метра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратного метра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} квадратного метра</unitPattern>
 				<perUnitPattern>{0} на квадратный метр</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
@@ -9009,29 +9009,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} квадратном сантиметре</unitPattern>
 				<unitPattern count="one" case="vocative">{0} квадратный сантиметр</unitPattern>
 				<unitPattern count="few">{0} квадратных сантиметра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратных сантиметра</unitPattern>
 				<unitPattern count="few" case="dative">{0} квадратным сантиметрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} квадратных сантиметров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} квадратными сантиметрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} квадратных сантиметрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} квадратных сантиметрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} квадратных сантиметра</unitPattern>
 				<unitPattern count="many">{0} квадратных сантиметров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} квадратных сантиметров</unitPattern>
 				<unitPattern count="many" case="dative">{0} квадратным сантиметрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} квадратных сантиметров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} квадратными сантиметрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} квадратных сантиметрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} квадратных сантиметрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} квадратных сантиметров</unitPattern>
 				<unitPattern count="other">{0} квадратного сантиметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="locative">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} квадратного сантиметра</unitPattern>
 				<perUnitPattern>{0} на квадратный сантиметр</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -9046,7 +9046,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} квадратной миле</unitPattern>
 				<unitPattern count="one" case="vocative">{0} квадратная миля</unitPattern>
 				<unitPattern count="few">{0} квадратные мили</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратные мили</unitPattern>
 				<unitPattern count="few" case="dative">{0} квадратным милям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} квадратных миль</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} квадратными милями</unitPattern>
@@ -9054,20 +9054,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} квадратных милях</unitPattern>
 				<unitPattern count="few" case="vocative">{0} квадратные мили</unitPattern>
 				<unitPattern count="many">{0} квадратных миль</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} квадратных миль</unitPattern>
 				<unitPattern count="many" case="dative">{0} квадратным милям</unitPattern>
 				<unitPattern count="many" case="genitive">{0} квадратных миль</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} квадратными милями</unitPattern>
 				<unitPattern count="many" case="locative">{0} квадратных милях</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} квадратных милях</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} квадратных миль</unitPattern>
 				<unitPattern count="other">{0} квадратной мили</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратной мили</unitPattern>
+				<unitPattern count="other" case="dative">{0} квадратной мили</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратной мили</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратной мили</unitPattern>
+				<unitPattern count="other" case="locative">{0} квадратной мили</unitPattern>
+				<unitPattern count="other" case="vocative">{0} квадратной мили</unitPattern>
 				<perUnitPattern>{0} на квадратную милю</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
@@ -9088,22 +9088,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} акрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} акрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} акрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} акра</unitPattern>
 				<unitPattern count="many">{0} акров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} акров</unitPattern>
 				<unitPattern count="many" case="dative">{0} акрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} акров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} акрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} акрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} акрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} акров</unitPattern>
 				<unitPattern count="other">{0} акра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} акра</unitPattern>
+				<unitPattern count="other" case="dative">{0} акра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} акра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} акра</unitPattern>
+				<unitPattern count="other" case="locative">{0} акра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} акра</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>квадратные ярды</displayName>
@@ -9124,28 +9124,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} квадратном футе</unitPattern>
 				<unitPattern count="one" case="vocative">{0} квадратный фут</unitPattern>
 				<unitPattern count="few">{0} квадратных фута</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратных фута</unitPattern>
 				<unitPattern count="few" case="dative">{0} квадратным футам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} квадратных футов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} квадратными футами</unitPattern>
 				<unitPattern count="few" case="locative">{0} квадратных футах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} квадратных футах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} квадратных фута</unitPattern>
 				<unitPattern count="many">{0} квадратных футов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} квадратных футов</unitPattern>
 				<unitPattern count="many" case="dative">{0} квадратным футам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} квадратных футов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} квадратными футами</unitPattern>
 				<unitPattern count="many" case="locative">{0} квадратных футах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} квадратных футах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} квадратных футов</unitPattern>
 				<unitPattern count="other">{0} квадратного фута</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратного фута</unitPattern>
+				<unitPattern count="other" case="dative">{0} квадратного фута</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратного фута</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратного фута</unitPattern>
+				<unitPattern count="other" case="locative">{0} квадратного фута</unitPattern>
+				<unitPattern count="other" case="vocative">{0} квадратного фута</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>квадратные дюймы</displayName>
@@ -9166,29 +9166,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>караты</displayName>
 				<unitPattern count="one">{0} карат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} карат</unitPattern>
 				<unitPattern count="one" case="dative">{0} карату</unitPattern>
 				<unitPattern count="one" case="genitive">{0} карата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} каратом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} карате</unitPattern>
 				<unitPattern count="few">{0} карата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} карата</unitPattern>
 				<unitPattern count="few" case="dative">{0} каратам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} карат</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} каратами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} каратах</unitPattern>
 				<unitPattern count="many">{0} карат</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} карат</unitPattern>
 				<unitPattern count="many" case="dative">{0} каратам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} карат</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} каратами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} каратах</unitPattern>
 				<unitPattern count="other">{0} карата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} карата</unitPattern>
+				<unitPattern count="other" case="dative">{0} карата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} карата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} карата</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} карата</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>миллиграммы на децилитр</displayName>
@@ -9201,57 +9201,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>миллимоли на литр</displayName>
 				<unitPattern count="one">{0} миллимоль на литр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} миллимоль на литр</unitPattern>
 				<unitPattern count="one" case="dative">{0} миллимолю на литр</unitPattern>
 				<unitPattern count="one" case="genitive">{0} миллимоля на литр</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} миллимолем на литр</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} миллимоле на литр</unitPattern>
 				<unitPattern count="few">{0} миллимоля на литр</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} миллимоля на литр</unitPattern>
 				<unitPattern count="few" case="dative">{0} миллимолям на литр</unitPattern>
 				<unitPattern count="few" case="genitive">{0} миллимолей на литр</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} миллимолями на литр</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} миллимолях на литр</unitPattern>
 				<unitPattern count="many">{0} миллимолей на литр</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} миллимолей на литр</unitPattern>
 				<unitPattern count="many" case="dative">{0} миллимолям на литр</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} миллимолей на литр</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} миллимолями на литр</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} миллимолях на литр</unitPattern>
 				<unitPattern count="other">{0} миллимоля на литр</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} миллимоля на литр</unitPattern>
+				<unitPattern count="other" case="dative">{0} миллимоля на литр</unitPattern>
+				<unitPattern count="other" case="genitive">{0} миллимоля на литр</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} миллимоля на литр</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} миллимоля на литр</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>masculine</gender>
 				<displayName>объекты</displayName>
 				<unitPattern count="one">{0} объект</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} объект</unitPattern>
 				<unitPattern count="one" case="dative">{0} объекту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} объекта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} объектом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} объекте</unitPattern>
 				<unitPattern count="few">{0} объекта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} объекта</unitPattern>
 				<unitPattern count="few" case="dative">{0} объектам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} объектов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} объектами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} объектах</unitPattern>
 				<unitPattern count="many">{0} объектов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} объектов</unitPattern>
 				<unitPattern count="many" case="dative">{0} объектам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} объектов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} объектами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} объектах</unitPattern>
 				<unitPattern count="other">{0} объекта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} объекта</unitPattern>
+				<unitPattern count="other" case="dative">{0} объекта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} объекта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} объекта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} объекта</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>feminine</gender>
@@ -9263,23 +9263,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} миллионной долей</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} миллионной доле</unitPattern>
 				<unitPattern count="few">{0} миллионные доли</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} миллионные доли</unitPattern>
 				<unitPattern count="few" case="dative">{0} миллионым долям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} миллионых долей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} миллиоными долями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} миллионых долях</unitPattern>
 				<unitPattern count="many">{0} миллионных долей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} миллионных долей</unitPattern>
 				<unitPattern count="many" case="dative">{0} миллионым долям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} миллионных долей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} миллионными долями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} миллионных долях</unitPattern>
 				<unitPattern count="other">{0} миллионной доли</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} миллионной доли</unitPattern>
+				<unitPattern count="other" case="dative">{0} миллионной доли</unitPattern>
+				<unitPattern count="other" case="genitive">{0} миллионной доли</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} миллионной доли</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} миллионной доли</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>masculine</gender>
@@ -9299,63 +9299,63 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} процентами</unitPattern>
 				<unitPattern count="few" case="locative">{0} процентах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} процентах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} процента</unitPattern>
 				<unitPattern count="many">{0} процентов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} процентов</unitPattern>
 				<unitPattern count="many" case="dative">{0} процентам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} процентов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} процентами</unitPattern>
 				<unitPattern count="many" case="locative">{0} процентах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} процентах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} процентов</unitPattern>
 				<unitPattern count="other">{0} процента</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} процента</unitPattern>
+				<unitPattern count="other" case="dative">{0} процента</unitPattern>
+				<unitPattern count="other" case="genitive">{0} процента</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} процента</unitPattern>
+				<unitPattern count="other" case="locative">{0} процента</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} процента</unitPattern>
+				<unitPattern count="other" case="vocative">{0} процента</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>feminine</gender>
 				<displayName>промилле</displayName>
 				<unitPattern count="one">{0} промилле</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} промилле</unitPattern>
+				<unitPattern count="one" case="dative">{0} промилле</unitPattern>
+				<unitPattern count="one" case="genitive">{0} промилле</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} промилле</unitPattern>
+				<unitPattern count="one" case="prepositional">{0} промилле</unitPattern>
 				<unitPattern count="few">{0} промилле</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} промилле</unitPattern>
+				<unitPattern count="few" case="dative">{0} промилле</unitPattern>
+				<unitPattern count="few" case="genitive">{0} промилле</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} промилле</unitPattern>
+				<unitPattern count="few" case="prepositional">{0} промилле</unitPattern>
 				<unitPattern count="many">{0} промилле</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} промилле</unitPattern>
+				<unitPattern count="many" case="dative">{0} промилле</unitPattern>
+				<unitPattern count="many" case="genitive">{0} промилле</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} промилле</unitPattern>
+				<unitPattern count="many" case="prepositional">{0} промилле</unitPattern>
 				<unitPattern count="other">{0} промилле</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} промилле</unitPattern>
+				<unitPattern count="other" case="dative">{0} промилле</unitPattern>
+				<unitPattern count="other" case="genitive">{0} промилле</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} промилле</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} промилле</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>masculine</gender>
 				<displayName>промириады</displayName>
 				<unitPattern count="one">{0} промириад</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} промириад</unitPattern>
 				<unitPattern count="one" case="dative">{0} промириаду</unitPattern>
 				<unitPattern count="one" case="genitive">{0} промириада</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} промириадом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} промириаде</unitPattern>
 				<unitPattern count="few">{0} промириада</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} промириада</unitPattern>
 				<unitPattern count="few" case="dative">{0} промириадам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} промириад</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} промириадами</unitPattern>
@@ -9367,67 +9367,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} промириадами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} промириадах</unitPattern>
 				<unitPattern count="other">{0} промириада</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} промириада</unitPattern>
+				<unitPattern count="other" case="dative">{0} промириада</unitPattern>
+				<unitPattern count="other" case="genitive">{0} промириада</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} промириада</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} промириада</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>masculine</gender>
 				<displayName>моли</displayName>
 				<unitPattern count="one">{0} моль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} моль</unitPattern>
 				<unitPattern count="one" case="dative">{0} молю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} моля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} молем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} моле</unitPattern>
 				<unitPattern count="few">{0} моля</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} моля</unitPattern>
 				<unitPattern count="few" case="dative">{0} молям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} молей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} молями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} молях</unitPattern>
 				<unitPattern count="many">{0} молей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} молей</unitPattern>
 				<unitPattern count="many" case="dative">{0} молям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} молей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} молями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} молях</unitPattern>
 				<unitPattern count="other">{0} моля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} моля</unitPattern>
+				<unitPattern count="other" case="dative">{0} моля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} моля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} моля</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} моля</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>masculine</gender>
 				<displayName>литры на километр</displayName>
 				<unitPattern count="one">{0} литр на километр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} литр на километр</unitPattern>
 				<unitPattern count="one" case="dative">{0} литру на километр</unitPattern>
 				<unitPattern count="one" case="genitive">{0} литра на километр</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} литром на километр</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} литре на километр</unitPattern>
 				<unitPattern count="few">{0} литра на километр</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} литра на километр</unitPattern>
 				<unitPattern count="few" case="dative">{0} литрам на километр</unitPattern>
 				<unitPattern count="few" case="genitive">{0} литров на километр</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} литрами на километр</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} литрах на километр</unitPattern>
 				<unitPattern count="many">{0} литров на километр</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} литров на километр</unitPattern>
 				<unitPattern count="many" case="dative">{0} литрам на километр</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} литров на километр</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} литрами на километр</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} литрах на километр</unitPattern>
 				<unitPattern count="other">{0} литра на километр</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} литра на километр</unitPattern>
+				<unitPattern count="other" case="dative">{0} литра на километр</unitPattern>
+				<unitPattern count="other" case="genitive">{0} литра на километр</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} литра на километр</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} литра на километр</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>masculine</gender>
@@ -9447,23 +9447,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} литрами на 100 километров</unitPattern>
 				<unitPattern count="few" case="locative">{0} литрах на 100 километров</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} литрах на 100 километров</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} литра на 100 километров</unitPattern>
 				<unitPattern count="many">{0} литров на 100 километров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} литров на 100 километров</unitPattern>
 				<unitPattern count="many" case="dative">{0} литрам на 100 километров</unitPattern>
 				<unitPattern count="many" case="genitive">{0} литров на 100 километров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} литрами на 100 километров</unitPattern>
 				<unitPattern count="many" case="locative">{0} литрах на 100 километров</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} литрах на 100 километров</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} литров на 100 километров</unitPattern>
 				<unitPattern count="other">{0} литра на 100 километров</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} литра на 100 километров</unitPattern>
+				<unitPattern count="other" case="dative">{0} литра на 100 километров</unitPattern>
+				<unitPattern count="other" case="genitive">{0} литра на 100 километров</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} литра на 100 километров</unitPattern>
+				<unitPattern count="other" case="locative">{0} литра на 100 километров</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} литра на 100 километров</unitPattern>
+				<unitPattern count="other" case="vocative">{0} литра на 100 километров</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<gender>feminine</gender>
@@ -9512,7 +9512,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} миле на имп. галлон</unitPattern>
 				<unitPattern count="one" case="vocative">{0} миля на имп. галлон</unitPattern>
 				<unitPattern count="few">{0} мили на имп. галлон</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мили на имп. галлон</unitPattern>
 				<unitPattern count="few" case="dative">{0} милям на имп. галлон</unitPattern>
 				<unitPattern count="few" case="genitive">{0} миль на имп. галлон</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} милями на имп. галлон</unitPattern>
@@ -9526,42 +9526,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} милями на имп. галлон</unitPattern>
 				<unitPattern count="many" case="locative">{0} милях на имп. галлон</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} милях на имп. галлон</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} миль на имп. галлон</unitPattern>
 				<unitPattern count="other">{0} мили на имп. галлон</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мили на имп. галлон</unitPattern>
+				<unitPattern count="other" case="dative">{0} мили на имп. галлон</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мили на имп. галлон</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мили на имп. галлон</unitPattern>
+				<unitPattern count="other" case="locative">{0} мили на имп. галлон</unitPattern>
+				<unitPattern count="other" case="vocative">{0} мили на имп. галлон</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<gender>masculine</gender>
 				<displayName>петабайты</displayName>
 				<unitPattern count="one">{0} петабайт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} петабайт</unitPattern>
 				<unitPattern count="one" case="dative">{0} петабайту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} петабайта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} петабайтом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} петабайте</unitPattern>
 				<unitPattern count="few">{0} петабайта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} петабайта</unitPattern>
 				<unitPattern count="few" case="dative">{0} петабайтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} петабайт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} петабайтами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} петабайтах</unitPattern>
 				<unitPattern count="many">{0} петабайт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} петабайт</unitPattern>
 				<unitPattern count="many" case="dative">{0} петабайтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} петабайт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} петабайтами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} петабайтах</unitPattern>
 				<unitPattern count="other">{0} петабайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} петабайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} петабайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} петабайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} петабайта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} петабайта</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>masculine</gender>
@@ -9581,21 +9581,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} терабайтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} терабайтах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} терабайтах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} терабайта</unitPattern>
 				<unitPattern count="many">{0} терабайт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} терабайт</unitPattern>
 				<unitPattern count="many" case="dative">{0} терабайтам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} терабайт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} терабайтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} терабайтах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} терабайтах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} терабайт</unitPattern>
 				<unitPattern count="other">{0} терабайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} терабайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} терабайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} терабайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} терабайта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} терабайта</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>masculine</gender>
@@ -9615,21 +9615,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} терабитами</unitPattern>
 				<unitPattern count="few" case="locative">{0} терабитах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} терабитах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} терабита</unitPattern>
 				<unitPattern count="many">{0} терабит</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} терабит</unitPattern>
 				<unitPattern count="many" case="dative">{0} терабитам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} терабит</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} терабитами</unitPattern>
 				<unitPattern count="many" case="locative">{0} терабитах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} терабитах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} терабит</unitPattern>
 				<unitPattern count="other">{0} терабита</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} терабита</unitPattern>
+				<unitPattern count="other" case="dative">{0} терабита</unitPattern>
+				<unitPattern count="other" case="genitive">{0} терабита</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} терабита</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} терабита</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>masculine</gender>
@@ -9649,21 +9649,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} гигабайтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гигабайтах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} гигабайтах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} гигабайта</unitPattern>
 				<unitPattern count="many">{0} гигабайт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гигабайт</unitPattern>
 				<unitPattern count="many" case="dative">{0} гигабайтам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} гигабайт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гигабайтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} гигабайтах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} гигабайтах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} гигабайт</unitPattern>
 				<unitPattern count="other">{0} гигабайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гигабайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} гигабайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гигабайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гигабайта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} гигабайта</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>masculine</gender>
@@ -9683,21 +9683,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} гигабитами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гигабитах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} гигабитах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} гигабита</unitPattern>
 				<unitPattern count="many">{0} гигабит</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гигабит</unitPattern>
 				<unitPattern count="many" case="dative">{0} гигабитам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} гигабит</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гигабитами</unitPattern>
 				<unitPattern count="many" case="locative">{0} гигабитах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} гигабитах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} гигабит</unitPattern>
 				<unitPattern count="other">{0} гигабита</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гигабита</unitPattern>
+				<unitPattern count="other" case="dative">{0} гигабита</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гигабита</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гигабита</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} гигабита</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>masculine</gender>
@@ -9717,21 +9717,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} мегабайтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мегабайтах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} мегабайтах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} мегабайта</unitPattern>
 				<unitPattern count="many">{0} мегабайт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегабайт</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегабайтам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} мегабайт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегабайтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мегабайтах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} мегабайтах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} мегабайт</unitPattern>
 				<unitPattern count="other">{0} мегабайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегабайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегабайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегабайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегабайта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} мегабайта</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>masculine</gender>
@@ -9751,21 +9751,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} мегабитами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мегабитах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} мегабитах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} мегабита</unitPattern>
 				<unitPattern count="many">{0} мегабит</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегабит</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегабитам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} мегабит</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегабитами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мегабитах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} мегабитах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} мегабит</unitPattern>
 				<unitPattern count="other">{0} мегабита</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегабита</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегабита</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегабита</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегабита</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} мегабита</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>masculine</gender>
@@ -9785,21 +9785,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} килобайтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} килобайтах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} килобайтах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} килобайта</unitPattern>
 				<unitPattern count="many">{0} килобайт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} килобайт</unitPattern>
 				<unitPattern count="many" case="dative">{0} килобайтам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} килобайт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} килобайтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} килобайтах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} килобайтах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} килобайт</unitPattern>
 				<unitPattern count="other">{0} килобайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килобайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} килобайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килобайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килобайта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} килобайта</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>masculine</gender>
@@ -9819,77 +9819,77 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} килобитами</unitPattern>
 				<unitPattern count="few" case="locative">{0} килобитах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} килобитах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} килобита</unitPattern>
 				<unitPattern count="many">{0} килобит</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} килобит</unitPattern>
 				<unitPattern count="many" case="dative">{0} килобитам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} килобит</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} килобитами</unitPattern>
 				<unitPattern count="many" case="locative">{0} килобитах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} килобитах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} килобит</unitPattern>
 				<unitPattern count="other">{0} килобита</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килобита</unitPattern>
+				<unitPattern count="other" case="dative">{0} килобита</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килобита</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килобита</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} килобита</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>masculine</gender>
 				<displayName>байты</displayName>
 				<unitPattern count="one">{0} байт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} байт</unitPattern>
 				<unitPattern count="one" case="dative">{0} байту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} байта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} байтом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} байте</unitPattern>
 				<unitPattern count="few">{0} байта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} байта</unitPattern>
 				<unitPattern count="few" case="dative">{0} байтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} байт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} байтами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} байтах</unitPattern>
 				<unitPattern count="many">{0} байт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} байт</unitPattern>
 				<unitPattern count="many" case="dative">{0} байтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} байт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} байтами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} байтах</unitPattern>
 				<unitPattern count="other">{0} байта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} байта</unitPattern>
+				<unitPattern count="other" case="dative">{0} байта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} байта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} байта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} байта</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>masculine</gender>
 				<displayName>биты</displayName>
 				<unitPattern count="one">{0} бит</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} бит</unitPattern>
 				<unitPattern count="one" case="dative">{0} биту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} бита</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} битом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} бите</unitPattern>
 				<unitPattern count="few">{0} бита</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} бита</unitPattern>
 				<unitPattern count="few" case="dative">{0} битам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} бит</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} битами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} битах</unitPattern>
 				<unitPattern count="many">{0} бит</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} бит</unitPattern>
 				<unitPattern count="many" case="dative">{0} битам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} бит</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} битами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} битах</unitPattern>
 				<unitPattern count="other">{0} бита</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} бита</unitPattern>
+				<unitPattern count="other" case="dative">{0} бита</unitPattern>
+				<unitPattern count="other" case="genitive">{0} бита</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} бита</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} бита</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>masculine</gender>
@@ -9901,51 +9901,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} веком</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} веке</unitPattern>
 				<unitPattern count="few">{0} века</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} века</unitPattern>
 				<unitPattern count="few" case="dative">{0} векам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} веков</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} веками</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} веках</unitPattern>
 				<unitPattern count="many">{0} веков</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} веков</unitPattern>
 				<unitPattern count="many" case="dative">{0} векам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} веков</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} веками</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} веках</unitPattern>
 				<unitPattern count="other">{0} века</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} века</unitPattern>
+				<unitPattern count="other" case="dative">{0} века</unitPattern>
+				<unitPattern count="other" case="genitive">{0} века</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} века</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} века</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>neuter</gender>
 				<displayName>десятилетия</displayName>
 				<unitPattern count="one">{0} десятилетие</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} десятилетие</unitPattern>
 				<unitPattern count="one" case="dative">{0} десятилетию</unitPattern>
 				<unitPattern count="one" case="genitive">{0} десятилетия</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} десятилетием</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} десятилетии</unitPattern>
 				<unitPattern count="few">{0} десятилетия</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} десятилетия</unitPattern>
 				<unitPattern count="few" case="dative">{0} десятилетиям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} десятилетий</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} десятилетиями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} десятилетиях</unitPattern>
 				<unitPattern count="many">{0} десятилетий</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} десятилетий</unitPattern>
 				<unitPattern count="many" case="dative">{0} десятилетиям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} десятилетий</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} десятилетиями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} десятилетиях</unitPattern>
 				<unitPattern count="other">{0} десятилетия</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} десятилетия</unitPattern>
+				<unitPattern count="other" case="dative">{0} десятилетия</unitPattern>
+				<unitPattern count="other" case="genitive">{0} десятилетия</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} десятилетия</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} десятилетия</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>masculine</gender>
@@ -9965,23 +9965,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} годами</unitPattern>
 				<unitPattern count="few" case="locative">{0} годах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} годах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} года</unitPattern>
 				<unitPattern count="many">{0} лет</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} лет</unitPattern>
 				<unitPattern count="many" case="dative">{0} годам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} лет</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} годами</unitPattern>
 				<unitPattern count="many" case="locative">{0} годах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} годах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} лет</unitPattern>
 				<unitPattern count="other">{0} года</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} года</unitPattern>
+				<unitPattern count="other" case="dative">{0} года</unitPattern>
+				<unitPattern count="other" case="genitive">{0} года</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} года</unitPattern>
+				<unitPattern count="other" case="locative">{0} года</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} года</unitPattern>
+				<unitPattern count="other" case="vocative">{0} года</unitPattern>
 				<perUnitPattern>{0} в год</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -10031,23 +10031,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} месяцами</unitPattern>
 				<unitPattern count="few" case="locative">{0} месяцах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} месяцах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} месяца</unitPattern>
 				<unitPattern count="many">{0} месяцев</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} месяцев</unitPattern>
 				<unitPattern count="many" case="dative">{0} месяцам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} месяцев</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} месяцами</unitPattern>
 				<unitPattern count="many" case="locative">{0} месяцах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} месяцах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} месяцев</unitPattern>
 				<unitPattern count="other">{0} месяца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} месяца</unitPattern>
+				<unitPattern count="other" case="dative">{0} месяца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} месяца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} месяца</unitPattern>
+				<unitPattern count="other" case="locative">{0} месяца</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} месяца</unitPattern>
+				<unitPattern count="other" case="vocative">{0} месяца</unitPattern>
 				<perUnitPattern>{0} в месяц</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
@@ -10070,21 +10070,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} неделях</unitPattern>
 				<unitPattern count="few" case="vocative">{0} недели</unitPattern>
 				<unitPattern count="many">{0} недель</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} недель</unitPattern>
 				<unitPattern count="many" case="dative">{0} неделям</unitPattern>
 				<unitPattern count="many" case="genitive">{0} недель</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} неделями</unitPattern>
 				<unitPattern count="many" case="locative">{0} неделях</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} неделях</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} недель</unitPattern>
 				<unitPattern count="other">{0} недели</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} недели</unitPattern>
+				<unitPattern count="other" case="dative">{0} недели</unitPattern>
+				<unitPattern count="other" case="genitive">{0} недели</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} недели</unitPattern>
+				<unitPattern count="other" case="locative">{0} недели</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} недели</unitPattern>
+				<unitPattern count="other" case="vocative">{0} недели</unitPattern>
 				<perUnitPattern>{0} в неделю</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
@@ -10105,23 +10105,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} днями</unitPattern>
 				<unitPattern count="few" case="locative">{0} днях</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} днях</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} дня</unitPattern>
 				<unitPattern count="many">{0} дней</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} дней</unitPattern>
 				<unitPattern count="many" case="dative">{0} дням</unitPattern>
 				<unitPattern count="many" case="genitive">{0} дней</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} днями</unitPattern>
 				<unitPattern count="many" case="locative">{0} днях</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} днях</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} дней</unitPattern>
 				<unitPattern count="other">{0} дня</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} дня</unitPattern>
+				<unitPattern count="other" case="dative">{0} дня</unitPattern>
+				<unitPattern count="other" case="genitive">{0} дня</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} дня</unitPattern>
+				<unitPattern count="other" case="locative">{0} дня</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} дня</unitPattern>
+				<unitPattern count="other" case="vocative">{0} дня</unitPattern>
 				<perUnitPattern>{0} в день</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -10142,23 +10142,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} часами</unitPattern>
 				<unitPattern count="few" case="locative">{0} часах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} часах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} часа</unitPattern>
 				<unitPattern count="many">{0} часов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} часов</unitPattern>
 				<unitPattern count="many" case="dative">{0} часам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} часов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} часами</unitPattern>
 				<unitPattern count="many" case="locative">{0} часах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} часах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} часов</unitPattern>
 				<unitPattern count="other">{0} часа</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} часа</unitPattern>
+				<unitPattern count="other" case="dative">{0} часа</unitPattern>
+				<unitPattern count="other" case="genitive">{0} часа</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} часа</unitPattern>
+				<unitPattern count="other" case="locative">{0} часа</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} часа</unitPattern>
+				<unitPattern count="other" case="vocative">{0} часа</unitPattern>
 				<perUnitPattern>{0} в час</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -10181,21 +10181,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} минутах</unitPattern>
 				<unitPattern count="few" case="vocative">{0} минуты</unitPattern>
 				<unitPattern count="many">{0} минут</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} минут</unitPattern>
 				<unitPattern count="many" case="dative">{0} минутам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} минут</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} минутами</unitPattern>
 				<unitPattern count="many" case="locative">{0} минутах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} минутах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} минут</unitPattern>
 				<unitPattern count="other">{0} минуты</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} минуты</unitPattern>
+				<unitPattern count="other" case="dative">{0} минуты</unitPattern>
+				<unitPattern count="other" case="genitive">{0} минуты</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} минуты</unitPattern>
+				<unitPattern count="other" case="locative">{0} минуты</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} минуты</unitPattern>
+				<unitPattern count="other" case="vocative">{0} минуты</unitPattern>
 				<perUnitPattern>{0} в минуту</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -10218,21 +10218,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} секундах</unitPattern>
 				<unitPattern count="few" case="vocative">{0} секунды</unitPattern>
 				<unitPattern count="many">{0} секунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} секунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} секундам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} секунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} секундами</unitPattern>
 				<unitPattern count="many" case="locative">{0} секундах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} секундах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} секунд</unitPattern>
 				<unitPattern count="other">{0} секунды</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} секунды</unitPattern>
+				<unitPattern count="other" case="dative">{0} секунды</unitPattern>
+				<unitPattern count="other" case="genitive">{0} секунды</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} секунды</unitPattern>
+				<unitPattern count="other" case="locative">{0} секунды</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} секунды</unitPattern>
+				<unitPattern count="other" case="vocative">{0} секунды</unitPattern>
 				<perUnitPattern>{0} в секунду</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
@@ -10245,23 +10245,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} миллисекундой</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} миллисекунде</unitPattern>
 				<unitPattern count="few">{0} миллисекунды</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} миллисекунды</unitPattern>
 				<unitPattern count="few" case="dative">{0} миллисекундам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} миллисекунд</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} миллисекундами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} миллисекундах</unitPattern>
 				<unitPattern count="many">{0} миллисекунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} миллисекунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} миллисекундам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} миллисекунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} миллисекундами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} миллисекундах</unitPattern>
 				<unitPattern count="other">{0} миллисекунды</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} миллисекунды</unitPattern>
+				<unitPattern count="other" case="dative">{0} миллисекунды</unitPattern>
+				<unitPattern count="other" case="genitive">{0} миллисекунды</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} миллисекунды</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} миллисекунды</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>feminine</gender>
@@ -10273,23 +10273,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} микросекундой</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} микросекунде</unitPattern>
 				<unitPattern count="few">{0} микросекунды</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} микросекунды</unitPattern>
 				<unitPattern count="few" case="dative">{0} микросекундам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} микросекунд</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} микросекундами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} микросекундах</unitPattern>
 				<unitPattern count="many">{0} микросекунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} микросекунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} микросекундам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} микросекунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} микросекундами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} микросекундах</unitPattern>
 				<unitPattern count="other">{0} микросекунды</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} микросекунды</unitPattern>
+				<unitPattern count="other" case="dative">{0} микросекунды</unitPattern>
+				<unitPattern count="other" case="genitive">{0} микросекунды</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} микросекунды</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} микросекунды</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>feminine</gender>
@@ -10301,135 +10301,135 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} наносекундой</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} наносекунде</unitPattern>
 				<unitPattern count="few">{0} наносекунды</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} наносекунды</unitPattern>
 				<unitPattern count="few" case="dative">{0} наносекундам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} наносекунд</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} наносекундами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} наносекундах</unitPattern>
 				<unitPattern count="many">{0} наносекунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} наносекунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} наносекундам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} наносекунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} наносекундами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} наносекундах</unitPattern>
 				<unitPattern count="other">{0} наносекунды</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} наносекунды</unitPattern>
+				<unitPattern count="other" case="dative">{0} наносекунды</unitPattern>
+				<unitPattern count="other" case="genitive">{0} наносекунды</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} наносекунды</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} наносекунды</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>masculine</gender>
 				<displayName>амперы</displayName>
 				<unitPattern count="one">{0} ампер</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ампер</unitPattern>
 				<unitPattern count="one" case="dative">{0} амперу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ампера</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ампером</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} ампере</unitPattern>
 				<unitPattern count="few">{0} ампера</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ампера</unitPattern>
 				<unitPattern count="few" case="dative">{0} амперам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ампер</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} амперами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} амперах</unitPattern>
 				<unitPattern count="many">{0} ампер</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ампер</unitPattern>
 				<unitPattern count="many" case="dative">{0} амперам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ампер</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} амперами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} амперах</unitPattern>
 				<unitPattern count="other">{0} ампера</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ампера</unitPattern>
+				<unitPattern count="other" case="dative">{0} ампера</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ампера</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ампера</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} ампера</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>masculine</gender>
 				<displayName>миллиамперы</displayName>
 				<unitPattern count="one">{0} миллиампер</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} миллиампер</unitPattern>
 				<unitPattern count="one" case="dative">{0} миллиамперу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} миллиампера</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} миллиампером</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} миллиампере</unitPattern>
 				<unitPattern count="few">{0} миллиампера</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} миллиампера</unitPattern>
 				<unitPattern count="few" case="dative">{0} миллиамперам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} миллиампер</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} миллиамперами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} миллиамперах</unitPattern>
 				<unitPattern count="many">{0} миллиампер</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} миллиампер</unitPattern>
 				<unitPattern count="many" case="dative">{0} миллиамперам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} миллиампер</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} миллиамперами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} миллиамперах</unitPattern>
 				<unitPattern count="other">{0} миллиампера</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} миллиампера</unitPattern>
+				<unitPattern count="other" case="dative">{0} миллиампера</unitPattern>
+				<unitPattern count="other" case="genitive">{0} миллиампера</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} миллиампера</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} миллиампера</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>masculine</gender>
 				<displayName>омы</displayName>
 				<unitPattern count="one">{0} ом</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ом</unitPattern>
 				<unitPattern count="one" case="dative">{0} ому</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ома</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} омом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} оме</unitPattern>
 				<unitPattern count="few">{0} ома</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ома</unitPattern>
 				<unitPattern count="few" case="dative">{0} омам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ом</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} омами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} омах</unitPattern>
 				<unitPattern count="many">{0} ом</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ом</unitPattern>
 				<unitPattern count="many" case="dative">{0} омам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ом</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} омами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} омах</unitPattern>
 				<unitPattern count="other">{0} ома</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ома</unitPattern>
+				<unitPattern count="other" case="dative">{0} ома</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ома</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ома</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} ома</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>masculine</gender>
 				<displayName>вольты</displayName>
 				<unitPattern count="one">{0} вольт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} вольт</unitPattern>
 				<unitPattern count="one" case="dative">{0} вольту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} вольта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} вольтом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} вольте</unitPattern>
 				<unitPattern count="few">{0} вольта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} вольта</unitPattern>
 				<unitPattern count="few" case="dative">{0} вольтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} вольт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} вольтами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} вольтах</unitPattern>
 				<unitPattern count="many">{0} вольт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} вольт</unitPattern>
 				<unitPattern count="many" case="dative">{0} вольтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} вольт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} вольтами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} вольтах</unitPattern>
 				<unitPattern count="other">{0} вольта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} вольта</unitPattern>
+				<unitPattern count="other" case="dative">{0} вольта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} вольта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} вольта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} вольта</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<gender>feminine</gender>
@@ -10451,20 +10451,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} килокалориях</unitPattern>
 				<unitPattern count="few" case="vocative">{0} килокалории</unitPattern>
 				<unitPattern count="many">{0} килокалорий</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} килокалорий</unitPattern>
 				<unitPattern count="many" case="dative">{0} килокалориям</unitPattern>
 				<unitPattern count="many" case="genitive">{0} килокалорий</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} килокалориями</unitPattern>
 				<unitPattern count="many" case="locative">{0} килокалориях</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} килокалориях</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} килокалорий</unitPattern>
 				<unitPattern count="other">{0} килокалории</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килокалории</unitPattern>
+				<unitPattern count="other" case="dative">{0} килокалории</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килокалории</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килокалории</unitPattern>
+				<unitPattern count="other" case="locative">{0} килокалории</unitPattern>
+				<unitPattern count="other" case="vocative">{0} килокалории</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<gender>feminine</gender>
@@ -10476,23 +10476,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} калорией</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} калории</unitPattern>
 				<unitPattern count="few">{0} калории</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} калории</unitPattern>
 				<unitPattern count="few" case="dative">{0} калориям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} калорий</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} калориями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} калориях</unitPattern>
 				<unitPattern count="many">{0} калорий</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} калорий</unitPattern>
 				<unitPattern count="many" case="dative">{0} калориям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} калорий</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} калориями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} калориях</unitPattern>
 				<unitPattern count="other">{0} калории</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} калории</unitPattern>
+				<unitPattern count="other" case="dative">{0} калории</unitPattern>
+				<unitPattern count="other" case="genitive">{0} калории</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} калории</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} калории</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<gender>feminine</gender>
@@ -10533,85 +10533,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>килоджоули</displayName>
 				<unitPattern count="one">{0} килоджоуль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} килоджоуль</unitPattern>
 				<unitPattern count="one" case="dative">{0} килоджоулю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} килоджоуля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} килоджоулем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} килоджоуле</unitPattern>
 				<unitPattern count="few">{0} килоджоуля</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} килоджоуля</unitPattern>
 				<unitPattern count="few" case="dative">{0} килоджоулям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} килоджоулей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} килоджоулями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} килоджоулях</unitPattern>
 				<unitPattern count="many">{0} килоджоулей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} килоджоулей</unitPattern>
 				<unitPattern count="many" case="dative">{0} килоджоулям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} килоджоулей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} килоджоулями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} килоджоулях</unitPattern>
 				<unitPattern count="other">{0} килоджоуля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килоджоуля</unitPattern>
+				<unitPattern count="other" case="dative">{0} килоджоуля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килоджоуля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килоджоуля</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} килоджоуля</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>masculine</gender>
 				<displayName>джоули</displayName>
 				<unitPattern count="one">{0} джоуль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} джоуль</unitPattern>
 				<unitPattern count="one" case="dative">{0} джоулю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} джоуля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} джоулем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} джоуле</unitPattern>
 				<unitPattern count="few">{0} джоуля</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} джоуля</unitPattern>
 				<unitPattern count="few" case="dative">{0} джоулям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} джоулей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} джоулями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} джоулях</unitPattern>
 				<unitPattern count="many">{0} джоулей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} джоулей</unitPattern>
 				<unitPattern count="many" case="dative">{0} джоулям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} джоулей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} джоулями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} джоулях</unitPattern>
 				<unitPattern count="other">{0} джоуля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} джоуля</unitPattern>
+				<unitPattern count="other" case="dative">{0} джоуля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} джоуля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} джоуля</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} джоуля</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>masculine</gender>
 				<displayName>киловатт-часы</displayName>
 				<unitPattern count="one">{0} киловатт-час</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} киловатт-час</unitPattern>
 				<unitPattern count="one" case="dative">{0} киловатт-часу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} киловатт-часа</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} киловатт-часом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} киловатт-часе</unitPattern>
 				<unitPattern count="few">{0} киловатт-часа</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} киловатт-часа</unitPattern>
 				<unitPattern count="few" case="dative">{0} киловатт-часам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} киловатт-часов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} киловатт-часами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} киловатт-часах</unitPattern>
 				<unitPattern count="many">{0} киловатт-часов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} киловатт-часов</unitPattern>
 				<unitPattern count="many" case="dative">{0} киловатт-часам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} киловатт-часов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} киловатт-часами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} киловатт-часах</unitPattern>
 				<unitPattern count="other">{0} киловатт-часа</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} киловатт-часа</unitPattern>
+				<unitPattern count="other" case="dative">{0} киловатт-часа</unitPattern>
+				<unitPattern count="other" case="genitive">{0} киловатт-часа</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} киловатт-часа</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} киловатт-часа</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>электронвольты</displayName>
@@ -10645,29 +10645,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ньютоны</displayName>
 				<unitPattern count="one">{0} ньютон</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ньютон</unitPattern>
 				<unitPattern count="one" case="dative">{0} ньютону</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ньютона</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ньютоном</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} ньютоне</unitPattern>
 				<unitPattern count="few">{0} ньютона</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ньютона</unitPattern>
 				<unitPattern count="few" case="dative">{0} ньютонам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ньютонов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} ньютонами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} ньютонах</unitPattern>
 				<unitPattern count="many">{0} ньютонов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ньютонов</unitPattern>
 				<unitPattern count="many" case="dative">{0} ньютонам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ньютонов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} ньютонами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} ньютонах</unitPattern>
 				<unitPattern count="other">{0} ньютона</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ньютона</unitPattern>
+				<unitPattern count="other" case="dative">{0} ньютона</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ньютона</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ньютона</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} ньютона</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>masculine</gender>
@@ -10701,225 +10701,225 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>гигагерцы</displayName>
 				<unitPattern count="one">{0} гигагерц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гигагерц</unitPattern>
 				<unitPattern count="one" case="dative">{0} гигагерцу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гигагерца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гигагерцем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} гигагерце</unitPattern>
 				<unitPattern count="few">{0} гигагерца</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гигагерца</unitPattern>
 				<unitPattern count="few" case="dative">{0} гигагерцам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гигагерц</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гигагерцами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} гигагерцах</unitPattern>
 				<unitPattern count="many">{0} гигагерц</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гигагерц</unitPattern>
 				<unitPattern count="many" case="dative">{0} гигагерцам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гигагерц</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гигагерцами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} гигагерцах</unitPattern>
 				<unitPattern count="other">{0} гигагерца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гигагерца</unitPattern>
+				<unitPattern count="other" case="dative">{0} гигагерца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гигагерца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гигагерца</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} гигагерца</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>masculine</gender>
 				<displayName>мегагерцы</displayName>
 				<unitPattern count="one">{0} мегагерц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегагерц</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегагерцу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегагерца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегагерцем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} мегагерце</unitPattern>
 				<unitPattern count="few">{0} мегагерца</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегагерца</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегагерцам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегагерц</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегагерцами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} мегагерцах</unitPattern>
 				<unitPattern count="many">{0} мегагерц</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегагерц</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегагерцам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегагерц</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегагерцами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} мегагерцах</unitPattern>
 				<unitPattern count="other">{0} мегагерца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегагерца</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегагерца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегагерца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегагерца</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} мегагерца</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>masculine</gender>
 				<displayName>килогерцы</displayName>
 				<unitPattern count="one">{0} килогерц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} килогерц</unitPattern>
 				<unitPattern count="one" case="dative">{0} килогерцу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} килогерца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} килогерцем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} килогерце</unitPattern>
 				<unitPattern count="few">{0} килогерца</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} килогерца</unitPattern>
 				<unitPattern count="few" case="dative">{0} килогерцам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} килогерц</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} килогерцами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} килогерцах</unitPattern>
 				<unitPattern count="many">{0} килогерц</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} килогерц</unitPattern>
 				<unitPattern count="many" case="dative">{0} килогерцам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} килогерц</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} килогерцами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} килогерцах</unitPattern>
 				<unitPattern count="other">{0} килогерца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килогерца</unitPattern>
+				<unitPattern count="other" case="dative">{0} килогерца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килогерца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килогерца</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} килогерца</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>masculine</gender>
 				<displayName>герцы</displayName>
 				<unitPattern count="one">{0} герц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} герц</unitPattern>
 				<unitPattern count="one" case="dative">{0} герцу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} герца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} герцем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} герце</unitPattern>
 				<unitPattern count="few">{0} герца</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} герца</unitPattern>
 				<unitPattern count="few" case="dative">{0} герцам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} герц</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} герцами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} герцах</unitPattern>
 				<unitPattern count="many">{0} герц</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} герц</unitPattern>
 				<unitPattern count="many" case="dative">{0} герцам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} герц</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} герцами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} герцах</unitPattern>
 				<unitPattern count="other">{0} герца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} герца</unitPattern>
+				<unitPattern count="other" case="dative">{0} герца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} герца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} герца</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} герца</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>neuter</gender>
 				<displayName>эм</displayName>
 				<unitPattern count="one">{0} эм</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} эм</unitPattern>
+				<unitPattern count="one" case="dative">{0} эм</unitPattern>
+				<unitPattern count="one" case="genitive">{0} эм</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} эм</unitPattern>
+				<unitPattern count="one" case="prepositional">{0} эм</unitPattern>
 				<unitPattern count="few">{0} эм</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} эм</unitPattern>
+				<unitPattern count="few" case="dative">{0} эм</unitPattern>
+				<unitPattern count="few" case="genitive">{0} эм</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} эм</unitPattern>
+				<unitPattern count="few" case="prepositional">{0} эм</unitPattern>
 				<unitPattern count="many">{0} эм</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} эм</unitPattern>
+				<unitPattern count="many" case="dative">{0} эм</unitPattern>
+				<unitPattern count="many" case="genitive">{0} эм</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} эм</unitPattern>
+				<unitPattern count="many" case="prepositional">{0} эм</unitPattern>
 				<unitPattern count="other">{0} эм</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} эм</unitPattern>
+				<unitPattern count="other" case="dative">{0} эм</unitPattern>
+				<unitPattern count="other" case="genitive">{0} эм</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} эм</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} эм</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>masculine</gender>
 				<displayName>пиксели</displayName>
 				<unitPattern count="one">{0} пиксель</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} пиксель</unitPattern>
 				<unitPattern count="one" case="dative">{0} пикселю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} пикселя</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} пикселем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} пикселе</unitPattern>
 				<unitPattern count="few">{0} пикселя</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} пикселя</unitPattern>
 				<unitPattern count="few" case="dative">{0} пикселям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} пикселей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} пикселями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} пикселях</unitPattern>
 				<unitPattern count="many">{0} пикселей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} пикселей</unitPattern>
 				<unitPattern count="many" case="dative">{0} пикселям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} пикселей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} пикселями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} пикселях</unitPattern>
 				<unitPattern count="other">{0} пикселя</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} пикселя</unitPattern>
+				<unitPattern count="other" case="dative">{0} пикселя</unitPattern>
+				<unitPattern count="other" case="genitive">{0} пикселя</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} пикселя</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} пикселя</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>masculine</gender>
 				<displayName>мегапиксели</displayName>
 				<unitPattern count="one">{0} мегапиксель</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегапиксель</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегапикселю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегапикселя</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегапикселем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} мегапикселе</unitPattern>
 				<unitPattern count="few">{0} мегапикселя</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегапикселя</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегапикселям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегапикселей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегапикселями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} мегапикселях</unitPattern>
 				<unitPattern count="many">{0} мегапикселей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегапикселей</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегапикселям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегапикселей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегапикселями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} мегапикселях</unitPattern>
 				<unitPattern count="other">{0} мегапикселя</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегапикселя</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегапикселя</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегапикселя</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегапикселя</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} мегапикселя</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>masculine</gender>
 				<displayName>пиксели на сантиметр</displayName>
 				<unitPattern count="one">{0} пиксель на сантиметр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} пиксель на сантиметр</unitPattern>
 				<unitPattern count="one" case="dative">{0} пикселю на сантиметр</unitPattern>
 				<unitPattern count="one" case="genitive">{0} пикселя на сантиметр</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} пикселем на сантиметр</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} пикселе на сантиметр</unitPattern>
 				<unitPattern count="few">{0} пикселя на сантиметр</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} пикселя на сантиметр</unitPattern>
 				<unitPattern count="few" case="dative">{0} пикселям на сантиметр</unitPattern>
 				<unitPattern count="few" case="genitive">{0} пикселей на сантиметр</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} пикселями на сантиметр</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} пикселях на сантиметр</unitPattern>
 				<unitPattern count="many">{0} пикселей на сантиметр</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} пикселей на сантиметр</unitPattern>
 				<unitPattern count="many" case="dative">{0} пикселям на сантиметр</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} пикселей на сантиметр</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} пикселями на сантиметр</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} пикселях на сантиметр</unitPattern>
 				<unitPattern count="other">{0} пикселя на сантиметр</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} пикселя на сантиметр</unitPattern>
+				<unitPattern count="other" case="dative">{0} пикселя на сантиметр</unitPattern>
+				<unitPattern count="other" case="genitive">{0} пикселя на сантиметр</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} пикселя на сантиметр</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} пикселя на сантиметр</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>пиксели на дюйм</displayName>
@@ -10974,23 +10974,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} километрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} километрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} километрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} километра</unitPattern>
 				<unitPattern count="many">{0} километров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} километров</unitPattern>
 				<unitPattern count="many" case="dative">{0} километрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} километров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} километрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} километрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} километрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} километров</unitPattern>
 				<unitPattern count="other">{0} километра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} километра</unitPattern>
+				<unitPattern count="other" case="dative">{0} километра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} километра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} километра</unitPattern>
+				<unitPattern count="other" case="locative">{0} километра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} километра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} километра</unitPattern>
 				<perUnitPattern>{0} на километр</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
@@ -11011,52 +11011,52 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} метрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} метрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} метрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} метра</unitPattern>
 				<unitPattern count="many">{0} метров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} метров</unitPattern>
 				<unitPattern count="many" case="dative">{0} метрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} метров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} метрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} метрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} метрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} метров</unitPattern>
 				<unitPattern count="other">{0} метра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метра</unitPattern>
+				<unitPattern count="other" case="dative">{0} метра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метра</unitPattern>
+				<unitPattern count="other" case="locative">{0} метра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} метра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} метра</unitPattern>
 				<perUnitPattern>{0} на метр</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<gender>masculine</gender>
 				<displayName>дециметры</displayName>
 				<unitPattern count="one">{0} дециметр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} дециметр</unitPattern>
 				<unitPattern count="one" case="dative">{0} дециметру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} дециметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} дециметром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} дециметре</unitPattern>
 				<unitPattern count="few">{0} дециметра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} дециметра</unitPattern>
 				<unitPattern count="few" case="dative">{0} дециметрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} дециметров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} дециметрами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} дециметрах</unitPattern>
 				<unitPattern count="many">{0} дециметров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} дециметров</unitPattern>
 				<unitPattern count="many" case="dative">{0} дециметрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} дециметров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} дециметрами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} дециметрах</unitPattern>
 				<unitPattern count="other">{0} дециметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} дециметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} дециметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} дециметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} дециметра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} дециметра</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>masculine</gender>
@@ -11076,23 +11076,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} сантиметрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} сантиметрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} сантиметрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} сантиметра</unitPattern>
 				<unitPattern count="many">{0} сантиметров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} сантиметров</unitPattern>
 				<unitPattern count="many" case="dative">{0} сантиметрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} сантиметров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} сантиметрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} сантиметрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} сантиметрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} сантиметров</unitPattern>
 				<unitPattern count="other">{0} сантиметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="locative">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} сантиметра</unitPattern>
 				<perUnitPattern>{0} на сантиметр</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
@@ -11113,79 +11113,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} миллиметрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} миллиметрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} миллиметрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} миллиметра</unitPattern>
 				<unitPattern count="many">{0} миллиметров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} миллиметров</unitPattern>
 				<unitPattern count="many" case="dative">{0} миллиметрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} миллиметров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} миллиметрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} миллиметрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} миллиметрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} миллиметров</unitPattern>
 				<unitPattern count="other">{0} миллиметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} миллиметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} миллиметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} миллиметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} миллиметра</unitPattern>
+				<unitPattern count="other" case="locative">{0} миллиметра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} миллиметра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} миллиметра</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>masculine</gender>
 				<displayName>микрометры</displayName>
 				<unitPattern count="one">{0} микрометр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} микрометр</unitPattern>
 				<unitPattern count="one" case="dative">{0} микрометру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} микрометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} микрометром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} микрометре</unitPattern>
 				<unitPattern count="few">{0} микрометра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} микрометра</unitPattern>
 				<unitPattern count="few" case="dative">{0} микрометрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} микрометров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} микрометрами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} микрометрах</unitPattern>
 				<unitPattern count="many">{0} микрометров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} микрометров</unitPattern>
 				<unitPattern count="many" case="dative">{0} микрометрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} микрометров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} микрометрами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} микрометрах</unitPattern>
 				<unitPattern count="other">{0} микрометра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} микрометра</unitPattern>
+				<unitPattern count="other" case="dative">{0} микрометра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} микрометра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} микрометра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} микрометра</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>masculine</gender>
 				<displayName>нанометры</displayName>
 				<unitPattern count="one">{0} нанометр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} нанометр</unitPattern>
 				<unitPattern count="one" case="dative">{0} нанометру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} нанометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} нанометром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} нанометре</unitPattern>
 				<unitPattern count="few">{0} нанометра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} нанометра</unitPattern>
 				<unitPattern count="few" case="dative">{0} нанометрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} нанометров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} нанометрами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} нанометрах</unitPattern>
 				<unitPattern count="many">{0} нанометров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} нанометров</unitPattern>
 				<unitPattern count="many" case="dative">{0} нанометрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} нанометров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} нанометрами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} нанометрах</unitPattern>
 				<unitPattern count="other">{0} нанометра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} нанометра</unitPattern>
+				<unitPattern count="other" case="dative">{0} нанометра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} нанометра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} нанометра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} нанометра</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>masculine</gender>
@@ -11205,23 +11205,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} пикометрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} пикометрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} пикометрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} пикометра</unitPattern>
 				<unitPattern count="many">{0} пикометров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} пикометров</unitPattern>
 				<unitPattern count="many" case="dative">{0} пикометрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} пикометров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} пикометрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} пикометрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} пикометрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} пикометров</unitPattern>
 				<unitPattern count="other">{0} пикометра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} пикометра</unitPattern>
+				<unitPattern count="other" case="dative">{0} пикометра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} пикометра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} пикометра</unitPattern>
+				<unitPattern count="other" case="locative">{0} пикометра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} пикометра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} пикометра</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<gender>feminine</gender>
@@ -11243,20 +11243,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} милях</unitPattern>
 				<unitPattern count="few" case="vocative">{0} мили</unitPattern>
 				<unitPattern count="many">{0} миль</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} миль</unitPattern>
 				<unitPattern count="many" case="dative">{0} милям</unitPattern>
 				<unitPattern count="many" case="genitive">{0} миль</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} милями</unitPattern>
 				<unitPattern count="many" case="locative">{0} милях</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} милях</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} миль</unitPattern>
 				<unitPattern count="other">{0} мили</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мили</unitPattern>
+				<unitPattern count="other" case="dative">{0} мили</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мили</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мили</unitPattern>
+				<unitPattern count="other" case="locative">{0} мили</unitPattern>
+				<unitPattern count="other" case="vocative">{0} мили</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<gender>masculine</gender>
@@ -11276,22 +11276,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} ярдами</unitPattern>
 				<unitPattern count="few" case="locative">{0} ярдах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} ярдах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} ярда</unitPattern>
 				<unitPattern count="many">{0} ярдов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ярдов</unitPattern>
 				<unitPattern count="many" case="dative">{0} ярдам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} ярдов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} ярдами</unitPattern>
 				<unitPattern count="many" case="locative">{0} ярдах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} ярдах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} ярдов</unitPattern>
 				<unitPattern count="other">{0} ярда</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ярда</unitPattern>
+				<unitPattern count="other" case="dative">{0} ярда</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ярда</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ярда</unitPattern>
+				<unitPattern count="other" case="locative">{0} ярда</unitPattern>
+				<unitPattern count="other" case="vocative">{0} ярда</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<gender>masculine</gender>
@@ -11311,22 +11311,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} футами</unitPattern>
 				<unitPattern count="few" case="locative">{0} футах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} футах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} фута</unitPattern>
 				<unitPattern count="many">{0} футов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} футов</unitPattern>
 				<unitPattern count="many" case="dative">{0} футам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} футов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} футами</unitPattern>
 				<unitPattern count="many" case="locative">{0} футах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} футах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} футов</unitPattern>
 				<unitPattern count="other">{0} фута</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} фута</unitPattern>
+				<unitPattern count="other" case="dative">{0} фута</unitPattern>
+				<unitPattern count="other" case="genitive">{0} фута</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} фута</unitPattern>
+				<unitPattern count="other" case="locative">{0} фута</unitPattern>
+				<unitPattern count="other" case="vocative">{0} фута</unitPattern>
 				<perUnitPattern>{0} на фут</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
@@ -11347,22 +11347,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} дюймами</unitPattern>
 				<unitPattern count="few" case="locative">{0} дюймах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} дюймах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} дюйма</unitPattern>
 				<unitPattern count="many">{0} дюймов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} дюймов</unitPattern>
 				<unitPattern count="many" case="dative">{0} дюймам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} дюймов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} дюймами</unitPattern>
 				<unitPattern count="many" case="locative">{0} дюймах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} дюймах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} дюймов</unitPattern>
 				<unitPattern count="other">{0} дюйма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} дюйма</unitPattern>
+				<unitPattern count="other" case="dative">{0} дюйма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} дюйма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} дюйма</unitPattern>
+				<unitPattern count="other" case="locative">{0} дюйма</unitPattern>
+				<unitPattern count="other" case="vocative">{0} дюйма</unitPattern>
 				<perUnitPattern>{0} на дюйм</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
@@ -11383,22 +11383,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} парсеками</unitPattern>
 				<unitPattern count="few" case="locative">{0} парсеках</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} парсеках</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} парсека</unitPattern>
 				<unitPattern count="many">{0} парсеков</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} парсеков</unitPattern>
 				<unitPattern count="many" case="dative">{0} парсекам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} парсеков</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} парсеками</unitPattern>
 				<unitPattern count="many" case="locative">{0} парсеках</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} парсеках</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} парсеков</unitPattern>
 				<unitPattern count="other">{0} парсека</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} парсека</unitPattern>
+				<unitPattern count="other" case="dative">{0} парсека</unitPattern>
+				<unitPattern count="other" case="genitive">{0} парсека</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} парсека</unitPattern>
+				<unitPattern count="other" case="locative">{0} парсека</unitPattern>
+				<unitPattern count="other" case="vocative">{0} парсека</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>световые годы</displayName>
@@ -11445,23 +11445,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} скандинавской милей</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} скандинавской миле</unitPattern>
 				<unitPattern count="few">{0} скандинавские мили</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} скандинавские мили</unitPattern>
 				<unitPattern count="few" case="dative">{0} скандинавским милям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} скандинавских миль</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} скандинавскими милями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} скандинавских милях</unitPattern>
 				<unitPattern count="many">{0} скандинавских миль</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} скандинавских миль</unitPattern>
 				<unitPattern count="many" case="dative">{0} скандинавским милям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} скандинавских миль</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} скандинавскими милями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} скандинавских милях</unitPattern>
 				<unitPattern count="other">{0} скандинавской мили</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} скандинавской мили</unitPattern>
+				<unitPattern count="other" case="dative">{0} скандинавской мили</unitPattern>
+				<unitPattern count="other" case="genitive">{0} скандинавской мили</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} скандинавской мили</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} скандинавской мили</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>пункты</displayName>
@@ -11474,15 +11474,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>солнечные радиусы</displayName>
 				<unitPattern count="one">{0} солнечный радиус</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} солнечный радиус</unitPattern>
 				<unitPattern count="one" case="dative">{0} солнечному радиусу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} солнечного радиуса</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} солнечным радиусом</unitPattern>
 				<unitPattern count="one" case="locative">{0} солнечном радиусе</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} солнечном радиусе</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} солнечный радиус</unitPattern>
 				<unitPattern count="few">{0} солнечных радиуса</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} солнечных радиуса</unitPattern>
 				<unitPattern count="few" case="dative">{0} солнечным радиусам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} солнечных радиусов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} солнечными радиусами</unitPattern>
@@ -11496,26 +11496,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} солнечными радиусами</unitPattern>
 				<unitPattern count="many" case="locative">{0} солнечных радиусах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} солнечных радиусах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} солнечных радиусов</unitPattern>
 				<unitPattern count="other">{0} солнечного радиуса</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} солнечного радиуса</unitPattern>
+				<unitPattern count="other" case="dative">{0} солнечного радиуса</unitPattern>
+				<unitPattern count="other" case="genitive">{0} солнечного радиуса</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} солнечного радиуса</unitPattern>
+				<unitPattern count="other" case="locative">{0} солнечного радиуса</unitPattern>
+				<unitPattern count="other" case="vocative">{0} солнечного радиуса</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<gender>masculine</gender>
 				<displayName>люксы</displayName>
 				<unitPattern count="one">{0} люкс</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} люкс</unitPattern>
 				<unitPattern count="one" case="dative">{0} люксу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} люкса</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} люксом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} люксе</unitPattern>
 				<unitPattern count="few">{0} люкса</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} люкса</unitPattern>
 				<unitPattern count="few" case="dative">{0} люксам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} люксов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} люксами</unitPattern>
@@ -11527,11 +11527,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} люксами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} люксах</unitPattern>
 				<unitPattern count="other">{0} люкса</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} люкса</unitPattern>
+				<unitPattern count="other" case="dative">{0} люкса</unitPattern>
+				<unitPattern count="other" case="genitive">{0} люкса</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} люкса</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} люкса</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
@@ -11543,35 +11543,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} канделой</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} канделе</unitPattern>
 				<unitPattern count="few">{0} канделы</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} канделы</unitPattern>
 				<unitPattern count="few" case="dative">{0} канделам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кандел</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} канделами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} канделах</unitPattern>
 				<unitPattern count="many">{0} кандел</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кандел</unitPattern>
 				<unitPattern count="many" case="dative">{0} канделам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кандел</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} канделами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} канделах</unitPattern>
 				<unitPattern count="other">{0} канделы</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} канделы</unitPattern>
+				<unitPattern count="other" case="dative">{0} канделы</unitPattern>
+				<unitPattern count="other" case="genitive">{0} канделы</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} канделы</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} канделы</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>masculine</gender>
 				<displayName>люмен</displayName>
 				<unitPattern count="one">{0} люмен</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} люмен</unitPattern>
 				<unitPattern count="one" case="dative">{0} люмену</unitPattern>
 				<unitPattern count="one" case="genitive">{0} люмена</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} люменом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} люмене</unitPattern>
 				<unitPattern count="few">{0} люмена</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} люмена</unitPattern>
 				<unitPattern count="few" case="dative">{0} люменам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} люмен</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} люменами</unitPattern>
@@ -11583,11 +11583,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} люменами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} люменах</unitPattern>
 				<unitPattern count="other">{0} люмена</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} люмена</unitPattern>
+				<unitPattern count="other" case="dative">{0} люмена</unitPattern>
+				<unitPattern count="other" case="genitive">{0} люмена</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} люмена</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} люмена</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<gender>feminine</gender>
@@ -11601,7 +11601,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} солнечной светимости</unitPattern>
 				<unitPattern count="one" case="vocative">{0} солнечная светимость</unitPattern>
 				<unitPattern count="few">{0} солнечные светимости</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} солнечные светимости</unitPattern>
 				<unitPattern count="few" case="dative">{0} солнечным светимостям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} солнечных светимостей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} солнечными светимостями</unitPattern>
@@ -11609,48 +11609,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} солнечных светимостях</unitPattern>
 				<unitPattern count="few" case="vocative">{0} солнечные светимости</unitPattern>
 				<unitPattern count="many">{0} солнечных светимостей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} солнечных светимостей</unitPattern>
 				<unitPattern count="many" case="dative">{0} солнечным светимостям</unitPattern>
 				<unitPattern count="many" case="genitive">{0} солнечных светимостей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} солнечными светимостями</unitPattern>
 				<unitPattern count="many" case="locative">{0} солнечных светимостях</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} солнечных светимостях</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} солнечных светимостей</unitPattern>
 				<unitPattern count="other">{0} солнечной светимости</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} солнечной светимости</unitPattern>
+				<unitPattern count="other" case="dative">{0} солнечной светимости</unitPattern>
+				<unitPattern count="other" case="genitive">{0} солнечной светимости</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} солнечной светимости</unitPattern>
+				<unitPattern count="other" case="locative">{0} солнечной светимости</unitPattern>
+				<unitPattern count="other" case="vocative">{0} солнечной светимости</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<gender>feminine</gender>
 				<displayName>тонны</displayName>
 				<unitPattern count="one">{0} тонна</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} тонна</unitPattern>
 				<unitPattern count="one" case="dative">{0} тонне</unitPattern>
 				<unitPattern count="one" case="genitive">{0} тонны</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} тонной</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} тонне</unitPattern>
 				<unitPattern count="few">{0} тонны</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} тонны</unitPattern>
 				<unitPattern count="few" case="dative">{0} тоннам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} тонн</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} тоннами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} тоннах</unitPattern>
 				<unitPattern count="many">{0} тонн</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} тонн</unitPattern>
 				<unitPattern count="many" case="dative">{0} тоннам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} тонн</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} тоннами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} тоннах</unitPattern>
 				<unitPattern count="other">{0} тонны</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} тонны</unitPattern>
+				<unitPattern count="other" case="dative">{0} тонны</unitPattern>
+				<unitPattern count="other" case="genitive">{0} тонны</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} тонны</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} тонны</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>masculine</gender>
@@ -11670,23 +11670,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} килограммами</unitPattern>
 				<unitPattern count="few" case="locative">{0} килограммах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} килограммах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} килограмма</unitPattern>
 				<unitPattern count="many">{0} килограмм</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} килограмм</unitPattern>
 				<unitPattern count="many" case="dative">{0} килограммам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} килограмм</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} килограммами</unitPattern>
 				<unitPattern count="many" case="locative">{0} килограммах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} килограммах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} килограмм</unitPattern>
 				<unitPattern count="other">{0} килограмма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килограмма</unitPattern>
+				<unitPattern count="other" case="dative">{0} килограмма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килограмма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килограмма</unitPattern>
+				<unitPattern count="other" case="locative">{0} килограмма</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} килограмма</unitPattern>
+				<unitPattern count="other" case="vocative">{0} килограмма</unitPattern>
 				<perUnitPattern>{0} на килограмм</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
@@ -11707,23 +11707,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} граммами</unitPattern>
 				<unitPattern count="few" case="locative">{0} граммах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} граммах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} грамма</unitPattern>
 				<unitPattern count="many">{0} грамм</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} грамм</unitPattern>
 				<unitPattern count="many" case="dative">{0} граммам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} грамм</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} граммами</unitPattern>
 				<unitPattern count="many" case="locative">{0} граммах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} граммах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} грамм</unitPattern>
 				<unitPattern count="other">{0} грамма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} грамма</unitPattern>
+				<unitPattern count="other" case="dative">{0} грамма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} грамма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} грамма</unitPattern>
+				<unitPattern count="other" case="locative">{0} грамма</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} грамма</unitPattern>
+				<unitPattern count="other" case="vocative">{0} грамма</unitPattern>
 				<perUnitPattern>{0} на грамм</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
@@ -11744,7 +11744,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} миллиграммами</unitPattern>
 				<unitPattern count="few" case="locative">{0} миллиграммах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} миллиграммах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} миллиграмма</unitPattern>
 				<unitPattern count="many">{0} миллиграмм</unitPattern>
 				<unitPattern count="many" case="accusative">{0} миллиграмм</unitPattern>
 				<unitPattern count="many" case="dative">{0} миллиграммам</unitPattern>
@@ -11754,25 +11754,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="prepositional">{0} миллиграммах</unitPattern>
 				<unitPattern count="many" case="vocative">{0} миллиграмм</unitPattern>
 				<unitPattern count="other">{0} миллиграмма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} миллиграмма</unitPattern>
+				<unitPattern count="other" case="dative">{0} миллиграмма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} миллиграмма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} миллиграмма</unitPattern>
+				<unitPattern count="other" case="locative">{0} миллиграмма</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} миллиграмма</unitPattern>
+				<unitPattern count="other" case="vocative">{0} миллиграмма</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>masculine</gender>
 				<displayName>микрограммы</displayName>
 				<unitPattern count="one">{0} микрограмм</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} микрограмм</unitPattern>
 				<unitPattern count="one" case="dative">{0} микрограмму</unitPattern>
 				<unitPattern count="one" case="genitive">{0} микрограмма</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} микрограммом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} микрограмме</unitPattern>
 				<unitPattern count="few">{0} микрограмма</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} микрограмма</unitPattern>
 				<unitPattern count="few" case="dative">{0} микрограммам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} микрограмм</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} микрограммами</unitPattern>
@@ -11784,11 +11784,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} микрограммами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} микрограммах</unitPattern>
 				<unitPattern count="other">{0} микрограмма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} микрограмма</unitPattern>
+				<unitPattern count="other" case="dative">{0} микрограмма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} микрограмма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} микрограмма</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} микрограмма</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>американские тонны</displayName>
@@ -11822,22 +11822,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} фунтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} фунтах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} фунтах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} фунта</unitPattern>
 				<unitPattern count="many">{0} фунтов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} фунтов</unitPattern>
 				<unitPattern count="many" case="dative">{0} фунтам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} фунтов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} фунтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} фунтах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} фунтах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} фунтов</unitPattern>
 				<unitPattern count="other">{0} фунта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} фунта</unitPattern>
+				<unitPattern count="other" case="dative">{0} фунта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} фунта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} фунта</unitPattern>
+				<unitPattern count="other" case="locative">{0} фунта</unitPattern>
+				<unitPattern count="other" case="vocative">{0} фунта</unitPattern>
 				<perUnitPattern>{0} на фунт</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
@@ -11860,20 +11860,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} унциях</unitPattern>
 				<unitPattern count="few" case="vocative">{0} унции</unitPattern>
 				<unitPattern count="many">{0} унций</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} унций</unitPattern>
 				<unitPattern count="many" case="dative">{0} унциям</unitPattern>
 				<unitPattern count="many" case="genitive">{0} унций</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} унциями</unitPattern>
 				<unitPattern count="many" case="locative">{0} унциях</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} унциях</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} унций</unitPattern>
 				<unitPattern count="other">{0} унции</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} унции</unitPattern>
+				<unitPattern count="other" case="dative">{0} унции</unitPattern>
+				<unitPattern count="other" case="genitive">{0} унции</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} унции</unitPattern>
+				<unitPattern count="other" case="locative">{0} унции</unitPattern>
+				<unitPattern count="other" case="vocative">{0} унции</unitPattern>
 				<perUnitPattern>{0} на унцию</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
@@ -11887,43 +11887,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>караты</displayName>
 				<unitPattern count="one">{0} карат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} карат</unitPattern>
 				<unitPattern count="one" case="dative">{0} карату</unitPattern>
 				<unitPattern count="one" case="genitive">{0} карата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} каратом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} карате</unitPattern>
 				<unitPattern count="few">{0} карата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} карата</unitPattern>
 				<unitPattern count="few" case="dative">{0} каратам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} карат</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} каратами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} каратах</unitPattern>
 				<unitPattern count="many">{0} карат</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} карат</unitPattern>
 				<unitPattern count="many" case="dative">{0} каратам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} карат</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} каратами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} каратах</unitPattern>
 				<unitPattern count="other">{0} карата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} карата</unitPattern>
+				<unitPattern count="other" case="dative">{0} карата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} карата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} карата</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} карата</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<gender>masculine</gender>
 				<displayName>дальтоны</displayName>
 				<unitPattern count="one">{0} дальтон</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} дальтон</unitPattern>
 				<unitPattern count="one" case="dative">{0} дальтону</unitPattern>
 				<unitPattern count="one" case="genitive">{0} дальтона</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} дальтоном</unitPattern>
 				<unitPattern count="one" case="locative">{0} дальтоне</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} дальтоне</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} дальтон</unitPattern>
 				<unitPattern count="few">{0} дальтона</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} дальтона</unitPattern>
 				<unitPattern count="few" case="dative">{0} дальтонам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} дальтонов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} дальтонами</unitPattern>
@@ -11939,12 +11939,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="prepositional">{0} дальтонах</unitPattern>
 				<unitPattern count="many" case="vocative">{0} дальтонов</unitPattern>
 				<unitPattern count="other">{0} дальтона</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} дальтона</unitPattern>
+				<unitPattern count="other" case="dative">{0} дальтона</unitPattern>
+				<unitPattern count="other" case="genitive">{0} дальтона</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} дальтона</unitPattern>
+				<unitPattern count="other" case="locative">{0} дальтона</unitPattern>
+				<unitPattern count="other" case="vocative">{0} дальтона</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<gender>feminine</gender>
@@ -11966,20 +11966,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} массах Земли</unitPattern>
 				<unitPattern count="few" case="vocative">{0} массы Земли</unitPattern>
 				<unitPattern count="many">{0} масс Земли</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} масс Земли</unitPattern>
 				<unitPattern count="many" case="dative">{0} массам Земли</unitPattern>
 				<unitPattern count="many" case="genitive">{0} масс Земли</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} массами Земли</unitPattern>
 				<unitPattern count="many" case="locative">{0} массах Земли</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} массах Земли</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} масс Земли</unitPattern>
 				<unitPattern count="other">{0} массы Земли</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} массы Земли</unitPattern>
+				<unitPattern count="other" case="dative">{0} массы Земли</unitPattern>
+				<unitPattern count="other" case="genitive">{0} массы Земли</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} массы Земли</unitPattern>
+				<unitPattern count="other" case="locative">{0} массы Земли</unitPattern>
+				<unitPattern count="other" case="vocative">{0} массы Земли</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<gender>feminine</gender>
@@ -11991,17 +11991,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} солнечной массой</unitPattern>
 				<unitPattern count="one" case="locative">{0} солнечной массе</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} солнечной массе</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} солнечная масса</unitPattern>
 				<unitPattern count="few">{0} солнечные массы</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} солнечные массы</unitPattern>
 				<unitPattern count="few" case="dative">{0} солнечным массам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} солнечных масс</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} солнечными массами</unitPattern>
 				<unitPattern count="few" case="locative">{0} солнечных массах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} солнечных массах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} солнечные массы</unitPattern>
 				<unitPattern count="many">{0} солнечных масс</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} солнечных масс</unitPattern>
 				<unitPattern count="many" case="dative">{0} солнечным массам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} солнечных масс</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} солнечными массами</unitPattern>
@@ -12009,12 +12009,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="prepositional">{0} солнечных массах</unitPattern>
 				<unitPattern count="many" case="vocative">{0} солнечных масс</unitPattern>
 				<unitPattern count="other">{0} солнечной массы</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} солнечной массы</unitPattern>
+				<unitPattern count="other" case="dative">{0} солнечной массы</unitPattern>
+				<unitPattern count="other" case="genitive">{0} солнечной массы</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} солнечной массы</unitPattern>
+				<unitPattern count="other" case="locative">{0} солнечной массы</unitPattern>
+				<unitPattern count="other" case="vocative">{0} солнечной массы</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<gender>masculine</gender>
@@ -12034,8 +12034,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} гранами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гранах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} гранах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} грана</unitPattern>
+				<unitPattern count="many">{0} гранов</unitPattern>
 				<unitPattern count="many" case="accusative">{0} гранов</unitPattern>
 				<unitPattern count="many" case="dative">{0} гранам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} гранов</unitPattern>
@@ -12055,141 +12055,141 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>гигаватты</displayName>
 				<unitPattern count="one">{0} гигаватт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гигаватт</unitPattern>
 				<unitPattern count="one" case="dative">{0} гигаватту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гигаватта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гигаваттом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} гигаватте</unitPattern>
 				<unitPattern count="few">{0} гигаватта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гигаватта</unitPattern>
 				<unitPattern count="few" case="dative">{0} гигаваттам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гигаватт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гигаваттами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} гигаваттах</unitPattern>
 				<unitPattern count="many">{0} гигаватт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гигаватт</unitPattern>
 				<unitPattern count="many" case="dative">{0} гигаваттам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гигаватт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гигаваттами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} гигаваттах</unitPattern>
 				<unitPattern count="other">{0} гигаватта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гигаватта</unitPattern>
+				<unitPattern count="other" case="dative">{0} гигаватта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гигаватта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гигаватта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} гигаватта</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>masculine</gender>
 				<displayName>мегаватты</displayName>
 				<unitPattern count="one">{0} мегаватт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегаватт</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегаватту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегаватта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегаваттом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} мегаватте</unitPattern>
 				<unitPattern count="few">{0} мегаватта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегаватта</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегаваттам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегаватт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегаваттами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} мегаваттах</unitPattern>
 				<unitPattern count="many">{0} мегаватт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегаватт</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегаваттам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегаватт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегаваттами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} мегаваттах</unitPattern>
 				<unitPattern count="other">{0} мегаватта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегаватта</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегаватта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегаватта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегаватта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} мегаватта</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>masculine</gender>
 				<displayName>киловатты</displayName>
 				<unitPattern count="one">{0} киловатт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} киловатт</unitPattern>
 				<unitPattern count="one" case="dative">{0} киловатту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} киловатта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} киловаттом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} киловатте</unitPattern>
 				<unitPattern count="few">{0} киловатта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} киловатта</unitPattern>
 				<unitPattern count="few" case="dative">{0} киловаттам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} киловатт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} киловаттами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} киловаттах</unitPattern>
 				<unitPattern count="many">{0} киловатт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} киловатт</unitPattern>
 				<unitPattern count="many" case="dative">{0} киловаттам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} киловатт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} киловаттами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} киловаттах</unitPattern>
 				<unitPattern count="other">{0} киловатта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} киловатта</unitPattern>
+				<unitPattern count="other" case="dative">{0} киловатта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} киловатта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} киловатта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} киловатта</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>masculine</gender>
 				<displayName>ватты</displayName>
 				<unitPattern count="one">{0} ватт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ватт</unitPattern>
 				<unitPattern count="one" case="dative">{0} ватту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ватта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ваттом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} ватте</unitPattern>
 				<unitPattern count="few">{0} ватта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ватта</unitPattern>
 				<unitPattern count="few" case="dative">{0} ваттам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ватт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} ваттами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} ваттах</unitPattern>
 				<unitPattern count="many">{0} ватт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ватт</unitPattern>
 				<unitPattern count="many" case="dative">{0} ваттам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ватт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} ваттами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} ваттах</unitPattern>
 				<unitPattern count="other">{0} ватта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ватта</unitPattern>
+				<unitPattern count="other" case="dative">{0} ватта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ватта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ватта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} ватта</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>masculine</gender>
 				<displayName>милливатты</displayName>
 				<unitPattern count="one">{0} милливатт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} милливатт</unitPattern>
 				<unitPattern count="one" case="dative">{0} милливатту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} милливатта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} милливаттом</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} милливатте</unitPattern>
 				<unitPattern count="few">{0} милливатта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} милливатта</unitPattern>
 				<unitPattern count="few" case="dative">{0} милливаттам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} милливатт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} милливаттами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} милливаттах</unitPattern>
 				<unitPattern count="many">{0} милливатт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} милливатт</unitPattern>
 				<unitPattern count="many" case="dative">{0} милливаттам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} милливатт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} милливаттами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} милливаттах</unitPattern>
 				<unitPattern count="other">{0} милливатта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} милливатта</unitPattern>
+				<unitPattern count="other" case="dative">{0} милливатта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} милливатта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} милливатта</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} милливатта</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>лошадиные силы</displayName>
@@ -12223,57 +12223,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>бары</displayName>
 				<unitPattern count="one">{0} бар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} бар</unitPattern>
 				<unitPattern count="one" case="dative">{0} бару</unitPattern>
 				<unitPattern count="one" case="genitive">{0} бара</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} баром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} баре</unitPattern>
 				<unitPattern count="few">{0} бара</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} бара</unitPattern>
 				<unitPattern count="few" case="dative">{0} барам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} бар</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} барами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} барах</unitPattern>
 				<unitPattern count="many">{0} бар</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} бар</unitPattern>
 				<unitPattern count="many" case="dative">{0} барам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} бар</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} барами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} барах</unitPattern>
 				<unitPattern count="other">{0} бара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} бара</unitPattern>
+				<unitPattern count="other" case="dative">{0} бара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} бара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} бара</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} бара</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>masculine</gender>
 				<displayName>миллибары</displayName>
 				<unitPattern count="one">{0} миллибар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} миллибар</unitPattern>
 				<unitPattern count="one" case="dative">{0} миллибару</unitPattern>
 				<unitPattern count="one" case="genitive">{0} миллибара</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} миллибаром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} миллибаре</unitPattern>
 				<unitPattern count="few">{0} миллибара</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} миллибара</unitPattern>
 				<unitPattern count="few" case="dative">{0} миллибарам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} миллибар</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} миллибарами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} миллибарах</unitPattern>
 				<unitPattern count="many">{0} миллибар</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} миллибар</unitPattern>
 				<unitPattern count="many" case="dative">{0} миллибарам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} миллибар</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} миллибарами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} миллибарах</unitPattern>
 				<unitPattern count="other">{0} миллибара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} миллибара</unitPattern>
+				<unitPattern count="other" case="dative">{0} миллибара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} миллибара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} миллибара</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} миллибара</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>feminine</gender>
@@ -12285,79 +12285,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} атмосферой</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} атмосфере</unitPattern>
 				<unitPattern count="few">{0} атмосферы</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} атмосферы</unitPattern>
 				<unitPattern count="few" case="dative">{0} атмосферам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} атмосфер</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} атмосферами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} атмосферах</unitPattern>
 				<unitPattern count="many">{0} атмосфер</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} атмосфер</unitPattern>
 				<unitPattern count="many" case="dative">{0} атмосферам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} атмосфер</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} атмосферами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} атмосферах</unitPattern>
 				<unitPattern count="other">{0} атмосферы</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} атмосферы</unitPattern>
+				<unitPattern count="other" case="dative">{0} атмосферы</unitPattern>
+				<unitPattern count="other" case="genitive">{0} атмосферы</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} атмосферы</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} атмосферы</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>masculine</gender>
 				<displayName>паскали</displayName>
 				<unitPattern count="one">{0} паскаль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} паскаль</unitPattern>
 				<unitPattern count="one" case="dative">{0} паскалю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} паскаля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} паскалем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} паскале</unitPattern>
 				<unitPattern count="few">{0} паскаля</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} паскаля</unitPattern>
 				<unitPattern count="few" case="dative">{0} паскалям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} паскалей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} паскалями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} паскалях</unitPattern>
 				<unitPattern count="many">{0} паскалей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} паскалей</unitPattern>
 				<unitPattern count="many" case="dative">{0} паскалям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} паскалей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} паскалями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} паскалях</unitPattern>
 				<unitPattern count="other">{0} паскаля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} паскаля</unitPattern>
+				<unitPattern count="other" case="dative">{0} паскаля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} паскаля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} паскаля</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} паскаля</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>masculine</gender>
 				<displayName>гектопаскали</displayName>
 				<unitPattern count="one">{0} гектопаскаль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гектопаскаль</unitPattern>
 				<unitPattern count="one" case="dative">{0} гектопаскалю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гектопаскаля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гектопаскалем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} гектопаскале</unitPattern>
 				<unitPattern count="few">{0} гектопаскаля</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гектопаскаля</unitPattern>
 				<unitPattern count="few" case="dative">{0} гектопаскалям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гектопаскалей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гектопаскалями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} гектопаскалях</unitPattern>
 				<unitPattern count="many">{0} гектопаскалей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гектопаскалей</unitPattern>
 				<unitPattern count="many" case="dative">{0} гектопаскалям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гектопаскалей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гектопаскалями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} гектопаскалях</unitPattern>
 				<unitPattern count="other">{0} гектопаскаля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гектопаскаля</unitPattern>
+				<unitPattern count="other" case="dative">{0} гектопаскаля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гектопаскаля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гектопаскаля</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} гектопаскаля</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>masculine</gender>
@@ -12377,51 +12377,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} килопаскалями</unitPattern>
 				<unitPattern count="few" case="locative">{0} килопаскалях</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} килопаскалях</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} килопаскаля</unitPattern>
 				<unitPattern count="many">{0} килопаскалей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} килопаскалей</unitPattern>
 				<unitPattern count="many" case="dative">{0} килопаскалям</unitPattern>
 				<unitPattern count="many" case="genitive">{0} килопаскалей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} килопаскалями</unitPattern>
 				<unitPattern count="many" case="locative">{0} килопаскалях</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} килопаскалях</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} килопаскалей</unitPattern>
 				<unitPattern count="other">{0} килопаскаля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килопаскаля</unitPattern>
+				<unitPattern count="other" case="dative">{0} килопаскаля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килопаскаля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килопаскаля</unitPattern>
+				<unitPattern count="other" case="locative">{0} килопаскаля</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} килопаскаля</unitPattern>
+				<unitPattern count="other" case="vocative">{0} килопаскаля</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>masculine</gender>
 				<displayName>мегапаскали</displayName>
 				<unitPattern count="one">{0} мегапаскаль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегапаскаль</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегапаскалю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегапаскаля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегапаскалем</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} мегапаскале</unitPattern>
 				<unitPattern count="few">{0} мегапаскаля</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегапаскаля</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегапаскалям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегапаскалей</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегапаскалями</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} мегапаскалях</unitPattern>
 				<unitPattern count="many">{0} мегапаскалей</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегапаскалей</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегапаскалям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегапаскалей</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегапаскалями</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} мегапаскалях</unitPattern>
 				<unitPattern count="other">{0} мегапаскаля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегапаскаля</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегапаскаля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегапаскаля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегапаскаля</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} мегапаскаля</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>masculine</gender>
@@ -12441,23 +12441,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} километрами в час</unitPattern>
 				<unitPattern count="few" case="locative">{0} километрах в час</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} километрах в час</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} километра в час</unitPattern>
 				<unitPattern count="many">{0} километров в час</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} километров в час</unitPattern>
 				<unitPattern count="many" case="dative">{0} километрам в час</unitPattern>
 				<unitPattern count="many" case="genitive">{0} километров в час</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} километрами в час</unitPattern>
 				<unitPattern count="many" case="locative">{0} километрах в час</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} километрах в час</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} километров в час</unitPattern>
 				<unitPattern count="other">{0} километра в час</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} километра в час</unitPattern>
+				<unitPattern count="other" case="dative">{0} километра в час</unitPattern>
+				<unitPattern count="other" case="genitive">{0} километра в час</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} километра в час</unitPattern>
+				<unitPattern count="other" case="locative">{0} километра в час</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} километра в час</unitPattern>
+				<unitPattern count="other" case="vocative">{0} километра в час</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>masculine</gender>
@@ -12477,23 +12477,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} метрами в секунду</unitPattern>
 				<unitPattern count="few" case="locative">{0} метрах в секунду</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} метрах в секунду</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} метра в секунду</unitPattern>
 				<unitPattern count="many">{0} метров в секунду</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} метров в секунду</unitPattern>
 				<unitPattern count="many" case="dative">{0} метрам в секунду</unitPattern>
 				<unitPattern count="many" case="genitive">{0} метров в секунду</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} метрами в секунду</unitPattern>
 				<unitPattern count="many" case="locative">{0} метрах в секунду</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} метрах в секунду</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} метров в секунду</unitPattern>
 				<unitPattern count="other">{0} метра в секунду</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метра в секунду</unitPattern>
+				<unitPattern count="other" case="dative">{0} метра в секунду</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метра в секунду</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метра в секунду</unitPattern>
+				<unitPattern count="other" case="locative">{0} метра в секунду</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} метра в секунду</unitPattern>
+				<unitPattern count="other" case="vocative">{0} метра в секунду</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<gender>feminine</gender>
@@ -12515,20 +12515,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} милях в час</unitPattern>
 				<unitPattern count="few" case="vocative">{0} мили в час</unitPattern>
 				<unitPattern count="many">{0} миль в час</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} миль в час</unitPattern>
 				<unitPattern count="many" case="dative">{0} милям в час</unitPattern>
 				<unitPattern count="many" case="genitive">{0} миль в час</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} милями в час</unitPattern>
 				<unitPattern count="many" case="locative">{0} милях в час</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} милях в час</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} миль в час</unitPattern>
 				<unitPattern count="other">{0} мили в час</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мили в час</unitPattern>
+				<unitPattern count="other" case="dative">{0} мили в час</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мили в час</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мили в час</unitPattern>
+				<unitPattern count="other" case="locative">{0} мили в час</unitPattern>
+				<unitPattern count="other" case="vocative">{0} мили в час</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>узел</displayName>
@@ -12570,7 +12570,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="genitive">{0} градуса</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} градуса</unitPattern>
 				<unitPattern count="other" case="locative">{0} градуса</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} градуса</unitPattern>
 				<unitPattern count="other" case="vocative">{0} градуса</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
@@ -12591,23 +12591,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} градусами Цельсия</unitPattern>
 				<unitPattern count="few" case="locative">{0} градусах Цельсия</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} градусах Цельсия</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} градуса Цельсия</unitPattern>
 				<unitPattern count="many">{0} градусов Цельсия</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} градусов Цельсия</unitPattern>
 				<unitPattern count="many" case="dative">{0} градусам Цельсия</unitPattern>
 				<unitPattern count="many" case="genitive">{0} градусов Цельсия</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} градусами Цельсия</unitPattern>
 				<unitPattern count="many" case="locative">{0} градусах Цельсия</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} градусах Цельсия</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} градусов Цельсия</unitPattern>
 				<unitPattern count="other">{0} градуса Цельсия</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} градуса Цельсия</unitPattern>
+				<unitPattern count="other" case="dative">{0} градуса Цельсия</unitPattern>
+				<unitPattern count="other" case="genitive">{0} градуса Цельсия</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} градуса Цельсия</unitPattern>
+				<unitPattern count="other" case="locative">{0} градуса Цельсия</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} градуса Цельсия</unitPattern>
+				<unitPattern count="other" case="vocative">{0} градуса Цельсия</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<gender>masculine</gender>
@@ -12627,58 +12627,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} градусами Фаренгейта</unitPattern>
 				<unitPattern count="few" case="locative">{0} градусах Фаренгейта</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} градусах Фаренгейта</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} градуса Фаренгейта</unitPattern>
 				<unitPattern count="many">{0} градусов Фаренгейта</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} градусов Фаренгейта</unitPattern>
 				<unitPattern count="many" case="dative">{0} градусам Фаренгейта</unitPattern>
 				<unitPattern count="many" case="genitive">{0} градусов Фаренгейта</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} градусами Фаренгейта</unitPattern>
 				<unitPattern count="many" case="locative">{0} градусах Фаренгейта</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} градусах Фаренгейта</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} градусов Фаренгейта</unitPattern>
 				<unitPattern count="other">{0} градуса Фаренгейта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} градуса Фаренгейта</unitPattern>
+				<unitPattern count="other" case="dative">{0} градуса Фаренгейта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} градуса Фаренгейта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} градуса Фаренгейта</unitPattern>
+				<unitPattern count="other" case="locative">{0} градуса Фаренгейта</unitPattern>
+				<unitPattern count="other" case="vocative">{0} градуса Фаренгейта</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<gender>masculine</gender>
 				<displayName>кельвины</displayName>
 				<unitPattern count="one">{0} кельвин</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кельвин</unitPattern>
 				<unitPattern count="one" case="dative">{0} кельвину</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кельвина</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кельвином</unitPattern>
 				<unitPattern count="one" case="locative">{0} кельвине</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} кельвине</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} кельвин</unitPattern>
 				<unitPattern count="few">{0} кельвина</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кельвина</unitPattern>
 				<unitPattern count="few" case="dative">{0} кельвинам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кельвинов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кельвинами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кельвинах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} кельвинах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} кельвина</unitPattern>
 				<unitPattern count="many">{0} кельвинов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кельвинов</unitPattern>
 				<unitPattern count="many" case="dative">{0} кельвинам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кельвинов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кельвинами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кельвинах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} кельвинах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} кельвинов</unitPattern>
 				<unitPattern count="other">{0} кельвина</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кельвина</unitPattern>
+				<unitPattern count="other" case="dative">{0} кельвина</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кельвина</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кельвина</unitPattern>
+				<unitPattern count="other" case="locative">{0} кельвина</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} кельвина</unitPattern>
+				<unitPattern count="other" case="vocative">{0} кельвина</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>фунт-футы</displayName>
@@ -12691,85 +12691,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ньютон-метры</displayName>
 				<unitPattern count="one">{0} ньютон-метр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ньютон-метр</unitPattern>
 				<unitPattern count="one" case="dative">{0} ньютон-метру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ньютон-метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ньютон-метром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} ньютон-метре</unitPattern>
 				<unitPattern count="few">{0} ньютон-метра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ньютон-метра</unitPattern>
 				<unitPattern count="few" case="dative">{0} ньютон-метрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ньютон-метров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} ньютон-метрами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} ньютон-метрах</unitPattern>
 				<unitPattern count="many">{0} ньютон-метров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ньютон-метров</unitPattern>
 				<unitPattern count="many" case="dative">{0} ньютон-метрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ньютон-метров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} ньютон-метрами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} ньютон-метрах</unitPattern>
 				<unitPattern count="other">{0} ньютон-метра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ньютон-метра</unitPattern>
+				<unitPattern count="other" case="dative">{0} ньютон-метра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ньютон-метра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ньютон-метра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} ньютон-метра</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>masculine</gender>
 				<displayName>кубические километры</displayName>
 				<unitPattern count="one">{0} кубический километр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кубический километр</unitPattern>
 				<unitPattern count="one" case="dative">{0} кубическому километру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кубического километра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кубическим километром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} кубическом километре</unitPattern>
 				<unitPattern count="few">{0} кубических километра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубических километра</unitPattern>
 				<unitPattern count="few" case="dative">{0} кубическим километрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кубических километров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кубическими километрами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} кубических километрах</unitPattern>
 				<unitPattern count="many">{0} кубических километров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кубических километров</unitPattern>
 				<unitPattern count="many" case="dative">{0} кубическим километрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кубических километров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кубическими километрами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} кубических километрах</unitPattern>
 				<unitPattern count="other">{0} кубического километра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубического километра</unitPattern>
+				<unitPattern count="other" case="dative">{0} кубического километра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубического километра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубического километра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} кубического километра</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>masculine</gender>
 				<displayName>кубические метры</displayName>
 				<unitPattern count="one">{0} кубический метр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кубический метр</unitPattern>
 				<unitPattern count="one" case="dative">{0} кубическому метру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кубического метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кубическим метром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} кубическом метре</unitPattern>
 				<unitPattern count="few">{0} кубических метра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубических метра</unitPattern>
 				<unitPattern count="few" case="dative">{0} кубическим метрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кубических метров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кубическими метрами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} кубических метрах</unitPattern>
 				<unitPattern count="many">{0} кубических метров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кубических метров</unitPattern>
 				<unitPattern count="many" case="dative">{0} кубическим метрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кубических метров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кубическими метрами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} кубических метрах</unitPattern>
 				<unitPattern count="other">{0} кубического метра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубического метра</unitPattern>
+				<unitPattern count="other" case="dative">{0} кубического метра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубического метра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубического метра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} кубического метра</unitPattern>
 				<perUnitPattern>{0} на кубический метр</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
@@ -12784,29 +12784,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} кубическом сантиметре</unitPattern>
 				<unitPattern count="one" case="vocative">{0} кубический сантиметр</unitPattern>
 				<unitPattern count="few">{0} кубических сантиметра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубических сантиметра</unitPattern>
 				<unitPattern count="few" case="dative">{0} кубическим сантиметрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кубических сантиметров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кубическими сантиметрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кубических сантиметрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} кубических сантиметрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} кубических сантиметра</unitPattern>
 				<unitPattern count="many">{0} кубических сантиметров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кубических сантиметров</unitPattern>
 				<unitPattern count="many" case="dative">{0} кубическим сантиметрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} кубических сантиметров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кубическими сантиметрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кубических сантиметрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} кубических сантиметрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} кубических сантиметров</unitPattern>
 				<unitPattern count="other">{0} кубического сантиметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубического сантиметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} кубического сантиметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубического сантиметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубического сантиметра</unitPattern>
+				<unitPattern count="other" case="locative">{0} кубического сантиметра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} кубического сантиметра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} кубического сантиметра</unitPattern>
 				<perUnitPattern>{0} на кубический сантиметр</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -12821,7 +12821,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} кубической миле</unitPattern>
 				<unitPattern count="one" case="vocative">{0} кубическая миля</unitPattern>
 				<unitPattern count="few">{0} кубические мили</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубические мили</unitPattern>
 				<unitPattern count="few" case="dative">{0} кубическим милям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кубических миль</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кубическими милями</unitPattern>
@@ -12829,20 +12829,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="prepositional">{0} кубических милях</unitPattern>
 				<unitPattern count="few" case="vocative">{0} кубические мили</unitPattern>
 				<unitPattern count="many">{0} кубических миль</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кубических миль</unitPattern>
 				<unitPattern count="many" case="dative">{0} кубическим милям</unitPattern>
 				<unitPattern count="many" case="genitive">{0} кубических миль</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кубическими милями</unitPattern>
 				<unitPattern count="many" case="locative">{0} кубических милях</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} кубических милях</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} кубических миль</unitPattern>
 				<unitPattern count="other">{0} кубической мили</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубической мили</unitPattern>
+				<unitPattern count="other" case="dative">{0} кубической мили</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубической мили</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубической мили</unitPattern>
+				<unitPattern count="other" case="locative">{0} кубической мили</unitPattern>
+				<unitPattern count="other" case="vocative">{0} кубической мили</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>кубические ярды</displayName>
@@ -12863,28 +12863,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} кубическом футе</unitPattern>
 				<unitPattern count="one" case="vocative">{0} кубический фут</unitPattern>
 				<unitPattern count="few">{0} кубических фута</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубических фута</unitPattern>
 				<unitPattern count="few" case="dative">{0} кубическим футам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кубических футов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кубическими футами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кубических футах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} кубических футах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} кубических фута</unitPattern>
 				<unitPattern count="many">{0} кубических футов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кубических футов</unitPattern>
 				<unitPattern count="many" case="dative">{0} кубическим футам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} кубических футов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кубическими футами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кубических футах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} кубических футах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} кубических футов</unitPattern>
 				<unitPattern count="other">{0} кубического фута</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубического фута</unitPattern>
+				<unitPattern count="other" case="dative">{0} кубического фута</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубического фута</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубического фута</unitPattern>
+				<unitPattern count="other" case="locative">{0} кубического фута</unitPattern>
+				<unitPattern count="other" case="vocative">{0} кубического фута</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>кубические дюймы</displayName>
@@ -12897,57 +12897,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>мегалитры</displayName>
 				<unitPattern count="one">{0} мегалитр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегалитр</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегалитру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегалитра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегалитром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} мегалитре</unitPattern>
 				<unitPattern count="few">{0} мегалитра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегалитра</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегалитрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегалитров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегалитрами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} мегалитрах</unitPattern>
 				<unitPattern count="many">{0} мегалитров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегалитров</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегалитрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегалитров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегалитрами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} мегалитрах</unitPattern>
 				<unitPattern count="other">{0} мегалитра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегалитра</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегалитра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегалитра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегалитра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} мегалитра</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>masculine</gender>
 				<displayName>гектолитры</displayName>
 				<unitPattern count="one">{0} гектолитр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гектолитр</unitPattern>
 				<unitPattern count="one" case="dative">{0} гектолитру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гектолитра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гектолитром</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} гектолитре</unitPattern>
 				<unitPattern count="few">{0} гектолитра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гектолитра</unitPattern>
 				<unitPattern count="few" case="dative">{0} гектолитрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гектолитров</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гектолитрами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} гектолитрах</unitPattern>
 				<unitPattern count="many">{0} гектолитров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гектолитров</unitPattern>
 				<unitPattern count="many" case="dative">{0} гектолитрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гектолитров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гектолитрами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} гектолитрах</unitPattern>
 				<unitPattern count="other">{0} гектолитра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гектолитра</unitPattern>
+				<unitPattern count="other" case="dative">{0} гектолитра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гектолитра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гектолитра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} гектолитра</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>masculine</gender>
@@ -12967,23 +12967,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} литрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} литрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} литрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} литра</unitPattern>
 				<unitPattern count="many">{0} литров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} литров</unitPattern>
 				<unitPattern count="many" case="dative">{0} литрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} литров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} литрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} литрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} литрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} литров</unitPattern>
 				<unitPattern count="other">{0} литра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} литра</unitPattern>
+				<unitPattern count="other" case="dative">{0} литра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} литра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} литра</unitPattern>
+				<unitPattern count="other" case="locative">{0} литра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} литра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} литра</unitPattern>
 				<perUnitPattern>{0} на литр</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
@@ -13004,23 +13004,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} децилитрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} децилитрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} децилитрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} децилитра</unitPattern>
 				<unitPattern count="many">{0} децилитров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} децилитров</unitPattern>
 				<unitPattern count="many" case="dative">{0} децилитрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} децилитров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} децилитрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} децилитрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} децилитрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} децилитров</unitPattern>
 				<unitPattern count="other">{0} децилитра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} децилитра</unitPattern>
+				<unitPattern count="other" case="dative">{0} децилитра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} децилитра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} децилитра</unitPattern>
+				<unitPattern count="other" case="locative">{0} децилитра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} децилитра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} децилитра</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>masculine</gender>
@@ -13040,23 +13040,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} сантилитрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} сантилитрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} сантилитрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} сантилитра</unitPattern>
 				<unitPattern count="many">{0} сантилитров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} сантилитров</unitPattern>
 				<unitPattern count="many" case="dative">{0} сантилитрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} сантилитров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} сантилитрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} сантилитрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} сантилитрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} сантилитров</unitPattern>
 				<unitPattern count="other">{0} сантилитра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} сантилитра</unitPattern>
+				<unitPattern count="other" case="dative">{0} сантилитра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} сантилитра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} сантилитра</unitPattern>
+				<unitPattern count="other" case="locative">{0} сантилитра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} сантилитра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} сантилитра</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>masculine</gender>
@@ -13076,23 +13076,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} миллилитрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} миллилитрах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} миллилитрах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} миллилитра</unitPattern>
 				<unitPattern count="many">{0} миллилитров</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} миллилитров</unitPattern>
 				<unitPattern count="many" case="dative">{0} миллилитрам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} миллилитров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} миллилитрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} миллилитрах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} миллилитрах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} миллилитров</unitPattern>
 				<unitPattern count="other">{0} миллилитра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} миллилитра</unitPattern>
+				<unitPattern count="other" case="dative">{0} миллилитра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} миллилитра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} миллилитра</unitPattern>
+				<unitPattern count="other" case="locative">{0} миллилитра</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} миллилитра</unitPattern>
+				<unitPattern count="other" case="vocative">{0} миллилитра</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>feminine</gender>
@@ -13104,23 +13104,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} метрической пинтой</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} метрической пинте</unitPattern>
 				<unitPattern count="few">{0} метрические пинты</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метрические пинты</unitPattern>
 				<unitPattern count="few" case="dative">{0} метрическим пинтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} метрических пинт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} метрическими пинтами</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} метрических пинтах</unitPattern>
 				<unitPattern count="many">{0} метрических пинт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} метрических пинт</unitPattern>
 				<unitPattern count="many" case="dative">{0} метрическим пинтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} метрических пинт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} метрическими пинтами</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} метрических пинтах</unitPattern>
 				<unitPattern count="other">{0} метрической пинты</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метрической пинты</unitPattern>
+				<unitPattern count="other" case="dative">{0} метрической пинты</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метрической пинты</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метрической пинты</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} метрической пинты</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>feminine</gender>
@@ -13132,23 +13132,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} метрической чашкой</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} метрической чашке</unitPattern>
 				<unitPattern count="few">{0} метрические чашки</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метрические чашки</unitPattern>
 				<unitPattern count="few" case="dative">{0} метрическим чашкам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} метрических чашек</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} метрическими чашками</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} метрических чашках</unitPattern>
 				<unitPattern count="many">{0} метрических чашек</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} метрических чашек</unitPattern>
 				<unitPattern count="many" case="dative">{0} метрическим чашкам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} метрических чашек</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} метрическими чашками</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} метрических чашках</unitPattern>
 				<unitPattern count="other">{0} метрической чашки</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="prepositional">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метрической чашки</unitPattern>
+				<unitPattern count="other" case="dative">{0} метрической чашки</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метрической чашки</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метрической чашки</unitPattern>
+				<unitPattern count="other" case="prepositional">{0} метрической чашки</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>акрофуты</displayName>
@@ -13204,36 +13204,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>имп. галлоны</displayName>
 				<unitPattern count="one">{0} имп. галлон</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} имп. галлон</unitPattern>
 				<unitPattern count="one" case="dative">{0} имп. галлону</unitPattern>
 				<unitPattern count="one" case="genitive">{0} имп. галлона</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} имп. галлоном</unitPattern>
 				<unitPattern count="one" case="locative">{0} имп. галлоне</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} имп. галлоне</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} имп. галлон</unitPattern>
 				<unitPattern count="few">{0} имп. галлона</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} имп. галлона</unitPattern>
 				<unitPattern count="few" case="dative">{0} имп. галлонам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} имп. галлонов</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} имп. галлонами</unitPattern>
 				<unitPattern count="few" case="locative">{0} имп. галлонах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} имп. галлонах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} имп. галлона</unitPattern>
 				<unitPattern count="many">{0} имп. галлонов</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} имп. галлонов</unitPattern>
 				<unitPattern count="many" case="dative">{0} имп. галлонам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} имп. галлонов</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} имп. галлонами</unitPattern>
 				<unitPattern count="many" case="locative">{0} имп. галлонах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} имп. галлонах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} имп. галлонов</unitPattern>
 				<unitPattern count="other">{0} имп. галлона</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} имп. галлона</unitPattern>
+				<unitPattern count="other" case="dative">{0} имп. галлона</unitPattern>
+				<unitPattern count="other" case="genitive">{0} имп. галлона</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} имп. галлона</unitPattern>
+				<unitPattern count="other" case="locative">{0} имп. галлона</unitPattern>
+				<unitPattern count="other" case="vocative">{0} имп. галлона</unitPattern>
 				<perUnitPattern>{0} на имп. галлон</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
@@ -13293,11 +13293,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} амер. пинт</unitPattern>
 				<unitPattern count="many" case="accusative">{0} амер. пинт</unitPattern>
 				<unitPattern count="many" case="dative">{0} амер. пинтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} амер. пинт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} амер. пинтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} амер. пинтах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} амер. пинтах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} амер. пинт</unitPattern>
 				<unitPattern count="other">{0} амер. пинты</unitPattern>
 				<unitPattern count="other" case="accusative">{0} амер. пинты</unitPattern>
 				<unitPattern count="other" case="dative">{0} амер. пинты</unitPattern>
@@ -13353,7 +13353,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="prepositional">{0} амер. жидкой унции</unitPattern>
 				<unitPattern count="one" case="vocative">{0} амер. жидкая унция</unitPattern>
 				<unitPattern count="few">{0} амер. жидкие унции</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} амер. жидкие унции</unitPattern>
 				<unitPattern count="few" case="dative">{0} амер. жидким унциям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} амер. жидких унций</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} амер. жидкими унциями</unitPattern>
@@ -13421,9 +13421,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} столовой ложкой</unitPattern>
 				<unitPattern count="one" case="locative">{0} столовой ложке</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} столовой ложке</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} столовая ложка</unitPattern>
 				<unitPattern count="few">{0} столовые ложки</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} столовые ложки</unitPattern>
 				<unitPattern count="few" case="dative">{0} столовым ложкам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} столовых ложек</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} столовыми ложками</unitPattern>
@@ -13439,12 +13439,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="prepositional">{0} столовых ложках</unitPattern>
 				<unitPattern count="many" case="vocative">{0} столовых ложек</unitPattern>
 				<unitPattern count="other">{0} столовой ложки</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} столовой ложки</unitPattern>
+				<unitPattern count="other" case="dative">{0} столовой ложки</unitPattern>
+				<unitPattern count="other" case="genitive">{0} столовой ложки</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} столовой ложки</unitPattern>
+				<unitPattern count="other" case="locative">{0} столовой ложки</unitPattern>
+				<unitPattern count="other" case="vocative">{0} столовой ложки</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
 				<gender>feminine</gender>
@@ -13456,30 +13456,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} чайной ложкой</unitPattern>
 				<unitPattern count="one" case="locative">{0} чайной ложке</unitPattern>
 				<unitPattern count="one" case="prepositional">{0} чайной ложке</unitPattern>
-				<unitPattern count="one" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="vocative">{0} чайная ложка</unitPattern>
 				<unitPattern count="few">{0} чайные ложки</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} чайные ложки</unitPattern>
 				<unitPattern count="few" case="dative">{0} чайным ложкам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} чайных ложек</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} чайными ложками</unitPattern>
 				<unitPattern count="few" case="locative">{0} чайных ложках</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} чайных ложках</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} чайные ложки</unitPattern>
 				<unitPattern count="many">{0} чайных ложек</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} чайных ложек</unitPattern>
 				<unitPattern count="many" case="dative">{0} чайным ложкам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} чайных ложек</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} чайными ложками</unitPattern>
 				<unitPattern count="many" case="locative">{0} чайных ложках</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} чайных ложках</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} чайных ложек</unitPattern>
 				<unitPattern count="other">{0} чайной ложки</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} чайной ложки</unitPattern>
+				<unitPattern count="other" case="dative">{0} чайной ложки</unitPattern>
+				<unitPattern count="other" case="genitive">{0} чайной ложки</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} чайной ложки</unitPattern>
+				<unitPattern count="other" case="locative">{0} чайной ложки</unitPattern>
+				<unitPattern count="other" case="vocative">{0} чайной ложки</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>баррели</displayName>
@@ -13586,12 +13586,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="prepositional">{0} каплях</unitPattern>
 				<unitPattern count="many" case="vocative">{0} капель</unitPattern>
 				<unitPattern count="other">{0} капли</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} капли</unitPattern>
+				<unitPattern count="other" case="dative">{0} капли</unitPattern>
+				<unitPattern count="other" case="genitive">{0} капли</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} капли</unitPattern>
+				<unitPattern count="other" case="locative">{0} капли</unitPattern>
+				<unitPattern count="other" case="vocative">{0} капли</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<gender>feminine</gender>
@@ -13646,18 +13646,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} джиггерами</unitPattern>
 				<unitPattern count="few" case="locative">{0} джиггерах</unitPattern>
 				<unitPattern count="few" case="prepositional">{0} джиггерах</unitPattern>
-				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few" case="vocative">{0} джиггера</unitPattern>
+				<unitPattern count="many">{0} джиггеров</unitPattern>
 				<unitPattern count="many" case="accusative">{0} джиггеров</unitPattern>
 				<unitPattern count="many" case="dative">{0} джиггерам</unitPattern>
 				<unitPattern count="many" case="genitive">{0} джиггеров</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} джиггерами</unitPattern>
 				<unitPattern count="many" case="locative">{0} джиггерах</unitPattern>
 				<unitPattern count="many" case="prepositional">{0} джиггерах</unitPattern>
-				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="vocative">{0} джиггеров</unitPattern>
 				<unitPattern count="other">{0} джиггера</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} джиггера</unitPattern>
+				<unitPattern count="other" case="dative">{0} джиггера</unitPattern>
 				<unitPattern count="other" case="genitive">{0} джиггера</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} джиггера</unitPattern>
 				<unitPattern count="other" case="locative">{0} джиггера</unitPattern>
@@ -13691,12 +13691,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="prepositional">{0} щепотках</unitPattern>
 				<unitPattern count="many" case="vocative">{0} щепоток</unitPattern>
 				<unitPattern count="other">{0} щепотки</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} щепотки</unitPattern>
+				<unitPattern count="other" case="dative">{0} щепотки</unitPattern>
+				<unitPattern count="other" case="genitive">{0} щепотки</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} щепотки</unitPattern>
+				<unitPattern count="other" case="locative">{0} щепотки</unitPattern>
+				<unitPattern count="other" case="vocative">{0} щепотки</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<gender>feminine</gender>
@@ -13831,9 +13831,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
@@ -13928,7 +13928,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>ми²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ми²</unitPattern>
 				<unitPattern count="few">{0} ми²</unitPattern>
 				<unitPattern count="many">{0} ми²</unitPattern>
 				<unitPattern count="other">{0} ми²</unitPattern>
@@ -14435,9 +14435,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -14615,9 +14615,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -14710,16 +14710,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -15251,28 +15251,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="few">{0} g</unitPattern>
+				<unitPattern count="many">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>м/с²</displayName>
@@ -15282,135 +15282,135 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} м/с²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>об.</displayName>
+				<unitPattern count="one">{0} об.</unitPattern>
+				<unitPattern count="few">{0} об.</unitPattern>
+				<unitPattern count="many">{0} об.</unitPattern>
+				<unitPattern count="other">{0} об.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>рад</displayName>
+				<unitPattern count="one">{0} рад</unitPattern>
+				<unitPattern count="few">{0} рад</unitPattern>
+				<unitPattern count="many">{0} рад</unitPattern>
+				<unitPattern count="other">{0} рад</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
 				<unitPattern count="many">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>′</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="many">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>″</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="many">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>км²</displayName>
 				<unitPattern count="one">{0} км²</unitPattern>
 				<unitPattern count="few">{0} км²</unitPattern>
 				<unitPattern count="many">{0} км²</unitPattern>
 				<unitPattern count="other">{0} км²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/км²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>га</displayName>
 				<unitPattern count="one">{0} га</unitPattern>
 				<unitPattern count="few">{0} га</unitPattern>
 				<unitPattern count="many">{0} га</unitPattern>
 				<unitPattern count="other">{0} га</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>м²</displayName>
 				<unitPattern count="one">{0} м²</unitPattern>
 				<unitPattern count="few">{0} м²</unitPattern>
 				<unitPattern count="many">{0} м²</unitPattern>
 				<unitPattern count="other">{0} м²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/м²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>см²</displayName>
+				<unitPattern count="one">{0} см²</unitPattern>
+				<unitPattern count="few">{0} см²</unitPattern>
+				<unitPattern count="many">{0} см²</unitPattern>
+				<unitPattern count="other">{0} см²</unitPattern>
+				<perUnitPattern>{0}/см²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>ми²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ми²</unitPattern>
+				<unitPattern count="few">{0} ми²</unitPattern>
+				<unitPattern count="many">{0} ми²</unitPattern>
+				<unitPattern count="other">{0} ми²</unitPattern>
 				<perUnitPattern>{0}/ми²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>акр.</displayName>
+				<unitPattern count="one">{0} акр</unitPattern>
+				<unitPattern count="few">{0} акр.</unitPattern>
+				<unitPattern count="many">{0} акр.</unitPattern>
+				<unitPattern count="other">{0} акр.</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ярд²</displayName>
+				<unitPattern count="one">{0} ярд²</unitPattern>
+				<unitPattern count="few">{0} ярд²</unitPattern>
+				<unitPattern count="many">{0} ярд²</unitPattern>
+				<unitPattern count="other">{0} ярд²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фт²</displayName>
+				<unitPattern count="one">{0} фт²</unitPattern>
+				<unitPattern count="few">{0} фт²</unitPattern>
+				<unitPattern count="many">{0} фт²</unitPattern>
+				<unitPattern count="other">{0} фт²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>дюйм²</displayName>
+				<unitPattern count="one">{0} дюйм²</unitPattern>
+				<unitPattern count="few">{0} дюйм²</unitPattern>
+				<unitPattern count="many">{0} дюйм²</unitPattern>
+				<unitPattern count="other">{0} дюйм²</unitPattern>
+				<perUnitPattern>{0}/дюйм²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дун.</displayName>
+				<unitPattern count="one">{0} дун.</unitPattern>
+				<unitPattern count="few">{0} дун.</unitPattern>
+				<unitPattern count="many">{0} дун.</unitPattern>
+				<unitPattern count="other">{0} дун.</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кар</displayName>
+				<unitPattern count="one">{0} кар</unitPattern>
+				<unitPattern count="few">{0} кар</unitPattern>
+				<unitPattern count="many">{0} кар</unitPattern>
+				<unitPattern count="other">{0} кар</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мг/дл</displayName>
+				<unitPattern count="one">{0} мг/дл</unitPattern>
+				<unitPattern count="few">{0} мг/дл</unitPattern>
+				<unitPattern count="many">{0} мг/дл</unitPattern>
+				<unitPattern count="other">{0} мг/дл</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ммоль/л</displayName>
+				<unitPattern count="one">{0} ммоль/л</unitPattern>
+				<unitPattern count="few">{0} ммоль/л</unitPattern>
+				<unitPattern count="many">{0} ммоль/л</unitPattern>
+				<unitPattern count="other">{0} ммоль/л</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>объекты</displayName>
@@ -15420,11 +15420,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} объекта</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="many">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -15434,32 +15434,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="few">{0} ‰</unitPattern>
+				<unitPattern count="many">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="few">{0} ‱</unitPattern>
+				<unitPattern count="many">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>моль</displayName>
+				<unitPattern count="one">{0} моль</unitPattern>
+				<unitPattern count="few">{0} моль</unitPattern>
+				<unitPattern count="many">{0} моль</unitPattern>
+				<unitPattern count="other">{0} моль</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>л/км</displayName>
+				<unitPattern count="one">{0} л/км</unitPattern>
+				<unitPattern count="few">{0} л/км</unitPattern>
+				<unitPattern count="many">{0} л/км</unitPattern>
+				<unitPattern count="other">{0} л/км</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>л/100 км</displayName>
@@ -15483,81 +15483,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ми/имп. гал</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ПБ</displayName>
+				<unitPattern count="one">{0} ПБ</unitPattern>
+				<unitPattern count="few">{0} ПБ</unitPattern>
+				<unitPattern count="many">{0} ПБ</unitPattern>
+				<unitPattern count="other">{0} ПБ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ТБ</displayName>
+				<unitPattern count="one">{0} ТБ</unitPattern>
+				<unitPattern count="few">{0} ТБ</unitPattern>
+				<unitPattern count="many">{0} ТБ</unitPattern>
+				<unitPattern count="other">{0} ТБ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Тбит</displayName>
+				<unitPattern count="one">{0} Тбит</unitPattern>
+				<unitPattern count="few">{0} Тбит</unitPattern>
+				<unitPattern count="many">{0} Тбит</unitPattern>
+				<unitPattern count="other">{0} Тбит</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ГБ</displayName>
+				<unitPattern count="one">{0} ГБ</unitPattern>
+				<unitPattern count="few">{0} ГБ</unitPattern>
+				<unitPattern count="many">{0} ГБ</unitPattern>
+				<unitPattern count="other">{0} ГБ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гбит</displayName>
+				<unitPattern count="one">{0} Гбит</unitPattern>
+				<unitPattern count="few">{0} Гбит</unitPattern>
+				<unitPattern count="many">{0} Гбит</unitPattern>
+				<unitPattern count="other">{0} Гбит</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МБ</displayName>
+				<unitPattern count="one">{0} МБ</unitPattern>
+				<unitPattern count="few">{0} МБ</unitPattern>
+				<unitPattern count="many">{0} МБ</unitPattern>
+				<unitPattern count="other">{0} МБ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мбит</displayName>
+				<unitPattern count="one">{0} Мбит</unitPattern>
+				<unitPattern count="few">{0} Мбит</unitPattern>
+				<unitPattern count="many">{0} Мбит</unitPattern>
+				<unitPattern count="other">{0} Мбит</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кБ</displayName>
+				<unitPattern count="one">{0} кБ</unitPattern>
+				<unitPattern count="few">{0} кБ</unitPattern>
+				<unitPattern count="many">{0} кБ</unitPattern>
+				<unitPattern count="other">{0} кБ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кбит</displayName>
+				<unitPattern count="one">{0} кбит</unitPattern>
+				<unitPattern count="few">{0} кбит</unitPattern>
+				<unitPattern count="many">{0} кбит</unitPattern>
+				<unitPattern count="other">{0} кбит</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Б</displayName>
+				<unitPattern count="one">{0} Б</unitPattern>
+				<unitPattern count="few">{0} Б</unitPattern>
+				<unitPattern count="many">{0} Б</unitPattern>
+				<unitPattern count="other">{0} Б</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бит</displayName>
+				<unitPattern count="one">{0} бит</unitPattern>
+				<unitPattern count="few">{0} бита</unitPattern>
+				<unitPattern count="many">{0} бит</unitPattern>
+				<unitPattern count="other">{0} бита</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>в.</displayName>
@@ -15567,11 +15567,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} в.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>10-летие</displayName>
+				<unitPattern count="one">{0} 10-летие</unitPattern>
+				<unitPattern count="few">{0} 10-летия</unitPattern>
+				<unitPattern count="many">{0} 10-летий</unitPattern>
+				<unitPattern count="other">{0} 10-летия</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>г.</displayName>
@@ -15619,7 +15619,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} ч</unitPattern>
 				<unitPattern count="many">{0} ч</unitPattern>
 				<unitPattern count="other">{0} ч</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ч</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>мин</displayName>
@@ -15627,7 +15627,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} мин</unitPattern>
 				<unitPattern count="many">{0} мин</unitPattern>
 				<unitPattern count="other">{0} мин</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/мин</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>c</displayName>
@@ -15659,109 +15659,109 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} нс</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>А</displayName>
+				<unitPattern count="one">{0} А</unitPattern>
+				<unitPattern count="few">{0} А</unitPattern>
+				<unitPattern count="many">{0} А</unitPattern>
+				<unitPattern count="other">{0} А</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мА</displayName>
+				<unitPattern count="one">{0} мА</unitPattern>
+				<unitPattern count="few">{0} мА</unitPattern>
+				<unitPattern count="many">{0} мА</unitPattern>
+				<unitPattern count="other">{0} мА</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ом</displayName>
+				<unitPattern count="one">{0} Ом</unitPattern>
+				<unitPattern count="few">{0} Ом</unitPattern>
+				<unitPattern count="many">{0} Ом</unitPattern>
+				<unitPattern count="other">{0} Ом</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>В</displayName>
+				<unitPattern count="one">{0} В</unitPattern>
+				<unitPattern count="few">{0} В</unitPattern>
+				<unitPattern count="many">{0} В</unitPattern>
+				<unitPattern count="other">{0} В</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ккал</displayName>
+				<unitPattern count="one">{0} ккал</unitPattern>
+				<unitPattern count="few">{0} ккал</unitPattern>
+				<unitPattern count="many">{0} ккал</unitPattern>
+				<unitPattern count="other">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кал</displayName>
+				<unitPattern count="one">{0} кал</unitPattern>
+				<unitPattern count="few">{0} кал</unitPattern>
+				<unitPattern count="many">{0} кал</unitPattern>
+				<unitPattern count="other">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ккал</displayName>
+				<unitPattern count="one">{0} ккал</unitPattern>
+				<unitPattern count="few">{0} ккал</unitPattern>
+				<unitPattern count="many">{0} ккал</unitPattern>
+				<unitPattern count="other">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кДж</displayName>
+				<unitPattern count="one">{0} кДж</unitPattern>
+				<unitPattern count="few">{0} кДж</unitPattern>
+				<unitPattern count="many">{0} кДж</unitPattern>
+				<unitPattern count="other">{0} кДж</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Дж</displayName>
+				<unitPattern count="one">{0} Дж</unitPattern>
+				<unitPattern count="few">{0} Дж</unitPattern>
+				<unitPattern count="many">{0} Дж</unitPattern>
+				<unitPattern count="other">{0} Дж</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кВт⋅ч</displayName>
+				<unitPattern count="one">{0} кВт⋅ч</unitPattern>
+				<unitPattern count="few">{0} кВт⋅ч</unitPattern>
+				<unitPattern count="many">{0} кВт⋅ч</unitPattern>
+				<unitPattern count="other">{0} кВт⋅ч</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>эВ</displayName>
+				<unitPattern count="one">{0} эВ</unitPattern>
+				<unitPattern count="few">{0} эВ</unitPattern>
+				<unitPattern count="many">{0} эВ</unitPattern>
+				<unitPattern count="other">{0} эВ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>БТЕ</displayName>
+				<unitPattern count="one">{0} БТЕ</unitPattern>
+				<unitPattern count="few">{0} БТЕ</unitPattern>
+				<unitPattern count="many">{0} БТЕ</unitPattern>
+				<unitPattern count="other">{0} БТЕ</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>терм США</displayName>
+				<unitPattern count="one">{0} терм США</unitPattern>
+				<unitPattern count="few">{0} терма США</unitPattern>
+				<unitPattern count="many">{0} термов США</unitPattern>
+				<unitPattern count="other">{0} терма США</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фнт-с</displayName>
+				<unitPattern count="one">{0} фнт-с</unitPattern>
+				<unitPattern count="few">{0} фнт-с</unitPattern>
+				<unitPattern count="many">{0} фнт-с</unitPattern>
+				<unitPattern count="other">{0} фнт-с</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Н</displayName>
+				<unitPattern count="one">{0} Н</unitPattern>
+				<unitPattern count="few">{0} Н</unitPattern>
+				<unitPattern count="many">{0} Н</unitPattern>
+				<unitPattern count="other">{0} Н</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>кВт⋅ч/100 км</displayName>
@@ -15771,95 +15771,95 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} кВт⋅ч/100 км</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ГГц</displayName>
+				<unitPattern count="one">{0} ГГц</unitPattern>
+				<unitPattern count="few">{0} ГГц</unitPattern>
+				<unitPattern count="many">{0} ГГц</unitPattern>
+				<unitPattern count="other">{0} ГГц</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МГц</displayName>
+				<unitPattern count="one">{0} МГц</unitPattern>
+				<unitPattern count="few">{0} МГц</unitPattern>
+				<unitPattern count="many">{0} МГц</unitPattern>
+				<unitPattern count="other">{0} МГц</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кГц</displayName>
+				<unitPattern count="one">{0} кГц</unitPattern>
+				<unitPattern count="few">{0} кГц</unitPattern>
+				<unitPattern count="many">{0} кГц</unitPattern>
+				<unitPattern count="other">{0} кГц</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Гц</displayName>
+				<unitPattern count="one">{0} Гц</unitPattern>
+				<unitPattern count="few">{0} Гц</unitPattern>
+				<unitPattern count="many">{0} Гц</unitPattern>
+				<unitPattern count="other">{0} Гц</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>эм</displayName>
+				<unitPattern count="one">{0} эм</unitPattern>
+				<unitPattern count="few">{0} эм</unitPattern>
+				<unitPattern count="many">{0} эм</unitPattern>
+				<unitPattern count="other">{0} эм</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пкс</displayName>
+				<unitPattern count="one">{0} пкс</unitPattern>
+				<unitPattern count="few">{0} пкс</unitPattern>
+				<unitPattern count="many">{0} пкс</unitPattern>
+				<unitPattern count="other">{0} пкс</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мпкс</displayName>
+				<unitPattern count="one">{0} Мпкс</unitPattern>
+				<unitPattern count="few">{0} Мпкс</unitPattern>
+				<unitPattern count="many">{0} Мпкс</unitPattern>
+				<unitPattern count="other">{0} Мпкс</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пкс/см</displayName>
+				<unitPattern count="one">{0} пкс/см</unitPattern>
+				<unitPattern count="few">{0} пкс/см</unitPattern>
+				<unitPattern count="many">{0} пкс/см</unitPattern>
+				<unitPattern count="other">{0} пкс/см</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>пкс/дюйм</displayName>
+				<unitPattern count="one">{0} пкс/дюйм</unitPattern>
+				<unitPattern count="few">{0} пкс/дюйм</unitPattern>
+				<unitPattern count="many">{0} пкс/дюйм</unitPattern>
+				<unitPattern count="other">{0} пкс/дюйм</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>тчк/см</displayName>
+				<unitPattern count="one">{0} тчк/см</unitPattern>
+				<unitPattern count="few">{0} тчк/см</unitPattern>
+				<unitPattern count="many">{0} тчк/см</unitPattern>
+				<unitPattern count="other">{0} тчк/см</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>тчк/дюйм</displayName>
+				<unitPattern count="one">{0} тчк/дюйм</unitPattern>
+				<unitPattern count="few">{0} тчк/дюйм</unitPattern>
+				<unitPattern count="many">{0} тчк/дюйм</unitPattern>
+				<unitPattern count="other">{0} тчк/дюйм</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>тчк</displayName>
+				<unitPattern count="one">{0} тчк</unitPattern>
+				<unitPattern count="few">{0} тчк</unitPattern>
+				<unitPattern count="many">{0} тчк</unitPattern>
+				<unitPattern count="other">{0} тчк</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>км</displayName>
@@ -15915,24 +15915,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-picometer">
 				<displayName>пм</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} пм</unitPattern>
+				<unitPattern count="few">{0} пм</unitPattern>
+				<unitPattern count="many">{0} пм</unitPattern>
+				<unitPattern count="other">{0} пм</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ми</displayName>
+				<unitPattern count="one">{0} ми</unitPattern>
+				<unitPattern count="few">{0} ми</unitPattern>
+				<unitPattern count="many">{0} ми</unitPattern>
+				<unitPattern count="other">{0} ми</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>ярд.</displayName>
 				<unitPattern count="one">{0} ярд</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} ярд.</unitPattern>
+				<unitPattern count="many">{0} ярд.</unitPattern>
+				<unitPattern count="other">{0} ярд.</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>фт</displayName>
@@ -15945,10 +15945,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-inch">
 				<displayName>дюйм.</displayName>
 				<unitPattern count="one">{0} дюйм.</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="few">{0} дюйм.</unitPattern>
+				<unitPattern count="many">{0} дюйм.</unitPattern>
+				<unitPattern count="other">{0} дюйм.</unitPattern>
+				<perUnitPattern>{0}/дюйм</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>пк</displayName>
@@ -15958,7 +15958,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} пк</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>св. г.</displayName>
 				<unitPattern count="one">{0} св. г.</unitPattern>
 				<unitPattern count="few">{0} св. г.</unitPattern>
 				<unitPattern count="many">{0} св. л.</unitPattern>
@@ -16007,39 +16007,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} пкт</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>лк</displayName>
+				<unitPattern count="one">{0} лк</unitPattern>
+				<unitPattern count="few">{0} лк</unitPattern>
+				<unitPattern count="many">{0} лк</unitPattern>
+				<unitPattern count="other">{0} лк</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кд</displayName>
+				<unitPattern count="one">{0} кд</unitPattern>
+				<unitPattern count="few">{0} кд</unitPattern>
+				<unitPattern count="many">{0} кд</unitPattern>
+				<unitPattern count="other">{0} кд</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>лм</displayName>
+				<unitPattern count="one">{0} лм</unitPattern>
+				<unitPattern count="few">{0} лм</unitPattern>
+				<unitPattern count="many">{0} лм</unitPattern>
+				<unitPattern count="other">{0} лм</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>т</displayName>
@@ -16094,19 +16094,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-pound">
 				<displayName>фнт</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} фнт</unitPattern>
+				<unitPattern count="few">{0} фнт</unitPattern>
+				<unitPattern count="many">{0} фнт</unitPattern>
+				<unitPattern count="other">{0} фнт</unitPattern>
 				<perUnitPattern>{0}/фнт</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>унц.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} унц.</unitPattern>
+				<unitPattern count="few">{0} унц.</unitPattern>
+				<unitPattern count="many">{0} унц.</unitPattern>
+				<unitPattern count="other">{0} унц.</unitPattern>
+				<perUnitPattern>{0}/унц</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>тр. унц.</displayName>
@@ -16123,74 +16123,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} кар</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Да</displayName>
+				<unitPattern count="one">{0} Да</unitPattern>
+				<unitPattern count="few">{0} Да</unitPattern>
+				<unitPattern count="many">{0} Да</unitPattern>
+				<unitPattern count="other">{0} Да</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>гран</displayName>
+				<unitPattern count="one">{0} гран</unitPattern>
+				<unitPattern count="few">{0} грана</unitPattern>
+				<unitPattern count="many">{0} гранов</unitPattern>
+				<unitPattern count="other">{0} грана</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ГВт</displayName>
+				<unitPattern count="one">{0} ГВт</unitPattern>
+				<unitPattern count="few">{0} ГВт</unitPattern>
+				<unitPattern count="many">{0} ГВт</unitPattern>
+				<unitPattern count="other">{0} ГВт</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МВт</displayName>
+				<unitPattern count="one">{0} МВт</unitPattern>
+				<unitPattern count="few">{0} МВт</unitPattern>
+				<unitPattern count="many">{0} МВт</unitPattern>
+				<unitPattern count="other">{0} МВт</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>кВт</displayName>
 				<unitPattern count="one">{0} кВт</unitPattern>
 				<unitPattern count="few">{0} кВт</unitPattern>
 				<unitPattern count="many">{0} кВт</unitPattern>
 				<unitPattern count="other">{0} кВт</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>Вт</displayName>
 				<unitPattern count="one">{0} Вт</unitPattern>
 				<unitPattern count="few">{0} Вт</unitPattern>
 				<unitPattern count="many">{0} Вт</unitPattern>
 				<unitPattern count="other">{0} Вт</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мВт</displayName>
+				<unitPattern count="one">{0} мВт</unitPattern>
+				<unitPattern count="few">{0} мВт</unitPattern>
+				<unitPattern count="many">{0} мВт</unitPattern>
+				<unitPattern count="other">{0} мВт</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>л. с.</displayName>
+				<unitPattern count="one">{0} л. с.</unitPattern>
+				<unitPattern count="few">{0} л. с.</unitPattern>
+				<unitPattern count="many">{0} л. с.</unitPattern>
+				<unitPattern count="other">{0} л. с.</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>мм рт. ст.</displayName>
@@ -16201,24 +16201,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>ф. на дюйм²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ф/дюйм²</unitPattern>
+				<unitPattern count="few">{0} ф/дюйм²</unitPattern>
+				<unitPattern count="many">{0} ф/дюйм²</unitPattern>
+				<unitPattern count="other">{0} ф/дюйм²</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>д. рт. ст.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} д. рт. ст.</unitPattern>
+				<unitPattern count="few">{0} д. рт. ст.</unitPattern>
+				<unitPattern count="many">{0} д. рт. ст.</unitPattern>
+				<unitPattern count="other">{0} д. рт. ст.</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бар</displayName>
+				<unitPattern count="one">{0} бар</unitPattern>
+				<unitPattern count="few">{0} бар</unitPattern>
+				<unitPattern count="many">{0} бар</unitPattern>
+				<unitPattern count="other">{0} бар</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>мбар</displayName>
@@ -16228,39 +16228,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мбар</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>атм</displayName>
+				<unitPattern count="one">{0} атм</unitPattern>
+				<unitPattern count="few">{0} атм</unitPattern>
+				<unitPattern count="many">{0} атм</unitPattern>
+				<unitPattern count="other">{0} атм</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Па</displayName>
+				<unitPattern count="one">{0} Па</unitPattern>
+				<unitPattern count="few">{0} Па</unitPattern>
+				<unitPattern count="many">{0} Па</unitPattern>
+				<unitPattern count="other">{0} Па</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>гПа</displayName>
 				<unitPattern count="one">{0} гПа</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} гПа</unitPattern>
 				<unitPattern count="many">{0} гПа</unitPattern>
 				<unitPattern count="other">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кПа</displayName>
+				<unitPattern count="one">{0} кПа</unitPattern>
+				<unitPattern count="few">{0} кПа</unitPattern>
+				<unitPattern count="many">{0} кПа</unitPattern>
+				<unitPattern count="other">{0} кПа</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>МПа</displayName>
+				<unitPattern count="one">{0} МПа</unitPattern>
+				<unitPattern count="few">{0} МПа</unitPattern>
+				<unitPattern count="many">{0} МПа</unitPattern>
+				<unitPattern count="other">{0} МПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/ч</displayName>
@@ -16272,16 +16272,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="speed-meter-per-second">
 				<displayName>м/с</displayName>
 				<unitPattern count="one">{0} м/с</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} м/с</unitPattern>
 				<unitPattern count="many">{0} м/с</unitPattern>
 				<unitPattern count="other">{0} м/с</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ми/ч</displayName>
+				<unitPattern count="one">{0} ми/ч</unitPattern>
+				<unitPattern count="few">{0} ми/ч</unitPattern>
+				<unitPattern count="many">{0} ми/ч</unitPattern>
+				<unitPattern count="other">{0} ми/ч</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>уз</displayName>
@@ -16307,7 +16307,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="temperature-fahrenheit">
 				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} °F</unitPattern>
 				<unitPattern count="many">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
@@ -16319,41 +16319,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фнт-фт</displayName>
+				<unitPattern count="one">{0} фнт-фт</unitPattern>
+				<unitPattern count="few">{0} фнт-фт</unitPattern>
+				<unitPattern count="many">{0} фнт-фт</unitPattern>
+				<unitPattern count="other">{0} фнт-фт</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Н⋅м</displayName>
+				<unitPattern count="one">{0} Н⋅м</unitPattern>
+				<unitPattern count="few">{0} Н⋅м</unitPattern>
+				<unitPattern count="many">{0} Н⋅м</unitPattern>
+				<unitPattern count="other">{0} Н⋅м</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>км³</displayName>
 				<unitPattern count="one">{0} км³</unitPattern>
 				<unitPattern count="few">{0} км³</unitPattern>
 				<unitPattern count="many">{0} км³</unitPattern>
 				<unitPattern count="other">{0} км³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>м³</displayName>
+				<unitPattern count="one">{0} м³</unitPattern>
+				<unitPattern count="few">{0} м³</unitPattern>
+				<unitPattern count="many">{0} м³</unitPattern>
+				<unitPattern count="other">{0} м³</unitPattern>
+				<perUnitPattern>{0}/м³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>см³</displayName>
+				<unitPattern count="one">{0} см³</unitPattern>
+				<unitPattern count="few">{0} см³</unitPattern>
+				<unitPattern count="many">{0} см³</unitPattern>
+				<unitPattern count="other">{0} см³</unitPattern>
+				<perUnitPattern>{0}/см³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>ми³</displayName>
@@ -16363,39 +16363,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ми³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ярд³</displayName>
+				<unitPattern count="one">{0} ярд³</unitPattern>
+				<unitPattern count="few">{0} ярд³</unitPattern>
+				<unitPattern count="many">{0} ярд³</unitPattern>
+				<unitPattern count="other">{0} ярд³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фт³</displayName>
+				<unitPattern count="one">{0} фт³</unitPattern>
+				<unitPattern count="few">{0} фт³</unitPattern>
+				<unitPattern count="many">{0} фт³</unitPattern>
+				<unitPattern count="other">{0} фт³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дюйм³</displayName>
+				<unitPattern count="one">{0} дюйм³</unitPattern>
+				<unitPattern count="few">{0} дюйм³</unitPattern>
+				<unitPattern count="many">{0} дюйм³</unitPattern>
+				<unitPattern count="other">{0} дюйм³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Мл</displayName>
+				<unitPattern count="one">{0} Мл</unitPattern>
+				<unitPattern count="few">{0} Мл</unitPattern>
+				<unitPattern count="many">{0} Мл</unitPattern>
+				<unitPattern count="other">{0} Мл</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>гл</displayName>
+				<unitPattern count="one">{0} гл</unitPattern>
+				<unitPattern count="few">{0} гл</unitPattern>
+				<unitPattern count="many">{0} гл</unitPattern>
+				<unitPattern count="other">{0} гл</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>л</displayName>
@@ -16403,177 +16403,177 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} л</unitPattern>
 				<unitPattern count="many">{0} л</unitPattern>
 				<unitPattern count="other">{0} л</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/л</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дл</displayName>
+				<unitPattern count="one">{0} дл</unitPattern>
+				<unitPattern count="few">{0} дл</unitPattern>
+				<unitPattern count="many">{0} дл</unitPattern>
+				<unitPattern count="other">{0} дл</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>сл</displayName>
+				<unitPattern count="one">{0} сл</unitPattern>
+				<unitPattern count="few">{0} сл</unitPattern>
+				<unitPattern count="many">{0} сл</unitPattern>
+				<unitPattern count="other">{0} сл</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мл</displayName>
+				<unitPattern count="one">{0} мл</unitPattern>
+				<unitPattern count="few">{0} мл</unitPattern>
+				<unitPattern count="many">{0} мл</unitPattern>
+				<unitPattern count="other">{0} мл</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>мпт</displayName>
+				<unitPattern count="one">{0} мпт</unitPattern>
+				<unitPattern count="few">{0} мпт</unitPattern>
+				<unitPattern count="many">{0} мпт</unitPattern>
+				<unitPattern count="other">{0} мпт</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>м. чаш.</displayName>
+				<unitPattern count="one">{0} м. чаш.</unitPattern>
+				<unitPattern count="few">{0} м. чаш.</unitPattern>
+				<unitPattern count="many">{0} м. чаш.</unitPattern>
+				<unitPattern count="other">{0} м. чаш.</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>акрофут.</displayName>
+				<unitPattern count="one">{0} акрофут</unitPattern>
+				<unitPattern count="few">{0} акрофут.</unitPattern>
+				<unitPattern count="many">{0} акрофут.</unitPattern>
+				<unitPattern count="other">{0} акрофут.</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>буш.</displayName>
+				<unitPattern count="one">{0} буш.</unitPattern>
+				<unitPattern count="few">{0} буш.</unitPattern>
+				<unitPattern count="many">{0} буш.</unitPattern>
+				<unitPattern count="other">{0} буш.</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ам. гал.</displayName>
+				<unitPattern count="one">{0} ам. гал.</unitPattern>
+				<unitPattern count="few">{0} ам. гал.</unitPattern>
+				<unitPattern count="many">{0} ам. гал.</unitPattern>
+				<unitPattern count="other">{0} ам. гал.</unitPattern>
+				<perUnitPattern>{0}/ам. гал</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>имп. гал.</displayName>
+				<unitPattern count="one">{0} имп. гал.</unitPattern>
+				<unitPattern count="few">{0} имп. гал.</unitPattern>
+				<unitPattern count="many">{0} имп. гал.</unitPattern>
+				<unitPattern count="other">{0} имп. гал.</unitPattern>
+				<perUnitPattern>{0}/имп. гал</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ам. кварт.</displayName>
+				<unitPattern count="one">{0} ам. кварт.</unitPattern>
+				<unitPattern count="few">{0} ам. кварт.</unitPattern>
+				<unitPattern count="many">{0} ам. кварт.</unitPattern>
+				<unitPattern count="other">{0} ам. кварт.</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ам. пинт.</displayName>
+				<unitPattern count="one">{0} ам. пинт.</unitPattern>
+				<unitPattern count="few">{0} ам. пинт.</unitPattern>
+				<unitPattern count="many">{0} ам. пинт.</unitPattern>
+				<unitPattern count="other">{0} ам. пинт.</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ам. чаш.</displayName>
+				<unitPattern count="one">{0} ам. чаш.</unitPattern>
+				<unitPattern count="few">{0} ам. чаш.</unitPattern>
+				<unitPattern count="many">{0} ам. чаш.</unitPattern>
+				<unitPattern count="other">{0} ам. чаш.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ам. жидк. унц.</displayName>
+				<unitPattern count="one">{0} ам. жидк. унц.</unitPattern>
+				<unitPattern count="few">{0} ам. жидк. унц.</unitPattern>
+				<unitPattern count="many">{0} ам. жидк. унц.</unitPattern>
+				<unitPattern count="other">{0} ам. жидк. унц.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>имп. жидк. унц.</displayName>
+				<unitPattern count="one">{0} имп. жидк. унц.</unitPattern>
+				<unitPattern count="few">{0} имп. жидк. унц.</unitPattern>
+				<unitPattern count="many">{0} имп. жидк. унц.</unitPattern>
+				<unitPattern count="other">{0} имп. жидк. унц.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ст. л.</displayName>
+				<unitPattern count="one">{0} ст. л.</unitPattern>
+				<unitPattern count="few">{0} ст. л.</unitPattern>
+				<unitPattern count="many">{0} ст. л.</unitPattern>
+				<unitPattern count="other">{0} ст. л.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ч. л.</displayName>
+				<unitPattern count="one">{0} ч. л.</unitPattern>
+				<unitPattern count="few">{0} ч. л.</unitPattern>
+				<unitPattern count="many">{0} ч. л.</unitPattern>
+				<unitPattern count="other">{0} ч. л.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>барр.</displayName>
+				<unitPattern count="one">{0} барр.</unitPattern>
+				<unitPattern count="few">{0} барр.</unitPattern>
+				<unitPattern count="many">{0} барр.</unitPattern>
+				<unitPattern count="other">{0} барр.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дес. л.</displayName>
+				<unitPattern count="one">{0} дес. л.</unitPattern>
+				<unitPattern count="few">{0} дес. л.</unitPattern>
+				<unitPattern count="many">{0} дес. л.</unitPattern>
+				<unitPattern count="other">{0} дес. л.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>имп. дес. л.</displayName>
+				<unitPattern count="one">{0} имп. дес. л.</unitPattern>
+				<unitPattern count="few">{0} имп. дес. л.</unitPattern>
+				<unitPattern count="many">{0} имп. дес. л.</unitPattern>
+				<unitPattern count="other">{0} имп. дес. л.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кап.</displayName>
+				<unitPattern count="one">{0} кап.</unitPattern>
+				<unitPattern count="few">{0} кап.</unitPattern>
+				<unitPattern count="many">{0} кап.</unitPattern>
+				<unitPattern count="other">{0} кап.</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>жидк. др.</displayName>
+				<unitPattern count="one">{0} жидк. др.</unitPattern>
+				<unitPattern count="few">{0} жидк. др.</unitPattern>
+				<unitPattern count="many">{0} жидк. др.</unitPattern>
+				<unitPattern count="other">{0} жидк. др.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>джиггер</displayName>
+				<unitPattern count="one">{0} джиггер</unitPattern>
+				<unitPattern count="few">{0} джиггера</unitPattern>
+				<unitPattern count="many">{0} джиггеров</unitPattern>
+				<unitPattern count="other">{0} джиггера</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>щепот.</displayName>
+				<unitPattern count="one">{0} щепот.</unitPattern>
+				<unitPattern count="few">{0} щепот.</unitPattern>
+				<unitPattern count="many">{0} щепот.</unitPattern>
+				<unitPattern count="other">{0} щепот.</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>имп. кварт.</displayName>
+				<unitPattern count="one">{0} имп. кварт.</unitPattern>
+				<unitPattern count="few">{0} имп. кварт.</unitPattern>
+				<unitPattern count="many">{0} имп. кварт.</unitPattern>
+				<unitPattern count="other">{0} имп. кварт.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>напр.</displayName>
@@ -16607,20 +16607,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} или {1}</listPatternPart>
+			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} или {1}</listPatternPart>
+			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -16854,7 +16854,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} — {generation}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>

--- a/common/main/sa.xml
+++ b/common/main/sa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -756,7 +756,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">श्वः</relative>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>वासर:</displayName>
 				<relative type="-1">ह्यः</relative>
 				<relative type="0">अद्य</relative>
 				<relative type="1">श्वः</relative>

--- a/common/main/sat.xml
+++ b/common/main/sat.xml
@@ -1192,7 +1192,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="3">ᱢᱟᱨ</month>
 							<month type="4">ᱟᱯᱨ</month>
 							<month type="5">ᱢᱮ</month>
-							<month type="6">↑↑↑</month>
+							<month type="6">ᱡᱩᱱ</month>
 							<month type="7">ᱡᱩᱞ</month>
 							<month type="8">ᱟᱜᱟ</month>
 							<month type="9">ᱥᱮᱯ</month>
@@ -1235,8 +1235,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="2">ᱯᱷᱟ</month>
 							<month type="3">ᱢᱟᱨ</month>
 							<month type="4">ᱟᱯᱨ</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
+							<month type="5">ᱢᱮ</month>
+							<month type="6">ᱡᱩᱱ</month>
 							<month type="7">ᱡᱩᱞ</month>
 							<month type="8">ᱟᱜᱟ</month>
 							<month type="9">ᱥᱮᱯ</month>
@@ -1259,18 +1259,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">ᱫ</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">ᱡᱟᱱᱣᱟᱨᱤ</month>
+							<month type="2">ᱯᱷᱟᱨᱣᱟᱨᱤ</month>
+							<month type="3">ᱢᱟᱨᱪ</month>
+							<month type="4">ᱟᱯᱨᱮᱞ</month>
+							<month type="5">ᱢᱮ</month>
+							<month type="6">ᱡᱩᱱ</month>
+							<month type="7">ᱡᱩᱞᱟᱭ</month>
+							<month type="8">ᱟᱜᱟᱥᱛ</month>
+							<month type="9">ᱥᱮᱯᱴᱮᱢᱵᱟᱨ</month>
+							<month type="10">ᱚᱠᱴᱚᱵᱟᱨ</month>
+							<month type="11">ᱱᱟᱣᱟᱢᱵᱟᱨ</month>
+							<month type="12">ᱫᱤᱥᱟᱢᱵᱟᱨ</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1295,13 +1295,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">ᱧ</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">ᱥᱤᱸ</day>
+							<day type="mon" draft="unconfirmed">ᱚᱛ</day>
+							<day type="tue" draft="unconfirmed">ᱵᱟ</day>
+							<day type="wed" draft="unconfirmed">ᱥᱟᱹ</day>
+							<day type="thu" draft="unconfirmed">ᱥᱟᱹᱨ</day>
+							<day type="fri" draft="unconfirmed">ᱡᱟᱹ</day>
+							<day type="sat" draft="unconfirmed">ᱧᱩ</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">ᱥᱤᱸᱜᱮ</day>
@@ -1315,10 +1315,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
+							<day type="sun">ᱥᱤᱸ</day>
+							<day type="mon">ᱚᱛ</day>
+							<day type="tue">ᱵᱟ</day>
+							<day type="wed">ᱥᱟᱹ</day>
 							<day type="thu">ᱥᱟᱹᱨ</day>
 							<day type="fri">ᱡᱟᱹ</day>
 							<day type="sat">ᱧᱩ</day>
@@ -1333,29 +1333,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">ᱧ</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">ᱥᱤᱸ</day>
+							<day type="mon" draft="unconfirmed">ᱚᱛ</day>
+							<day type="tue" draft="unconfirmed">ᱵᱟ</day>
+							<day type="wed" draft="unconfirmed">ᱥᱟᱹ</day>
+							<day type="thu" draft="unconfirmed">ᱥᱟᱹᱨ</day>
+							<day type="fri" draft="unconfirmed">ᱡᱟᱹ</day>
+							<day type="sat" draft="unconfirmed">ᱧᱩ</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">ᱥᱤᱸᱜᱮ</day>
+							<day type="mon">ᱚᱛᱮ</day>
+							<day type="tue">ᱵᱟᱞᱮ</day>
+							<day type="wed">ᱥᱟᱹᱜᱩᱱ</day>
+							<day type="thu">ᱥᱟᱹᱨᱫᱤ</day>
+							<day type="fri">ᱡᱟᱹᱨᱩᱢ</day>
+							<day type="sat">ᱧᱩᱦᱩᱢ</day>
 						</dayWidth>
 					</dayContext>
 				</days>
 				<quarters>
 					<quarterContext type="format">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
+							<quarter type="1">᱑ᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
 							<quarter type="2">᱒ᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
 							<quarter type="3">᱓ᱭᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
 							<quarter type="4">᱔ᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
@@ -1375,10 +1375,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">᱑ᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
+							<quarter type="2">᱒ᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
+							<quarter type="3">᱓ᱭᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
+							<quarter type="4">᱔ᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">᱑</quarter>
@@ -1387,7 +1387,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">᱔</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
+							<quarter type="1">᱑ᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
 							<quarter type="2">᱒ᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
 							<quarter type="3">᱓ᱭᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
 							<quarter type="4">᱔ᱟᱜ ᱯᱮ ᱪᱟᱸᱫᱚᱠᱤᱭᱟᱹ</quarter>
@@ -1413,7 +1413,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="0">ᱥᱮᱨᱢᱟ ᱞᱟᱦᱟ</era>
 						<era type="0" alt="variant">ᱥᱮᱨᱢᱟ ᱞᱟᱦᱟ</era>
 						<era type="1">ᱤᱥᱣᱤ</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">ᱤᱥᱣᱤ</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0" draft="unconfirmed">ᱡᱤ</era>
@@ -1554,18 +1554,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">ᱢᱟᱜᱽ</month>
+							<month type="2" draft="unconfirmed">ᱯᱷᱟ.ᱜᱩᱱ</month>
+							<month type="3" draft="unconfirmed">ᱪᱟ.ᱛ</month>
+							<month type="4" draft="unconfirmed">ᱵᱟ.ᱭᱥᱟ.ᱠ</month>
+							<month type="5" draft="unconfirmed">ᱡᱷᱮᱴ</month>
+							<month type="6" draft="unconfirmed">ᱟᱥᱟᱲ</month>
+							<month type="7" draft="unconfirmed">ᱥᱟᱱ</month>
+							<month type="8" draft="unconfirmed">ᱵᱷᱟᱫᱚᱨᱵ</month>
+							<month type="9" draft="unconfirmed">ᱫᱟᱥᱟᱸᱭ</month>
+							<month type="10" draft="unconfirmed">ᱥᱚᱦᱨᱟᱭ</month>
+							<month type="11" draft="unconfirmed">ᱟᱜᱷᱟᱲ</month>
+							<month type="12" draft="unconfirmed">ᱯᱩᱥ</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="unconfirmed">᱑</month>
@@ -1598,18 +1598,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">ᱢᱟᱜᱽ</month>
+							<month type="2" draft="unconfirmed">ᱯᱷᱟ.ᱜᱩᱱ</month>
+							<month type="3" draft="unconfirmed">ᱪᱟ.ᱛ</month>
+							<month type="4" draft="unconfirmed">ᱵᱟ.ᱭᱥᱟ.ᱠ</month>
+							<month type="5" draft="unconfirmed">ᱡᱷᱮᱴ</month>
+							<month type="6" draft="unconfirmed">ᱟᱥᱟᱲ</month>
+							<month type="7" draft="unconfirmed">ᱥᱟᱱ</month>
+							<month type="8" draft="unconfirmed">ᱵᱷᱟᱫᱚᱨᱵ</month>
+							<month type="9" draft="unconfirmed">ᱫᱟᱥᱟᱸᱭ</month>
+							<month type="10" draft="unconfirmed">ᱥᱚᱦᱨᱟᱭ</month>
+							<month type="11" draft="unconfirmed">ᱟᱜᱷᱟᱲ</month>
+							<month type="12" draft="unconfirmed">ᱯᱩᱥ</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="unconfirmed">᱑</month>
@@ -1626,18 +1626,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12" draft="unconfirmed">᱑᱒</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">ᱢᱟᱜᱽ</month>
+							<month type="2" draft="unconfirmed">ᱯᱷᱟ.ᱜᱩᱱ</month>
+							<month type="3" draft="unconfirmed">ᱪᱟ.ᱛ</month>
+							<month type="4" draft="unconfirmed">ᱵᱟ.ᱭᱥᱟ.ᱠ</month>
+							<month type="5" draft="unconfirmed">ᱡᱷᱮᱴ</month>
+							<month type="6" draft="unconfirmed">ᱟᱥᱟᱲ</month>
+							<month type="7" draft="unconfirmed">ᱥᱟᱱ</month>
+							<month type="8" draft="unconfirmed">ᱵᱷᱟᱫᱚᱨᱵ</month>
+							<month type="9" draft="unconfirmed">ᱫᱟᱥᱟᱸᱭ</month>
+							<month type="10" draft="unconfirmed">ᱥᱚᱦᱨᱟᱭ</month>
+							<month type="11" draft="unconfirmed">ᱟᱜᱷᱟᱲ</month>
+							<month type="12" draft="unconfirmed">ᱯᱩᱥ</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1666,13 +1666,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>ᱥᱮᱨᱢᱟ</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">ᱢᱟᱲᱟᱝ ᱥᱮᱨᱢᱟ</relative>
 				<relative type="0" draft="unconfirmed">ᱱᱚᱶᱟ ᱥᱮᱨᱢᱟ</relative>
 				<relative type="1" draft="unconfirmed">ᱦᱟᱹᱡᱩᱜ ᱠᱟᱱ ᱥᱮᱨᱢᱟ</relative>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
+				<displayName>ᱥᱮᱨᱢᱟ</displayName>
+				<relative type="-1" draft="unconfirmed">ᱢᱟᱲᱟᱝ ᱥᱮᱨᱢᱟ</relative>
 				<relative type="0" draft="unconfirmed">ᱱᱚᱶᱟ ᱥᱮᱨᱢᱟ</relative>
 				<relative type="1" draft="unconfirmed">ᱦᱟᱹᱡᱩᱜ ᱠᱟᱱ ᱥᱮᱨᱢᱟ</relative>
 			</field>
@@ -1741,15 +1741,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>ᱢᱟᱦᱟ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ᱦᱚᱞᱟ</relative>
+				<relative type="0">ᱛᱮᱦᱮᱧ</relative>
+				<relative type="1">ᱜᱟᱯᱟ</relative>
 			</field>
 			<field type="day-narrow">
 				<displayName>ᱢᱟᱦᱟ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ᱦᱚᱞᱟ</relative>
+				<relative type="0">ᱛᱮᱦᱮᱧ</relative>
+				<relative type="1">ᱜᱟᱯᱟ</relative>
 			</field>
 			<field type="dayOfYear">
 				<displayName>ᱥᱮᱨᱢᱟ ᱨᱮᱭᱟᱠ ᱢᱟᱦᱟ</displayName>
@@ -1764,16 +1764,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ᱦᱟᱯᱛᱟ ᱨᱮᱭᱟᱜ ᱢᱟᱦᱟ</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᱦᱟᱯᱛᱟ ᱨᱮᱭᱟᱜ ᱢᱟᱦᱟ</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᱦᱟᱯᱛᱟ ᱨᱮᱭᱟᱜ ᱢᱟᱦᱟ</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>ᱪᱟᱸᱫᱚ ᱨᱮᱭᱟᱠ ᱢᱟᱦᱟ</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᱪᱟᱸᱫᱚ ᱨᱮᱭᱟᱠ ᱢᱟᱦᱟ</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
 				<displayName>ᱪᱟᱸᱫᱚ ᱨᱮᱭᱟᱠ ᱢᱟᱦᱟ</displayName>
@@ -1784,31 +1784,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">ᱦᱟᱹᱡᱩᱜ ᱠᱟᱱ ᱥᱤᱸᱜᱮ</relative>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᱥᱮᱛᱟᱜ/ᱟᱹᱭᱩᱵ</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>ᱥᱮᱛᱟᱜ/ᱟᱹᱭᱩᱵ</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᱥᱮᱛᱟᱜ/ᱟᱹᱭᱩᱵ</displayName>
 			</field>
 			<field type="hour">
 				<displayName>ᱴᱟᱲᱟᱝ</displayName>
 			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᱴᱟᱲᱟᱝ</displayName>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᱴᱟᱲᱟᱝ</displayName>
 			</field>
 			<field type="minute">
 				<displayName>ᱴᱤᱯᱤᱡ</displayName>
 			</field>
 			<field type="minute-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᱴᱤᱯᱤᱡ</displayName>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ᱴᱤᱯᱤᱡ</displayName>
 			</field>
 			<field type="second">
 				<displayName>ᱴᱤᱨᱤᱡ</displayName>
@@ -2364,7 +2364,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -2375,13 +2375,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000" count="one" draft="unconfirmed">¤ 00 ᱜᱮᱞᱥᱟᱭ</pattern>
 					<pattern type="10000" count="two" draft="unconfirmed">¤ 00 ᱜᱮᱞᱥᱟᱭ</pattern>
 					<pattern type="10000" count="other" draft="unconfirmed">¤ 00 ᱜᱮᱞᱥᱟᱭ</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="two">↑↑↑</pattern>
+					<pattern type="100000" count="one">¤ 000 ᱜᱮᱞᱥᱟᱭ</pattern>
+					<pattern type="100000" count="two">¤ 000 ᱜᱮᱞᱥᱟᱭ</pattern>
 					<pattern type="100000" count="other">¤ 000 ᱜᱮᱞᱥᱟᱭ</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="two">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="two">{0} {1}</unitPattern>
 			<unitPattern count="other">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencies>
@@ -2403,9 +2403,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CNY">
 				<displayName>ᱪᱤᱱᱤ ᱭᱩᱣᱟᱱ</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="two">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">ᱪᱤᱱᱤ ᱭᱩᱣᱟᱱ</displayName>
+				<displayName count="two">ᱪᱤᱱᱤ ᱭᱩᱣᱟᱱ</displayName>
+				<displayName count="other">ᱪᱤᱱᱤ ᱭᱩᱣᱟᱱ</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -2481,10 +2481,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<unitLength type="long">
 			<coordinateUnit>
 				<displayName draft="unconfirmed">ᱢᱩᱞ ᱟᱸᱫᱮ</displayName>
-				<coordinateUnitPattern type="east" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="east" draft="unconfirmed">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north" draft="unconfirmed">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south" draft="unconfirmed">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west" draft="unconfirmed">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<unitLength type="short">
@@ -2499,15 +2499,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<unitLength type="narrow">
 			<unit type="volume-dessert-spoon-imperial">
 				<unitPattern count="one">{0}dsp-Imp</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName draft="unconfirmed">ᱟᱸᱫᱮ</displayName>
-				<coordinateUnitPattern type="east" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="east" draft="unconfirmed">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north" draft="unconfirmed">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south" draft="unconfirmed">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west" draft="unconfirmed">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -2534,46 +2534,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0} ᱟᱨᱵᱟᱝᱠᱷᱟᱱ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}, ᱟᱨᱵᱟᱝᱠᱷᱟᱱ {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} ᱟᱨᱵᱟᱝᱠᱷᱟᱱ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}, ᱟᱨᱵᱟᱝᱠᱷᱟᱱ {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} ᱟᱨᱵᱟᱝᱠᱷᱟᱱ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} ᱟᱨ {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} ᱟᱨ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} ᱟᱨ {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0} ᱟᱨ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0}, ᱟᱨ {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0} ᱟᱨ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0}, {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/sc.xml
+++ b/common/main/sc.xml
@@ -921,7 +921,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turchia</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turchia</territory>
 			<territory type="TT">Trinidad e Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwàn</territory>
@@ -1276,230 +1276,230 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
 							<greatestDifference id="d">d–d MMM y G</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM y G</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM y G</greatestDifference>
+							<greatestDifference id="y">dd MMM y – dd MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1507,6 +1507,50 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="chinese">
 				<months>
 					<monthContext type="format">
+						<monthWidth type="abbreviated">
+							<month type="1">m01</month>
+							<month type="2">m02</month>
+							<month type="3">m03</month>
+							<month type="4">m04</month>
+							<month type="5">m05</month>
+							<month type="6">m06</month>
+							<month type="7">m07</month>
+							<month type="8">m08</month>
+							<month type="9">m09</month>
+							<month type="10">m10</month>
+							<month type="11">m11</month>
+							<month type="12">m12</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">su de unu mese</month>
+							<month type="2">su de duos meses</month>
+							<month type="3">su de tres meses</month>
+							<month type="4">su de bator meses</month>
+							<month type="5">su de chimbe meses</month>
+							<month type="6">su de ses meses</month>
+							<month type="7">su de sete meses</month>
+							<month type="8">su de oto meses</month>
+							<month type="9">su de nove meses</month>
+							<month type="10">su de deghe meses</month>
+							<month type="11">su de ùndighi meses</month>
+							<month type="12">su de dòighi meses</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
 							<month type="1">m01</month>
 							<month type="2">m02</month>
@@ -1550,58 +1594,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">su de dòighi meses</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">su de unu mese</month>
-							<month type="2">su de duos meses</month>
-							<month type="3">su de tres meses</month>
-							<month type="4">su de bator meses</month>
-							<month type="5">su de chimbe meses</month>
-							<month type="6">su de ses meses</month>
-							<month type="7">su de sete meses</month>
-							<month type="8">su de oto meses</month>
-							<month type="9">su de nove meses</month>
-							<month type="10">su de deghe meses</month>
-							<month type="11">su de ùndighi meses</month>
-							<month type="12">su de dòighi meses</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0} bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
 							<monthPattern type="leap">{0} bis</monthPattern>
@@ -1614,7 +1614,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthPatternContext>
 					<monthPatternContext type="stand-alone">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0} bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
 							<monthPattern type="leap">↑↑↑</monthPattern>
@@ -1642,412 +1642,412 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 								<cyclicName type="12">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="months">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2198,128 +2198,128 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 								<cyclicName type="60">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2418,7 +2418,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2426,7 +2426,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2588,19 +2588,66 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">tout</month>
+							<month type="2">baba</month>
+							<month type="3">hator</month>
+							<month type="4">kiahk</month>
+							<month type="5">toba</month>
+							<month type="6">amshir</month>
+							<month type="7">baramhat</month>
+							<month type="8">baramouda</month>
+							<month type="9">bashans</month>
+							<month type="10">paona</month>
+							<month type="11">epep</month>
+							<month type="12">mesra</month>
+							<month type="13">nasie</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">tout</month>
+							<month type="2">baba</month>
+							<month type="3">hator</month>
+							<month type="4">kiahk</month>
+							<month type="5">toba</month>
+							<month type="6">amshir</month>
+							<month type="7">baramhat</month>
+							<month type="8">baramouda</month>
+							<month type="9">bashans</month>
+							<month type="10">paona</month>
+							<month type="11">epep</month>
+							<month type="12">mesra</month>
+							<month type="13">nasie</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">tout</month>
+							<month type="2">baba</month>
+							<month type="3">hator</month>
+							<month type="4">kiahk</month>
+							<month type="5">toba</month>
+							<month type="6">amshir</month>
+							<month type="7">baramhat</month>
+							<month type="8">baramouda</month>
+							<month type="9">bashans</month>
+							<month type="10">paona</month>
+							<month type="11">epep</month>
+							<month type="12">mesra</month>
+							<month type="13">nasie</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -2633,53 +2680,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="13">nasie</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
@@ -2691,237 +2691,237 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="1">a.M.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">a.D.</era>
+						<era type="1">a.M.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM y G</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM y G</greatestDifference>
+							<greatestDifference id="y">dd MMM y – dd MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2930,32 +2930,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">m01</month>
+							<month type="2">m02</month>
+							<month type="3">m03</month>
+							<month type="4">m04</month>
+							<month type="5">m05</month>
+							<month type="6">m06</month>
+							<month type="7">m07</month>
+							<month type="8">m08</month>
+							<month type="9">m09</month>
+							<month type="10">m10</month>
+							<month type="11">m11</month>
+							<month type="12">m12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">su de unu mese</month>
@@ -2974,32 +2974,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">m01</month>
+							<month type="2">m02</month>
+							<month type="3">m03</month>
+							<month type="4">m04</month>
+							<month type="5">m05</month>
+							<month type="6">m06</month>
+							<month type="7">m07</month>
+							<month type="8">m08</month>
+							<month type="9">m09</month>
+							<month type="10">m10</month>
+							<month type="11">m11</month>
+							<month type="12">m12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">su de unu mese</month>
@@ -3020,10 +3020,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0} bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
 							<monthPattern type="leap">{0} bis</monthPattern>
@@ -3031,15 +3031,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthPatternContext>
 					<monthPatternContext type="numeric">
 						<monthPatternWidth type="all">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 					<monthPatternContext type="stand-alone">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0} bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
 							<monthPattern type="leap">{0} bis</monthPattern>
@@ -3050,426 +3050,426 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<cyclicNameSet type="dayParts">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
+								<cyclicName type="6">si</cyclicName>
+								<cyclicName type="7">wu</cyclicName>
+								<cyclicName type="8">wei</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
+								<cyclicName type="10">you</cyclicName>
+								<cyclicName type="11">xu</cyclicName>
+								<cyclicName type="12">hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="months">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -3558,190 +3558,190 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<cyclicNameSet type="years">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
-								<cyclicName type="25">↑↑↑</cyclicName>
-								<cyclicName type="26">↑↑↑</cyclicName>
-								<cyclicName type="27">↑↑↑</cyclicName>
-								<cyclicName type="28">↑↑↑</cyclicName>
-								<cyclicName type="29">↑↑↑</cyclicName>
-								<cyclicName type="30">↑↑↑</cyclicName>
-								<cyclicName type="31">↑↑↑</cyclicName>
-								<cyclicName type="32">↑↑↑</cyclicName>
-								<cyclicName type="33">↑↑↑</cyclicName>
-								<cyclicName type="34">↑↑↑</cyclicName>
-								<cyclicName type="35">↑↑↑</cyclicName>
-								<cyclicName type="36">↑↑↑</cyclicName>
-								<cyclicName type="37">↑↑↑</cyclicName>
-								<cyclicName type="38">↑↑↑</cyclicName>
-								<cyclicName type="39">↑↑↑</cyclicName>
-								<cyclicName type="40">↑↑↑</cyclicName>
-								<cyclicName type="41">↑↑↑</cyclicName>
-								<cyclicName type="42">↑↑↑</cyclicName>
-								<cyclicName type="43">↑↑↑</cyclicName>
-								<cyclicName type="44">↑↑↑</cyclicName>
-								<cyclicName type="45">↑↑↑</cyclicName>
-								<cyclicName type="46">↑↑↑</cyclicName>
-								<cyclicName type="47">↑↑↑</cyclicName>
-								<cyclicName type="48">↑↑↑</cyclicName>
-								<cyclicName type="49">↑↑↑</cyclicName>
-								<cyclicName type="50">↑↑↑</cyclicName>
-								<cyclicName type="51">↑↑↑</cyclicName>
-								<cyclicName type="52">↑↑↑</cyclicName>
-								<cyclicName type="53">↑↑↑</cyclicName>
-								<cyclicName type="54">↑↑↑</cyclicName>
-								<cyclicName type="55">↑↑↑</cyclicName>
-								<cyclicName type="56">↑↑↑</cyclicName>
-								<cyclicName type="57">↑↑↑</cyclicName>
-								<cyclicName type="58">↑↑↑</cyclicName>
-								<cyclicName type="59">↑↑↑</cyclicName>
-								<cyclicName type="60">↑↑↑</cyclicName>
+								<cyclicName type="1">jia-zi</cyclicName>
+								<cyclicName type="2">yi-chou</cyclicName>
+								<cyclicName type="3">bing-yin</cyclicName>
+								<cyclicName type="4">ding-mao</cyclicName>
+								<cyclicName type="5">wu-chen</cyclicName>
+								<cyclicName type="6">ji-si</cyclicName>
+								<cyclicName type="7">geng-wu</cyclicName>
+								<cyclicName type="8">xin-wei</cyclicName>
+								<cyclicName type="9">ren-shen</cyclicName>
+								<cyclicName type="10">gui-you</cyclicName>
+								<cyclicName type="11">jia-xu</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
+								<cyclicName type="13">bing-zi</cyclicName>
+								<cyclicName type="14">ding-chou</cyclicName>
+								<cyclicName type="15">wu-yin</cyclicName>
+								<cyclicName type="16">ji-mao</cyclicName>
+								<cyclicName type="17">geng-chen</cyclicName>
+								<cyclicName type="18">xin-si</cyclicName>
+								<cyclicName type="19">ren-wu</cyclicName>
+								<cyclicName type="20">gui-wei</cyclicName>
+								<cyclicName type="21">jia-shen</cyclicName>
+								<cyclicName type="22">yi-you</cyclicName>
+								<cyclicName type="23">bing-xu</cyclicName>
+								<cyclicName type="24">ding-hai</cyclicName>
+								<cyclicName type="25">wu-zi</cyclicName>
+								<cyclicName type="26">ji-chou</cyclicName>
+								<cyclicName type="27">geng-yin</cyclicName>
+								<cyclicName type="28">xin-mao</cyclicName>
+								<cyclicName type="29">ren-chen</cyclicName>
+								<cyclicName type="30">gui-si</cyclicName>
+								<cyclicName type="31">jia-wu</cyclicName>
+								<cyclicName type="32">yi-wei</cyclicName>
+								<cyclicName type="33">bing-shen</cyclicName>
+								<cyclicName type="34">ding-you</cyclicName>
+								<cyclicName type="35">wu-xu</cyclicName>
+								<cyclicName type="36">ji-hai</cyclicName>
+								<cyclicName type="37">geng-zi</cyclicName>
+								<cyclicName type="38">xin-chou</cyclicName>
+								<cyclicName type="39">ren-yin</cyclicName>
+								<cyclicName type="40">gui-mao</cyclicName>
+								<cyclicName type="41">jia-chen</cyclicName>
+								<cyclicName type="42">yi-si</cyclicName>
+								<cyclicName type="43">bing-wu</cyclicName>
+								<cyclicName type="44">ding-wei</cyclicName>
+								<cyclicName type="45">wu-shen</cyclicName>
+								<cyclicName type="46">ji-you</cyclicName>
+								<cyclicName type="47">geng-xu</cyclicName>
+								<cyclicName type="48">xin-hai</cyclicName>
+								<cyclicName type="49">ren-zi</cyclicName>
+								<cyclicName type="50">gui-chou</cyclicName>
+								<cyclicName type="51">jia-yin</cyclicName>
+								<cyclicName type="52">yi-mao</cyclicName>
+								<cyclicName type="53">bing-chen</cyclicName>
+								<cyclicName type="54">ding-si</cyclicName>
+								<cyclicName type="55">wu-wu</cyclicName>
+								<cyclicName type="56">ji-wei</cyclicName>
+								<cyclicName type="57">geng-shen</cyclicName>
+								<cyclicName type="58">xin-you</cyclicName>
+								<cyclicName type="59">ren-xu</cyclicName>
+								<cyclicName type="60">gui-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -3795,201 +3795,201 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE dd 'de' MMMM 'de' 'su' r (U)</pattern>
+							<datetimeSkeleton draft="unconfirmed">rMMMMEEEEdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd 'de' MMMM 'de' 'su' r (U)</pattern>
+							<datetimeSkeleton draft="unconfirmed">rMMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM r</pattern>
+							<datetimeSkeleton draft="unconfirmed">rMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd-MM-r</pattern>
+							<datetimeSkeleton draft="unconfirmed">rMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">r (U)</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM r (U)</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM r</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM r (U)</dateFormatItem>
+						<dateFormatItem id="GyMMMM">MMMM 'de' 'su' r (U)</dateFormatItem>
+						<dateFormatItem id="GyMMMMd">d 'de' MMMM 'de' 'su' r (U)</dateFormatItem>
+						<dateFormatItem id="GyMMMMEd">E d 'de' MMMM 'de' 'su' r (U)</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="UM">MM/U</dateFormatItem>
+						<dateFormatItem id="UMd">dd/MM/U</dateFormatItem>
+						<dateFormatItem id="UMMM">MMM U</dateFormatItem>
+						<dateFormatItem id="UMMMd">d MMM U</dateFormatItem>
+						<dateFormatItem id="y">r (U)</dateFormatItem>
+						<dateFormatItem id="yMd">dd/MM/r</dateFormatItem>
+						<dateFormatItem id="yyyy">r (U)</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM/r</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd/MM/r</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E dd/MM/r</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM r (U)</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM r</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM r (U)</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' r (U)</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMd">d 'de' MMMM 'de' 'su' r (U)</dateFormatItem>
+						<dateFormatItem id="yyyyMMMMEd">E d 'de' MMMM 'de' 'su' r (U)</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ r (U)</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' r (U)</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">U–U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM U</greatestDifference>
+							<greatestDifference id="y">MMM U – MMM U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM U</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM U</greatestDifference>
+							<greatestDifference id="y">dd MMM U – dd MMM U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM U</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM U</greatestDifference>
+							<greatestDifference id="y">E d MMM U – E d MMM U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM 'de' 'su' U</greatestDifference>
+							<greatestDifference id="y">MMMM 'de' 'su' U – MMMM 'de' 'su' U</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3997,6 +3997,53 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="ethiopic">
 				<months>
 					<monthContext type="format">
+						<monthWidth type="abbreviated">
+							<month type="1">mes.</month>
+							<month type="2">tek.</month>
+							<month type="3">hed.</month>
+							<month type="4">tah.</month>
+							<month type="5">ter</month>
+							<month type="6">yek.</month>
+							<month type="7">meg.</month>
+							<month type="8">mia.</month>
+							<month type="9">gen.</month>
+							<month type="10">sene</month>
+							<month type="11">ham.</month>
+							<month type="12">neh.</month>
+							<month type="13">pagu.</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">meskerem</month>
+							<month type="2">tekemt</month>
+							<month type="3">hedar</month>
+							<month type="4">tahsas</month>
+							<month type="5">ter</month>
+							<month type="6">yekatit</month>
+							<month type="7">megabit</month>
+							<month type="8">miazia</month>
+							<month type="9">genbot</month>
+							<month type="10">sene</month>
+							<month type="11">hamle</month>
+							<month type="12">nehasse</month>
+							<month type="13">pagumen</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
 							<month type="1">mes.</month>
 							<month type="2">tek.</month>
@@ -4043,53 +4090,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="13">pagumen</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
@@ -4108,230 +4108,230 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM y G</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM y G</greatestDifference>
+							<greatestDifference id="y">dd MMM y – dd MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4345,7 +4345,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="0">a.m.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">a.m.</era>
 					</eraNarrow>
 				</eras>
 			</calendar>
@@ -4398,7 +4398,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4406,7 +4406,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4852,10 +4852,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="1" alt="variant">E.C.</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="0">a.C.</era>
+						<era type="0" alt="variant">a.E.C.</era>
+						<era type="1">p.C.</era>
+						<era type="1" alt="variant">E.C.</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -4932,7 +4932,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4940,7 +4940,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5161,6 +5161,56 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="13">elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="7" yeartype="leap">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">tishri</month>
+							<month type="2">heshvan</month>
+							<month type="3">kislev</month>
+							<month type="4">tevet</month>
+							<month type="5">shevat</month>
+							<month type="6">adar I</month>
+							<month type="7">adar</month>
+							<month type="7" yeartype="leap">adar II</month>
+							<month type="8">nisan</month>
+							<month type="9">iyar</month>
+							<month type="10">sivan</month>
+							<month type="11">tamuz</month>
+							<month type="12">av</month>
+							<month type="13">elul</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">tis.</month>
+							<month type="2">hes.</month>
+							<month type="3">kis.</month>
+							<month type="4">tev.</month>
+							<month type="5">she.</month>
+							<month type="6">ad.I</month>
+							<month type="7">adar</month>
+							<month type="7" yeartype="leap">ad.II</month>
+							<month type="8">nis.</month>
+							<month type="9">iyar</month>
+							<month type="10">siv.</month>
+							<month type="11">tam.</month>
+							<month type="12">av</month>
+							<month type="13">elul</month>
+						</monthWidth>
+						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
 							<month type="2">↑↑↑</month>
 							<month type="3">↑↑↑</month>
@@ -5193,56 +5243,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="13">elul</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
@@ -5258,230 +5258,230 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM y G</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM y G</greatestDifference>
+							<greatestDifference id="y">dd MMM y – dd MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5489,6 +5489,50 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="indian">
 				<months>
 					<monthContext type="format">
+						<monthWidth type="abbreviated">
+							<month type="1">cha.</month>
+							<month type="2">vai.</month>
+							<month type="3">jya.</month>
+							<month type="4">asa.</month>
+							<month type="5">sra.</month>
+							<month type="6">bha.</month>
+							<month type="7">asv.</month>
+							<month type="8">kar.</month>
+							<month type="9">agr.</month>
+							<month type="10">pau.</month>
+							<month type="11">mag.</month>
+							<month type="12">pha.</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">chaitra</month>
+							<month type="2">vaisakha</month>
+							<month type="3">jyaistha</month>
+							<month type="4">asadha</month>
+							<month type="5">sravana</month>
+							<month type="6">bhadra</month>
+							<month type="7">asvina</month>
+							<month type="8">kartika</month>
+							<month type="9">agrahayana</month>
+							<month type="10">pausa</month>
+							<month type="11">magha</month>
+							<month type="12">phalguna</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
 							<month type="1">cha.</month>
 							<month type="2">vai.</month>
@@ -5532,50 +5576,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">phalguna</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
@@ -5585,236 +5585,236 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">Saka</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM y G</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM y G</greatestDifference>
+							<greatestDifference id="y">dd MMM y – dd MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5822,6 +5822,50 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="islamic">
 				<months>
 					<monthContext type="format">
+						<monthWidth type="abbreviated">
+							<month type="1">muh.</month>
+							<month type="2">saf.</month>
+							<month type="3">rab. I</month>
+							<month type="4">rab. II</month>
+							<month type="5">jum. I</month>
+							<month type="6">jum. II</month>
+							<month type="7">raj.</month>
+							<month type="8">sha.</month>
+							<month type="9">ram.</month>
+							<month type="10">shaw.</month>
+							<month type="11">dhuʻl-q.</month>
+							<month type="12">dhuʻl-h.</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">muharram</month>
+							<month type="2">safar</month>
+							<month type="3">rabiʻ I</month>
+							<month type="4">rabiʻ II</month>
+							<month type="5">jumada I</month>
+							<month type="6">jumada II</month>
+							<month type="7">rajab</month>
+							<month type="8">shaban</month>
+							<month type="9">ramadan</month>
+							<month type="10">shawwal</month>
+							<month type="11">dhuʻl-qiʻdah</month>
+							<month type="12">dhuʻl-hijjah</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
 							<month type="1">muh.</month>
 							<month type="2">saf.</month>
@@ -5865,50 +5909,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">dhuʻl-hijjah</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
@@ -5924,230 +5924,230 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM y G</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM y G</greatestDifference>
+							<greatestDifference id="y">dd MMM y – dd MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -6155,243 +6155,243 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="japanese">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="2">↑↑↑</era>
-						<era type="3">↑↑↑</era>
-						<era type="4">↑↑↑</era>
-						<era type="5">↑↑↑</era>
-						<era type="6">↑↑↑</era>
-						<era type="7">↑↑↑</era>
-						<era type="8">↑↑↑</era>
-						<era type="9">↑↑↑</era>
-						<era type="10">↑↑↑</era>
-						<era type="11">↑↑↑</era>
-						<era type="12">↑↑↑</era>
-						<era type="13">↑↑↑</era>
-						<era type="14">↑↑↑</era>
-						<era type="15">↑↑↑</era>
-						<era type="16">↑↑↑</era>
-						<era type="17">↑↑↑</era>
-						<era type="18">↑↑↑</era>
-						<era type="19">↑↑↑</era>
-						<era type="20">↑↑↑</era>
-						<era type="21">↑↑↑</era>
-						<era type="22">↑↑↑</era>
-						<era type="23">↑↑↑</era>
-						<era type="24">↑↑↑</era>
-						<era type="25">↑↑↑</era>
-						<era type="26">↑↑↑</era>
-						<era type="27">↑↑↑</era>
-						<era type="28">↑↑↑</era>
-						<era type="29">↑↑↑</era>
-						<era type="30">↑↑↑</era>
-						<era type="31">↑↑↑</era>
-						<era type="32">↑↑↑</era>
-						<era type="33">↑↑↑</era>
-						<era type="34">↑↑↑</era>
-						<era type="35">↑↑↑</era>
-						<era type="36">↑↑↑</era>
-						<era type="37">↑↑↑</era>
-						<era type="38">↑↑↑</era>
-						<era type="39">↑↑↑</era>
-						<era type="40">↑↑↑</era>
-						<era type="41">↑↑↑</era>
-						<era type="42">↑↑↑</era>
-						<era type="43">↑↑↑</era>
-						<era type="44">↑↑↑</era>
-						<era type="45">↑↑↑</era>
-						<era type="46">↑↑↑</era>
-						<era type="47">↑↑↑</era>
-						<era type="48">↑↑↑</era>
-						<era type="49">↑↑↑</era>
-						<era type="50">↑↑↑</era>
-						<era type="51">↑↑↑</era>
-						<era type="52">↑↑↑</era>
-						<era type="53">↑↑↑</era>
-						<era type="54">↑↑↑</era>
-						<era type="55">↑↑↑</era>
-						<era type="56">↑↑↑</era>
-						<era type="57">↑↑↑</era>
-						<era type="58">↑↑↑</era>
-						<era type="59">↑↑↑</era>
-						<era type="60">↑↑↑</era>
-						<era type="61">↑↑↑</era>
-						<era type="62">↑↑↑</era>
-						<era type="63">↑↑↑</era>
-						<era type="64">↑↑↑</era>
-						<era type="65">↑↑↑</era>
-						<era type="66">↑↑↑</era>
-						<era type="67">↑↑↑</era>
-						<era type="68">↑↑↑</era>
-						<era type="69">↑↑↑</era>
-						<era type="70">↑↑↑</era>
-						<era type="71">↑↑↑</era>
-						<era type="72">↑↑↑</era>
-						<era type="73">↑↑↑</era>
-						<era type="74">↑↑↑</era>
-						<era type="75">↑↑↑</era>
-						<era type="76">↑↑↑</era>
-						<era type="77">↑↑↑</era>
-						<era type="78">↑↑↑</era>
-						<era type="79">↑↑↑</era>
-						<era type="80">↑↑↑</era>
-						<era type="81">↑↑↑</era>
-						<era type="82">↑↑↑</era>
-						<era type="83">↑↑↑</era>
-						<era type="84">↑↑↑</era>
-						<era type="85">↑↑↑</era>
-						<era type="86">↑↑↑</era>
-						<era type="87">↑↑↑</era>
-						<era type="88">↑↑↑</era>
-						<era type="89">↑↑↑</era>
-						<era type="90">↑↑↑</era>
-						<era type="91">↑↑↑</era>
-						<era type="92">↑↑↑</era>
-						<era type="93">↑↑↑</era>
-						<era type="94">↑↑↑</era>
-						<era type="95">↑↑↑</era>
-						<era type="96">↑↑↑</era>
-						<era type="97">↑↑↑</era>
-						<era type="98">↑↑↑</era>
-						<era type="99">↑↑↑</era>
-						<era type="100">↑↑↑</era>
-						<era type="101">↑↑↑</era>
-						<era type="102">↑↑↑</era>
-						<era type="103">↑↑↑</era>
-						<era type="104">↑↑↑</era>
-						<era type="105">↑↑↑</era>
-						<era type="106">↑↑↑</era>
-						<era type="107">↑↑↑</era>
-						<era type="108">↑↑↑</era>
-						<era type="109">↑↑↑</era>
-						<era type="110">↑↑↑</era>
-						<era type="111">↑↑↑</era>
-						<era type="112">↑↑↑</era>
-						<era type="113">↑↑↑</era>
-						<era type="114">↑↑↑</era>
-						<era type="115">↑↑↑</era>
-						<era type="116">↑↑↑</era>
-						<era type="117">↑↑↑</era>
-						<era type="118">↑↑↑</era>
-						<era type="119">↑↑↑</era>
-						<era type="120">↑↑↑</era>
-						<era type="121">↑↑↑</era>
-						<era type="122">↑↑↑</era>
-						<era type="123">↑↑↑</era>
-						<era type="124">↑↑↑</era>
-						<era type="125">↑↑↑</era>
-						<era type="126">↑↑↑</era>
-						<era type="127">↑↑↑</era>
-						<era type="128">↑↑↑</era>
-						<era type="129">↑↑↑</era>
-						<era type="130">↑↑↑</era>
-						<era type="131">↑↑↑</era>
-						<era type="132">↑↑↑</era>
-						<era type="133">↑↑↑</era>
-						<era type="134">↑↑↑</era>
-						<era type="135">↑↑↑</era>
-						<era type="136">↑↑↑</era>
-						<era type="137">↑↑↑</era>
-						<era type="138">↑↑↑</era>
-						<era type="139">↑↑↑</era>
-						<era type="140">↑↑↑</era>
-						<era type="141">↑↑↑</era>
-						<era type="142">↑↑↑</era>
-						<era type="143">↑↑↑</era>
-						<era type="144">↑↑↑</era>
-						<era type="145">↑↑↑</era>
-						<era type="146">↑↑↑</era>
-						<era type="147">↑↑↑</era>
-						<era type="148">↑↑↑</era>
-						<era type="149">↑↑↑</era>
-						<era type="150">↑↑↑</era>
-						<era type="151">↑↑↑</era>
-						<era type="152">↑↑↑</era>
-						<era type="153">↑↑↑</era>
-						<era type="154">↑↑↑</era>
-						<era type="155">↑↑↑</era>
-						<era type="156">↑↑↑</era>
-						<era type="157">↑↑↑</era>
-						<era type="158">↑↑↑</era>
-						<era type="159">↑↑↑</era>
-						<era type="160">↑↑↑</era>
-						<era type="161">↑↑↑</era>
-						<era type="162">↑↑↑</era>
-						<era type="163">↑↑↑</era>
-						<era type="164">↑↑↑</era>
-						<era type="165">↑↑↑</era>
-						<era type="166">↑↑↑</era>
-						<era type="167">↑↑↑</era>
-						<era type="168">↑↑↑</era>
-						<era type="169">↑↑↑</era>
-						<era type="170">↑↑↑</era>
-						<era type="171">↑↑↑</era>
-						<era type="172">↑↑↑</era>
-						<era type="173">↑↑↑</era>
-						<era type="174">↑↑↑</era>
-						<era type="175">↑↑↑</era>
-						<era type="176">↑↑↑</era>
-						<era type="177">↑↑↑</era>
-						<era type="178">↑↑↑</era>
-						<era type="179">↑↑↑</era>
-						<era type="180">↑↑↑</era>
-						<era type="181">↑↑↑</era>
-						<era type="182">↑↑↑</era>
-						<era type="183">↑↑↑</era>
-						<era type="184">↑↑↑</era>
-						<era type="185">↑↑↑</era>
-						<era type="186">↑↑↑</era>
-						<era type="187">↑↑↑</era>
-						<era type="188">↑↑↑</era>
-						<era type="189">↑↑↑</era>
-						<era type="190">↑↑↑</era>
-						<era type="191">↑↑↑</era>
-						<era type="192">↑↑↑</era>
-						<era type="193">↑↑↑</era>
-						<era type="194">↑↑↑</era>
-						<era type="195">↑↑↑</era>
-						<era type="196">↑↑↑</era>
-						<era type="197">↑↑↑</era>
-						<era type="198">↑↑↑</era>
-						<era type="199">↑↑↑</era>
-						<era type="200">↑↑↑</era>
-						<era type="201">↑↑↑</era>
-						<era type="202">↑↑↑</era>
-						<era type="203">↑↑↑</era>
-						<era type="204">↑↑↑</era>
-						<era type="205">↑↑↑</era>
-						<era type="206">↑↑↑</era>
-						<era type="207">↑↑↑</era>
-						<era type="208">↑↑↑</era>
-						<era type="209">↑↑↑</era>
-						<era type="210">↑↑↑</era>
-						<era type="211">↑↑↑</era>
-						<era type="212">↑↑↑</era>
-						<era type="213">↑↑↑</era>
-						<era type="214">↑↑↑</era>
-						<era type="215">↑↑↑</era>
-						<era type="216">↑↑↑</era>
-						<era type="217">↑↑↑</era>
-						<era type="218">↑↑↑</era>
-						<era type="219">↑↑↑</era>
-						<era type="220">↑↑↑</era>
-						<era type="221">↑↑↑</era>
-						<era type="222">↑↑↑</era>
-						<era type="223">↑↑↑</era>
-						<era type="224">↑↑↑</era>
-						<era type="225">↑↑↑</era>
-						<era type="226">↑↑↑</era>
-						<era type="227">↑↑↑</era>
-						<era type="228">↑↑↑</era>
-						<era type="229">↑↑↑</era>
-						<era type="230">↑↑↑</era>
-						<era type="231">↑↑↑</era>
-						<era type="232">↑↑↑</era>
-						<era type="233">↑↑↑</era>
-						<era type="234">↑↑↑</era>
-						<era type="235">↑↑↑</era>
-						<era type="236">↑↑↑</era>
+						<era type="0">Taika (645–650)</era>
+						<era type="1">Hakuchi (650–671)</era>
+						<era type="2">Hakuhō (672–686)</era>
+						<era type="3">Shuchō (686–701)</era>
+						<era type="4">Taihō (701–704)</era>
+						<era type="5">Keiun (704–708)</era>
+						<era type="6">Wadō (708–715)</era>
+						<era type="7">Reiki (715–717)</era>
+						<era type="8">Yōrō (717–724)</era>
+						<era type="9">Jinki (724–729)</era>
+						<era type="10">Tenpyō (729–749)</era>
+						<era type="11">Tenpyō-kampō (749–749)</era>
+						<era type="12">Tenpyō-shōhō (749–757)</era>
+						<era type="13">Tenpyō-hōji (757–765)</era>
+						<era type="14">Tenpyō-jingo (765–767)</era>
+						<era type="15">Jingo-keiun (767–770)</era>
+						<era type="16">Hōki (770–780)</era>
+						<era type="17">Ten-ō (781–782)</era>
+						<era type="18">Enryaku (782–806)</era>
+						<era type="19">Daidō (806–810)</era>
+						<era type="20">Kōnin (810–824)</era>
+						<era type="21">Tenchō (824–834)</era>
+						<era type="22">Jōwa (834–848)</era>
+						<era type="23">Kajō (848–851)</era>
+						<era type="24">Ninju (851–854)</era>
+						<era type="25">Saikō (854–857)</era>
+						<era type="26">Ten-an (857–859)</era>
+						<era type="27">Jōgan (859–877)</era>
+						<era type="28">Gangyō (877–885)</era>
+						<era type="29">Ninna (885–889)</era>
+						<era type="30">Kanpyō (889–898)</era>
+						<era type="31">Shōtai (898–901)</era>
+						<era type="32">Engi (901–923)</era>
+						<era type="33">Enchō (923–931)</era>
+						<era type="34">Jōhei (931–938)</era>
+						<era type="35">Tengyō (938–947)</era>
+						<era type="36">Tenryaku (947–957)</era>
+						<era type="37">Tentoku (957–961)</era>
+						<era type="38">Ōwa (961–964)</era>
+						<era type="39">Kōhō (964–968)</era>
+						<era type="40">Anna (968–970)</era>
+						<era type="41">Tenroku (970–973)</era>
+						<era type="42">Ten’en (973–976)</era>
+						<era type="43">Jōgen (976–978)</era>
+						<era type="44">Tengen (978–983)</era>
+						<era type="45">Eikan (983–985)</era>
+						<era type="46">Kanna (985–987)</era>
+						<era type="47">Eien (987–989)</era>
+						<era type="48">Eiso (989–990)</era>
+						<era type="49">Shōryaku (990–995)</era>
+						<era type="50">Chōtoku (995–999)</era>
+						<era type="51">Chōhō (999–1004)</era>
+						<era type="52">Kankō (1004–1012)</era>
+						<era type="53">Chōwa (1012–1017)</era>
+						<era type="54">Kannin (1017–1021)</era>
+						<era type="55">Jian (1021–1024)</era>
+						<era type="56">Manju (1024–1028)</era>
+						<era type="57">Chōgen (1028–1037)</era>
+						<era type="58">Chōryaku (1037–1040)</era>
+						<era type="59">Chōkyū (1040–1044)</era>
+						<era type="60">Kantoku (1044–1046)</era>
+						<era type="61">Eishō (1046–1053)</era>
+						<era type="62">Tengi (1053–1058)</era>
+						<era type="63">Kōhei (1058–1065)</era>
+						<era type="64">Jiryaku (1065–1069)</era>
+						<era type="65">Enkyū (1069–1074)</era>
+						<era type="66">Shōho (1074–1077)</era>
+						<era type="67">Shōryaku (1077–1081)</era>
+						<era type="68">Eihō (1081–1084)</era>
+						<era type="69">Ōtoku (1084–1087)</era>
+						<era type="70">Kanji (1087–1094)</era>
+						<era type="71">Kahō (1094–1096)</era>
+						<era type="72">Eichō (1096–1097)</era>
+						<era type="73">Jōtoku (1097–1099)</era>
+						<era type="74">Kōwa (1099–1104)</era>
+						<era type="75">Chōji (1104–1106)</era>
+						<era type="76">Kashō (1106–1108)</era>
+						<era type="77">Tennin (1108–1110)</era>
+						<era type="78">Ten-ei (1110–1113)</era>
+						<era type="79">Eikyū (1113–1118)</era>
+						<era type="80">Gen’ei (1118–1120)</era>
+						<era type="81">Hōan (1120–1124)</era>
+						<era type="82">Tenji (1124–1126)</era>
+						<era type="83">Daiji (1126–1131)</era>
+						<era type="84">Tenshō (1131–1132)</era>
+						<era type="85">Chōshō (1132–1135)</era>
+						<era type="86">Hōen (1135–1141)</era>
+						<era type="87">Eiji (1141–1142)</era>
+						<era type="88">Kōji (1142–1144)</era>
+						<era type="89">Ten’yō (1144–1145)</era>
+						<era type="90">Kyūan (1145–1151)</era>
+						<era type="91">Ninpei (1151–1154)</era>
+						<era type="92">Kyūju (1154–1156)</era>
+						<era type="93">Hōgen (1156–1159)</era>
+						<era type="94">Heiji (1159–1160)</era>
+						<era type="95">Eiryaku (1160–1161)</era>
+						<era type="96">Ōho (1161–1163)</era>
+						<era type="97">Chōkan (1163–1165)</era>
+						<era type="98">Eiman (1165–1166)</era>
+						<era type="99">Nin’an (1166–1169)</era>
+						<era type="100">Kaō (1169–1171)</era>
+						<era type="101">Shōan (1171–1175)</era>
+						<era type="102">Angen (1175–1177)</era>
+						<era type="103">Jishō (1177–1181)</era>
+						<era type="104">Yōwa (1181–1182)</era>
+						<era type="105">Juei (1182–1184)</era>
+						<era type="106">Genryaku (1184–1185)</era>
+						<era type="107">Bunji (1185–1190)</era>
+						<era type="108">Kenkyū (1190–1199)</era>
+						<era type="109">Shōji (1199–1201)</era>
+						<era type="110">Kennin (1201–1204)</era>
+						<era type="111">Genkyū (1204–1206)</era>
+						<era type="112">Ken’ei (1206–1207)</era>
+						<era type="113">Jōgen (1207–1211)</era>
+						<era type="114">Kenryaku (1211–1213)</era>
+						<era type="115">Kenpō (1213–1219)</era>
+						<era type="116">Jōkyū (1219–1222)</era>
+						<era type="117">Jōō (1222–1224)</era>
+						<era type="118">Gennin (1224–1225)</era>
+						<era type="119">Karoku (1225–1227)</era>
+						<era type="120">Antei (1227–1229)</era>
+						<era type="121">Kanki (1229–1232)</era>
+						<era type="122">Jōei (1232–1233)</era>
+						<era type="123">Tenpuku (1233–1234)</era>
+						<era type="124">Bunryaku (1234–1235)</era>
+						<era type="125">Katei (1235–1238)</era>
+						<era type="126">Ryakunin (1238–1239)</era>
+						<era type="127">En’ō (1239–1240)</era>
+						<era type="128">Ninji (1240–1243)</era>
+						<era type="129">Kangen (1243–1247)</era>
+						<era type="130">Hōji (1247–1249)</era>
+						<era type="131">Kenchō (1249–1256)</era>
+						<era type="132">Kōgen (1256–1257)</era>
+						<era type="133">Shōka (1257–1259)</era>
+						<era type="134">Shōgen (1259–1260)</era>
+						<era type="135">Bun’ō (1260–1261)</era>
+						<era type="136">Kōchō (1261–1264)</era>
+						<era type="137">Bun’ei (1264–1275)</era>
+						<era type="138">Kenji (1275–1278)</era>
+						<era type="139">Kōan (1278–1288)</era>
+						<era type="140">Shōō (1288–1293)</era>
+						<era type="141">Einin (1293–1299)</era>
+						<era type="142">Shōan (1299–1302)</era>
+						<era type="143">Kengen (1302–1303)</era>
+						<era type="144">Kagen (1303–1306)</era>
+						<era type="145">Tokuji (1306–1308)</era>
+						<era type="146">Enkyō (1308–1311)</era>
+						<era type="147">Ōchō (1311–1312)</era>
+						<era type="148">Shōwa (1312–1317)</era>
+						<era type="149">Bunpō (1317–1319)</era>
+						<era type="150">Genō (1319–1321)</era>
+						<era type="151">Genkō (1321–1324)</era>
+						<era type="152">Shōchū (1324–1326)</era>
+						<era type="153">Karyaku (1326–1329)</era>
+						<era type="154">Gentoku (1329–1331)</era>
+						<era type="155">Genkō (1331–1334)</era>
+						<era type="156">Kenmu (1334–1336)</era>
+						<era type="157">Engen (1336–1340)</era>
+						<era type="158">Kōkoku (1340–1346)</era>
+						<era type="159">Shōhei (1346–1370)</era>
+						<era type="160">Kentoku (1370–1372)</era>
+						<era type="161">Bunchū (1372–1375)</era>
+						<era type="162">Tenju (1375–1379)</era>
+						<era type="163">Kōryaku (1379–1381)</era>
+						<era type="164">Kōwa (1381–1384)</era>
+						<era type="165">Genchū (1384–1392)</era>
+						<era type="166">Meitoku (1384–1387)</era>
+						<era type="167">Kakei (1387–1389)</era>
+						<era type="168">Kōō (1389–1390)</era>
+						<era type="169">Meitoku (1390–1394)</era>
+						<era type="170">Ōei (1394–1428)</era>
+						<era type="171">Shōchō (1428–1429)</era>
+						<era type="172">Eikyō (1429–1441)</era>
+						<era type="173">Kakitsu (1441–1444)</era>
+						<era type="174">Bun’an (1444–1449)</era>
+						<era type="175">Hōtoku (1449–1452)</era>
+						<era type="176">Kyōtoku (1452–1455)</era>
+						<era type="177">Kōshō (1455–1457)</era>
+						<era type="178">Chōroku (1457–1460)</era>
+						<era type="179">Kanshō (1460–1466)</era>
+						<era type="180">Bunshō (1466–1467)</era>
+						<era type="181">Ōnin (1467–1469)</era>
+						<era type="182">Bunmei (1469–1487)</era>
+						<era type="183">Chōkyō (1487–1489)</era>
+						<era type="184">Entoku (1489–1492)</era>
+						<era type="185">Meiō (1492–1501)</era>
+						<era type="186">Bunki (1501–1504)</era>
+						<era type="187">Eishō (1504–1521)</era>
+						<era type="188">Taiei (1521–1528)</era>
+						<era type="189">Kyōroku (1528–1532)</era>
+						<era type="190">Tenbun (1532–1555)</era>
+						<era type="191">Kōji (1555–1558)</era>
+						<era type="192">Eiroku (1558–1570)</era>
+						<era type="193">Genki (1570–1573)</era>
+						<era type="194">Tenshō (1573–1592)</era>
+						<era type="195">Bunroku (1592–1596)</era>
+						<era type="196">Keichō (1596–1615)</era>
+						<era type="197">Genna (1615–1624)</era>
+						<era type="198">Kan’ei (1624–1644)</era>
+						<era type="199">Shōho (1644–1648)</era>
+						<era type="200">Keian (1648–1652)</era>
+						<era type="201">Jōō (1652–1655)</era>
+						<era type="202">Meireki (1655–1658)</era>
+						<era type="203">Manji (1658–1661)</era>
+						<era type="204">Kanbun (1661–1673)</era>
+						<era type="205">Enpō (1673–1681)</era>
+						<era type="206">Tenna (1681–1684)</era>
+						<era type="207">Jōkyō (1684–1688)</era>
+						<era type="208">Genroku (1688–1704)</era>
+						<era type="209">Hōei (1704–1711)</era>
+						<era type="210">Shōtoku (1711–1716)</era>
+						<era type="211">Kyōhō (1716–1736)</era>
+						<era type="212">Genbun (1736–1741)</era>
+						<era type="213">Kanpō (1741–1744)</era>
+						<era type="214">Enkyō (1744–1748)</era>
+						<era type="215">Kan’en (1748–1751)</era>
+						<era type="216">Hōreki (1751–1764)</era>
+						<era type="217">Meiwa (1764–1772)</era>
+						<era type="218">An’ei (1772–1781)</era>
+						<era type="219">Tenmei (1781–1789)</era>
+						<era type="220">Kansei (1789–1801)</era>
+						<era type="221">Kyōwa (1801–1804)</era>
+						<era type="222">Bunka (1804–1818)</era>
+						<era type="223">Bunsei (1818–1830)</era>
+						<era type="224">Tenpō (1830–1844)</era>
+						<era type="225">Kōka (1844–1848)</era>
+						<era type="226">Kaei (1848–1854)</era>
+						<era type="227">Ansei (1854–1860)</era>
+						<era type="228">Man’en (1860–1861)</era>
+						<era type="229">Bunkyū (1861–1864)</era>
+						<era type="230">Genji (1864–1865)</era>
+						<era type="231">Keiō (1865–1868)</era>
+						<era type="232">Meiji</era>
+						<era type="233">Taishō</era>
+						<era type="234">Shōwa</era>
+						<era type="235">Heisei</era>
+						<era type="236">Reiwa</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
@@ -6875,230 +6875,230 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM y G</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM y G</greatestDifference>
+							<greatestDifference id="y">dd MMM y – dd MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7106,6 +7106,50 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="persian">
 				<months>
 					<monthContext type="format">
+						<monthWidth type="abbreviated">
+							<month type="1">far.</month>
+							<month type="2">ord.</month>
+							<month type="3">kho.</month>
+							<month type="4">tir</month>
+							<month type="5">mor.</month>
+							<month type="6">sha.</month>
+							<month type="7">mehr</month>
+							<month type="8">aban</month>
+							<month type="9">azar</month>
+							<month type="10">dey</month>
+							<month type="11">bah.</month>
+							<month type="12">esf.</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">farvardin</month>
+							<month type="2">ordibehesht</month>
+							<month type="3">khordad</month>
+							<month type="4">tir</month>
+							<month type="5">mordad</month>
+							<month type="6">shahrivar</month>
+							<month type="7">mehr</month>
+							<month type="8">aban</month>
+							<month type="9">azar</month>
+							<month type="10">dey</month>
+							<month type="11">bahman</month>
+							<month type="12">esfand</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
 							<month type="1">far.</month>
 							<month type="2">ord.</month>
@@ -7149,50 +7193,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">esfand</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
@@ -7208,230 +7208,230 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM y G</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM y G</greatestDifference>
+							<greatestDifference id="y">dd MMM y – dd MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7447,237 +7447,237 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="1">R.d.T</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">a.R.d.T.</era>
+						<era type="1">R.d.T</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>EEEE d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>d 'de' MMMM 'de' 'su' y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'a' 'sas' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM 'de' 'su' y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ 'de' 'su' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM – dd/MM</greatestDifference>
+							<greatestDifference id="M">dd/MM – dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM – E dd/MM</greatestDifference>
+							<greatestDifference id="M">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd – E dd MMM</greatestDifference>
+							<greatestDifference id="M">E dd MMM – E dd MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">dd/MM/y – dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E dd/MM/y – E dd/MM/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd–dd MMM y G</greatestDifference>
+							<greatestDifference id="M">dd MMM – dd MMM y G</greatestDifference>
+							<greatestDifference id="y">dd MMM y – dd MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E d – E d MMM y G</greatestDifference>
+							<greatestDifference id="M">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -7792,7 +7792,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>mese</displayName>
 				<relative type="-1">su mese coladu</relative>
 				<relative type="0">custu mese</relative>
 				<relative type="1">su mese chi intrat</relative>
@@ -7806,7 +7806,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>mese</displayName>
 				<relative type="-1">su mese coladu</relative>
 				<relative type="0">custu mese</relative>
 				<relative type="1">su mese chi intrat</relative>
@@ -7889,9 +7889,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>die</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">eris</relative>
+				<relative type="0">oe</relative>
+				<relative type="1">cras</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">intro de {0} die</relativeTimePattern>
 					<relativeTimePattern count="other">intro de {0} dies</relativeTimePattern>
@@ -7903,9 +7903,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>die</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">eris</relative>
+				<relative type="0">oe</relative>
+				<relative type="1">cras</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">intro de {0} die</relativeTimePattern>
 					<relativeTimePattern count="other">intro de {0} dies</relativeTimePattern>
@@ -7919,10 +7919,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>die de s’annu</displayName>
 			</field>
 			<field type="dayOfYear-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>die de s’annu</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>die de s’annu</displayName>
 			</field>
 			<field type="weekday">
 				<displayName>die de sa chida</displayName>
@@ -7937,10 +7937,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>die de su mese</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>die de su mese</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>die de su mese</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1">domìniga colada</relative>
@@ -10663,19 +10663,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</otherNumberingSystems>
 		<minimumGroupingDigits draft="contributed">↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal>↑↑↑</decimal>
@@ -10708,304 +10708,304 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
@@ -11023,501 +11023,501 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign>↑↑↑</plusSign>
-			<minusSign>↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal>,</decimal>
+			<group>.</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign>+</plusSign>
+			<minusSign>-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arab">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="bali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="beng">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="brah">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cakm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="deva">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="fullwide">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gonm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gujr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="guru">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="hanidec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="java">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="kali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="khmr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="knda">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lana">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lanatham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="laoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -11587,315 +11587,315 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<decimalFormats numberSystem="lepc">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="limb">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mlym">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mtei">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymrshan">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="nkoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="olck">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="orya">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="osma">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="rohg">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="saur">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="shrd">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sora">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sund">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="takr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="talu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tamldec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="telu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="thai">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tibt">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="vaii">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arab">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arabext">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="bali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="beng">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="brah">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cakm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="deva">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="fullwide">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gonm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gujr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="guru">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="hanidec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="java">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="kali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="khmr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="knda">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lana">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lanatham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="laoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -11909,168 +11909,168 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<scientificFormats numberSystem="lepc">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="limb">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mlym">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mtei">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymrshan">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="nkoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="olck">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="orya">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="osma">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="rohg">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="saur">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="shrd">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sora">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sund">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="takr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="talu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tamldec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="telu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="thai">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tibt">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="vaii">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -12084,140 +12084,140 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="arabext">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="bali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="beng">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="brah">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cakm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="deva">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="fullwide">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gonm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gujr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="guru">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="hanidec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="java">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="kali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="khmr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="knda">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lana">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lanatham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="laoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -12231,178 +12231,178 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="lepc">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="limb">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mlym">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mtei">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymrshan">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="nkoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="olck">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="orya">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="osma">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="rohg">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="saur">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="shrd">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sora">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sund">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="takr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="talu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tamldec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="telu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="thai">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tibt">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="vaii">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -12411,310 +12411,310 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -12756,353 +12756,353 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">
@@ -13449,7 +13449,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="one">rublu bielorussu</displayName>
 				<displayName count="other">rublos bielorussos</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">BYN</symbol>
 			</currency>
 			<currency type="BYR">
 				<displayName>rublu bielorussu (2000–2016)</displayName>
@@ -14455,7 +14455,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="one">rublu russu (1991–1998)</displayName>
 				<displayName count="other">rublos russos (1991–1998)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">RUR</symbol>
 			</currency>
 			<currency type="RWF">
 				<displayName>francu ruandesu</displayName>
@@ -15040,136 +15040,136 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 		</currencies>
 		<miscPatterns numberSystem="adlm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arab">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arabext">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="bali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="beng">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="brah">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cakm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="deva">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="fullwide">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gonm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gujr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="guru">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="hanidec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="java">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="kali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="khmr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="knda">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lana">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lanatham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="laoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="latn">
 			<pattern type="approximately">↑↑↑</pattern>
@@ -15178,142 +15178,142 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lepc">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="limb">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mlym">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mtei">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymrshan">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="nkoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="olck">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="orya">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="osma">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="rohg">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="saur">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="shrd">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sora">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sund">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="takr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="talu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tamldec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="telu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="thai">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tibt">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="vaii">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one" draft="contributed">{0} die</pluralMinimalPairs>
@@ -15419,7 +15419,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">{0} cùbicos</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>fortza g</displayName>
@@ -15806,7 +15806,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em tipogràficu</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} ems</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -16159,9 +16159,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} nodos</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>grados Cèlsius</displayName>
@@ -16460,11 +16460,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -16472,12 +16472,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>fortza g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
@@ -16487,77 +16487,77 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="angle-radian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>°</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>′</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>″</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ètaros</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>acros</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunams</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -16582,27 +16582,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -16627,47 +16627,47 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} PB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-byte">
@@ -16677,7 +16677,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-bit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bit</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -16728,7 +16728,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-minute">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -16740,7 +16740,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
@@ -16755,62 +16755,62 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>A</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>Ω</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>V</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>J</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -16820,62 +16820,62 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -16895,77 +16895,77 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mìllias</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>iardas</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
@@ -16980,106 +16980,106 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nmi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-carat">
@@ -17089,17 +17089,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -17109,27 +17109,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>W</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
@@ -17144,72 +17144,72 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} psi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} atm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
@@ -17224,54 +17224,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
@@ -17286,7 +17286,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -17307,7 +17307,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
@@ -17317,7 +17317,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
@@ -17339,12 +17339,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-quart">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup">
@@ -17374,12 +17374,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
@@ -17422,102 +17422,102 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -17525,7 +17525,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s²</displayName>
 				<unitPattern count="one">{0}m/s²</unitPattern>
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
@@ -17535,30 +17535,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}riv</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>rad</displayName>
 				<unitPattern count="one">{0}rad</unitPattern>
 				<unitPattern count="other">{0}rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>°</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>′</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}′</unitPattern>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>″</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}″</unitPattern>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0}km²</unitPattern>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ètaru</displayName>
@@ -17566,22 +17566,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm²</displayName>
 				<unitPattern count="one">{0}cm²</unitPattern>
 				<unitPattern count="other">{0}cm²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0}mi²</unitPattern>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>acru</displayName>
@@ -17589,20 +17589,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd²</displayName>
 				<unitPattern count="one">{0}yd²</unitPattern>
 				<unitPattern count="other">{0}yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="one">{0}ft²</unitPattern>
 				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in²</displayName>
 				<unitPattern count="one">{0}in²</unitPattern>
 				<unitPattern count="other">{0}in²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
@@ -17630,27 +17630,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}elem.</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppm</displayName>
 				<unitPattern count="one">{0}ppm</unitPattern>
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="one">{0}%</unitPattern>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0}mol</unitPattern>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
@@ -17675,47 +17675,47 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mi/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>PB</displayName>
 				<unitPattern count="one">{0}PB</unitPattern>
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>TB</displayName>
 				<unitPattern count="one">{0}TB</unitPattern>
 				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Tb</displayName>
 				<unitPattern count="one">{0}Tb</unitPattern>
 				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>GB</displayName>
 				<unitPattern count="one">{0}GB</unitPattern>
 				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gb</displayName>
 				<unitPattern count="one">{0}Gb</unitPattern>
 				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="one">{0}MB</unitPattern>
 				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mb</displayName>
 				<unitPattern count="one">{0}Mb</unitPattern>
 				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>kB</displayName>
 				<unitPattern count="one">{0}kB</unitPattern>
 				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>kb</displayName>
 				<unitPattern count="one">{0}kb</unitPattern>
 				<unitPattern count="other">{0}kb</unitPattern>
 			</unit>
@@ -17725,7 +17725,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>bit</displayName>
 				<unitPattern count="one">{0}bit</unitPattern>
 				<unitPattern count="other">{0}bit</unitPattern>
 			</unit>
@@ -17735,7 +17735,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}sèc.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>dèc.</displayName>
 				<unitPattern count="one">{0}dèc.</unitPattern>
 				<unitPattern count="other">{0}dèc.</unitPattern>
 			</unit>
@@ -17767,7 +17767,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>die</displayName>
 				<unitPattern count="one">{0}d</unitPattern>
 				<unitPattern count="other">{0}d</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ora</displayName>
@@ -17785,20 +17785,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>seg</displayName>
 				<unitPattern count="one">{0}s</unitPattern>
 				<unitPattern count="other">{0}s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ms</displayName>
 				<unitPattern count="one">{0}ms</unitPattern>
 				<unitPattern count="other">{0}ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>μs</displayName>
 				<unitPattern count="one">{0}μs</unitPattern>
 				<unitPattern count="other">{0}μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ns</displayName>
 				<unitPattern count="one">{0}ns</unitPattern>
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
@@ -17808,7 +17808,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>mA</displayName>
 				<unitPattern count="one">{0}mA</unitPattern>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
@@ -17823,22 +17823,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0}kcal</unitPattern>
 				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="one">{0}cal</unitPattern>
 				<unitPattern count="other">{0}cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0}Cal</unitPattern>
 				<unitPattern count="other">{0}Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kJ</displayName>
 				<unitPattern count="one">{0}kJ</unitPattern>
 				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
@@ -17848,17 +17848,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh</displayName>
 				<unitPattern count="one">{0}kWh</unitPattern>
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>eV</displayName>
 				<unitPattern count="one">{0}eV</unitPattern>
 				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Btu</displayName>
 				<unitPattern count="one">{0}Btu</unitPattern>
 				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
@@ -17868,62 +17868,62 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}thm US</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf</displayName>
 				<unitPattern count="one">{0}lbf</unitPattern>
 				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>N</displayName>
 				<unitPattern count="one">{0}N</unitPattern>
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="one">{0}GHz</unitPattern>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="one">{0}MHz</unitPattern>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="one">{0}kHz</unitPattern>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="one">{0}Hz</unitPattern>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="one">{0}px</unitPattern>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>MP</displayName>
 				<unitPattern count="one">{0}MP</unitPattern>
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">{0}ppi</unitPattern>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
@@ -17943,77 +17943,77 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}pg</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">{0}R⊕</unitPattern>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km</displayName>
 				<unitPattern count="one">{0}km</unitPattern>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dm</displayName>
 				<unitPattern count="one">{0}dm</unitPattern>
 				<unitPattern count="other">{0}dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm</displayName>
 				<unitPattern count="one">{0}cm</unitPattern>
 				<unitPattern count="other">{0}cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mm</displayName>
 				<unitPattern count="one">{0}mm</unitPattern>
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>μm</displayName>
 				<unitPattern count="one">{0}μm</unitPattern>
 				<unitPattern count="other">{0}μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>nm</displayName>
 				<unitPattern count="one">{0}nm</unitPattern>
 				<unitPattern count="other">{0}nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0}pm</unitPattern>
 				<unitPattern count="other">{0}pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mìllias</displayName>
 				<unitPattern count="one">{0}mi</unitPattern>
 				<unitPattern count="other">{0}mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>iardas</displayName>
 				<unitPattern count="one">{0}yd</unitPattern>
 				<unitPattern count="other">{0}yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft</displayName>
 				<unitPattern count="one">{0}ft</unitPattern>
 				<unitPattern count="other">{0}ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in</displayName>
 				<unitPattern count="one">{0}in</unitPattern>
 				<unitPattern count="other">{0}in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>pc</displayName>
 				<unitPattern count="one">{0}pc</unitPattern>
 				<unitPattern count="other">{0}pc</unitPattern>
 			</unit>
@@ -18028,106 +18028,106 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ua</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>fur</displayName>
 				<unitPattern count="one">{0}fur</unitPattern>
 				<unitPattern count="other">{0}fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>fm</displayName>
 				<unitPattern count="one">{0}fth</unitPattern>
 				<unitPattern count="other">{0}fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>nmi</displayName>
 				<unitPattern count="one">{0}nmi</unitPattern>
 				<unitPattern count="other">{0}nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
+				<displayName>smi</displayName>
 				<unitPattern count="one">{0}smi</unitPattern>
 				<unitPattern count="other">{0}smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="one">{0}pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R☉</displayName>
 				<unitPattern count="one">{0}R☉</unitPattern>
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lx</displayName>
 				<unitPattern count="one">{0}lx</unitPattern>
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">{0}cd</unitPattern>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>L☉</displayName>
 				<unitPattern count="one">{0}L☉</unitPattern>
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>t</displayName>
 				<unitPattern count="one">{0}t</unitPattern>
 				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
+				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="one">{0}mg</unitPattern>
 				<unitPattern count="other">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>μg</displayName>
 				<unitPattern count="one">{0}μg</unitPattern>
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>tn</displayName>
 				<unitPattern count="one">{0}tn</unitPattern>
 				<unitPattern count="other">{0}tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>st</displayName>
 				<unitPattern count="one">{0}st</unitPattern>
 				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0}lb</unitPattern>
 				<unitPattern count="other">{0}lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0}oz</unitPattern>
 				<unitPattern count="other">{0}oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz t</displayName>
 				<unitPattern count="one">{0}oz t</unitPattern>
 				<unitPattern count="other">{0}oz t</unitPattern>
 			</unit>
@@ -18137,17 +18137,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>Da</displayName>
 				<unitPattern count="one">{0}Da</unitPattern>
 				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M⊕</displayName>
 				<unitPattern count="one">{0}M⊕</unitPattern>
 				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M☉</displayName>
 				<unitPattern count="one">{0}M☉</unitPattern>
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
@@ -18157,17 +18157,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="one">{0}GW</unitPattern>
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="one">{0}MW</unitPattern>
 				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
@@ -18177,7 +18177,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">{0}mW</unitPattern>
 				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
@@ -18192,124 +18192,124 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 				<unitPattern count="one">{0}psi</unitPattern>
 				<unitPattern count="other">{0}psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0}inHg</unitPattern>
 				<unitPattern count="other">{0}inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="one">{0}bar</unitPattern>
 				<unitPattern count="other">{0}bars</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0}mbar</unitPattern>
 				<unitPattern count="other">{0}mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm</displayName>
 				<unitPattern count="one">{0}atm</unitPattern>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="one">{0}Pa</unitPattern>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0}hPa</unitPattern>
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="one">{0}kPa</unitPattern>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="one">{0}MPa</unitPattern>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>km/h</displayName>
 				<unitPattern count="one">{0}km/h</unitPattern>
 				<unitPattern count="other">{0}km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="one">{0}m/s</unitPattern>
 				<unitPattern count="other">{0}m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/h</displayName>
 				<unitPattern count="one">{0}mi/h</unitPattern>
 				<unitPattern count="other">{0}mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kn</displayName>
 				<unitPattern count="one">{0}kn</unitPattern>
 				<unitPattern count="other">{0}kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°C</displayName>
+				<unitPattern count="one">{0} °C</unitPattern>
+				<unitPattern count="other">{0} °C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="one">{0} °F</unitPattern>
+				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="one">{0}K</unitPattern>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="one">{0}lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>N⋅m</displayName>
 				<unitPattern count="one">{0}N⋅m</unitPattern>
 				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0}km³</unitPattern>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">{0}m³</unitPattern>
 				<unitPattern count="other">{0}m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0}cm³</unitPattern>
 				<unitPattern count="other">{0}cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0}mi³</unitPattern>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd³</displayName>
 				<unitPattern count="one">{0}yd³</unitPattern>
 				<unitPattern count="other">{0}yd³</unitPattern>
 			</unit>
@@ -18319,17 +18319,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in³</displayName>
 				<unitPattern count="one">{0}in³</unitPattern>
 				<unitPattern count="other">{0}in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ml</displayName>
 				<unitPattern count="one">{0}Ml</unitPattern>
 				<unitPattern count="other">{0}Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>hl</displayName>
 				<unitPattern count="one">{0}hl</unitPattern>
 				<unitPattern count="other">{0}hl</unitPattern>
 			</unit>
@@ -18337,25 +18337,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>l</displayName>
 				<unitPattern count="one">{0}l</unitPattern>
 				<unitPattern count="other">{0}l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0}dl</unitPattern>
 				<unitPattern count="other">{0}dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cl</displayName>
 				<unitPattern count="one">{0}cl</unitPattern>
 				<unitPattern count="other">{0}cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ml</displayName>
 				<unitPattern count="one">{0}ml</unitPattern>
 				<unitPattern count="other">{0}ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpt</displayName>
 				<unitPattern count="one">{0}mpt</unitPattern>
 				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
@@ -18365,7 +18365,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}tzm</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ac ft</displayName>
 				<unitPattern count="one">{0}ac ft</unitPattern>
 				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
@@ -18375,24 +18375,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ca</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">{0}gal</unitPattern>
 				<unitPattern count="other">{0}gal</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal imp.</displayName>
 				<unitPattern count="one">{0}gal imp.</unitPattern>
 				<unitPattern count="other">{0}gal imp.</unitPattern>
 				<perUnitPattern>{0}/gal imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt</displayName>
 				<unitPattern count="one">{0}qt</unitPattern>
 				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="one">{0}pt</unitPattern>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
@@ -18422,7 +18422,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}culld</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bbl</displayName>
 				<unitPattern count="one">{0}bbl</unitPattern>
 				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
@@ -18463,9 +18463,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<coordinateUnit>
 				<displayName>puntu</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="east">{0} E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0} S</coordinateUnitPattern>
 				<coordinateUnitPattern type="west">{0}O</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
@@ -18493,32 +18493,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} o {1}</listPatternPart>
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} o {1}</listPatternPart>
 			<listPatternPart type="2">{0} o {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} e {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} e {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} e {1}</listPatternPart>
 			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
@@ -18529,8 +18529,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} e {1}</listPatternPart>
 			<listPatternPart type="2">{0} e {1}</listPatternPart>
 		</listPattern>
@@ -18749,7 +18749,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>

--- a/common/main/scn.xml
+++ b/common/main/scn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -354,18 +354,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">jin</month>
+							<month type="2" draft="unconfirmed">fri</month>
+							<month type="3" draft="unconfirmed">mar</month>
+							<month type="4" draft="unconfirmed">apr</month>
+							<month type="5" draft="unconfirmed">maj</month>
+							<month type="6" draft="unconfirmed">giu</month>
+							<month type="7" draft="unconfirmed">gnt</month>
+							<month type="8" draft="unconfirmed">agu</month>
+							<month type="9" draft="unconfirmed">sit</month>
+							<month type="10" draft="unconfirmed">utt</month>
+							<month type="11" draft="unconfirmed">nuv</month>
+							<month type="12" draft="unconfirmed">dic</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="unconfirmed">J</month>
@@ -554,18 +554,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</otherNumberingSystems>
 		<minimumGroupingDigits draft="unconfirmed">↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="unconfirmed">↑↑↑</decimal>
@@ -595,145 +595,145 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed">.</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed">.</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed">.</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed">.</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed">.</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed">.</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">,</decimal>
+			<group draft="unconfirmed">.</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">NaN</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal draft="unconfirmed">,</decimal>
@@ -751,73 +751,73 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 	</numbers>
 	<posix>

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -79,8 +79,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">چروڪي</language>
 			<language type="chy">چايان</language>
 			<language type="ckb">مرڪزي ڪردش</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">مرڪزي ڪردش</language>
+			<language type="ckb" alt="variant">مرڪزي ڪردش</language>
 			<language type="clc">چلڪوٽن</language>
 			<language type="co">ڪارسيڪائي</language>
 			<language type="crg">ميچيف</language>
@@ -750,7 +750,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">نائورو</territory>
 			<territory type="NU">نووي</territory>
 			<territory type="NZ">نيو زيلينڊ</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">نيو زيلينڊ</territory>
 			<territory type="OM">عمان</territory>
 			<territory type="PA">پناما</territory>
 			<territory type="PE">پيرو</territory>
@@ -810,7 +810,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">تيونيسيا</territory>
 			<territory type="TO">ٽونگا</territory>
 			<territory type="TR">ترڪييي</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ترڪييي</territory>
 			<territory type="TT">ٽريني ڊيڊ ۽ ٽوباگو ٻيٽ</territory>
 			<territory type="TV">توالو</territory>
 			<territory type="TW">تائیوان</territory>
@@ -1030,7 +1030,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1038,7 +1038,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1046,7 +1046,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1054,7 +1054,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1526,7 +1526,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1534,7 +1534,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1542,7 +1542,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1550,7 +1550,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1769,18 +1769,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">ڦلگونا</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">چئترا</month>
@@ -1866,6 +1866,50 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">ذوالحجہ</month>
 						</monthWidth>
 						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">محرم</month>
+							<month type="2">صفر</month>
+							<month type="3">ربيع الاول</month>
+							<month type="4">ربیع الاخر</month>
+							<month type="5">جمادی الاول</month>
+							<month type="6">جمادي الاخر</month>
+							<month type="7">رجب</month>
+							<month type="8">شعبان</month>
+							<month type="9">رمضان</month>
+							<month type="10">شوال</month>
+							<month type="11">ذوالقعد</month>
+							<month type="12">ذوالحجہ</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">محرم</month>
+							<month type="2">صفر</month>
+							<month type="3">ربيع الاول</month>
+							<month type="4">ربیع الاخر</month>
+							<month type="5">جمادی الاول</month>
+							<month type="6">جمادي الاخر</month>
+							<month type="7">رجب</month>
+							<month type="8">شعبان</month>
+							<month type="9">رمضان</month>
+							<month type="10">شوال</month>
+							<month type="11">ذوالقعد</month>
+							<month type="12">ذوالحجہ</month>
+						</monthWidth>
+						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
 							<month type="2">↑↑↑</month>
 							<month type="3">↑↑↑</month>
@@ -1894,277 +1938,233 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">ذوالحجہ</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">محرم</month>
-							<month type="2">صفر</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AH</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AH</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>G y MMMM d, EEEE</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>G y MMMM d</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>G y MMM d</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>GGGGG y-MM-dd</pattern>
+							<datetimeSkeleton>GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">G y</dateFormatItem>
+						<dateFormatItem id="GyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">G y MMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G y MMM d, E</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM-dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM-dd, E</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM d, E</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="y">G y</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">GGGGG y-MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">GGGGG y-MM-dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">GGGGG y-MM-dd, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G y MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G y MMM d, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G y MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">G y MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">G y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2274,9 +2274,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName>مهينو</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">پوئين مهيني</relative>
+				<relative type="0">هن مهيني</relative>
+				<relative type="1">اڳين مهيني</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} مهينن ۾</relativeTimePattern>
 					<relativeTimePattern count="other">{0} مهينن ۾</relativeTimePattern>
@@ -2288,9 +2288,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>مهينو</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">پوئين مهيني</relative>
+				<relative type="0">هن مهيني</relative>
+				<relative type="1">اڳين مهيني</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} مهينن ۾</relativeTimePattern>
 					<relativeTimePattern count="other">{0} مهينن ۾</relativeTimePattern>
@@ -2317,9 +2317,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>هفتو</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">پوئين هفتي</relative>
+				<relative type="0">هن هفتي</relative>
+				<relative type="1">اڳين هفتي</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} هفتن ۾</relativeTimePattern>
 					<relativeTimePattern count="other">{0} هفتن ۾</relativeTimePattern>
@@ -2332,9 +2332,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>هفتو</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">پوئين هفتي</relative>
+				<relative type="0">هن هفتي</relative>
+				<relative type="1">اڳين هفتي</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} هفتن ۾</relativeTimePattern>
 					<relativeTimePattern count="other">{0} هفتن ۾</relativeTimePattern>
@@ -2370,23 +2370,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>ڏينهن</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ڪل</relative>
+				<relative type="0">اڄ</relative>
+				<relative type="1">سڀاڻي</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ڏينهن ۾</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ڏينهن ۾</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} ڏينهن پهرين</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} ڏينهن پهرين</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
 				<displayName>ڏينهن</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ڪل</relative>
+				<relative type="0">اڄ</relative>
+				<relative type="1">سڀاڻي</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ڏينهن ۾</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ڏينهن ۾</relativeTimePattern>
@@ -5928,7 +5928,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="PYG">
 				<displayName>پيراگوئي گاراني</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">پيراگوئي گاراني</displayName>
 				<displayName count="other">پيراگوئي گاراني</displayName>
 				<symbol draft="contributed">PYG</symbol>
 				<symbol alt="narrow" draft="contributed">₲</symbol>
@@ -6261,7 +6261,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>سينٽي{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
 				<unitPrefixPattern>micro{0}</unitPrefixPattern>
@@ -6643,7 +6643,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ایمپئیر</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>ملي ايمپئير</displayName>
 				<unitPattern count="one">{0} ملي ايمپئير</unitPattern>
 				<unitPattern count="other">{0} ملي ايمپئير</unitPattern>
 			</unit>
@@ -6739,7 +6739,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>ٽائپوگرافڪ em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} ems</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -6773,14 +6773,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ڊاٽس في انچ</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>پڪسلز</displayName>
 				<unitPattern count="one">{0} dot</unitPattern>
 				<unitPattern count="other">{0} dots</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ڪلوميٽر</displayName>
@@ -6863,14 +6863,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} فلڪيات جا يونٽ</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>سمندري ميل</displayName>
@@ -6945,9 +6945,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ٽن</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>پائونڊ</displayName>
@@ -7205,9 +7205,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ايڪڙ فٽ</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>گيلن</displayName>
@@ -7262,39 +7262,39 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} بيريلز</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>drop</displayName>
+				<unitPattern count="one">{0} drop</unitPattern>
+				<unitPattern count="other">{0} drop</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram fluid</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="one">{0} pinch</unitPattern>
+				<unitPattern count="other">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ڪارڊينل ڊائريڪشن</displayName>
@@ -7675,12 +7675,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ملي سيڪنڊ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ملي سيڪنڊ</unitPattern>
 				<unitPattern count="other">{0} ملي سيڪنڊ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>مائڪرو سيڪنڊ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} مائڪرو سيڪنڊ</unitPattern>
 				<unitPattern count="other">{0} مائڪرو سيڪنڊ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
@@ -7695,7 +7695,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>ملي ايمپئير</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ملي ايمپيئر</unitPattern>
 				<unitPattern count="other">{0} ملي ايمپيئر</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
@@ -7790,27 +7790,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>پڪسلز</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>ميگا پڪسلز</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -7824,13 +7824,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پڪسلز</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7915,12 +7915,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -7950,12 +7950,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -7997,7 +7997,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -8079,7 +8079,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} psi</unitPattern>
 				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
@@ -8104,7 +8104,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8257,7 +8257,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -8314,37 +8314,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} drop</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pinch</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -8372,7 +8372,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
 				<unitPrefixPattern>f{0}</unitPrefixPattern>
@@ -8417,28 +8417,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
@@ -8449,109 +8449,109 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>گردش</displayName>
+				<unitPattern count="one">{0} گردشون</unitPattern>
+				<unitPattern count="other">{0} گردشون</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<unitPattern count="one">{0}رئڊ</unitPattern>
 				<unitPattern count="other">{0}رئڊ</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڊگري</displayName>
+				<unitPattern count="one">{0} ڊگريز</unitPattern>
+				<unitPattern count="other">{0} ڊگريز</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>آرڪ منٽز</displayName>
+				<unitPattern count="one">{0} آرڪ منٽز</unitPattern>
+				<unitPattern count="other">{0} آرڪ منٽز</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>آرڪ سيڪنڊز</displayName>
+				<unitPattern count="one">{0} آرڪ سيڪنڊز</unitPattern>
+				<unitPattern count="other">{0} آرڪ سيڪنڊز</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>اسڪوائر ڪلوميٽر</displayName>
+				<unitPattern count="one">{0} اسڪوائر ڪلوميٽر</unitPattern>
+				<unitPattern count="other">{0} اسڪوائر ڪلوميٽر</unitPattern>
+				<perUnitPattern>{0} اسڪوائر ڪلوميٽر</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>هيڪٽر</displayName>
 				<unitPattern count="one">{0}ھيڪٽر</unitPattern>
 				<unitPattern count="other">{0}ھيڪٽر</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>اسڪوائر ميٽر</displayName>
 				<unitPattern count="one">{0}m²</unitPattern>
 				<unitPattern count="other">{0}m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في اسڪوائر ميٽر</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>اسڪوائر سينٽي ميٽر</displayName>
+				<unitPattern count="one">{0} اسڪوائر سينٽي ميٽر</unitPattern>
+				<unitPattern count="other">{0} اسڪوائر سينٽي ميٽر</unitPattern>
+				<perUnitPattern>{0} في اسڪوائر سينٽي ميٽر</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>اسڪوائر ميل</displayName>
+				<unitPattern count="one">{0} اسڪوائر ميل</unitPattern>
+				<unitPattern count="other">{0} اسڪوائر ميل</unitPattern>
+				<perUnitPattern>{0} في اسڪوائر ميل</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ايڪڙ</displayName>
+				<unitPattern count="one">{0} ايڪڙ</unitPattern>
+				<unitPattern count="other">{0} ايڪڙ</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>اسڪوائر يارڊ</displayName>
+				<unitPattern count="one">{0} ااسڪوائر يارڊ</unitPattern>
+				<unitPattern count="other">{0} ااسڪوائر يارڊ</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>اسڪوائر فٽ</displayName>
+				<unitPattern count="one">{0} اسڪوائر فٽ</unitPattern>
+				<unitPattern count="other">{0} اسڪوائر فٽ</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>اسڪوائر انچ</displayName>
+				<unitPattern count="one">{0} اسڪوائر انچ</unitPattern>
+				<unitPattern count="other">{0} اسڪوائر انچ</unitPattern>
+				<perUnitPattern>{0} في اسڪوائر انچ</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>دنام</displayName>
+				<unitPattern count="one">{0} دنام</unitPattern>
+				<unitPattern count="other">{0} دنام</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قيراط</displayName>
+				<unitPattern count="one">{0} قيراط</unitPattern>
+				<unitPattern count="other">{0} قيراط</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ملي گرامز في ڊيسي ليٽر</displayName>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملي مولز في ليٽر</displayName>
+				<unitPattern count="one">{0} ملي مولز في ليٽر</unitPattern>
+				<unitPattern count="other">{0} ملي مولز في ليٽر</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>آئٽم</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} آئٽم</unitPattern>
+				<unitPattern count="other">{0} آئٽم</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -8559,13 +8559,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>پيرمائيرڊ</displayName>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>مول</displayName>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ليٽرز في ڪلو ميٽر</displayName>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -8573,54 +8573,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ميل في گيلن</displayName>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ميل في امپيريل گيلن</displayName>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gb</displayName>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميگا بٽ</displayName>
+				<unitPattern count="one">{0} ميگا بٽز</unitPattern>
+				<unitPattern count="other">{0} ميگا بٽز</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪلو بائيٽ</displayName>
+				<unitPattern count="one">{0} ڪلو بائيٽ</unitPattern>
+				<unitPattern count="other">{0} ڪلو بائيٽز</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪلو بٽ</displayName>
+				<unitPattern count="one">{0} ڪلو بٽز</unitPattern>
+				<unitPattern count="other">{0} ڪلو بٽز</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بائيٽ</displayName>
+				<unitPattern count="one">{0} بائيٽ</unitPattern>
+				<unitPattern count="other">{0} بائيٽ</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بٽ</displayName>
+				<unitPattern count="one">{0} بٽ</unitPattern>
+				<unitPattern count="other">{0} بٽ</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڏهاڪا</displayName>
+				<unitPattern count="one">{0} ڏهاڪو</unitPattern>
+				<unitPattern count="other">{0} ڏهاڪا</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>سال</displayName>
 				<unitPattern count="one">{0} سال</unitPattern>
 				<unitPattern count="other">{0} سال</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في سال</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>ٽه ماهي</displayName>
@@ -8632,37 +8632,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>مهينو</displayName>
 				<unitPattern count="one">{0} مهينا</unitPattern>
 				<unitPattern count="other">{0} مهينا</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في مهيني</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>هفتو</displayName>
 				<unitPattern count="one">{0} هفتا</unitPattern>
 				<unitPattern count="other">{0} هفتي</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في هفتي</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ڏينهن</displayName>
 				<unitPattern count="one">{0} ڏينهن</unitPattern>
 				<unitPattern count="other">{0} ڏينهن</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في ڏينهن</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ڪلاڪ</displayName>
 				<unitPattern count="one">{0} ڪلاڪ</unitPattern>
 				<unitPattern count="other">{0} ڪلاڪ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في ڪلاڪ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>منٽ</displayName>
 				<unitPattern count="one">{0} منٽ</unitPattern>
 				<unitPattern count="other">{0} منٽ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في منٽ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>سيڪنڊ</displayName>
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="other">{0} سيڪنڊ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في سيڪنڊ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ملي سيڪنڊ</displayName>
@@ -8670,97 +8670,97 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مائڪرو سيڪنڊ</displayName>
+				<unitPattern count="one">{0} مائڪرو سيڪنڊ</unitPattern>
+				<unitPattern count="other">{0} مائڪرو سيڪنڊ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نينو سيڪنڊ</displayName>
+				<unitPattern count="one">{0} نينو سيڪنڊ</unitPattern>
+				<unitPattern count="other">{0} نينو سيڪنڊ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ایمپئیر</displayName>
+				<unitPattern count="one">{0} ایمپئیر</unitPattern>
+				<unitPattern count="other">{0} ایمپئیر</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملي ايمپئير</displayName>
+				<unitPattern count="one">{0} ملي ايمپيئر</unitPattern>
+				<unitPattern count="other">{0} ملي ايمپيئر</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>اوهمس</displayName>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>وولٽ</displayName>
+				<unitPattern count="one">{0} وولٽ</unitPattern>
+				<unitPattern count="other">{0} وولٽ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪلو ڪيلوريز</displayName>
+				<unitPattern count="one">{0} ڪلو ڪيلوريز</unitPattern>
+				<unitPattern count="other">{0} ڪلو ڪيلوريز</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪيلوري</displayName>
+				<unitPattern count="one">{0} ڪيلوري</unitPattern>
+				<unitPattern count="other">{0} ڪيلوري</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪيلوري</displayName>
+				<unitPattern count="one">{0} ڪيلوري</unitPattern>
+				<unitPattern count="other">{0} ڪيلوري</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>ڪلو جول</displayName>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>جول</displayName>
+				<unitPattern count="one">{0} جول</unitPattern>
+				<unitPattern count="other">{0} جول</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪلو واٽ في ڪلاڪ</displayName>
+				<unitPattern count="one">{0} ڪلو واٽ في ڪلڪ</unitPattern>
+				<unitPattern count="other">{0} ڪلو واٽ في ڪلڪ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>اليڪٽرون وولٽ</displayName>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>پائونڊ-فورس</displayName>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>نيوٽن</displayName>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ڪ و آ / 100 ڪ م</displayName>
 				<unitPattern count="one">{0}ڪ و آ/100 ڪ م</unitPattern>
 				<unitPattern count="other">{0}ڪ و آ/100 ڪ م</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>گيگا هرٽز</displayName>
+				<unitPattern count="one">{0} گيگا هرٽز</unitPattern>
+				<unitPattern count="other">{0} گيگا هرٽز</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميگا هرٽز</displayName>
+				<unitPattern count="one">{0} ميگا هرٽز</unitPattern>
+				<unitPattern count="other">{0} ميگا هرٽز</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪلو هرٽز</displayName>
+				<unitPattern count="one">{0} ڪلو هرٽز</unitPattern>
+				<unitPattern count="other">{0} ڪلو هرٽز</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>هرٽز</displayName>
+				<unitPattern count="one">{0} هرٽز</unitPattern>
+				<unitPattern count="other">{0} هرٽز</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="one">{0}em</unitPattern>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
@@ -8775,12 +8775,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0}ppcm</unitPattern>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">{0}ppi</unitPattern>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
@@ -8795,37 +8795,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>پڪسلز</displayName>
 				<unitPattern count="one">{0}dot</unitPattern>
 				<unitPattern count="other">{0}dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>R⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ڪلوميٽر</displayName>
 				<unitPattern count="one">{0} ڪلوميٽر</unitPattern>
 				<unitPattern count="other">{0} ڪلوميٽر</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في ڪلوميٽر</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>ميٽر</displayName>
 				<unitPattern count="one">{0} ميٽر</unitPattern>
 				<unitPattern count="other">{0} ميٽر</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في ميٽر</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڊيسي ميٽر</displayName>
+				<unitPattern count="one">{0} ڊيسي ميٽر</unitPattern>
+				<unitPattern count="other">{0} ڊيسي ميٽر</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>سينٽي ميٽر</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في سينٽي ميٽر</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>ملي ميٽر</displayName>
@@ -8833,71 +8833,71 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ملي ميٽر</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مائڪرو ميٽر</displayName>
+				<unitPattern count="one">{0} مائڪرو ميٽر</unitPattern>
+				<unitPattern count="other">{0} مائڪرو ميٽر</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نينو ميٽر</displayName>
+				<unitPattern count="one">{0} نينو ميٽر</unitPattern>
+				<unitPattern count="other">{0} نينو ميٽر</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پيڪو ميٽر</displayName>
+				<unitPattern count="one">{0} پيڪو ميٽر</unitPattern>
+				<unitPattern count="other">{0} پيڪو ميٽر</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميل</displayName>
+				<unitPattern count="one">{0} ميل</unitPattern>
+				<unitPattern count="other">{0} ميل</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>گز</displayName>
+				<unitPattern count="one">{0} گز</unitPattern>
+				<unitPattern count="other">{0} گز</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>فوٽ</displayName>
+				<unitPattern count="one">{0} فوٽ</unitPattern>
+				<unitPattern count="other">{0} فوٽ</unitPattern>
+				<perUnitPattern>{0} في فوٽ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>انچ</displayName>
+				<unitPattern count="one">{0} انچ</unitPattern>
+				<unitPattern count="other">{0} انچ</unitPattern>
+				<perUnitPattern>{0} في انچ</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پارسيڪ</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>لائيٽ ايئرس</displayName>
+				<unitPattern count="one">{0} لائيٽ ايئرس</unitPattern>
+				<unitPattern count="other">{0} لائيٽ ايئرس</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>فلڪيات جا يونٽ</displayName>
+				<unitPattern count="one">{0} فلڪيات جا يونٽ</unitPattern>
+				<unitPattern count="other">{0} فلڪيات جا يونٽ</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>سمندري ميل</displayName>
+				<unitPattern count="one">{0} سمندري ميل</unitPattern>
+				<unitPattern count="other">{0} سمندري ميل</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>ايس ايم آئي</displayName>
@@ -8905,7 +8905,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ايس ايم آئي</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>پوائينٽون</displayName>
 				<unitPattern count="one">{0}پوائينٽ</unitPattern>
 				<unitPattern count="other">{0}پوائينٽ</unitPattern>
 			</unit>
@@ -8915,10 +8915,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>لڪس</displayName>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>سولر ليومينوسائيٽيز</displayName>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>ٽَـ</displayName>
@@ -8928,7 +8928,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} kg</unitPattern>
 				<perUnitPattern>{0}/ڪ.گـ.</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
@@ -8943,77 +8943,77 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}مـ.گـ.</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ٽن</displayName>
+				<unitPattern count="one">{0} ٽن</unitPattern>
+				<unitPattern count="other">{0} ٽن</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>پائونڊ</displayName>
+				<unitPattern count="one">{0} پائونڊ</unitPattern>
+				<unitPattern count="other">{0} پائونڊ</unitPattern>
+				<perUnitPattern>{0} في پائونڊ</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>اونس</displayName>
+				<unitPattern count="one">{0} اونس</unitPattern>
+				<unitPattern count="other">{0} اونس</unitPattern>
+				<perUnitPattern>{0} في اونس</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ٽرائي اونس</displayName>
+				<unitPattern count="one">{0} ٽرائي اونس</unitPattern>
+				<unitPattern count="other">{0} ٽرائي اونس</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪيرٽ</displayName>
+				<unitPattern count="one">{0} ڪيرٽ</unitPattern>
+				<unitPattern count="other">{0} ڪيرٽ</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>ڊالٽنز</displayName>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>ارٿ ماسز</displayName>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>گرين</displayName>
+				<unitPattern count="one">{0} گرين</unitPattern>
+				<unitPattern count="other">{0} گرين</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>گيگا واٽ</displayName>
+				<unitPattern count="one">{0} گيگا واٽ</unitPattern>
+				<unitPattern count="other">{0} گيگا واٽ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميگا واٽ</displayName>
+				<unitPattern count="one">{0} ميگا واٽ</unitPattern>
+				<unitPattern count="other">{0} ميگا واٽ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪلو واٽ</displayName>
+				<unitPattern count="one">{0} ڪلو واٽ</unitPattern>
+				<unitPattern count="other">{0} ڪلو واٽ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>واٽز</displayName>
+				<unitPattern count="one">{0} واٽ</unitPattern>
+				<unitPattern count="other">{0} واٽ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملي واٽ</displayName>
+				<unitPattern count="one">{0} ملي واٽ</unitPattern>
+				<unitPattern count="other">{0} ملي واٽ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>هارس پاور</displayName>
+				<unitPattern count="one">{0} هارس پاور</unitPattern>
+				<unitPattern count="other">{0} هارس پاور</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بار</displayName>
+				<unitPattern count="one">{0} بار</unitPattern>
+				<unitPattern count="other">{0} بارس</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ڪلوميٽر في ڪلاڪ</displayName>
@@ -9021,19 +9021,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميٽر في سيڪنڊ</displayName>
+				<unitPattern count="one">{0} ميٽر في سيڪنڊ</unitPattern>
+				<unitPattern count="other">{0} ميٽر في سيڪنڊ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميل في ڪلاڪ</displayName>
+				<unitPattern count="one">{0} ميل في ڪلاڪ</unitPattern>
+				<unitPattern count="other">{0} ميل في ڪلاڪ</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ناٽ</displayName>
+				<unitPattern count="one">{0} ناٽ</unitPattern>
+				<unitPattern count="other">{0} ناٽ</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9041,119 +9041,119 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪيوبڪ ڪلوميٽر</displayName>
+				<unitPattern count="one">{0} ڪيوبڪ ڪلوميٽر</unitPattern>
+				<unitPattern count="other">{0} ڪيوبڪ ڪلوميٽر</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ڪيوبڪ ميٽر</displayName>
+				<unitPattern count="one">{0} ڪيوبڪ ميٽر</unitPattern>
+				<unitPattern count="other">{0} ڪيوبڪ ميٽر</unitPattern>
+				<perUnitPattern>{0} في ڪيوبڪ ميٽر</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ڪيوبڪ سينٽي ميٽر</displayName>
+				<unitPattern count="one">{0} ڪيوبڪ سينٽي ميٽر</unitPattern>
+				<unitPattern count="other">{0} ڪيوبڪ سينٽي ميٽر</unitPattern>
+				<perUnitPattern>{0} في ڪيوبڪ سينٽي ميٽر</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪيوبڪ ميل</displayName>
+				<unitPattern count="one">{0} ڪيوبڪ ميل</unitPattern>
+				<unitPattern count="other">{0} ڪيوبڪ ميل</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪيوبڪ يارڊ</displayName>
+				<unitPattern count="one">{0} ڪيوبڪ يارڊ</unitPattern>
+				<unitPattern count="other">{0} ڪيوبڪ يارڊ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪيوبڪ فٽ</displayName>
+				<unitPattern count="one">{0} ڪيوبڪ فٽ</unitPattern>
+				<unitPattern count="other">{0} ڪيوبڪ فٽ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪيوبڪ انچ</displayName>
+				<unitPattern count="one">{0} ڪيوبڪ انچ</unitPattern>
+				<unitPattern count="other">{0} ڪيوبڪ انچ</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميگا ليٽر</displayName>
+				<unitPattern count="one">{0} ميگا ليٽر</unitPattern>
+				<unitPattern count="other">{0} ميگا ليٽر</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>هيڪٽو ليٽر</displayName>
+				<unitPattern count="one">{0} هيڪٽو ليٽر</unitPattern>
+				<unitPattern count="other">{0} هيڪٽو ليٽر</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ليٽر</displayName>
 				<unitPattern count="one">{0} ليٽر</unitPattern>
 				<unitPattern count="other">{0} ليٽر</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} في ليٽر</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڊيسي ليٽر</displayName>
+				<unitPattern count="one">{0} ڊيسي ليٽر</unitPattern>
+				<unitPattern count="other">{0} ڊيسي ليٽر</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>سينٽي ليٽر</displayName>
+				<unitPattern count="one">{0} سينٽي ليٽر</unitPattern>
+				<unitPattern count="other">{0} سينٽي ليٽر</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملي ليٽر</displayName>
+				<unitPattern count="one">{0} ملي ليٽر</unitPattern>
+				<unitPattern count="other">{0} ملي ليٽر</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ميٽرڪ ڪپ</displayName>
+				<unitPattern count="one">{0} ميٽرڪ ڪپ</unitPattern>
+				<unitPattern count="other">{0} ميٽرڪ ڪپ</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ايڪڙ فٽ</displayName>
+				<unitPattern count="one">{0} ايڪڙ فٽ</unitPattern>
+				<unitPattern count="other">{0} ايڪڙ فٽ</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>گيلن</displayName>
+				<unitPattern count="one">{0} گيلن</unitPattern>
+				<unitPattern count="other">{0} گيلن</unitPattern>
+				<perUnitPattern>{0} في گيلن</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>امپيريل گيلن</displayName>
+				<unitPattern count="one">{0} امپيريل گيلن</unitPattern>
+				<unitPattern count="other">{0} امپيريل گيلن</unitPattern>
+				<perUnitPattern>{0} في امپيريل گيلن</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>چوٿائي گيلن</displayName>
+				<unitPattern count="one">{0} چوٿائي گيلن</unitPattern>
+				<unitPattern count="other">{0} چوٿائي گيلن</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڪپ ماپو</displayName>
+				<unitPattern count="one">{0} ڪپ ماپو</unitPattern>
+				<unitPattern count="other">{0} ڪپ ماپو</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پاڻياٺ اونس</displayName>
+				<unitPattern count="one">{0} پاڻياٺ اونس</unitPattern>
+				<unitPattern count="other">{0} پاڻياٺ اونس</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>کاڌي جا چمچا</displayName>
+				<unitPattern count="one">{0} کاڌي جا چمچا</unitPattern>
+				<unitPattern count="other">{0} کاڌي جا چمچا</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>چانهن جا چمچا</displayName>
+				<unitPattern count="one">{0} چانهن جا چمچا</unitPattern>
+				<unitPattern count="other">{0} چانهن جا چمچا</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ڊائريڪشن</displayName>
@@ -9187,28 +9187,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} يا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, يا {1}</listPatternPart>
+			<listPatternPart type="2">{0} يا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, يا {1}</listPatternPart>
+			<listPatternPart type="2">{0} يا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0}، ۽ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ۽ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -9416,127 +9416,127 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">سنباد</nameField>

--- a/common/main/sd_Deva.xml
+++ b/common/main/sd_Deva.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -185,17 +185,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">डिसं</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">ज</month>
+							<month type="2">फ़</month>
 							<month type="3">मा</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
+							<month type="4">अ</month>
+							<month type="5">मा</month>
+							<month type="6">जू</month>
+							<month type="7">जु</month>
 							<month type="8">अग</month>
 							<month type="9">स</month>
 							<month type="10">ऑ</month>
-							<month type="11">↑↑↑</month>
+							<month type="11">न</month>
 							<month type="12">डि</month>
 						</monthWidth>
 						<monthWidth type="wide">
@@ -215,17 +215,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
+							<month type="1">जन</month>
+							<month type="2">फर</month>
+							<month type="3">मार्च</month>
+							<month type="4">अप्रै</month>
+							<month type="5">मई</month>
+							<month type="6">जून</month>
 							<month type="7">जुला</month>
-							<month type="8">↑↑↑</month>
+							<month type="8">अग</month>
 							<month type="9">सप्टे</month>
 							<month type="10">ऑक्टो</month>
-							<month type="11">↑↑↑</month>
+							<month type="11">नवं</month>
 							<month type="12">डिसं</month>
 						</monthWidth>
 						<monthWidth type="narrow">
@@ -243,17 +243,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">डि</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
+							<month type="1">जनवरी</month>
+							<month type="2">फरवरी</month>
+							<month type="3">मार्चु</month>
+							<month type="4">अप्रैल</month>
+							<month type="5">मई</month>
+							<month type="6">जून</month>
+							<month type="7">जुलाई</month>
 							<month type="8">अगस्ट</month>
 							<month type="9">सप्टेंबर</month>
 							<month type="10">ऑक्टोबर</month>
-							<month type="11">↑↑↑</month>
+							<month type="11">नवंबर</month>
 							<month type="12">डिसंबर</month>
 						</monthWidth>
 					</monthContext>
@@ -270,13 +270,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">छंछ</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
+							<day type="sun">आ</day>
 							<day type="mon">सू</day>
 							<day type="tue">मं</day>
 							<day type="wed">बु॒</day>
-							<day type="thu">↑↑↑</day>
+							<day type="thu">वि</day>
 							<day type="fri">जु</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">छं</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">आर्तवार</day>
@@ -296,7 +296,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="wed">बुध</day>
 							<day type="thu">विस</day>
 							<day type="fri">जु</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">छंछ</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">आ</day>
@@ -353,9 +353,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
+							<quarter type="1">पहिंरी टिमाही</quarter>
+							<quarter type="2">बीं॒ टिमाही</quarter>
+							<quarter type="3">टीं टिमाही</quarter>
 							<quarter type="4">चोथीं टिमाही</quarter>
 						</quarterWidth>
 					</quarterContext>
@@ -519,7 +519,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>साल</displayName>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>साल</displayName>
 			</field>
 			<field type="quarter">
 				<displayName>टिमाही</displayName>
@@ -543,10 +543,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>हफ्तो</displayName>
 			</field>
 			<field type="week-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>हफ्तो</displayName>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>हफ्तो</displayName>
 			</field>
 			<field type="day">
 				<displayName>दीं॒हुं</displayName>
@@ -556,15 +556,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>दीं॒हुं</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">कल</relative>
+				<relative type="0">अॼु</relative>
+				<relative type="1">सुभाणे</relative>
 			</field>
 			<field type="day-narrow">
 				<displayName>दीं॒हुं</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">कल</relative>
+				<relative type="0">अॼु</relative>
+				<relative type="1">सुभाणे</relative>
 			</field>
 			<field type="weekday">
 				<displayName>हफ्ते जो दीं॒हुं</displayName>
@@ -576,10 +576,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>कलाक</displayName>
 			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>कलाक</displayName>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>कलाक</displayName>
 			</field>
 			<field type="minute">
 				<displayName>मिंटु</displayName>
@@ -594,10 +594,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>सेकिंडु</displayName>
 			</field>
 			<field type="second-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>सेकिंडु</displayName>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>सेकिंडु</displayName>
 			</field>
 			<field type="zone">
 				<displayName>वक्तु जो दायरो</displayName>
@@ -721,12 +721,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="BRL">
@@ -745,8 +745,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="EUR">
 				<displayName>यूरो</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">यूरो</displayName>
+				<displayName count="other">यूरो</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -759,7 +759,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="INR">
 				<displayName>हिंदुस्तानी रुपयो</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">हिंदुस्तानी रुपया</displayName>
 				<displayName count="other">हिंदुस्तानी रुपया</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -818,7 +818,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ටියුනීසියාව</territory>
 			<territory type="TO">ටොංගා</territory>
 			<territory type="TR">තුර්කිය</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">තුර්කිය</territory>
 			<territory type="TT">ට්‍රිනිඩෑඩ් සහ ටොබැගෝ</territory>
 			<territory type="TV">ටුවාලූ</territory>
 			<territory type="TW">තායිවානය</territory>
@@ -2039,9 +2039,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>දිනය</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ඊයේ</relative>
+				<relative type="0">අද</relative>
+				<relative type="1">හෙට</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">දින {0}න්</relativeTimePattern>
 					<relativeTimePattern count="other">දින {0}න්</relativeTimePattern>
@@ -2053,9 +2053,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>දිනය</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ඊයේ</relative>
+				<relative type="0">අද</relative>
+				<relative type="1">හෙට</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">දින {0}න්</relativeTimePattern>
 					<relativeTimePattern count="other">දින {0}න්</relativeTimePattern>
@@ -4695,19 +4695,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
@@ -4729,148 +4729,148 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign>~</approximatelySign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -4888,73 +4888,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">.</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="latn">
 			<decimalFormatLength>
@@ -6293,7 +6293,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">ඝන {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-බලය</displayName>
@@ -6680,8 +6680,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>යතුරු ලියන එම්</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>පික්සල්</displayName>
@@ -7335,12 +7335,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7731,37 +7731,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>පික්සල්</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>මෙගාපික්සල්</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
@@ -8386,39 +8386,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>g-බලය</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>මී/තව</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">මී/තව {0}</unitPattern>
+				<unitPattern count="other">මී/තව {0}</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>පරිභ්‍ර</displayName>
+				<unitPattern count="one">පරිභ්‍ර {0}</unitPattern>
+				<unitPattern count="other">පරිභ්‍ර {0}</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>රේඩියන්</displayName>
+				<unitPattern count="one">රේඩි {0}</unitPattern>
+				<unitPattern count="other">රේඩි {0}</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>අංශක</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
@@ -8433,27 +8433,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ව.කී</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
 				<perUnitPattern>{0}/ව.කී</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>හෙක්ටයාර්</displayName>
+				<unitPattern count="one">හෙක් {0}</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>වර්ග මීටර්</displayName>
+				<unitPattern count="one">ව.මී {0}</unitPattern>
+				<unitPattern count="other">ව.මී {0}</unitPattern>
+				<perUnitPattern>{0}/ව.මී</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>වසෙ</displayName>
 				<unitPattern count="one">වසෙ{0}</unitPattern>
 				<unitPattern count="other">වසෙ{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/වසෙ</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>ව.සැ</displayName>
@@ -8462,14 +8462,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/ව.සැ</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>අක්කර</displayName>
 				<unitPattern count="one">අක්කර {0}</unitPattern>
 				<unitPattern count="other">අක්කර {0}</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>වයා</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">වයා {0}</unitPattern>
+				<unitPattern count="other">වයා {0}</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>වඅ²</displayName>
@@ -8483,24 +8483,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/වඅඟ²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ඩනම්ස්</displayName>
+				<unitPattern count="one">{0} ඩනම්ස්</unitPattern>
+				<unitPattern count="other">{0} ඩනම්ස්</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ක්‍රාත්</displayName>
+				<unitPattern count="one">ක්‍රාත් {0}</unitPattern>
+				<unitPattern count="other">ක්‍රාත් {0}</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මිග්‍රෑ/ඩෙලි</displayName>
+				<unitPattern count="one">{0} මිග්‍රෑ/ඩෙලි</unitPattern>
+				<unitPattern count="other">{0} මිග්‍රෑ/ඩෙලි</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මිලිමෝල්/ලීටර්</displayName>
+				<unitPattern count="one">{0} මිමෝල්/ලී</unitPattern>
+				<unitPattern count="other">{0} මිමෝල්/ලී</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>අයිතමය</displayName>
@@ -8509,8 +8509,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>මිලිකො</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} මිලිකො</unitPattern>
+				<unitPattern count="other">{0} මිලිකො</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -8518,24 +8518,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මවුල</displayName>
+				<unitPattern count="one">{0} මවුල</unitPattern>
+				<unitPattern count="other">{0} මවුල</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ලීටරය/කිමී</displayName>
+				<unitPattern count="one">ලී/කිමී {0}</unitPattern>
+				<unitPattern count="other">ලී/කිමී {0}</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>ලී/කිමී100</displayName>
@@ -8544,8 +8544,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>හැගැ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">හැගැ {0}</unitPattern>
+				<unitPattern count="other">හැගැ {0}</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>ගැහැ එ.රා.</displayName>
@@ -8553,75 +8553,75 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ගැහැ එ.රා.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>පෙබයිට්</displayName>
+				<unitPattern count="one">පෙබ {0}</unitPattern>
+				<unitPattern count="other">පෙබ {0}</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ටෙබයිට්</displayName>
+				<unitPattern count="one">ටෙබ {0}</unitPattern>
+				<unitPattern count="other">ටෙබ {0}</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ටෙබිට්</displayName>
+				<unitPattern count="one">ටේබි {0}</unitPattern>
+				<unitPattern count="other">ටේබි {0}</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ගිබයිට්‌</displayName>
+				<unitPattern count="one">ගිබ {0}</unitPattern>
+				<unitPattern count="other">ගිබ {0}</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ගිබීට්</displayName>
+				<unitPattern count="one">ගිබී {0}</unitPattern>
+				<unitPattern count="other">ගිබී {0}</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මෙබයිට්</displayName>
+				<unitPattern count="one">මෙබ {0}</unitPattern>
+				<unitPattern count="other">මෙබ {0}</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මෙබීට්</displayName>
+				<unitPattern count="one">මෙබි {0}</unitPattern>
+				<unitPattern count="other">මෙබි {0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කිබයිට්</displayName>
+				<unitPattern count="one">කිබ {0}</unitPattern>
+				<unitPattern count="other">කිබ {0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කිබීට්</displayName>
+				<unitPattern count="one">කිබී {0}</unitPattern>
+				<unitPattern count="other">කිබී {0}</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>බයිට්</displayName>
+				<unitPattern count="one">බයිට් {0}</unitPattern>
+				<unitPattern count="other">බයිට් {0}</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>බීට්</displayName>
+				<unitPattern count="one">බීට් {0}</unitPattern>
+				<unitPattern count="other">බීට් {0}</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>සි</displayName>
+				<unitPattern count="one">සි {0}</unitPattern>
+				<unitPattern count="other">සි {0}</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>දශක</displayName>
+				<unitPattern count="one">දශක {0}</unitPattern>
+				<unitPattern count="other">දශක {0}</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>වසර</displayName>
 				<unitPattern count="one">ව {0}</unitPattern>
 				<unitPattern count="other">ව {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ව</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>කාල</displayName>
@@ -8633,37 +8633,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>මාස</displayName>
 				<unitPattern count="one">මා {0}</unitPattern>
 				<unitPattern count="other">මා {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/මා</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>සති</displayName>
 				<unitPattern count="one">ස {0}</unitPattern>
 				<unitPattern count="other">ස {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ස</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>දින</displayName>
 				<unitPattern count="one">දි {0}</unitPattern>
 				<unitPattern count="other">දි {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/දි</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>පැය</displayName>
 				<unitPattern count="one">පැය {0}</unitPattern>
 				<unitPattern count="other">පැය {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>පැයට {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>මිනි</displayName>
 				<unitPattern count="one">මි {0}</unitPattern>
 				<unitPattern count="other">මි {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/මිනි</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>තත්</displayName>
 				<unitPattern count="one">ත {0}</unitPattern>
 				<unitPattern count="other">ත {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>තත්පරයට {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>මිලිතත්</displayName>
@@ -8671,74 +8671,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">මිලිතත් {0}</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මයික්‍රොතත්</displayName>
+				<unitPattern count="one">මයික්‍රොතත් {0}</unitPattern>
+				<unitPattern count="other">මයික්‍රොතත් {0}</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>නැනෝතත්</displayName>
+				<unitPattern count="one">නැත {0}</unitPattern>
+				<unitPattern count="other">නැත {0}</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>ඇ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ඇ {0}</unitPattern>
+				<unitPattern count="other">ඇ {0}</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>මිඇ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">මිඇ {0}</unitPattern>
+				<unitPattern count="other">මිඇ {0}</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ඕම්</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>වෝල්ට්</displayName>
+				<unitPattern count="one">වෝ {0}</unitPattern>
+				<unitPattern count="other">වෝ {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කිකැලරි</displayName>
+				<unitPattern count="one">කිකැලරි {0}</unitPattern>
+				<unitPattern count="other">කිකැලරි {0}</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කැල</displayName>
+				<unitPattern count="one">කැල {0}</unitPattern>
+				<unitPattern count="other">කැල {0}</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කැල</displayName>
+				<unitPattern count="one">කැල {0}</unitPattern>
+				<unitPattern count="other">කැල {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>කිජු</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">කිජු {0}</unitPattern>
+				<unitPattern count="other">කිජු {0}</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ජුල්</displayName>
+				<unitPattern count="one">ජු {0}</unitPattern>
+				<unitPattern count="other">ජු {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කිවො-පැය</displayName>
+				<unitPattern count="one">කිවො-පැය {0}</unitPattern>
+				<unitPattern count="other">කිවො-පැය {0}</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>ඉවෝ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ඉවෝ</unitPattern>
+				<unitPattern count="other">{0} ඉවෝ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>බ්‍රිතාඒ</displayName>
+				<unitPattern count="one">{0} බ්‍රිතාඒ</unitPattern>
+				<unitPattern count="other">{0} බ්‍රිතාඒ</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>එජ තාප ඒකක</displayName>
@@ -8747,13 +8747,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>බරා</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} බරා</unitPattern>
+				<unitPattern count="other">{0} බරා</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>නි</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} නි</unitPattern>
+				<unitPattern count="other">{0} නි</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>කිවොපැ/100කිමී</displayName>
@@ -8761,92 +8761,92 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} කිවොපැ/100කිමී</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ගිහස්</displayName>
+				<unitPattern count="one">ගිහස් {0}</unitPattern>
+				<unitPattern count="other">ගිහස් {0}</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මෙග</displayName>
+				<unitPattern count="one">මෙහ {0}</unitPattern>
+				<unitPattern count="other">මෙහ {0}</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කිහස්</displayName>
+				<unitPattern count="one">කිහස් {0}</unitPattern>
+				<unitPattern count="other">කිහස් {0}</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>හස්</displayName>
+				<unitPattern count="one">හස් {0}</unitPattern>
+				<unitPattern count="other">හස් {0}</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>පික්සල්</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මෙගාපික්සල්</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>තිත</displayName>
+				<unitPattern count="one">{0} තිත</unitPattern>
+				<unitPattern count="other">තිත් {0}</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>කි.මී</displayName>
 				<unitPattern count="one">කි.මී {0}</unitPattern>
 				<unitPattern count="other">කි.මී {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/කි.මී</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>මීටර්</displayName>
 				<unitPattern count="one">මී {0}</unitPattern>
 				<unitPattern count="other">මී {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/මී</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ඩෙමී</displayName>
+				<unitPattern count="one">ඩෙමී {0}</unitPattern>
+				<unitPattern count="other">ඩෙමී {0}</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>සෙ.මී</displayName>
 				<unitPattern count="one">සෙ.මී {0}</unitPattern>
 				<unitPattern count="other">සෙ.මී {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/සෙ.මී</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>මිමී</displayName>
@@ -8854,14 +8854,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">මිමී {0}</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මමීටර</displayName>
+				<unitPattern count="one">මමී {0}</unitPattern>
+				<unitPattern count="other">මමී {0}</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>නැමී</displayName>
+				<unitPattern count="one">නැමී {0}</unitPattern>
+				<unitPattern count="other">නැමී {0}</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>පිමී</displayName>
@@ -8869,31 +8869,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">පිමී {0}</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>සැතපුම්</displayName>
 				<unitPattern count="one">සැත {0}</unitPattern>
 				<unitPattern count="other">සැත {0}</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>යාර</displayName>
 				<unitPattern count="one">යාර {0}</unitPattern>
 				<unitPattern count="other">යාර {0}</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>අඩි</displayName>
 				<unitPattern count="one">{0}'</unitPattern>
 				<unitPattern count="other">{0}'</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/අඩි</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>අඟල්</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/අඟල්</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>පාර්සෙක්</displayName>
+				<unitPattern count="one">පාසෙ {0}</unitPattern>
+				<unitPattern count="other">පාසෙ {0}</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>ආ.ව</displayName>
@@ -8901,64 +8901,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">ආ.ව {0}</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>නඒ</displayName>
+				<unitPattern count="one">නඒ {0}</unitPattern>
+				<unitPattern count="other">නඒ {0}</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>පර්ලොම</displayName>
+				<unitPattern count="one">පර්ලොම {0}</unitPattern>
+				<unitPattern count="other">පර්ලොම {0}</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>බඹය</displayName>
+				<unitPattern count="one">බඹ {0}</unitPattern>
+				<unitPattern count="other">බඹ {0}</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>නාසැත</displayName>
+				<unitPattern count="one">නාසැත {0}</unitPattern>
+				<unitPattern count="other">නාසැත {0}</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ස්කැන්සැත</displayName>
+				<unitPattern count="one">ස්කැසැත {0}</unitPattern>
+				<unitPattern count="other">ස්කැසැත {0}</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>පොයින්ට්</displayName>
+				<unitPattern count="one">පො {0}</unitPattern>
+				<unitPattern count="other">පො {0}</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>අ☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} අ☉</unitPattern>
+				<unitPattern count="other">{0} අ☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ලක්ස්</displayName>
+				<unitPattern count="one">ලක් {0}</unitPattern>
+				<unitPattern count="other">ලක් {0}</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කැන්ඩෙලා</displayName>
+				<unitPattern count="one">කැන්ඩෙලා {0}</unitPattern>
+				<unitPattern count="other">කැන්ඩෙලා {0}</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ලූමනය</displayName>
+				<unitPattern count="one">ලූමන {0}</unitPattern>
+				<unitPattern count="other">ලූමන {0}</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>සූර්ය දීප්ති</displayName>
+				<unitPattern count="one">{0} දි☉</unitPattern>
+				<unitPattern count="other">{0} දි☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ටො</displayName>
+				<unitPattern count="one">ටො {0}</unitPattern>
+				<unitPattern count="other">ටො {0}</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>කි.ග්‍රෑ.</displayName>
@@ -8973,30 +8973,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/ග්‍රෑ</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මිග්‍රෑ</displayName>
+				<unitPattern count="one">මිග්‍රෑ {0}</unitPattern>
+				<unitPattern count="other">මිග්‍රෑ {0}</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මග්‍රෑ</displayName>
+				<unitPattern count="one">මග්‍රෑ {0}</unitPattern>
+				<unitPattern count="other">මග්‍රෑ {0}</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ටොන්</displayName>
+				<unitPattern count="one">ටොන් {0}</unitPattern>
+				<unitPattern count="other">ටොන් {0}</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ගල්</displayName>
+				<unitPattern count="one">ගල් {0}</unitPattern>
+				<unitPattern count="other">ගල් {0}</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>රා</displayName>
 				<unitPattern count="one">රා{0}</unitPattern>
 				<unitPattern count="other">රා{0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/රා</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>අවුස</displayName>
@@ -9005,29 +9005,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/අවුස</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>අවුස ට්‍රෝයි</displayName>
+				<unitPattern count="one">අවුස ට්‍රෝ {0}</unitPattern>
+				<unitPattern count="other">අවුස ට්‍රෝ {0}</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කැරට්</displayName>
+				<unitPattern count="one">කැට් {0}</unitPattern>
+				<unitPattern count="other">කැට් {0}</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ඩෝ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ඩෝ</unitPattern>
+				<unitPattern count="other">{0} ඩෝ</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>ස්⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ස්⊕</unitPattern>
+				<unitPattern count="other">{0} ස්⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>ස්☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ස්☉</unitPattern>
+				<unitPattern count="other">{0} ස්☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>ඇ</displayName>
@@ -9035,44 +9035,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">ඇ {0}</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ගිවො</displayName>
+				<unitPattern count="one">ගිවො {0}</unitPattern>
+				<unitPattern count="other">ගිවො {0}</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මෙවො</displayName>
+				<unitPattern count="one">මෙවො {0}</unitPattern>
+				<unitPattern count="other">මෙවො {0}</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කිවො</displayName>
+				<unitPattern count="one">කිවො {0}</unitPattern>
+				<unitPattern count="other">කිවො {0}</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>වොට්</displayName>
+				<unitPattern count="one">වොට් {0}</unitPattern>
+				<unitPattern count="other">වොට් {0}</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මිවො</displayName>
+				<unitPattern count="one">මිවො {0}</unitPattern>
+				<unitPattern count="other">මිවො {0}</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>අබ</displayName>
+				<unitPattern count="one">අබ {0}</unitPattern>
+				<unitPattern count="other">අබ {0}</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ර මිමී</displayName>
+				<unitPattern count="one">ර මිමී {0}</unitPattern>
+				<unitPattern count="other">ර මිමී {0}</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>වඅරා</displayName>
+				<unitPattern count="one">වඅරා {0}</unitPattern>
+				<unitPattern count="other">වඅරා {0}</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>&quot; ර</displayName>
@@ -9080,39 +9080,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">ර {0}&quot;</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>බාර්</displayName>
+				<unitPattern count="one">බාර් {0}</unitPattern>
+				<unitPattern count="other">බාර් {0}</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>මිලිබාර්</displayName>
 				<unitPattern count="one">මි.බා. {0}</unitPattern>
 				<unitPattern count="other">මි.බා. {0}</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>වායුගෝ</displayName>
+				<unitPattern count="one">වායුගෝ {0}</unitPattern>
+				<unitPattern count="other">වායුගෝ {0}</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>පැස්</displayName>
+				<unitPattern count="one">පැස් {0}</unitPattern>
+				<unitPattern count="other">පැස් {0}</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>හෙක්ටොපැස්කල්</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කිපැස්</displayName>
+				<unitPattern count="one">{0} කිපැස්</unitPattern>
+				<unitPattern count="other">{0} කිපැස්</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මෙපැස්</displayName>
+				<unitPattern count="one">{0} මෙපැස්</unitPattern>
+				<unitPattern count="other">{0} මෙපැස්</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>පැයට කිලෝමීටර්</displayName>
@@ -9130,14 +9130,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">පැසැ {0}</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>නාසැ</displayName>
+				<unitPattern count="one">නාසැ {0}</unitPattern>
+				<unitPattern count="other">නාසැ {0}</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>සෙල්සියස් අංශක</displayName>
@@ -9145,7 +9145,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>ෆැර. අ</displayName>
 				<unitPattern count="one">ෆැර. {0}°</unitPattern>
 				<unitPattern count="other">ෆැර. {0}°</unitPattern>
 			</unit>
@@ -9155,189 +9155,189 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">කෙ {0}</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>රාත්-පාද</displayName>
+				<unitPattern count="one">{0} රාත්-පාද</unitPattern>
+				<unitPattern count="other">{0} රාත්-පාද</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>නි-මී</displayName>
+				<unitPattern count="one">{0} නි-මී</unitPattern>
+				<unitPattern count="other">{0} නි-මී</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>කිමී³</displayName>
+				<unitPattern count="one">කිමී³ {0}</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>මී³</displayName>
+				<unitPattern count="one">මී³ {0}</unitPattern>
+				<unitPattern count="other">මී³ {0}</unitPattern>
+				<perUnitPattern>{0}/මී³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>සෙමී³</displayName>
+				<unitPattern count="one">ඝසෙ {0}</unitPattern>
+				<unitPattern count="other">ඝසෙ {0}</unitPattern>
+				<perUnitPattern>{0}/ඝසෙ</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>සැත³</displayName>
+				<unitPattern count="one">සැත³ {0}</unitPattern>
+				<unitPattern count="other">සැත³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>යාර³</displayName>
+				<unitPattern count="one">යාර³ {0}</unitPattern>
+				<unitPattern count="other">යාර³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>අඩි³</displayName>
+				<unitPattern count="one">අඩි³ {0}</unitPattern>
+				<unitPattern count="other">අඩි³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>අල්³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">අල්³ {0}</unitPattern>
+				<unitPattern count="other">අල්³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මෙලී</displayName>
+				<unitPattern count="one">මෙලී {0}</unitPattern>
+				<unitPattern count="other">මෙලී {0}</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>හෙලී</displayName>
+				<unitPattern count="one">හෙලී {0}</unitPattern>
+				<unitPattern count="other">හෙලී {0}</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ලීටර්</displayName>
 				<unitPattern count="one">ලී {0}</unitPattern>
 				<unitPattern count="other">ලී {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ලී</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ඩෙලී</displayName>
+				<unitPattern count="one">ඩෙලී {0}</unitPattern>
+				<unitPattern count="other">ඩෙලී {0}</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>සෙලී</displayName>
+				<unitPattern count="one">සෙලී {0}</unitPattern>
+				<unitPattern count="other">සෙලී {0}</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මිලී</displayName>
+				<unitPattern count="one">මිලී {0}</unitPattern>
+				<unitPattern count="other">මිලී {0}</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මෙපට්</displayName>
+				<unitPattern count="one">මෙපට් {0}</unitPattern>
+				<unitPattern count="other">මෙපට් {0}</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මෙකෝප්ප</displayName>
+				<unitPattern count="one">මෙකෝ {0}</unitPattern>
+				<unitPattern count="other">මෙකෝ {0}</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>අක්කර-අඩි</displayName>
+				<unitPattern count="one">අක්-අඩි {0}</unitPattern>
+				<unitPattern count="other">අක්-අඩි {0}</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>බුසල්</displayName>
+				<unitPattern count="one">බුසල් {0}</unitPattern>
+				<unitPattern count="other">බුසල් {0}</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ගැලු</displayName>
+				<unitPattern count="one">ගැලු {0}</unitPattern>
+				<unitPattern count="other">ගැලු {0}</unitPattern>
+				<perUnitPattern>{0}/ගැලු</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ඉම්පී. ගැ</displayName>
+				<unitPattern count="one">{0} ගැ ඉම්පී.</unitPattern>
+				<unitPattern count="other">{0} ගැ ඉම්පී.</unitPattern>
+				<perUnitPattern>{0}/ ගැ ඉම්පී.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ක්වාට්</displayName>
+				<unitPattern count="one">ක්ට් {0}</unitPattern>
+				<unitPattern count="other">ක්ට් {0}</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>පයින්ට්</displayName>
+				<unitPattern count="one">පට් {0}</unitPattern>
+				<unitPattern count="other">පට් {0}</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>කෝප්ප</displayName>
+				<unitPattern count="one">කෝ {0}</unitPattern>
+				<unitPattern count="other">කෝ {0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ද්‍රව අවු</displayName>
+				<unitPattern count="one">ද්‍රව අවු {0}</unitPattern>
+				<unitPattern count="other">ද්‍රව අවු {0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>අධිරා. තර අවු</displayName>
+				<unitPattern count="one">{0} තර අවු අධිරා.</unitPattern>
+				<unitPattern count="other">{0} තර අවු අධිරා.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>මේසහැදී</displayName>
+				<unitPattern count="one">මේසහැදී {0}</unitPattern>
+				<unitPattern count="other">මේසහැදී {0}</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>තේහැදී</displayName>
+				<unitPattern count="one">තේහැදී {0}</unitPattern>
+				<unitPattern count="other">තේහැදී {0}</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>බැරල්</displayName>
+				<unitPattern count="one">{0} බැරල්</unitPattern>
+				<unitPattern count="other">{0} බැරල්</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>අතුරුපස හැන්ද</displayName>
+				<unitPattern count="one">අතුරුපස හැඳි {0}</unitPattern>
+				<unitPattern count="other">අතුරුපස හැඳි {0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>ඉම්පී. අතුරුපස හැඳි</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ඉම්පී. අතුරුපස හැඳි {0}</unitPattern>
+				<unitPattern count="other">ඉම්පී. අතුරුපස හැඳි {0}</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>බින්දුව</displayName>
+				<unitPattern count="one">බින්දු {0}</unitPattern>
+				<unitPattern count="other">බින්දු {0}</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ඩ්‍රූම තරල</displayName>
+				<unitPattern count="one">ඩ්‍රූම තරල {0}</unitPattern>
+				<unitPattern count="other">ඩ්‍රූම තරල {0}</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>තැටි වාහකය</displayName>
+				<unitPattern count="one">තැටි වාහක {0}</unitPattern>
+				<unitPattern count="other">තැටි වාහක {0}</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ඩිංග</displayName>
+				<unitPattern count="one">ඩිංග {0}</unitPattern>
+				<unitPattern count="other">ඩිංග {0}</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ඉම්පීරියල් නැළිය</displayName>
+				<unitPattern count="one">ඉම්පීරියල් නැළි {0}</unitPattern>
+				<unitPattern count="other">ඉම්පීරියල් නැළි {0}</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>දිශාව</displayName>
@@ -9371,22 +9371,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} හෝ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, හෝ {1}</listPatternPart>
+			<listPatternPart type="2">{0} හෝ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, හෝ {1}</listPatternPart>
+			<listPatternPart type="2">{0} හෝ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, සහ {1}</listPatternPart>
+			<listPatternPart type="2">{0} සහ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -107,8 +107,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">čerokí</language>
 			<language type="chy">čejenčina</language>
 			<language type="ckb">kurdčina (sorání)</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">kurdčina (sorání)</language>
+			<language type="ckb" alt="variant">kurdčina (sorání)</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">korzičtina</language>
 			<language type="cop">koptčina</language>
@@ -746,7 +746,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="CG" alt="variant">Kongo (republika)</territory>
 			<territory type="CH">Švajčiarsko</territory>
 			<territory type="CI">Pobrežie Slonoviny</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
+			<territory type="CI" alt="variant">Pobrežie Slonoviny</territory>
 			<territory type="CK">Cookove ostrovy</territory>
 			<territory type="CL">Čile</territory>
 			<territory type="CM">Kamerun</territory>
@@ -885,7 +885,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">Nový Zéland</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Nový Zéland</territory>
 			<territory type="OM">Omán</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -940,12 +940,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TJ">Tadžikistan</territory>
 			<territory type="TK">Tokelau</territory>
 			<territory type="TL">Východný Timor</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">Východný Timor</territory>
 			<territory type="TM">Turkménsko</territory>
 			<territory type="TN">Tunisko</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turecko</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turecko</territory>
 			<territory type="TT">Trinidad a Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1423,7 +1423,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1431,7 +1431,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2000,7 +2000,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2008,7 +2008,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2701,9 +2701,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>mes.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">minulý mes.</relative>
+				<relative type="0">tento mes.</relative>
+				<relative type="1">budúci mes.</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">o {0} mes.</relativeTimePattern>
 					<relativeTimePattern count="few">o {0} mes.</relativeTimePattern>
@@ -2757,9 +2757,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>týž.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">minulý týž.</relative>
+				<relative type="0">tento týž.</relative>
+				<relative type="1">budúci týž.</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">o {0} týž.</relativeTimePattern>
 					<relativeTimePattern count="few">o {0} týž.</relativeTimePattern>
@@ -8540,66 +8540,66 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">štvorcovej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">štvorcovou {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="locative">štvorcovej {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate">štvorcový {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">štvorcové {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="dative">štvorcovému {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">štvorcového {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">štvorcovým {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="locative">štvorcovom {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">štvorcové {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">štvorcové {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="dative">štvorcovým {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="genitive">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="instrumental">štvorcovými {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="locative">štvorcových {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">štvorcové {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">štvorcové {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="dative">štvorcovým {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">štvorcovými {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="locative">štvorcových {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="dative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate">štvorcové {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">štvorcové {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="dative">štvorcovým {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">štvorcovými {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="locative">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">štvorcového {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="accusative">štvorcového {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="dative">štvorcového {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="genitive">štvorcového {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="instrumental">štvorcového {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="locative">štvorcového {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine">štvorcovej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">štvorcovej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="dative">štvorcovej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">štvorcovej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">štvorcovej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="locative">štvorcovej {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="inanimate">štvorcového {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="inanimate" case="accusative">štvorcového {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="inanimate" case="dative">štvorcového {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="inanimate" case="genitive">štvorcového {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="inanimate" case="instrumental">štvorcového {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="inanimate" case="locative">štvorcového {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">štvorcových {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="dative">štvorcovým {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="instrumental">štvorcovými {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">štvorcových {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">štvorcových {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="dative">štvorcovým {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">štvorcovými {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="locative">štvorcových {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate">štvorcových {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="inanimate" case="dative">štvorcovým {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">štvorcových {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">štvorcovými {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="locative">štvorcových {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>kubické {0}</compoundUnitPattern1>
@@ -8615,66 +8615,66 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">kubickej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">kubickou {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="locative">kubickej {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate">kubický {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">kubické {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="dative">kubickému {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">kubického {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">kubickým {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="locative">kubickom {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">kubické {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">kubické {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="dative">kubickým {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="genitive">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="instrumental">kubickými {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="locative">kubických {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">kubické {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">kubické {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="dative">kubickým {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">kubickými {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="locative">kubických {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate">kubické {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">kubické {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="dative">kubickým {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">kubickými {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="inanimate" case="locative">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">kubického {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="accusative">kubického {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="dative">kubického {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="genitive">kubického {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="instrumental">kubického {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="locative">kubického {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine">kubickej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">kubickej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="dative">kubickej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">kubickej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">kubickej {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="locative">kubickej {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="inanimate" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="inanimate" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="inanimate">kubického {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="inanimate" case="accusative">kubického {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="inanimate" case="dative">kubického {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="inanimate" case="genitive">kubického {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="inanimate" case="instrumental">kubického {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="inanimate" case="locative">kubického {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kubických {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="dative">kubickému {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="instrumental">kubickými {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">kubických {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">kubických {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="dative">kubickej {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">kubickými {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="locative">kubických {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate">kubických {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="inanimate" case="dative">kubickému {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">kubických {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">kubickými {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="locative">kubických {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}{1}</compoundUnitPattern>
@@ -8689,21 +8689,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} jednotkou preťaženia</unitPattern>
 				<unitPattern count="one" case="locative">{0} jednotke preťaženia</unitPattern>
 				<unitPattern count="few">{0} jednotky preťaženia</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} jednotky preťaženia</unitPattern>
 				<unitPattern count="few" case="dative">{0} jednotkám preťaženia</unitPattern>
 				<unitPattern count="few" case="genitive">{0} jednotiek preťaženia</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} jednotkami preťaženia</unitPattern>
 				<unitPattern count="few" case="locative">{0} jednotkách preťaženia</unitPattern>
 				<unitPattern count="many">{0} jednotky preťaženia</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} jednotky preťaženia</unitPattern>
+				<unitPattern count="many" case="dative">{0} jednotky preťaženia</unitPattern>
+				<unitPattern count="many" case="genitive">{0} jednotky preťaženia</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} jednotky preťaženia</unitPattern>
+				<unitPattern count="many" case="locative">{0} jednotky preťaženia</unitPattern>
 				<unitPattern count="other">{0} jednotiek preťaženia</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} jednotiek preťaženia</unitPattern>
 				<unitPattern count="other" case="dative">{0} jednotkám preťaženia</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} jednotiek preťaženia</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} jednotkami preťaženia</unitPattern>
 				<unitPattern count="other" case="locative">{0} jednotkách preťaženia</unitPattern>
 			</unit>
@@ -8711,25 +8711,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>metre za sekundu na druhú</displayName>
 				<unitPattern count="one">{0} meter za sekundu na druhú</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} meter za sekundu na druhú</unitPattern>
 				<unitPattern count="one" case="dative">{0} metru za sekundu na druhú</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra za sekundu na druhú</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom za sekundu na druhú</unitPattern>
 				<unitPattern count="one" case="locative">{0} metri za sekundu na druhú</unitPattern>
 				<unitPattern count="few">{0} metre za sekundu na druhú</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metre za sekundu na druhú</unitPattern>
 				<unitPattern count="few" case="dative">{0} metrom za sekundu na druhú</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metrov za sekundu na druhú</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} metrami za sekundu na druhú</unitPattern>
 				<unitPattern count="few" case="locative">{0} metroch za sekundu na druhú</unitPattern>
 				<unitPattern count="many">{0} metra za sekundu na druhú</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metra za sekundu na druhú</unitPattern>
+				<unitPattern count="many" case="dative">{0} metra za sekundu na druhú</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metra za sekundu na druhú</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metra za sekundu na druhú</unitPattern>
+				<unitPattern count="many" case="locative">{0} metra za sekundu na druhú</unitPattern>
 				<unitPattern count="other">{0} metrov za sekundu na druhú</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrov za sekundu na druhú</unitPattern>
 				<unitPattern count="other" case="dative">{0} metrom za sekundu na druhú</unitPattern>
 				<unitPattern count="other" case="genitive">{0} metrov za sekundu na druhú</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metrami za sekundu na druhú</unitPattern>
@@ -8745,21 +8745,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} otáčkou</unitPattern>
 				<unitPattern count="one" case="locative">{0} otáčke</unitPattern>
 				<unitPattern count="few">{0} otáčky</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} otáčky</unitPattern>
 				<unitPattern count="few" case="dative">{0} otáčkam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} otáčok</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} otáčkami</unitPattern>
 				<unitPattern count="few" case="locative">{0} otáčkach</unitPattern>
 				<unitPattern count="many">{0} otáčky</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} otáčky</unitPattern>
+				<unitPattern count="many" case="dative">{0} otáčky</unitPattern>
+				<unitPattern count="many" case="genitive">{0} otáčky</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} otáčky</unitPattern>
+				<unitPattern count="many" case="locative">{0} otáčky</unitPattern>
 				<unitPattern count="other">{0} otáčok</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} otáčok</unitPattern>
 				<unitPattern count="other" case="dative">{0} otáčkam</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} otáčok</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} otáčkami</unitPattern>
 				<unitPattern count="other" case="locative">{0} otáčkach</unitPattern>
 			</unit>
@@ -8767,27 +8767,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>radiány</displayName>
 				<unitPattern count="one">{0} radián</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} radián</unitPattern>
 				<unitPattern count="one" case="dative">{0} radiánu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} radiánu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} radiánom</unitPattern>
 				<unitPattern count="one" case="locative">{0} radiáne</unitPattern>
 				<unitPattern count="few">{0} radiány</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} radiány</unitPattern>
 				<unitPattern count="few" case="dative">{0} radiánom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} radiánov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} radiánmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} radiánoch</unitPattern>
 				<unitPattern count="many">{0} radiánu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} radiánu</unitPattern>
+				<unitPattern count="many" case="dative">{0} radiánu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} radiánu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} radiánu</unitPattern>
+				<unitPattern count="many" case="locative">{0} radiánu</unitPattern>
 				<unitPattern count="other">{0} radiánov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} radiánov</unitPattern>
 				<unitPattern count="other" case="dative">{0} radiánom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} radiánov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} radiánmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} radiánoch</unitPattern>
 			</unit>
@@ -8795,27 +8795,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>stupne</displayName>
 				<unitPattern count="one">{0} stupeň</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} stupeň</unitPattern>
 				<unitPattern count="one" case="dative">{0} stupňu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} stupňa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stupňom</unitPattern>
 				<unitPattern count="one" case="locative">{0} stupni</unitPattern>
 				<unitPattern count="few">{0} stupne</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stupne</unitPattern>
 				<unitPattern count="few" case="dative">{0} stupňom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} stupňov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} stupňami</unitPattern>
 				<unitPattern count="few" case="locative">{0} stupňoch</unitPattern>
 				<unitPattern count="many">{0} stupňa</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stupňa</unitPattern>
+				<unitPattern count="many" case="dative">{0} stupňa</unitPattern>
+				<unitPattern count="many" case="genitive">{0} stupňa</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} stupňa</unitPattern>
+				<unitPattern count="many" case="locative">{0} stupňa</unitPattern>
 				<unitPattern count="other">{0} stupňov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stupňov</unitPattern>
 				<unitPattern count="other" case="dative">{0} stupňom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stupňov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} stupňami</unitPattern>
 				<unitPattern count="other" case="locative">{0} stupňoch</unitPattern>
 			</unit>
@@ -8836,10 +8836,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} arcminútach</unitPattern>
 				<unitPattern count="many">{0} arcminúty</unitPattern>
 				<unitPattern count="many" case="accusative">{0} arcminúty</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="dative">{0} arcminúty</unitPattern>
 				<unitPattern count="many" case="genitive">{0} arcminúty</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} arcminúty</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="locative">{0} arcminúty</unitPattern>
 				<unitPattern count="other">{0} arcminút</unitPattern>
 				<unitPattern count="other" case="accusative">{0} arcminút</unitPattern>
 				<unitPattern count="other" case="dative">{0} arcminútam</unitPattern>
@@ -8864,10 +8864,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="locative">{0} arcsekundách</unitPattern>
 				<unitPattern count="many">{0} arcsekundy</unitPattern>
 				<unitPattern count="many" case="accusative">{0} arcsekundy</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="dative">{0} arcsekundy</unitPattern>
 				<unitPattern count="many" case="genitive">{0} arcsekundy</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} arcsekundy</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="locative">{0} arcsekundy</unitPattern>
 				<unitPattern count="other">{0} arcsekúnd</unitPattern>
 				<unitPattern count="other" case="accusative">{0} arcsekúnd</unitPattern>
 				<unitPattern count="other" case="dative">{0} arcsekundám</unitPattern>
@@ -8879,27 +8879,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>štvorcové kilometre</displayName>
 				<unitPattern count="one">{0} kilometer štvorcový</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilometer štvorcový</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilometru štvorcovému</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilometra štvorcového</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilometrom štvorcovým</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilometri štvorcovom</unitPattern>
 				<unitPattern count="few">{0} kilometre štvorcové</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilometre štvorcové</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilometrom štvorcovým</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilometrov štvorcových</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilometrami štvorcovými</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilometroch štvorcových</unitPattern>
 				<unitPattern count="many">{0} kilometra štvorcového</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilometra štvorcového</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilometra štvorcového</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilometra štvorcového</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilometra štvorcového</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilometra štvorcového</unitPattern>
 				<unitPattern count="other">{0} kilometrov štvorcových</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometrov štvorcových</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilometrom štvorcovým</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometrov štvorcových</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilometrami štvorcovými</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilometroch štvorcových</unitPattern>
 				<perUnitPattern>{0} na kilometer štvorcový</perUnitPattern>
@@ -8908,27 +8908,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>hektáre</displayName>
 				<unitPattern count="one">{0} hektár</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektár</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektáru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektára</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektárom</unitPattern>
 				<unitPattern count="one" case="locative">{0} hektári</unitPattern>
 				<unitPattern count="few">{0} hektáre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektáre</unitPattern>
 				<unitPattern count="few" case="dative">{0} hektárom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} hektárov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} hektármi</unitPattern>
 				<unitPattern count="few" case="locative">{0} hektároch</unitPattern>
 				<unitPattern count="many">{0} hektára</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hektára</unitPattern>
+				<unitPattern count="many" case="dative">{0} hektára</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hektára</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} hektára</unitPattern>
+				<unitPattern count="many" case="locative">{0} hektára</unitPattern>
 				<unitPattern count="other">{0} hektárov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektárov</unitPattern>
 				<unitPattern count="other" case="dative">{0} hektárom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektárov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} hektármi</unitPattern>
 				<unitPattern count="other" case="locative">{0} hektároch</unitPattern>
 			</unit>
@@ -8936,25 +8936,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>štvorcové metre</displayName>
 				<unitPattern count="one">{0} meter štvorcový</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} meter štvorcový</unitPattern>
 				<unitPattern count="one" case="dative">{0} metru štvorcovému</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra štvorcového</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom štvorcovým</unitPattern>
 				<unitPattern count="one" case="locative">{0} metri štvorcovom</unitPattern>
 				<unitPattern count="few">{0} metre štvorcové</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metre štvorcové</unitPattern>
 				<unitPattern count="few" case="dative">{0} metrom štvorcovým</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metrov štvorcových</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} metrami štvorcovými</unitPattern>
 				<unitPattern count="few" case="locative">{0} metroch štvorcových</unitPattern>
 				<unitPattern count="many">{0} metra štvorcového</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metra štvorcového</unitPattern>
+				<unitPattern count="many" case="dative">{0} metra štvorcového</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metra štvorcového</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metra štvorcového</unitPattern>
+				<unitPattern count="many" case="locative">{0} metra štvorcového</unitPattern>
 				<unitPattern count="other">{0} metrov štvorcových</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrov štvorcových</unitPattern>
 				<unitPattern count="other" case="dative">{0} metrom štvorcovým</unitPattern>
 				<unitPattern count="other" case="genitive">{0} metrov štvorcových</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metrami štvorcovými</unitPattern>
@@ -8965,25 +8965,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>štvorcové centimetre</displayName>
 				<unitPattern count="one">{0} centimeter štvorcový</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} centimeter štvorcový</unitPattern>
 				<unitPattern count="one" case="dative">{0} centimetru štvorcovému</unitPattern>
 				<unitPattern count="one" case="genitive">{0} centimetra štvorcového</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} centimetrom štvorcovým</unitPattern>
 				<unitPattern count="one" case="locative">{0} centimetri štvorcovom</unitPattern>
 				<unitPattern count="few">{0} centimetre štvorcové</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} centimetre štvorcové</unitPattern>
 				<unitPattern count="few" case="dative">{0} centimetrom štvorcovým</unitPattern>
 				<unitPattern count="few" case="genitive">{0} centimetrov štvorcových</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} centimetrami štvorcovými</unitPattern>
 				<unitPattern count="few" case="locative">{0} centimetroch štvorcových</unitPattern>
 				<unitPattern count="many">{0} centimetra štvorcového</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} centimetra štvorcového</unitPattern>
+				<unitPattern count="many" case="dative">{0} centimetra štvorcového</unitPattern>
+				<unitPattern count="many" case="genitive">{0} centimetra štvorcového</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} centimetra štvorcového</unitPattern>
+				<unitPattern count="many" case="locative">{0} centimetra štvorcového</unitPattern>
 				<unitPattern count="other">{0} centimetrov štvorcových</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centimetrov štvorcových</unitPattern>
 				<unitPattern count="other" case="dative">{0} centimetrom štvorcovým</unitPattern>
 				<unitPattern count="other" case="genitive">{0} centimetrov štvorcových</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} centimetrami štvorcovými</unitPattern>
@@ -9038,27 +9038,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>karáty</displayName>
 				<unitPattern count="one">{0} karát</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karát</unitPattern>
 				<unitPattern count="one" case="dative">{0} karátu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karátu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} karátom</unitPattern>
 				<unitPattern count="one" case="locative">{0} karáte</unitPattern>
 				<unitPattern count="few">{0} karáty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} karáty</unitPattern>
 				<unitPattern count="few" case="dative">{0} karátom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} karátov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} karátmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} karátoch</unitPattern>
 				<unitPattern count="many">{0} karátu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} karátu</unitPattern>
+				<unitPattern count="many" case="dative">{0} karátu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} karátu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} karátu</unitPattern>
+				<unitPattern count="many" case="locative">{0} karátu</unitPattern>
 				<unitPattern count="other">{0} karátov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karátov</unitPattern>
 				<unitPattern count="other" case="dative">{0} karátom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karátov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} karátmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} karátoch</unitPattern>
 			</unit>
@@ -9073,27 +9073,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>milimoly na liter</displayName>
 				<unitPattern count="one">{0} milimol na liter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milimol na liter</unitPattern>
 				<unitPattern count="one" case="dative">{0} milimolu na liter</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milimolu na liter</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milimolom na liter</unitPattern>
 				<unitPattern count="one" case="locative">{0} milimole na liter</unitPattern>
 				<unitPattern count="few">{0} milimoly na liter</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milimoly na liter</unitPattern>
 				<unitPattern count="few" case="dative">{0} milimolom na liter</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milimolov na liter</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milimolmi na liter</unitPattern>
 				<unitPattern count="few" case="locative">{0} milimoloch na liter</unitPattern>
 				<unitPattern count="many">{0} milimolu na liter</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milimolu na liter</unitPattern>
+				<unitPattern count="many" case="dative">{0} milimolu na liter</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milimolu na liter</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milimolu na liter</unitPattern>
+				<unitPattern count="many" case="locative">{0} milimolu na liter</unitPattern>
 				<unitPattern count="other">{0} milimolov na liter</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimolov na liter</unitPattern>
 				<unitPattern count="other" case="dative">{0} milimolom na liter</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimolov na liter</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} milimolmi na liter</unitPattern>
 				<unitPattern count="other" case="locative">{0} milimoloch na liter</unitPattern>
 			</unit>
@@ -9107,21 +9107,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} položkou</unitPattern>
 				<unitPattern count="one" case="locative">{0} položke</unitPattern>
 				<unitPattern count="few">{0} položky</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} položky</unitPattern>
 				<unitPattern count="few" case="dative">{0} položkám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} položiek</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} položkami</unitPattern>
 				<unitPattern count="few" case="locative">{0} položkách</unitPattern>
 				<unitPattern count="many">{0} položky</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} položky</unitPattern>
+				<unitPattern count="many" case="dative">{0} položky</unitPattern>
+				<unitPattern count="many" case="genitive">{0} položky</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} položky</unitPattern>
+				<unitPattern count="many" case="locative">{0} položky</unitPattern>
 				<unitPattern count="other">{0} položiek</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} položiek</unitPattern>
 				<unitPattern count="other" case="dative">{0} položkám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} položiek</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} položkami</unitPattern>
 				<unitPattern count="other" case="locative">{0} položkách</unitPattern>
 			</unit>
@@ -9135,21 +9135,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} milióntinou</unitPattern>
 				<unitPattern count="one" case="locative">{0} milióntine</unitPattern>
 				<unitPattern count="few">{0} milióntiny</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milióntiny</unitPattern>
 				<unitPattern count="few" case="dative">{0} milióntinám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milióntin</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milióntinami</unitPattern>
 				<unitPattern count="few" case="locative">{0} milióntinách</unitPattern>
 				<unitPattern count="many">{0} milióntiny</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milióntiny</unitPattern>
+				<unitPattern count="many" case="dative">{0} milióntiny</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milióntiny</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milióntiny</unitPattern>
+				<unitPattern count="many" case="locative">{0} milióntiny</unitPattern>
 				<unitPattern count="other">{0} milióntin</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milióntin</unitPattern>
 				<unitPattern count="other" case="dative">{0} milióntinám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milióntin</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} milióntinami</unitPattern>
 				<unitPattern count="other" case="locative">{0} milióntinách</unitPattern>
 			</unit>
@@ -9157,27 +9157,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>percentá</displayName>
 				<unitPattern count="one">{0} percento</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} percento</unitPattern>
 				<unitPattern count="one" case="dative">{0} percentu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} percenta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} percentom</unitPattern>
 				<unitPattern count="one" case="locative">{0} percente</unitPattern>
 				<unitPattern count="few">{0} percentá</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} percentá</unitPattern>
 				<unitPattern count="few" case="dative">{0} percentám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} percent</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} percentami</unitPattern>
 				<unitPattern count="few" case="locative">{0} percentách</unitPattern>
 				<unitPattern count="many">{0} percenta</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} percenta</unitPattern>
+				<unitPattern count="many" case="dative">{0} percenta</unitPattern>
+				<unitPattern count="many" case="genitive">{0} percenta</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} percenta</unitPattern>
+				<unitPattern count="many" case="locative">{0} percenta</unitPattern>
 				<unitPattern count="other">{0} percent</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} percent</unitPattern>
 				<unitPattern count="other" case="dative">{0} percentám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} percent</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} percentami</unitPattern>
 				<unitPattern count="other" case="locative">{0} percentách</unitPattern>
 			</unit>
@@ -9185,29 +9185,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>promile</displayName>
 				<unitPattern count="one">{0} promile</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} promile</unitPattern>
+				<unitPattern count="one" case="dative">{0} promile</unitPattern>
+				<unitPattern count="one" case="genitive">{0} promile</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} promile</unitPattern>
+				<unitPattern count="one" case="locative">{0} promile</unitPattern>
 				<unitPattern count="few">{0} promile</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} promile</unitPattern>
+				<unitPattern count="few" case="dative">{0} promile</unitPattern>
+				<unitPattern count="few" case="genitive">{0} promile</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} promile</unitPattern>
+				<unitPattern count="few" case="locative">{0} promile</unitPattern>
 				<unitPattern count="many">{0} promile</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} promile</unitPattern>
+				<unitPattern count="many" case="dative">{0} promile</unitPattern>
+				<unitPattern count="many" case="genitive">{0} promile</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} promile</unitPattern>
+				<unitPattern count="many" case="locative">{0} promile</unitPattern>
 				<unitPattern count="other">{0} promile</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} promile</unitPattern>
+				<unitPattern count="other" case="dative">{0} promile</unitPattern>
+				<unitPattern count="other" case="genitive">{0} promile</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} promile</unitPattern>
+				<unitPattern count="other" case="locative">{0} promile</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>feminine</gender>
@@ -9219,21 +9219,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} desatinou promile</unitPattern>
 				<unitPattern count="one" case="locative">{0} desatine promile</unitPattern>
 				<unitPattern count="few">{0} desatiny promile</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} desatiny promile</unitPattern>
 				<unitPattern count="few" case="dative">{0} desatinám promile</unitPattern>
 				<unitPattern count="few" case="genitive">{0} desatín promile</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} desatinami promile</unitPattern>
 				<unitPattern count="few" case="locative">{0} desatinách promile</unitPattern>
 				<unitPattern count="many">{0} desatiny promile</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} desatiny promile</unitPattern>
+				<unitPattern count="many" case="dative">{0} desatiny promile</unitPattern>
+				<unitPattern count="many" case="genitive">{0} desatiny promile</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} desatiny promile</unitPattern>
+				<unitPattern count="many" case="locative">{0} desatiny promile</unitPattern>
 				<unitPattern count="other">{0} desatín promile</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} desatín promile</unitPattern>
 				<unitPattern count="other" case="dative">{0} desatinám promile</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} desatín promile</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} desatinami promile</unitPattern>
 				<unitPattern count="other" case="locative">{0} desatinách promile</unitPattern>
 			</unit>
@@ -9241,27 +9241,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>moly</displayName>
 				<unitPattern count="one">{0} mol</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mol</unitPattern>
 				<unitPattern count="one" case="dative">{0} molu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} molu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} molom</unitPattern>
 				<unitPattern count="one" case="locative">{0} mole</unitPattern>
 				<unitPattern count="few">{0} moly</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} moly</unitPattern>
 				<unitPattern count="few" case="dative">{0} molom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} molov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} molmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} moloch</unitPattern>
 				<unitPattern count="many">{0} molu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} molu</unitPattern>
+				<unitPattern count="many" case="dative">{0} molu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} molu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} molu</unitPattern>
+				<unitPattern count="many" case="locative">{0} molu</unitPattern>
 				<unitPattern count="other">{0} molov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} molov</unitPattern>
 				<unitPattern count="other" case="dative">{0} molom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} molov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} molmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} moloch</unitPattern>
 			</unit>
@@ -9269,27 +9269,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>litre na kilometer</displayName>
 				<unitPattern count="one">{0} liter na kilometer</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} liter na kilometer</unitPattern>
 				<unitPattern count="one" case="dative">{0} litru na kilometer</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra na kilometer</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom na kilometer</unitPattern>
 				<unitPattern count="one" case="locative">{0} litri na kilometer</unitPattern>
 				<unitPattern count="few">{0} litre na kilometer</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litre na kilometer</unitPattern>
 				<unitPattern count="few" case="dative">{0} litrom na kilometer</unitPattern>
 				<unitPattern count="few" case="genitive">{0} litrov na kilometer</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} litrami na kilometer</unitPattern>
 				<unitPattern count="few" case="locative">{0} litroch na kilometer</unitPattern>
 				<unitPattern count="many">{0} litra na kilometer</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} litra na kilometer</unitPattern>
+				<unitPattern count="many" case="dative">{0} litra na kilometer</unitPattern>
+				<unitPattern count="many" case="genitive">{0} litra na kilometer</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} litra na kilometer</unitPattern>
+				<unitPattern count="many" case="locative">{0} litra na kilometer</unitPattern>
 				<unitPattern count="other">{0} litrov na kilometer</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litrov na kilometer</unitPattern>
 				<unitPattern count="other" case="dative">{0} litrom na kilometer</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litrov na kilometer</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} litrami na kilometer</unitPattern>
 				<unitPattern count="other" case="locative">{0} litroch na kilometer</unitPattern>
 			</unit>
@@ -9297,25 +9297,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>litre na 100 kilometrov</displayName>
 				<unitPattern count="one">{0} liter na 100 kilometrov</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} liter na 100 kilometrov</unitPattern>
 				<unitPattern count="one" case="dative">{0} litru na 100 kilometrov</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra na 100 kilometrov</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom na 100 kilometrov</unitPattern>
 				<unitPattern count="one" case="locative">{0} litri na 100 kilometrov</unitPattern>
 				<unitPattern count="few">{0} litre na 100 kilometrov</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litre na 100 kilometrov</unitPattern>
 				<unitPattern count="few" case="dative">{0} litrom na 100 kilometrov</unitPattern>
 				<unitPattern count="few" case="genitive">{0} litrov na 100 kilometrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} litrami na 100 kilometrov</unitPattern>
 				<unitPattern count="few" case="locative">{0} litroch na 100 kilometrov</unitPattern>
 				<unitPattern count="many">{0} litra na 100 kilometrov</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} litra na 100 kilometrov</unitPattern>
+				<unitPattern count="many" case="dative">{0} litra na 100 kilometrov</unitPattern>
+				<unitPattern count="many" case="genitive">{0} litra na 100 kilometrov</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} litra na 100 kilometrov</unitPattern>
+				<unitPattern count="many" case="locative">{0} litra na 100 kilometrov</unitPattern>
 				<unitPattern count="other">{0} litrov na 100 kilometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litrov na 100 kilometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} litrom na 100 kilometrov</unitPattern>
 				<unitPattern count="other" case="genitive">{0} litrov na 100 kilometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} litrami na 100 kilometrov</unitPattern>
@@ -9339,27 +9339,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>petabajty</displayName>
 				<unitPattern count="one">{0} petabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} petabajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} petabajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} petabajtu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} petabajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} petabajte</unitPattern>
 				<unitPattern count="few">{0} petabajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} petabajty</unitPattern>
 				<unitPattern count="few" case="dative">{0} petabajtom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} petabajtov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} petabajtmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} petabajtoch</unitPattern>
 				<unitPattern count="many">{0} petabajtu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} petabajtu</unitPattern>
+				<unitPattern count="many" case="dative">{0} petabajtu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} petabajtu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} petabajtu</unitPattern>
+				<unitPattern count="many" case="locative">{0} petabajtu</unitPattern>
 				<unitPattern count="other">{0} petabajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} petabajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} petabajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} petabajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} petabajtmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} petabajtoch</unitPattern>
 			</unit>
@@ -9367,27 +9367,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>terabajty</displayName>
 				<unitPattern count="one">{0} terabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} terabajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabajtu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} terabajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} terabajte</unitPattern>
 				<unitPattern count="few">{0} terabajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} terabajty</unitPattern>
 				<unitPattern count="few" case="dative">{0} terabajtom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} terabajtov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} terabajtmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} terabajtoch</unitPattern>
 				<unitPattern count="many">{0} terabajtu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} terabajtu</unitPattern>
+				<unitPattern count="many" case="dative">{0} terabajtu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} terabajtu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} terabajtu</unitPattern>
+				<unitPattern count="many" case="locative">{0} terabajtu</unitPattern>
 				<unitPattern count="other">{0} terabajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} terabajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} terabajtmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} terabajtoch</unitPattern>
 			</unit>
@@ -9395,27 +9395,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>terabity</displayName>
 				<unitPattern count="one">{0} terabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabit</unitPattern>
 				<unitPattern count="one" case="dative">{0} terabitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabitu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} terabitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} terabite</unitPattern>
 				<unitPattern count="few">{0} terabity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} terabity</unitPattern>
 				<unitPattern count="few" case="dative">{0} terabitom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} terabitov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} terabitmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} terabitoch</unitPattern>
 				<unitPattern count="many">{0} terabitu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} terabitu</unitPattern>
+				<unitPattern count="many" case="dative">{0} terabitu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} terabitu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} terabitu</unitPattern>
+				<unitPattern count="many" case="locative">{0} terabitu</unitPattern>
 				<unitPattern count="other">{0} terabitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} terabitom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} terabitmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} terabitoch</unitPattern>
 			</unit>
@@ -9423,27 +9423,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>gigabajty</displayName>
 				<unitPattern count="one">{0} gigabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigabajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabajtu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigabajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} gigabajte</unitPattern>
 				<unitPattern count="few">{0} gigabajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigabajty</unitPattern>
 				<unitPattern count="few" case="dative">{0} gigabajtom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigabajtov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} gigabajtmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigabajtoch</unitPattern>
 				<unitPattern count="many">{0} gigabajtu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigabajtu</unitPattern>
+				<unitPattern count="many" case="dative">{0} gigabajtu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigabajtu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gigabajtu</unitPattern>
+				<unitPattern count="many" case="locative">{0} gigabajtu</unitPattern>
 				<unitPattern count="other">{0} gigabajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} gigabajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} gigabajtmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} gigabajtoch</unitPattern>
 			</unit>
@@ -9451,25 +9451,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>gigabity</displayName>
 				<unitPattern count="one">{0} gigabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabit</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigabitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabitu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigabitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} gigabite</unitPattern>
 				<unitPattern count="few">{0} gigabity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigabity</unitPattern>
 				<unitPattern count="few" case="dative">{0} gigabitom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigabitov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} gigabitmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigabitoch</unitPattern>
 				<unitPattern count="many">{0} gigabitu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigabitu</unitPattern>
+				<unitPattern count="many" case="dative">{0} gigabitu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigabitu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gigabitu</unitPattern>
+				<unitPattern count="many" case="locative">{0} gigabitu</unitPattern>
 				<unitPattern count="other">{0} gigabitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} gigabitom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} gigabitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} gigabitmi</unitPattern>
@@ -9479,27 +9479,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>megabajty</displayName>
 				<unitPattern count="one">{0} megabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} megabajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabajtu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megabajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megabajte</unitPattern>
 				<unitPattern count="few">{0} megabajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megabajty</unitPattern>
 				<unitPattern count="few" case="dative">{0} megabajtom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megabajtov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} megabajtmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} megabajtoch</unitPattern>
 				<unitPattern count="many">{0} megabajtu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megabajtu</unitPattern>
+				<unitPattern count="many" case="dative">{0} megabajtu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megabajtu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megabajtu</unitPattern>
+				<unitPattern count="many" case="locative">{0} megabajtu</unitPattern>
 				<unitPattern count="other">{0} megabajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megabajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megabajtmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} megabajtoch</unitPattern>
 			</unit>
@@ -9507,27 +9507,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>megabity</displayName>
 				<unitPattern count="one">{0} megabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabit</unitPattern>
 				<unitPattern count="one" case="dative">{0} megabitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabitu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megabitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megabite</unitPattern>
 				<unitPattern count="few">{0} megabity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megabity</unitPattern>
 				<unitPattern count="few" case="dative">{0} megabitom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megabitov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} megabitmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} megabitoch</unitPattern>
 				<unitPattern count="many">{0} megabitu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megabitu</unitPattern>
+				<unitPattern count="many" case="dative">{0} megabitu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megabitu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megabitu</unitPattern>
+				<unitPattern count="many" case="locative">{0} megabitu</unitPattern>
 				<unitPattern count="other">{0} megabitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megabitom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megabitmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} megabitoch</unitPattern>
 			</unit>
@@ -9535,27 +9535,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilobajty</displayName>
 				<unitPattern count="one">{0} kilobajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilobajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobajtu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilobajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilobajte</unitPattern>
 				<unitPattern count="few">{0} kilobajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilobajty</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilobajtom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilobajtov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilobajtmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilobajtoch</unitPattern>
 				<unitPattern count="many">{0} kilobajtu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilobajtu</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilobajtu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilobajtu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilobajtu</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilobajtu</unitPattern>
 				<unitPattern count="other">{0} kilobajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilobajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilobajtmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilobajtoch</unitPattern>
 			</unit>
@@ -9563,25 +9563,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilobity</displayName>
 				<unitPattern count="one">{0} kilobit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobit</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilobitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobitu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilobitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilobite</unitPattern>
 				<unitPattern count="few">{0} kilobity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilobity</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilobitom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilobitov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilobitmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilobitoch</unitPattern>
 				<unitPattern count="many">{0} kilobitu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilobitu</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilobitu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilobitu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilobitu</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilobitu</unitPattern>
 				<unitPattern count="other">{0} kilobitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilobitom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilobitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilobitmi</unitPattern>
@@ -9591,27 +9591,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>bajty</displayName>
 				<unitPattern count="one">{0} bajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} bajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bajtu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} bajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} bajte</unitPattern>
 				<unitPattern count="few">{0} bajty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bajty</unitPattern>
 				<unitPattern count="few" case="dative">{0} bajtom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} bajtov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} bajtmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} bajtoch</unitPattern>
 				<unitPattern count="many">{0} bajtu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} bajtu</unitPattern>
+				<unitPattern count="many" case="dative">{0} bajtu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} bajtu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} bajtu</unitPattern>
+				<unitPattern count="many" case="locative">{0} bajtu</unitPattern>
 				<unitPattern count="other">{0} bajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} bajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} bajtmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} bajtoch</unitPattern>
 			</unit>
@@ -9619,27 +9619,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>bity</displayName>
 				<unitPattern count="one">{0} bit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bit</unitPattern>
 				<unitPattern count="one" case="dative">{0} bitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bitu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} bitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} bite</unitPattern>
 				<unitPattern count="few">{0} bity</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bity</unitPattern>
 				<unitPattern count="few" case="dative">{0} bitom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} bitov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} bitmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} bitoch</unitPattern>
 				<unitPattern count="many">{0} bitu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} bitu</unitPattern>
+				<unitPattern count="many" case="dative">{0} bitu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} bitu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} bitu</unitPattern>
+				<unitPattern count="many" case="locative">{0} bitu</unitPattern>
 				<unitPattern count="other">{0} bitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} bitom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} bitmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} bitoch</unitPattern>
 			</unit>
@@ -9647,27 +9647,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>storočia</displayName>
 				<unitPattern count="one">{0} storočie</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} storočie</unitPattern>
 				<unitPattern count="one" case="dative">{0} storočiu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} storočia</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} storočím</unitPattern>
 				<unitPattern count="one" case="locative">{0} storočí</unitPattern>
 				<unitPattern count="few">{0} storočia</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} storočia</unitPattern>
 				<unitPattern count="few" case="dative">{0} storočiam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} storočí</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} storočiami</unitPattern>
 				<unitPattern count="few" case="locative">{0} storočiach</unitPattern>
 				<unitPattern count="many">{0} storočia</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} storočia</unitPattern>
+				<unitPattern count="many" case="dative">{0} storočia</unitPattern>
+				<unitPattern count="many" case="genitive">{0} storočia</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} storočia</unitPattern>
+				<unitPattern count="many" case="locative">{0} storočia</unitPattern>
 				<unitPattern count="other">{0} storočí</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} storočí</unitPattern>
 				<unitPattern count="other" case="dative">{0} storočiam</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} storočí</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} storočiami</unitPattern>
 				<unitPattern count="other" case="locative">{0} storočiach</unitPattern>
 			</unit>
@@ -9675,27 +9675,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>desaťročia</displayName>
 				<unitPattern count="one">{0} desaťročie</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} desaťročie</unitPattern>
 				<unitPattern count="one" case="dative">{0} desaťročiu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} desaťročia</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} desaťročím</unitPattern>
 				<unitPattern count="one" case="locative">{0} desaťročí</unitPattern>
 				<unitPattern count="few">{0} desaťročia</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} desaťročia</unitPattern>
 				<unitPattern count="few" case="dative">{0} desaťročiam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} desaťročí</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} desaťročiami</unitPattern>
 				<unitPattern count="few" case="locative">{0} desaťročiach</unitPattern>
 				<unitPattern count="many">{0} desaťročia</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} desaťročia</unitPattern>
+				<unitPattern count="many" case="dative">{0} desaťročia</unitPattern>
+				<unitPattern count="many" case="genitive">{0} desaťročia</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} desaťročia</unitPattern>
+				<unitPattern count="many" case="locative">{0} desaťročia</unitPattern>
 				<unitPattern count="other">{0} desaťročí</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} desaťročí</unitPattern>
 				<unitPattern count="other" case="dative">{0} desaťročiam</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} desaťročí</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} desaťročiami</unitPattern>
 				<unitPattern count="other" case="locative">{0} desaťročiach</unitPattern>
 			</unit>
@@ -9703,27 +9703,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>roky</displayName>
 				<unitPattern count="one">{0} rok</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} rok</unitPattern>
 				<unitPattern count="one" case="dative">{0} roku</unitPattern>
 				<unitPattern count="one" case="genitive">{0} roka</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} rokom</unitPattern>
 				<unitPattern count="one" case="locative">{0} roku</unitPattern>
 				<unitPattern count="few">{0} roky</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} roky</unitPattern>
 				<unitPattern count="few" case="dative">{0} rokom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} rokov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} rokmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} rokoch</unitPattern>
 				<unitPattern count="many">{0} roka</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} roka</unitPattern>
+				<unitPattern count="many" case="dative">{0} roka</unitPattern>
+				<unitPattern count="many" case="genitive">{0} roka</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} roka</unitPattern>
+				<unitPattern count="many" case="locative">{0} roka</unitPattern>
 				<unitPattern count="other">{0} rokov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} rokov</unitPattern>
 				<unitPattern count="other" case="dative">{0} rokom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} rokov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} rokmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} rokoch</unitPattern>
 				<perUnitPattern>{0} za rok</perUnitPattern>
@@ -9761,27 +9761,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>mesiace</displayName>
 				<unitPattern count="one">{0} mesiac</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mesiac</unitPattern>
 				<unitPattern count="one" case="dative">{0} mesiacu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mesiaca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mesiacom</unitPattern>
 				<unitPattern count="one" case="locative">{0} mesiaci</unitPattern>
 				<unitPattern count="few">{0} mesiace</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mesiace</unitPattern>
 				<unitPattern count="few" case="dative">{0} mesiacom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mesiacov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} mesiacmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} mesiacoch</unitPattern>
 				<unitPattern count="many">{0} mesiaca</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mesiaca</unitPattern>
+				<unitPattern count="many" case="dative">{0} mesiaca</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mesiaca</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mesiaca</unitPattern>
+				<unitPattern count="many" case="locative">{0} mesiaca</unitPattern>
 				<unitPattern count="other">{0} mesiacov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mesiacov</unitPattern>
 				<unitPattern count="other" case="dative">{0} mesiacom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mesiacov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} mesiacmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} mesiacoch</unitPattern>
 				<perUnitPattern>{0} za mesiac</perUnitPattern>
@@ -9790,27 +9790,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>týždne</displayName>
 				<unitPattern count="one">{0} týždeň</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} týždeň</unitPattern>
 				<unitPattern count="one" case="dative">{0} týždňu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} týždňa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} týždňom</unitPattern>
 				<unitPattern count="one" case="locative">{0} týždni</unitPattern>
 				<unitPattern count="few">{0} týždne</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} týždne</unitPattern>
 				<unitPattern count="few" case="dative">{0} týždňom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} týždňov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} týždňami</unitPattern>
 				<unitPattern count="few" case="locative">{0} týždňoch</unitPattern>
 				<unitPattern count="many">{0} týždňa</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} týždňa</unitPattern>
+				<unitPattern count="many" case="dative">{0} týždňa</unitPattern>
+				<unitPattern count="many" case="genitive">{0} týždňa</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} týždňa</unitPattern>
+				<unitPattern count="many" case="locative">{0} týždňa</unitPattern>
 				<unitPattern count="other">{0} týždňov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} týždňov</unitPattern>
 				<unitPattern count="other" case="dative">{0} týždňom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} týždňov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} týždňami</unitPattern>
 				<unitPattern count="other" case="locative">{0} týždňoch</unitPattern>
 				<perUnitPattern>{0} za týždeň</perUnitPattern>
@@ -9819,48 +9819,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>dni</displayName>
 				<unitPattern count="one">{0} deň</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} deň</unitPattern>
 				<unitPattern count="one" case="dative">{0} dňu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dňa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} dňom</unitPattern>
 				<unitPattern count="one" case="locative">{0} dni</unitPattern>
 				<unitPattern count="few">{0} dni</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} dni</unitPattern>
 				<unitPattern count="few" case="dative">{0} dňom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} dní</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} dňami</unitPattern>
 				<unitPattern count="few" case="locative">{0} dňoch</unitPattern>
 				<unitPattern count="many">{0} dňa</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} dňa</unitPattern>
+				<unitPattern count="many" case="dative">{0} dňa</unitPattern>
+				<unitPattern count="many" case="genitive">{0} dňa</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} dňa</unitPattern>
+				<unitPattern count="many" case="locative">{0} dňa</unitPattern>
 				<unitPattern count="other">{0} dní</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dní</unitPattern>
 				<unitPattern count="other" case="dative">{0} dňom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dní</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} dňami</unitPattern>
 				<unitPattern count="other" case="locative">{0} dňoch</unitPattern>
 				<perUnitPattern>{0} za deň</perUnitPattern>
 			</unit>
 			<unit type="duration-day-person">
 				<gender>inanimate</gender>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} deň</unitPattern>
+				<unitPattern count="one" case="accusative">{0} deň</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dňa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} dňom</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few">{0} dni</unitPattern>
+				<unitPattern count="few" case="accusative">{0} dni</unitPattern>
 				<unitPattern count="few" case="genitive">{0} dní</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} dňami</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many">{0} dňa</unitPattern>
+				<unitPattern count="many" case="accusative">{0} dňa</unitPattern>
+				<unitPattern count="many" case="genitive">{0} dňa</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} dňa</unitPattern>
+				<unitPattern count="other">{0} dní</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dní</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dní</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} dňami</unitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -9873,21 +9873,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} hodinou</unitPattern>
 				<unitPattern count="one" case="locative">{0} hodine</unitPattern>
 				<unitPattern count="few">{0} hodiny</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hodiny</unitPattern>
 				<unitPattern count="few" case="dative">{0} hodinám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} hodín</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} hodinami</unitPattern>
 				<unitPattern count="few" case="locative">{0} hodinách</unitPattern>
 				<unitPattern count="many">{0} hodiny</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hodiny</unitPattern>
+				<unitPattern count="many" case="dative">{0} hodiny</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hodiny</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} hodiny</unitPattern>
+				<unitPattern count="many" case="locative">{0} hodiny</unitPattern>
 				<unitPattern count="other">{0} hodín</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hodín</unitPattern>
 				<unitPattern count="other" case="dative">{0} hodinám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hodín</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} hodinami</unitPattern>
 				<unitPattern count="other" case="locative">{0} hodinách</unitPattern>
 				<perUnitPattern>{0} za hodinu</perUnitPattern>
@@ -9902,21 +9902,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} minútou</unitPattern>
 				<unitPattern count="one" case="locative">{0} minúte</unitPattern>
 				<unitPattern count="few">{0} minúty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} minúty</unitPattern>
 				<unitPattern count="few" case="dative">{0} minútam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} minút</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} minútami</unitPattern>
 				<unitPattern count="few" case="locative">{0} minútach</unitPattern>
 				<unitPattern count="many">{0} minúty</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} minúty</unitPattern>
+				<unitPattern count="many" case="dative">{0} minúty</unitPattern>
+				<unitPattern count="many" case="genitive">{0} minúty</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} minúty</unitPattern>
+				<unitPattern count="many" case="locative">{0} minúty</unitPattern>
 				<unitPattern count="other">{0} minút</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} minút</unitPattern>
 				<unitPattern count="other" case="dative">{0} minútam</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} minút</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} minútami</unitPattern>
 				<unitPattern count="other" case="locative">{0} minútach</unitPattern>
 				<perUnitPattern>{0} za minútu</perUnitPattern>
@@ -9931,21 +9931,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} sekundou</unitPattern>
 				<unitPattern count="one" case="locative">{0} sekunde</unitPattern>
 				<unitPattern count="few">{0} sekundy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} sekundy</unitPattern>
 				<unitPattern count="few" case="dative">{0} sekundám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} sekúnd</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} sekundami</unitPattern>
 				<unitPattern count="few" case="locative">{0} sekundách</unitPattern>
 				<unitPattern count="many">{0} sekundy</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} sekundy</unitPattern>
+				<unitPattern count="many" case="dative">{0} sekundy</unitPattern>
+				<unitPattern count="many" case="genitive">{0} sekundy</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} sekundy</unitPattern>
+				<unitPattern count="many" case="locative">{0} sekundy</unitPattern>
 				<unitPattern count="other">{0} sekúnd</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sekúnd</unitPattern>
 				<unitPattern count="other" case="dative">{0} sekundám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} sekúnd</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} sekundami</unitPattern>
 				<unitPattern count="other" case="locative">{0} sekundách</unitPattern>
 				<perUnitPattern>{0} za sekundu</perUnitPattern>
@@ -9960,21 +9960,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} milisekundou</unitPattern>
 				<unitPattern count="one" case="locative">{0} milisekunde</unitPattern>
 				<unitPattern count="few">{0} milisekundy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milisekundy</unitPattern>
 				<unitPattern count="few" case="dative">{0} milisekundám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milisekúnd</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milisekundami</unitPattern>
 				<unitPattern count="few" case="locative">{0} milisekundách</unitPattern>
 				<unitPattern count="many">{0} milisekundy</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milisekundy</unitPattern>
+				<unitPattern count="many" case="dative">{0} milisekundy</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milisekundy</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milisekundy</unitPattern>
+				<unitPattern count="many" case="locative">{0} milisekundy</unitPattern>
 				<unitPattern count="other">{0} milisekúnd</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milisekúnd</unitPattern>
 				<unitPattern count="other" case="dative">{0} milisekundám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milisekúnd</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} milisekundami</unitPattern>
 				<unitPattern count="other" case="locative">{0} milisekundách</unitPattern>
 			</unit>
@@ -9988,21 +9988,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} mikrosekundou</unitPattern>
 				<unitPattern count="one" case="locative">{0} mikrosekunde</unitPattern>
 				<unitPattern count="few">{0} mikrosekundy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrosekundy</unitPattern>
 				<unitPattern count="few" case="dative">{0} mikrosekundám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mikrosekúnd</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} mikrosekundami</unitPattern>
 				<unitPattern count="few" case="locative">{0} mikrosekundách</unitPattern>
 				<unitPattern count="many">{0} mikrosekundy</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mikrosekundy</unitPattern>
+				<unitPattern count="many" case="dative">{0} mikrosekundy</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mikrosekundy</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mikrosekundy</unitPattern>
+				<unitPattern count="many" case="locative">{0} mikrosekundy</unitPattern>
 				<unitPattern count="other">{0} mikrosekúnd</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrosekúnd</unitPattern>
 				<unitPattern count="other" case="dative">{0} mikrosekundám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrosekúnd</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} mikrosekundami</unitPattern>
 				<unitPattern count="other" case="locative">{0} mikrosekundách</unitPattern>
 			</unit>
@@ -10016,21 +10016,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} nanosekundou</unitPattern>
 				<unitPattern count="one" case="locative">{0} nanosekunde</unitPattern>
 				<unitPattern count="few">{0} nanosekundy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} nanosekundy</unitPattern>
 				<unitPattern count="few" case="dative">{0} nanosekundám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} nanosekúnd</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} nanosekundami</unitPattern>
 				<unitPattern count="few" case="locative">{0} nanosekundách</unitPattern>
 				<unitPattern count="many">{0} nanosekundy</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} nanosekundy</unitPattern>
+				<unitPattern count="many" case="dative">{0} nanosekundy</unitPattern>
+				<unitPattern count="many" case="genitive">{0} nanosekundy</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} nanosekundy</unitPattern>
+				<unitPattern count="many" case="locative">{0} nanosekundy</unitPattern>
 				<unitPattern count="other">{0} nanosekúnd</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanosekúnd</unitPattern>
 				<unitPattern count="other" case="dative">{0} nanosekundám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nanosekúnd</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} nanosekundami</unitPattern>
 				<unitPattern count="other" case="locative">{0} nanosekundách</unitPattern>
 			</unit>
@@ -10038,27 +10038,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>ampéry</displayName>
 				<unitPattern count="one">{0} ampér</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ampér</unitPattern>
 				<unitPattern count="one" case="dative">{0} ampéru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ampéra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ampérom</unitPattern>
 				<unitPattern count="one" case="locative">{0} ampéri</unitPattern>
 				<unitPattern count="few">{0} ampéry</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ampéry</unitPattern>
 				<unitPattern count="few" case="dative">{0} ampérom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ampérov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} ampérmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} ampéroch</unitPattern>
 				<unitPattern count="many">{0} ampéra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ampéra</unitPattern>
+				<unitPattern count="many" case="dative">{0} ampéra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ampéra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} ampéra</unitPattern>
+				<unitPattern count="many" case="locative">{0} ampéra</unitPattern>
 				<unitPattern count="other">{0} ampérov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ampérov</unitPattern>
 				<unitPattern count="other" case="dative">{0} ampérom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ampérov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} ampérmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} ampéroch</unitPattern>
 			</unit>
@@ -10066,27 +10066,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>miliampéry</displayName>
 				<unitPattern count="one">{0} miliampér</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miliampér</unitPattern>
 				<unitPattern count="one" case="dative">{0} miliampéru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miliampéra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} miliampérom</unitPattern>
 				<unitPattern count="one" case="locative">{0} miliampéri</unitPattern>
 				<unitPattern count="few">{0} miliampéry</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} miliampéry</unitPattern>
 				<unitPattern count="few" case="dative">{0} miliampérom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} miliampérov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} miliampérmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} miliampéroch</unitPattern>
 				<unitPattern count="many">{0} miliampéra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} miliampéra</unitPattern>
+				<unitPattern count="many" case="dative">{0} miliampéra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} miliampéra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} miliampéra</unitPattern>
+				<unitPattern count="many" case="locative">{0} miliampéra</unitPattern>
 				<unitPattern count="other">{0} miliampérov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miliampérov</unitPattern>
 				<unitPattern count="other" case="dative">{0} miliampérom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miliampérov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} miliampérmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} miliampéroch</unitPattern>
 			</unit>
@@ -10094,27 +10094,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>ohmy</displayName>
 				<unitPattern count="one">{0} ohm</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ohm</unitPattern>
 				<unitPattern count="one" case="dative">{0} ohmu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ohmu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ohmom</unitPattern>
 				<unitPattern count="one" case="locative">{0} ohme</unitPattern>
 				<unitPattern count="few">{0} ohmy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ohmy</unitPattern>
 				<unitPattern count="few" case="dative">{0} ohmom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ohmov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} ohmami</unitPattern>
 				<unitPattern count="few" case="locative">{0} ohmoch</unitPattern>
 				<unitPattern count="many">{0} ohmu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ohmu</unitPattern>
+				<unitPattern count="many" case="dative">{0} ohmu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ohmu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} ohmu</unitPattern>
+				<unitPattern count="many" case="locative">{0} ohmu</unitPattern>
 				<unitPattern count="other">{0} ohmov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ohmov</unitPattern>
 				<unitPattern count="other" case="dative">{0} ohmom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ohmov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} ohmami</unitPattern>
 				<unitPattern count="other" case="locative">{0} ohmoch</unitPattern>
 			</unit>
@@ -10122,27 +10122,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>volty</displayName>
 				<unitPattern count="one">{0} volt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} volt</unitPattern>
 				<unitPattern count="one" case="dative">{0} voltu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} voltu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} voltom</unitPattern>
 				<unitPattern count="one" case="locative">{0} volte</unitPattern>
 				<unitPattern count="few">{0} volty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} volty</unitPattern>
 				<unitPattern count="few" case="dative">{0} voltom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} voltov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} voltmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} voltoch</unitPattern>
 				<unitPattern count="many">{0} voltu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} voltu</unitPattern>
+				<unitPattern count="many" case="dative">{0} voltu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} voltu</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} voltom</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="locative">{0} voltu</unitPattern>
 				<unitPattern count="other">{0} voltov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} voltov</unitPattern>
 				<unitPattern count="other" case="dative">{0} voltom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} voltov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} voltmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} voltoch</unitPattern>
 			</unit>
@@ -10163,21 +10163,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kalóriou</unitPattern>
 				<unitPattern count="one" case="locative">{0} kalórii</unitPattern>
 				<unitPattern count="few">{0} kalórie</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kalórie</unitPattern>
 				<unitPattern count="few" case="dative">{0} kalóriám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kalórií</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kalóriami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kalóriách</unitPattern>
 				<unitPattern count="many">{0} kalórie</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kalórie</unitPattern>
+				<unitPattern count="many" case="dative">{0} kalórie</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kalórie</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kalórie</unitPattern>
+				<unitPattern count="many" case="locative">{0} kalórie</unitPattern>
 				<unitPattern count="other">{0} kalórií</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kalórií</unitPattern>
 				<unitPattern count="other" case="dative">{0} kalóriám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kalórií</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kalóriami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kalóriách</unitPattern>
 			</unit>
@@ -10192,27 +10192,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilojouly</displayName>
 				<unitPattern count="one">{0} kilojoule</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilojoule</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilojoulu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilojoulu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilojoulom</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="locative">{0} kilojoule</unitPattern>
 				<unitPattern count="few">{0} kilojouly</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilojouly</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilojoulom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilojoulov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilojoulami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilojouloch</unitPattern>
 				<unitPattern count="many">{0} kilojoulu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilojoulu</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilojoulu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilojoulu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilojoulu</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilojoulu</unitPattern>
 				<unitPattern count="other">{0} kilojoulov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilojoulov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilojoulom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilojoulov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilojoulami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilojouloch</unitPattern>
 			</unit>
@@ -10226,21 +10226,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} joulom</unitPattern>
 				<unitPattern count="one" case="locative">{0} joule</unitPattern>
 				<unitPattern count="few">{0} jouly</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} jouly</unitPattern>
 				<unitPattern count="few" case="dative">{0} joulom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} joulov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} joulami</unitPattern>
 				<unitPattern count="few" case="locative">{0} jouloch</unitPattern>
 				<unitPattern count="many">{0} joulu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} joulu</unitPattern>
+				<unitPattern count="many" case="dative">{0} joulu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} joulu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} joulu</unitPattern>
+				<unitPattern count="many" case="locative">{0} joulu</unitPattern>
 				<unitPattern count="other">{0} joulov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} joulov</unitPattern>
 				<unitPattern count="other" case="dative">{0} joulom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} joulov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} joulami</unitPattern>
 				<unitPattern count="other" case="locative">{0} jouloch</unitPattern>
 			</unit>
@@ -10254,21 +10254,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kilowatthodinou</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilowatthodine</unitPattern>
 				<unitPattern count="few">{0} kilowatthodiny</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilowatthodiny</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilowatthodinám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilowatthodín</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilowatthodinami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilowatthodinách</unitPattern>
 				<unitPattern count="many">{0} kilowatthodiny</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilowatthodiny</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilowatthodiny</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilowatthodiny</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilowatthodiny</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilowatthodiny</unitPattern>
 				<unitPattern count="other">{0} kilowatthodín</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilowatthodín</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilowatthodinám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilowatthodín</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilowatthodinami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilowatthodinách</unitPattern>
 			</unit>
@@ -10304,83 +10304,83 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>newtony</displayName>
 				<unitPattern count="one">{0} newton</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} newton</unitPattern>
 				<unitPattern count="one" case="dative">{0} newtonu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} newtona</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} newtonom</unitPattern>
 				<unitPattern count="one" case="locative">{0} newtone</unitPattern>
 				<unitPattern count="few">{0} newtony</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} newtony</unitPattern>
 				<unitPattern count="few" case="dative">{0} newtonom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} newtonov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} newtonmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} newtonoch</unitPattern>
 				<unitPattern count="many">{0} newtona</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} newtona</unitPattern>
+				<unitPattern count="many" case="dative">{0} newtona</unitPattern>
+				<unitPattern count="many" case="genitive">{0} newtona</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} newtona</unitPattern>
+				<unitPattern count="many" case="locative">{0} newtona</unitPattern>
 				<unitPattern count="other">{0} newtonov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} newtonov</unitPattern>
 				<unitPattern count="other" case="dative">{0} newtonom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} newtonov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} newtonmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} newtonoch</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>feminine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="dative">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="locative">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="dative">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="locative">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="many" case="dative">{0} kWh/100km</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kWh/100km</unitPattern>
+				<unitPattern count="many" case="locative">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="dative">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="locative">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>inanimate</gender>
 				<displayName>gigahertze</displayName>
 				<unitPattern count="one">{0} gigahertz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigahertz</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigahertzu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigahertza</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigahertzom</unitPattern>
 				<unitPattern count="one" case="locative">{0} gigahertzi</unitPattern>
 				<unitPattern count="few">{0} gigahertze</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigahertze</unitPattern>
 				<unitPattern count="few" case="dative">{0} gigahertzom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigahertzov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} gigahertzmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigahertzoch</unitPattern>
 				<unitPattern count="many">{0} gigahertza</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigahertza</unitPattern>
+				<unitPattern count="many" case="dative">{0} gigahertza</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigahertza</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gigahertza</unitPattern>
+				<unitPattern count="many" case="locative">{0} gigahertza</unitPattern>
 				<unitPattern count="other">{0} gigahertzov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigahertzov</unitPattern>
 				<unitPattern count="other" case="dative">{0} gigahertzom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigahertzov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} gigahertzmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} gigahertzoch</unitPattern>
 			</unit>
@@ -10388,25 +10388,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>megahertze</displayName>
 				<unitPattern count="one">{0} megahertz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megahertz</unitPattern>
 				<unitPattern count="one" case="dative">{0} megahertzu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megahertza</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megahertzom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megahertzi</unitPattern>
 				<unitPattern count="few">{0} megahertze</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megahertze</unitPattern>
 				<unitPattern count="few" case="dative">{0} megahertzom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megahertzov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} megahertzmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} megahertzoch</unitPattern>
 				<unitPattern count="many">{0} megahertza</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megahertza</unitPattern>
+				<unitPattern count="many" case="dative">{0} megahertza</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megahertza</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megahertza</unitPattern>
+				<unitPattern count="many" case="locative">{0} megahertza</unitPattern>
 				<unitPattern count="other">{0} megahertzov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megahertzov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megahertzom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} megahertzov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megahertzmi</unitPattern>
@@ -10416,27 +10416,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilohertze</displayName>
 				<unitPattern count="one">{0} kilohertz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilohertz</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilohertzu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilohertza</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilohertzom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilohertzi</unitPattern>
 				<unitPattern count="few">{0} kilohertze</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilohertze</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilohertzom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilohertzov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilohertzmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilohertzoch</unitPattern>
 				<unitPattern count="many">{0} kilohertza</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilohertza</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilohertza</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilohertza</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilohertza</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilohertza</unitPattern>
 				<unitPattern count="other">{0} kilohertzov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilohertzov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilohertzom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilohertzov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilohertzmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilohertzoch</unitPattern>
 			</unit>
@@ -10444,83 +10444,83 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>hertze</displayName>
 				<unitPattern count="one">{0} hertz</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hertz</unitPattern>
 				<unitPattern count="one" case="dative">{0} hertzu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hertza</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hertzom</unitPattern>
 				<unitPattern count="one" case="locative">{0} hertzi</unitPattern>
 				<unitPattern count="few">{0} hertze</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hertze</unitPattern>
 				<unitPattern count="few" case="dative">{0} hertzom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} hertzov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} hertzmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} hertzoch</unitPattern>
 				<unitPattern count="many">{0} hertza</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hertza</unitPattern>
+				<unitPattern count="many" case="dative">{0} hertza</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hertza</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} hertza</unitPattern>
+				<unitPattern count="many" case="locative">{0} hertza</unitPattern>
 				<unitPattern count="other">{0} hertzov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hertzov</unitPattern>
 				<unitPattern count="other" case="dative">{0} hertzom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hertzov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} hertzmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} hertzoch</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="accusative">{0} em</unitPattern>
+				<unitPattern count="one" case="dative">{0} em</unitPattern>
+				<unitPattern count="one" case="genitive">{0} em</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="one" case="locative">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="few" case="accusative">{0} em</unitPattern>
+				<unitPattern count="few" case="dative">{0} em</unitPattern>
+				<unitPattern count="few" case="genitive">{0} em</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="few" case="locative">{0} em</unitPattern>
+				<unitPattern count="many">{0} em</unitPattern>
+				<unitPattern count="many" case="accusative">{0} em</unitPattern>
+				<unitPattern count="many" case="dative">{0} em</unitPattern>
+				<unitPattern count="many" case="genitive">{0} em</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="many" case="locative">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="accusative">{0} em</unitPattern>
+				<unitPattern count="other" case="dative">{0} em</unitPattern>
+				<unitPattern count="other" case="genitive">{0} em</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="other" case="locative">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>inanimate</gender>
 				<displayName>pixely</displayName>
 				<unitPattern count="one">{0} pixel</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} pixel</unitPattern>
 				<unitPattern count="one" case="dative">{0} pixelu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} pixela</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} pixelom</unitPattern>
 				<unitPattern count="one" case="locative">{0} pixeli</unitPattern>
 				<unitPattern count="few">{0} pixely</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} pixely</unitPattern>
 				<unitPattern count="few" case="dative">{0} pixelom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} pixelov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} pixelmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} pixeloch</unitPattern>
 				<unitPattern count="many">{0} pixela</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pixela</unitPattern>
+				<unitPattern count="many" case="dative">{0} pixela</unitPattern>
+				<unitPattern count="many" case="genitive">{0} pixela</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} pixela</unitPattern>
+				<unitPattern count="many" case="locative">{0} pixela</unitPattern>
 				<unitPattern count="other">{0} pixelov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pixelov</unitPattern>
 				<unitPattern count="other" case="dative">{0} pixelom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pixelov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} pixelmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} pixeloch</unitPattern>
 			</unit>
@@ -10528,27 +10528,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>megapixely</displayName>
 				<unitPattern count="one">{0} megapixel</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapixel</unitPattern>
 				<unitPattern count="one" case="dative">{0} megapixelu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megapixela</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megapixelom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megapixeli</unitPattern>
 				<unitPattern count="few">{0} megapixely</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megapixely</unitPattern>
 				<unitPattern count="few" case="dative">{0} megapixelom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megapixelov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} megapixelmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} megapixeloch</unitPattern>
 				<unitPattern count="many">{0} megapixela</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megapixela</unitPattern>
+				<unitPattern count="many" case="dative">{0} megapixela</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megapixela</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megapixela</unitPattern>
+				<unitPattern count="many" case="locative">{0} megapixela</unitPattern>
 				<unitPattern count="other">{0} megapixelov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapixelov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megapixelom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapixelov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megapixelmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} megapixeloch</unitPattern>
 			</unit>
@@ -10556,25 +10556,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>pixely na centimeter</displayName>
 				<unitPattern count="one">{0} pixel na centimeter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} pixel na centimeter</unitPattern>
 				<unitPattern count="one" case="dative">{0} pixelu na centimeter</unitPattern>
 				<unitPattern count="one" case="genitive">{0} pixela na centimeter</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} pixelom na centimeter</unitPattern>
 				<unitPattern count="one" case="locative">{0} pixeli na centimeter</unitPattern>
 				<unitPattern count="few">{0} pixely na centimeter</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} pixely na centimeter</unitPattern>
 				<unitPattern count="few" case="dative">{0} pixelom na centimeter</unitPattern>
 				<unitPattern count="few" case="genitive">{0} pixelov na centimeter</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} pixelmi na centimeter</unitPattern>
 				<unitPattern count="few" case="locative">{0} pixeloch na centimeter</unitPattern>
 				<unitPattern count="many">{0} pixela na centimeter</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pixela na centimeter</unitPattern>
+				<unitPattern count="many" case="dative">{0} pixela na centimeter</unitPattern>
+				<unitPattern count="many" case="genitive">{0} pixela na centimeter</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} pixela na centimeter</unitPattern>
+				<unitPattern count="many" case="locative">{0} pixela na centimeter</unitPattern>
 				<unitPattern count="other">{0} pixelov na centimeter</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pixelov na centimeter</unitPattern>
 				<unitPattern count="other" case="dative">{0} pixelom na centimeter</unitPattern>
 				<unitPattern count="other" case="genitive">{0} pixelov na centimeter</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} pixelmi na centimeter</unitPattern>
@@ -10609,35 +10609,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} bodov</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<gender>inanimate</gender>
 				<displayName>kilometre</displayName>
 				<unitPattern count="one">{0} kilometer</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilometer</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilometru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilometrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilometri</unitPattern>
 				<unitPattern count="few">{0} kilometre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilometre</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilometrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilometrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilometrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilometroch</unitPattern>
 				<unitPattern count="many">{0} kilometra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilometra</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilometra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilometra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilometra</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilometra</unitPattern>
 				<unitPattern count="other">{0} kilometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilometrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilometrami</unitPattern>
@@ -10648,27 +10648,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>metre</displayName>
 				<unitPattern count="one">{0} meter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} meter</unitPattern>
 				<unitPattern count="one" case="dative">{0} metru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} metri</unitPattern>
 				<unitPattern count="few">{0} metre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metre</unitPattern>
 				<unitPattern count="few" case="dative">{0} metrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} metrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} metroch</unitPattern>
 				<unitPattern count="many">{0} metra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metra</unitPattern>
+				<unitPattern count="many" case="dative">{0} metra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metra</unitPattern>
+				<unitPattern count="many" case="locative">{0} metra</unitPattern>
 				<unitPattern count="other">{0} metrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} metrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} metroch</unitPattern>
 				<perUnitPattern>{0} na meter</perUnitPattern>
@@ -10677,27 +10677,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>decimetre</displayName>
 				<unitPattern count="one">{0} decimeter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} decimeter</unitPattern>
 				<unitPattern count="one" case="dative">{0} decimetru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} decimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} decimetrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} decimetri</unitPattern>
 				<unitPattern count="few">{0} decimetre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} decimetre</unitPattern>
 				<unitPattern count="few" case="dative">{0} decimetrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} decimetrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} decimetrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} decimetroch</unitPattern>
 				<unitPattern count="many">{0} decimetra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} decimetra</unitPattern>
+				<unitPattern count="many" case="dative">{0} decimetra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} decimetra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} decimetra</unitPattern>
+				<unitPattern count="many" case="locative">{0} decimetra</unitPattern>
 				<unitPattern count="other">{0} decimetrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decimetrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} decimetrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decimetrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} decimetrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} decimetroch</unitPattern>
 			</unit>
@@ -10705,25 +10705,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>centimetre</displayName>
 				<unitPattern count="one">{0} centimeter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} centimeter</unitPattern>
 				<unitPattern count="one" case="dative">{0} centimetru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} centimetrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} centimetri</unitPattern>
 				<unitPattern count="few">{0} centimetre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} centimetre</unitPattern>
 				<unitPattern count="few" case="dative">{0} centimetrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} centimetrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} centimetrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} centimetroch</unitPattern>
 				<unitPattern count="many">{0} centimetra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} centimetra</unitPattern>
+				<unitPattern count="many" case="dative">{0} centimetra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} centimetra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} centimetra</unitPattern>
+				<unitPattern count="many" case="locative">{0} centimetra</unitPattern>
 				<unitPattern count="other">{0} centimetrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centimetrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} centimetrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} centimetrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} centimetrami</unitPattern>
@@ -10734,25 +10734,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>milimetre</displayName>
 				<unitPattern count="one">{0} milimeter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milimeter</unitPattern>
 				<unitPattern count="one" case="dative">{0} milimetru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milimetrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} milimetri</unitPattern>
 				<unitPattern count="few">{0} milimetre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milimetre</unitPattern>
 				<unitPattern count="few" case="dative">{0} milimetrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milimetrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milimetrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} milimetroch</unitPattern>
 				<unitPattern count="many">{0} milimetra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milimetra</unitPattern>
+				<unitPattern count="many" case="dative">{0} milimetra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milimetra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milimetra</unitPattern>
+				<unitPattern count="many" case="locative">{0} milimetra</unitPattern>
 				<unitPattern count="other">{0} milimetrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimetrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} milimetrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} milimetrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} milimetrami</unitPattern>
@@ -10762,25 +10762,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>mikrometre</displayName>
 				<unitPattern count="one">{0} mikrometer</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrometer</unitPattern>
 				<unitPattern count="one" case="dative">{0} mikrometru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mikrometrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} mikrometri</unitPattern>
 				<unitPattern count="few">{0} mikrometre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrometre</unitPattern>
 				<unitPattern count="few" case="dative">{0} mikrometrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mikrometrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} mikrometrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} mikrometroch</unitPattern>
 				<unitPattern count="many">{0} mikrometra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mikrometra</unitPattern>
+				<unitPattern count="many" case="dative">{0} mikrometra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mikrometra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mikrometra</unitPattern>
+				<unitPattern count="many" case="locative">{0} mikrometra</unitPattern>
 				<unitPattern count="other">{0} mikrometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} mikrometrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mikrometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} mikrometrami</unitPattern>
@@ -10790,25 +10790,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>nanometre</displayName>
 				<unitPattern count="one">{0} nanometer</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} nanometer</unitPattern>
 				<unitPattern count="one" case="dative">{0} nanometru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} nanometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} nanometrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} nanometri</unitPattern>
 				<unitPattern count="few">{0} nanometre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} nanometre</unitPattern>
 				<unitPattern count="few" case="dative">{0} nanometrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} nanometrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} nanometrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} nanometroch</unitPattern>
 				<unitPattern count="many">{0} nanometra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} nanometra</unitPattern>
+				<unitPattern count="many" case="dative">{0} nanometra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} nanometra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} nanometra</unitPattern>
+				<unitPattern count="many" case="locative">{0} nanometra</unitPattern>
 				<unitPattern count="other">{0} nanometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} nanometrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} nanometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} nanometrami</unitPattern>
@@ -10818,25 +10818,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>pikometre</displayName>
 				<unitPattern count="one">{0} pikometer</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} pikometer</unitPattern>
 				<unitPattern count="one" case="dative">{0} pikometru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} pikometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} pikometrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} pikometri</unitPattern>
 				<unitPattern count="few">{0} pikometre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} pikometre</unitPattern>
 				<unitPattern count="few" case="dative">{0} pikometrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} pikometrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} pikometrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} pikometroch</unitPattern>
 				<unitPattern count="many">{0} pikometra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pikometra</unitPattern>
+				<unitPattern count="many" case="dative">{0} pikometra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} pikometra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} pikometra</unitPattern>
+				<unitPattern count="many" case="locative">{0} pikometra</unitPattern>
 				<unitPattern count="other">{0} pikometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pikometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} pikometrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} pikometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} pikometrami</unitPattern>
@@ -10924,21 +10924,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} škandinávskou míľou</unitPattern>
 				<unitPattern count="one" case="locative">{0} škandinávskej míli</unitPattern>
 				<unitPattern count="few">{0} škandinávske míle</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} škandinávske míle</unitPattern>
 				<unitPattern count="few" case="dative">{0} škandinávskym míľam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} škandinávskych míľ</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} škandinávskymi míľami</unitPattern>
 				<unitPattern count="few" case="locative">{0} škandinávskych míľach</unitPattern>
 				<unitPattern count="many">{0} škandinávskej míle</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} škandinávskej míle</unitPattern>
+				<unitPattern count="many" case="dative">{0} škandinávskej míle</unitPattern>
+				<unitPattern count="many" case="genitive">{0} škandinávskej míle</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} škandinávskej míle</unitPattern>
+				<unitPattern count="many" case="locative">{0} škandinávskej míle</unitPattern>
 				<unitPattern count="other">{0} škandinávskych míľ</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} škandinávskych míľ</unitPattern>
 				<unitPattern count="other" case="dative">{0} škandinávskym míľam</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} škandinávskych míľ</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} škandinávskymi míľami</unitPattern>
 				<unitPattern count="other" case="locative">{0} škandinávskych míľach</unitPattern>
 			</unit>
@@ -10960,27 +10960,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>luxy</displayName>
 				<unitPattern count="one">{0} lux</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} lux</unitPattern>
 				<unitPattern count="one" case="dative">{0} luxu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} luxu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} luxom</unitPattern>
 				<unitPattern count="one" case="locative">{0} luxe</unitPattern>
 				<unitPattern count="few">{0} luxy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} luxy</unitPattern>
 				<unitPattern count="few" case="dative">{0} luxom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} luxov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} luxmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} luxoch</unitPattern>
 				<unitPattern count="many">{0} luxu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} luxu</unitPattern>
+				<unitPattern count="many" case="dative">{0} luxu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} luxu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} luxu</unitPattern>
+				<unitPattern count="many" case="locative">{0} luxu</unitPattern>
 				<unitPattern count="other">{0} luxov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} luxov</unitPattern>
 				<unitPattern count="other" case="dative">{0} luxom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} luxov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} luxmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} luxoch</unitPattern>
 			</unit>
@@ -10994,21 +10994,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kandelou</unitPattern>
 				<unitPattern count="one" case="locative">{0} kandele</unitPattern>
 				<unitPattern count="few">{0} kandely</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kandely</unitPattern>
 				<unitPattern count="few" case="dative">{0} kandelám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kandel</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kandelami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kandelách</unitPattern>
 				<unitPattern count="many">{0} kandely</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kandely</unitPattern>
+				<unitPattern count="many" case="dative">{0} kandely</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kandely</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kandely</unitPattern>
+				<unitPattern count="many" case="locative">{0} kandely</unitPattern>
 				<unitPattern count="other">{0} kandel</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kandel</unitPattern>
 				<unitPattern count="other" case="dative">{0} kandelám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kandel</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kandelami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kandelách</unitPattern>
 			</unit>
@@ -11016,27 +11016,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>lúmeny</displayName>
 				<unitPattern count="one">{0} lúmen</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} lúmen</unitPattern>
 				<unitPattern count="one" case="dative">{0} lúmenu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} lúmenu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} lúmenom</unitPattern>
 				<unitPattern count="one" case="locative">{0} lúmene</unitPattern>
 				<unitPattern count="few">{0} lúmeny</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} lúmeny</unitPattern>
 				<unitPattern count="few" case="dative">{0} lúmenom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} lúmenov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} lúmenmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} lúmenoch</unitPattern>
 				<unitPattern count="many">{0} lúmenu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} lúmenu</unitPattern>
+				<unitPattern count="many" case="dative">{0} lúmenu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} lúmenu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} lúmenu</unitPattern>
+				<unitPattern count="many" case="locative">{0} lúmenu</unitPattern>
 				<unitPattern count="other">{0} lúmenov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} lúmenov</unitPattern>
 				<unitPattern count="other" case="dative">{0} lúmenom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} lúmenov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} lúmenmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} lúmenoch</unitPattern>
 			</unit>
@@ -11057,21 +11057,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} tonou</unitPattern>
 				<unitPattern count="one" case="locative">{0} tone</unitPattern>
 				<unitPattern count="few">{0} tony</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} tony</unitPattern>
 				<unitPattern count="few" case="dative">{0} tonám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ton</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} tonami</unitPattern>
 				<unitPattern count="few" case="locative">{0} tonách</unitPattern>
 				<unitPattern count="many">{0} tony</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} tony</unitPattern>
+				<unitPattern count="many" case="dative">{0} tony</unitPattern>
+				<unitPattern count="many" case="genitive">{0} tony</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} tony</unitPattern>
+				<unitPattern count="many" case="locative">{0} tony</unitPattern>
 				<unitPattern count="other">{0} ton</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ton</unitPattern>
 				<unitPattern count="other" case="dative">{0} tonám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ton</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} tonami</unitPattern>
 				<unitPattern count="other" case="locative">{0} tonách</unitPattern>
 			</unit>
@@ -11079,27 +11079,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilogramy</displayName>
 				<unitPattern count="one">{0} kilogram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilogram</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilogramu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilogramu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilogramom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilograme</unitPattern>
 				<unitPattern count="few">{0} kilogramy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilogramy</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilogramom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilogramov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilogramami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilogramoch</unitPattern>
 				<unitPattern count="many">{0} kilogramu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilogramu</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilogramu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilogramu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilogramu</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilogramu</unitPattern>
 				<unitPattern count="other">{0} kilogramov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilogramov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilogramom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilogramov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilogramami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilogramoch</unitPattern>
 				<perUnitPattern>{0} na kilogram</perUnitPattern>
@@ -11108,27 +11108,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>gramy</displayName>
 				<unitPattern count="one">{0} gram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gram</unitPattern>
 				<unitPattern count="one" case="dative">{0} gramu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gramu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gramom</unitPattern>
 				<unitPattern count="one" case="locative">{0} grame</unitPattern>
 				<unitPattern count="few">{0} gramy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gramy</unitPattern>
 				<unitPattern count="few" case="dative">{0} gramom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gramov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} gramami</unitPattern>
 				<unitPattern count="few" case="locative">{0} gramoch</unitPattern>
 				<unitPattern count="many">{0} gramu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gramu</unitPattern>
+				<unitPattern count="many" case="dative">{0} gramu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gramu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gramu</unitPattern>
+				<unitPattern count="many" case="locative">{0} gramu</unitPattern>
 				<unitPattern count="other">{0} gramov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gramov</unitPattern>
 				<unitPattern count="other" case="dative">{0} gramom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gramov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} gramami</unitPattern>
 				<unitPattern count="other" case="locative">{0} gramoch</unitPattern>
 				<perUnitPattern>{0} na gram</perUnitPattern>
@@ -11137,25 +11137,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>miligramy</displayName>
 				<unitPattern count="one">{0} miligram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miligram</unitPattern>
 				<unitPattern count="one" case="dative">{0} miligramu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miligramu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} miligramom</unitPattern>
 				<unitPattern count="one" case="locative">{0} miligrame</unitPattern>
 				<unitPattern count="few">{0} miligramy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} miligramy</unitPattern>
 				<unitPattern count="few" case="dative">{0} miligramom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} miligramov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} miligramami</unitPattern>
 				<unitPattern count="few" case="locative">{0} miligramoch</unitPattern>
 				<unitPattern count="many">{0} miligramu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} miligramu</unitPattern>
+				<unitPattern count="many" case="dative">{0} miligramu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} miligramu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} miligramu</unitPattern>
+				<unitPattern count="many" case="locative">{0} miligramu</unitPattern>
 				<unitPattern count="other">{0} miligramov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miligramov</unitPattern>
 				<unitPattern count="other" case="dative">{0} miligramom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} miligramov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} miligramami</unitPattern>
@@ -11165,25 +11165,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>mikrogramy</displayName>
 				<unitPattern count="one">{0} mikrogram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrogram</unitPattern>
 				<unitPattern count="one" case="dative">{0} mikrogramu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrogramu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mikrogramom</unitPattern>
 				<unitPattern count="one" case="locative">{0} mikrograme</unitPattern>
 				<unitPattern count="few">{0} mikrogramy</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrogramy</unitPattern>
 				<unitPattern count="few" case="dative">{0} mikrogramom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mikrogramov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} mikrogramami</unitPattern>
 				<unitPattern count="few" case="locative">{0} mikrogramoch</unitPattern>
 				<unitPattern count="many">{0} mikrogramu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mikrogramu</unitPattern>
+				<unitPattern count="many" case="dative">{0} mikrogramu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mikrogramu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mikrogramu</unitPattern>
+				<unitPattern count="many" case="locative">{0} mikrogramu</unitPattern>
 				<unitPattern count="other">{0} mikrogramov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrogramov</unitPattern>
 				<unitPattern count="other" case="dative">{0} mikrogramom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mikrogramov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} mikrogramami</unitPattern>
@@ -11230,27 +11230,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>karáty</displayName>
 				<unitPattern count="one">{0} karát</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karát</unitPattern>
 				<unitPattern count="one" case="dative">{0} karátu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karátu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} karátom</unitPattern>
 				<unitPattern count="one" case="locative">{0} karáte</unitPattern>
 				<unitPattern count="few">{0} karáty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} karáty</unitPattern>
 				<unitPattern count="few" case="dative">{0} karátom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} karátov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} karátmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} karátoch</unitPattern>
 				<unitPattern count="many">{0} karátu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} karátu</unitPattern>
+				<unitPattern count="many" case="dative">{0} karátu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} karátu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} karátu</unitPattern>
+				<unitPattern count="many" case="locative">{0} karátu</unitPattern>
 				<unitPattern count="other">{0} karátov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karátov</unitPattern>
 				<unitPattern count="other" case="dative">{0} karátom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karátov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} karátmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} karátoch</unitPattern>
 			</unit>
@@ -11286,27 +11286,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>gigawatty</displayName>
 				<unitPattern count="one">{0} gigawatt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigawatt</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigawattu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigawattu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigawattom</unitPattern>
 				<unitPattern count="one" case="locative">{0} gigawatte</unitPattern>
 				<unitPattern count="few">{0} gigawatty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigawatty</unitPattern>
 				<unitPattern count="few" case="dative">{0} gigawattom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigawattov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} gigawattmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigawattoch</unitPattern>
 				<unitPattern count="many">{0} gigawattu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} gigawattu</unitPattern>
+				<unitPattern count="many" case="dative">{0} gigawattu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} gigawattu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} gigawattu</unitPattern>
+				<unitPattern count="many" case="locative">{0} gigawattu</unitPattern>
 				<unitPattern count="other">{0} gigawattov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigawattov</unitPattern>
 				<unitPattern count="other" case="dative">{0} gigawattom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigawattov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} gigawattmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} gigawattoch</unitPattern>
 			</unit>
@@ -11314,27 +11314,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>megawatty</displayName>
 				<unitPattern count="one">{0} megawatt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megawatt</unitPattern>
 				<unitPattern count="one" case="dative">{0} megawattu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megawattu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megawattom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megawatte</unitPattern>
 				<unitPattern count="few">{0} megawatty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megawatty</unitPattern>
 				<unitPattern count="few" case="dative">{0} megawattom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megawattov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} megawattmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} megawattoch</unitPattern>
 				<unitPattern count="many">{0} megawattu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megawattu</unitPattern>
+				<unitPattern count="many" case="dative">{0} megawattu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megawattu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megawattu</unitPattern>
+				<unitPattern count="many" case="locative">{0} megawattu</unitPattern>
 				<unitPattern count="other">{0} megawattov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megawattov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megawattom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megawattov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megawattmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} megawattoch</unitPattern>
 			</unit>
@@ -11342,25 +11342,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilowatty</displayName>
 				<unitPattern count="one">{0} kilowatt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilowatt</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilowattu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilowattu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilowattom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilowatte</unitPattern>
 				<unitPattern count="few">{0} kilowatty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilowatty</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilowattom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilowattov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilowattmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilowattoch</unitPattern>
 				<unitPattern count="many">{0} kilowattu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilowattu</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilowattu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilowattu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilowattu</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilowattu</unitPattern>
 				<unitPattern count="other">{0} kilowattov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilowattov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilowattom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilowattov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilowattmi</unitPattern>
@@ -11370,27 +11370,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>watty</displayName>
 				<unitPattern count="one">{0} watt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} watt</unitPattern>
 				<unitPattern count="one" case="dative">{0} wattu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} wattu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} wattom</unitPattern>
 				<unitPattern count="one" case="locative">{0} watte</unitPattern>
 				<unitPattern count="few">{0} watty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} watty</unitPattern>
 				<unitPattern count="few" case="dative">{0} wattom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} wattov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} wattmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} wattoch</unitPattern>
 				<unitPattern count="many">{0} wattu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} wattu</unitPattern>
+				<unitPattern count="many" case="dative">{0} wattu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} wattu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} wattu</unitPattern>
+				<unitPattern count="many" case="locative">{0} wattu</unitPattern>
 				<unitPattern count="other">{0} wattov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} wattov</unitPattern>
 				<unitPattern count="other" case="dative">{0} wattom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} wattov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} wattmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} wattoch</unitPattern>
 			</unit>
@@ -11398,25 +11398,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>milliwatty</displayName>
 				<unitPattern count="one">{0} milliwatt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milliwatt</unitPattern>
 				<unitPattern count="one" case="dative">{0} milliwattu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milliwattu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milliwattom</unitPattern>
 				<unitPattern count="one" case="locative">{0} milliwatte</unitPattern>
 				<unitPattern count="few">{0} milliwatty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milliwatty</unitPattern>
 				<unitPattern count="few" case="dative">{0} milliwattom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milliwattov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milliwattmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} milliwattoch</unitPattern>
 				<unitPattern count="many">{0} milliwattu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milliwattu</unitPattern>
+				<unitPattern count="many" case="dative">{0} milliwattu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milliwattu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milliwattu</unitPattern>
+				<unitPattern count="many" case="locative">{0} milliwattu</unitPattern>
 				<unitPattern count="other">{0} milliwattov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milliwattov</unitPattern>
 				<unitPattern count="other" case="dative">{0} milliwattom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} milliwattov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} milliwattmi</unitPattern>
@@ -11454,27 +11454,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>bary</displayName>
 				<unitPattern count="one">{0} bar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bar</unitPattern>
 				<unitPattern count="one" case="dative">{0} baru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} baru</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} barom</unitPattern>
 				<unitPattern count="one" case="locative">{0} bare</unitPattern>
 				<unitPattern count="few">{0} bary</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bary</unitPattern>
 				<unitPattern count="few" case="dative">{0} barom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} barov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} barmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} baroch</unitPattern>
 				<unitPattern count="many">{0} baru</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} baru</unitPattern>
+				<unitPattern count="many" case="dative">{0} baru</unitPattern>
+				<unitPattern count="many" case="genitive">{0} baru</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} baru</unitPattern>
+				<unitPattern count="many" case="locative">{0} baru</unitPattern>
 				<unitPattern count="other">{0} barov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} barov</unitPattern>
 				<unitPattern count="other" case="dative">{0} barom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} barov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} barmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} baroch</unitPattern>
 			</unit>
@@ -11482,27 +11482,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>milibary</displayName>
 				<unitPattern count="one">{0} milibar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milibar</unitPattern>
 				<unitPattern count="one" case="dative">{0} milibaru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milibaru</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milibarom</unitPattern>
 				<unitPattern count="one" case="locative">{0} milibare</unitPattern>
 				<unitPattern count="few">{0} milibary</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milibary</unitPattern>
 				<unitPattern count="few" case="dative">{0} milibarom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milibarov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} milibarmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} milibaroch</unitPattern>
 				<unitPattern count="many">{0} milibaru</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} milibaru</unitPattern>
+				<unitPattern count="many" case="dative">{0} milibaru</unitPattern>
+				<unitPattern count="many" case="genitive">{0} milibaru</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} milibaru</unitPattern>
+				<unitPattern count="many" case="locative">{0} milibaru</unitPattern>
 				<unitPattern count="other">{0} milibarov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milibarov</unitPattern>
 				<unitPattern count="other" case="dative">{0} milibarom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milibarov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} milibarmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} milibaroch</unitPattern>
 			</unit>
@@ -11516,21 +11516,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} atmosférou</unitPattern>
 				<unitPattern count="one" case="locative">{0} atmosfére</unitPattern>
 				<unitPattern count="few">{0} atmosféry</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} atmosféry</unitPattern>
 				<unitPattern count="few" case="dative">{0} atmosféram</unitPattern>
 				<unitPattern count="few" case="genitive">{0} atmosfér</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} atmosférami</unitPattern>
 				<unitPattern count="few" case="locative">{0} atmosférach</unitPattern>
 				<unitPattern count="many">{0} atmosféry</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} atmosféry</unitPattern>
+				<unitPattern count="many" case="dative">{0} atmosféry</unitPattern>
+				<unitPattern count="many" case="genitive">{0} atmosféry</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} atmosféry</unitPattern>
+				<unitPattern count="many" case="locative">{0} atmosféry</unitPattern>
 				<unitPattern count="other">{0} atmosfér</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} atmosfér</unitPattern>
 				<unitPattern count="other" case="dative">{0} atmosféram</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} atmosfér</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} atmosférami</unitPattern>
 				<unitPattern count="other" case="locative">{0} atmosférach</unitPattern>
 			</unit>
@@ -11538,27 +11538,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>pascaly</displayName>
 				<unitPattern count="one">pascal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">pascal</unitPattern>
 				<unitPattern count="one" case="dative">{0} pascalu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} pascala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} pascalom</unitPattern>
 				<unitPattern count="one" case="locative">{0} pascale</unitPattern>
 				<unitPattern count="few">{0} pascaly</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} pascaly</unitPattern>
 				<unitPattern count="few" case="dative">{0} pascalom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} pascalov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} pascalmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} pascaloch</unitPattern>
 				<unitPattern count="many">{0} pascala</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} pascala</unitPattern>
+				<unitPattern count="many" case="dative">{0} pascala</unitPattern>
+				<unitPattern count="many" case="genitive">{0} pascala</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} pascala</unitPattern>
+				<unitPattern count="many" case="locative">{0} pascala</unitPattern>
 				<unitPattern count="other">{0} pascalov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pascalov</unitPattern>
 				<unitPattern count="other" case="dative">{0} pascalom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pascalov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} pascalmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} pascaloch</unitPattern>
 			</unit>
@@ -11566,27 +11566,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>hektopascaly</displayName>
 				<unitPattern count="one">{0} hektopascal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektopascal</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektopascalu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektopascala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektopascalom</unitPattern>
 				<unitPattern count="one" case="locative">{0} hektopascale</unitPattern>
 				<unitPattern count="few">{0} hektopascaly</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektopascaly</unitPattern>
 				<unitPattern count="few" case="dative">{0} hektopascalom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} hektopascalov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} hektopascalmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} hektopascaloch</unitPattern>
 				<unitPattern count="many">{0} hektopascala</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hektopascala</unitPattern>
+				<unitPattern count="many" case="dative">{0} hektopascala</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hektopascala</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} hektopascala</unitPattern>
+				<unitPattern count="many" case="locative">{0} hektopascala</unitPattern>
 				<unitPattern count="other">{0} hektopascalov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektopascalov</unitPattern>
 				<unitPattern count="other" case="dative">{0} hektopascalom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektopascalov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} hektopascalmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} hektopascaloch</unitPattern>
 			</unit>
@@ -11594,25 +11594,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilopascaly</displayName>
 				<unitPattern count="one">{0} kilopascal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilopascal</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilopascalu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilopascala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilopascalom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilopascale</unitPattern>
 				<unitPattern count="few">{0} kilopascaly</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilopascaly</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilopascalom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilopascalov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilopascalmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilopascaloch</unitPattern>
 				<unitPattern count="many">{0} kilopascala</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilopascala</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilopascala</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilopascala</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilopascala</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilopascala</unitPattern>
 				<unitPattern count="other">{0} kilopascalov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilopascalov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilopascalom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilopascalov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilopascalmi</unitPattern>
@@ -11622,25 +11622,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>megapascaly</displayName>
 				<unitPattern count="one">{0} megapascal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapascal</unitPattern>
 				<unitPattern count="one" case="dative">{0} megapascalu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megapascala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megapascalom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megapascale</unitPattern>
 				<unitPattern count="few">{0} megapascaly</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megapascaly</unitPattern>
 				<unitPattern count="few" case="dative">{0} megapascalom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megapascalov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} megapascalmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} megapascaloch</unitPattern>
 				<unitPattern count="many">{0} megapascala</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megapascala</unitPattern>
+				<unitPattern count="many" case="dative">{0} megapascala</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megapascala</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megapascala</unitPattern>
+				<unitPattern count="many" case="locative">{0} megapascala</unitPattern>
 				<unitPattern count="other">{0} megapascalov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapascalov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megapascalom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} megapascalov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megapascalmi</unitPattern>
@@ -11650,25 +11650,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kilometre za hodinu</displayName>
 				<unitPattern count="one">{0} kilometer za hodinu</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilometer za hodinu</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilometru za hodinu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilometra za hodinu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilometrom za hodinu</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilometri za hodinu</unitPattern>
 				<unitPattern count="few">{0} kilometre za hodinu</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilometre za hodinu</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilometrom za hodinu</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilometrov za hodinu</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilometrami za hodinu</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilometroch za hodinu</unitPattern>
 				<unitPattern count="many">{0} kilometra za hodinu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kilometra za hodinu</unitPattern>
+				<unitPattern count="many" case="dative">{0} kilometra za hodinu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kilometra za hodinu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kilometra za hodinu</unitPattern>
+				<unitPattern count="many" case="locative">{0} kilometra za hodinu</unitPattern>
 				<unitPattern count="other">{0} kilometrov za hodinu</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometrov za hodinu</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilometrom za hodinu</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilometrov za hodinu</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilometrami za hodinu</unitPattern>
@@ -11678,25 +11678,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>metre za sekundu</displayName>
 				<unitPattern count="one">{0} meter za sekundu</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} meter za sekundu</unitPattern>
 				<unitPattern count="one" case="dative">{0} metru za sekundu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra za sekundu</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom za sekundu</unitPattern>
 				<unitPattern count="one" case="locative">{0} metri za sekundu</unitPattern>
 				<unitPattern count="few">{0} metre za sekundu</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metre za sekundu</unitPattern>
 				<unitPattern count="few" case="dative">{0} metrom za sekundu</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metrov za sekundu</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} metrami za sekundu</unitPattern>
 				<unitPattern count="few" case="locative">{0} metroch za sekundu</unitPattern>
 				<unitPattern count="many">{0} metra za sekundu</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metra za sekundu</unitPattern>
+				<unitPattern count="many" case="dative">{0} metra za sekundu</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metra za sekundu</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metra za sekundu</unitPattern>
+				<unitPattern count="many" case="locative">{0} metra za sekundu</unitPattern>
 				<unitPattern count="other">{0} metrov za sekundu</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrov za sekundu</unitPattern>
 				<unitPattern count="other" case="dative">{0} metrom za sekundu</unitPattern>
 				<unitPattern count="other" case="genitive">{0} metrov za sekundu</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metrami za sekundu</unitPattern>
@@ -11720,27 +11720,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>stupne</displayName>
 				<unitPattern count="one">{0} stupeň</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} stupeň</unitPattern>
 				<unitPattern count="one" case="dative">{0} stupňu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} stupňa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stupňom</unitPattern>
 				<unitPattern count="one" case="locative">{0} stupni</unitPattern>
 				<unitPattern count="few">{0} stupne</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stupne</unitPattern>
 				<unitPattern count="few" case="dative">{0} stupňom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} stupňov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} stupňami</unitPattern>
 				<unitPattern count="few" case="locative">{0} stupňoch</unitPattern>
 				<unitPattern count="many">{0} stupňa</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stupňa</unitPattern>
+				<unitPattern count="many" case="dative">{0} stupňa</unitPattern>
+				<unitPattern count="many" case="genitive">{0} stupňa</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} stupňa</unitPattern>
+				<unitPattern count="many" case="locative">{0} stupňa</unitPattern>
 				<unitPattern count="other">{0} stupňov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stupňov</unitPattern>
 				<unitPattern count="other" case="dative">{0} stupňom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stupňov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} stupňami</unitPattern>
 				<unitPattern count="other" case="locative">{0} stupňoch</unitPattern>
 			</unit>
@@ -11748,27 +11748,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>stupne Celzia</displayName>
 				<unitPattern count="one">{0} stupeň Celzia</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} stupeň Celzia</unitPattern>
 				<unitPattern count="one" case="dative">{0} stupňu Celzia</unitPattern>
 				<unitPattern count="one" case="genitive">{0} stupňa Celzia</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stupňom Celzia</unitPattern>
 				<unitPattern count="one" case="locative">{0} stupni Celzia</unitPattern>
 				<unitPattern count="few">{0} stupne Celzia</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stupne Celzia</unitPattern>
 				<unitPattern count="few" case="dative">{0} stupňom Celzia</unitPattern>
 				<unitPattern count="few" case="genitive">{0} stupňov Celzia</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} stupňami Celzia</unitPattern>
 				<unitPattern count="few" case="locative">{0} stupňoch Celzia</unitPattern>
 				<unitPattern count="many">{0} stupňa Celzia</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} stupňa Celzia</unitPattern>
+				<unitPattern count="many" case="dative">{0} stupňa Celzia</unitPattern>
+				<unitPattern count="many" case="genitive">{0} stupňa Celzia</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} stupňa Celzia</unitPattern>
+				<unitPattern count="many" case="locative">{0} stupňa Celzia</unitPattern>
 				<unitPattern count="other">{0} stupňov Celzia</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stupňov Celzia</unitPattern>
 				<unitPattern count="other" case="dative">{0} stupňom Celzia</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stupňov Celzia</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} stupňami Celzia</unitPattern>
 				<unitPattern count="other" case="locative">{0} stupňoch Celzia</unitPattern>
 			</unit>
@@ -11783,27 +11783,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kelviny</displayName>
 				<unitPattern count="one">{0} kelvin</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kelvin</unitPattern>
 				<unitPattern count="one" case="dative">{0} kelvinu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kelvina</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kelvinom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kelvine</unitPattern>
 				<unitPattern count="few">{0} kelviny</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kelviny</unitPattern>
 				<unitPattern count="few" case="dative">{0} kelvinom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kelvinov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kelvinmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} kelvinoch</unitPattern>
 				<unitPattern count="many">{0} kelvina</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kelvina</unitPattern>
+				<unitPattern count="many" case="dative">{0} kelvina</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kelvina</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kelvina</unitPattern>
+				<unitPattern count="many" case="locative">{0} kelvina</unitPattern>
 				<unitPattern count="other">{0} kelvinov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kelvinov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kelvinom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kelvinov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kelvinmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} kelvinoch</unitPattern>
 			</unit>
@@ -11818,27 +11818,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>newtonmetre</displayName>
 				<unitPattern count="one">{0} newtonmeter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} newtonmeter</unitPattern>
 				<unitPattern count="one" case="dative">{0} newtonmetru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} newtonmetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} newtonmetrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} newtonmetri</unitPattern>
 				<unitPattern count="few">{0} newtonmetre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} newtonmetre</unitPattern>
 				<unitPattern count="few" case="dative">{0} newtonmetrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} newtonmetrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} newtonmetrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} newtonmetroch</unitPattern>
 				<unitPattern count="many">{0} newtonmetra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} newtonmetra</unitPattern>
+				<unitPattern count="many" case="dative">{0} newtonmetra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} newtonmetra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} newtonmetra</unitPattern>
+				<unitPattern count="many" case="locative">{0} newtonmetra</unitPattern>
 				<unitPattern count="other">{0} newtonmetrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} newtonmetrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} newtonmetrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} newtonmetrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} newtonmetrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} newtonmetroch</unitPattern>
 			</unit>
@@ -11846,27 +11846,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kubické kilometre</displayName>
 				<unitPattern count="one">{0} kubický kilometer</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubický kilometer</unitPattern>
 				<unitPattern count="one" case="dative">{0} kubickému kilometru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubického kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubickým kilometrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kubickom kilometri</unitPattern>
 				<unitPattern count="few">{0} kubické kilometre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kubické kilometre</unitPattern>
 				<unitPattern count="few" case="dative">{0} kubickým kilometrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kubických kilometrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kubickými kilometrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kubických kilometroch</unitPattern>
 				<unitPattern count="many">{0} kubického kilometra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kubického kilometra</unitPattern>
+				<unitPattern count="many" case="dative">{0} kubického kilometra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kubického kilometra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kubického kilometra</unitPattern>
+				<unitPattern count="many" case="locative">{0} kubického kilometra</unitPattern>
 				<unitPattern count="other">{0} kubických kilometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubických kilometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kubickým kilometrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubických kilometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kubickými kilometrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kubických kilometroch</unitPattern>
 			</unit>
@@ -11874,27 +11874,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kubické metre</displayName>
 				<unitPattern count="one">{0} kubický meter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubický meter</unitPattern>
 				<unitPattern count="one" case="dative">{0} kubickému metru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubického metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubickým metrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kubickom metri</unitPattern>
 				<unitPattern count="few">{0} kubické metre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kubické metre</unitPattern>
 				<unitPattern count="few" case="dative">{0} kubickým metrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kubických metrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kubickými metrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kubických metroch</unitPattern>
 				<unitPattern count="many">{0} kubického metra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kubického metra</unitPattern>
+				<unitPattern count="many" case="dative">{0} kubického metra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kubického metra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kubického metra</unitPattern>
+				<unitPattern count="many" case="locative">{0} kubického metra</unitPattern>
 				<unitPattern count="other">{0} kubických metrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubických metrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kubickým metrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubických metrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kubickými metrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kubických metroch</unitPattern>
 				<perUnitPattern>{0} na kubický meter</perUnitPattern>
@@ -11903,27 +11903,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>kubické centimetre</displayName>
 				<unitPattern count="one">{0} kubický centimeter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubický centimeter</unitPattern>
 				<unitPattern count="one" case="dative">{0} kubickému centimetru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubického centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubickým centimetrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kubickom centimetri</unitPattern>
 				<unitPattern count="few">{0} kubické centimetre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kubické centimetre</unitPattern>
 				<unitPattern count="few" case="dative">{0} kubickým centimetrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kubických centimetrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kubickými centimetrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kubických centimetroch</unitPattern>
 				<unitPattern count="many">{0} kubického centimetra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} kubického centimetra</unitPattern>
+				<unitPattern count="many" case="dative">{0} kubického centimetra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} kubického centimetra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} kubického centimetra</unitPattern>
+				<unitPattern count="many" case="locative">{0} kubického centimetra</unitPattern>
 				<unitPattern count="other">{0} kubických centimetrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubických centimetrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kubickým centimetrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubických centimetrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kubickými centimetrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kubických centimetroch</unitPattern>
 				<perUnitPattern>{0} na kubický centimeter</perUnitPattern>
@@ -11960,27 +11960,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>megalitre</displayName>
 				<unitPattern count="one">{0} megaliter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megaliter</unitPattern>
 				<unitPattern count="one" case="dative">{0} megalitru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megalitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megalitrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megalitri</unitPattern>
 				<unitPattern count="few">{0} megalitre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megalitre</unitPattern>
 				<unitPattern count="few" case="dative">{0} megalitrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megalitrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} megalitrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} megalitroch</unitPattern>
 				<unitPattern count="many">{0} megalitra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} megalitra</unitPattern>
+				<unitPattern count="many" case="dative">{0} megalitra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} megalitra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} megalitra</unitPattern>
+				<unitPattern count="many" case="locative">{0} megalitra</unitPattern>
 				<unitPattern count="other">{0} megalitrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megalitrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megalitrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megalitrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megalitrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} megalitroch</unitPattern>
 			</unit>
@@ -11988,27 +11988,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>hektolitre</displayName>
 				<unitPattern count="one">{0} hektoliter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektoliter</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektolitru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektolitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektolitrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} hektolitri</unitPattern>
 				<unitPattern count="few">{0} hektolitre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektolitre</unitPattern>
 				<unitPattern count="few" case="dative">{0} hektolitrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} hektolitrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} hektolitrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} hektolitroch</unitPattern>
 				<unitPattern count="many">{0} hektolitra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} hektolitra</unitPattern>
+				<unitPattern count="many" case="dative">{0} hektolitra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} hektolitra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} hektolitra</unitPattern>
+				<unitPattern count="many" case="locative">{0} hektolitra</unitPattern>
 				<unitPattern count="other">{0} hektolitrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektolitrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} hektolitrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektolitrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} hektolitrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} hektolitroch</unitPattern>
 			</unit>
@@ -12016,27 +12016,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>litre</displayName>
 				<unitPattern count="one">{0} liter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} liter</unitPattern>
 				<unitPattern count="one" case="dative">{0} litru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} litri</unitPattern>
 				<unitPattern count="few">{0} litre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litre</unitPattern>
 				<unitPattern count="few" case="dative">{0} litrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} litrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} litrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} litroch</unitPattern>
 				<unitPattern count="many">{0} litra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} litra</unitPattern>
+				<unitPattern count="many" case="dative">{0} litra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} litra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} litra</unitPattern>
+				<unitPattern count="many" case="locative">{0} litra</unitPattern>
 				<unitPattern count="other">{0} litrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} litrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} litrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} litroch</unitPattern>
 				<perUnitPattern>{0} na liter</perUnitPattern>
@@ -12045,25 +12045,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>decilitre</displayName>
 				<unitPattern count="one">{0} deciliter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} deciliter</unitPattern>
 				<unitPattern count="one" case="dative">{0} decilitru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} decilitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} decilitrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} decilitri</unitPattern>
 				<unitPattern count="few">{0} decilitre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} decilitre</unitPattern>
 				<unitPattern count="few" case="dative">{0} decilitrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} decilitrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} decilitrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} decilitroch</unitPattern>
 				<unitPattern count="many">{0} decilitra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} decilitra</unitPattern>
+				<unitPattern count="many" case="dative">{0} decilitra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} decilitra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} decilitra</unitPattern>
+				<unitPattern count="many" case="locative">{0} decilitra</unitPattern>
 				<unitPattern count="other">{0} decilitrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decilitrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} decilitrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} decilitrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} decilitrami</unitPattern>
@@ -12073,7 +12073,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>centilitre</displayName>
 				<unitPattern count="one">{0} centiliter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} centiliter</unitPattern>
 				<unitPattern count="one" case="dative">{0} centilitru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} centilitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} centilitrom</unitPattern>
@@ -12085,13 +12085,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} centilitrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} centilitroch</unitPattern>
 				<unitPattern count="many">{0} centilitra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} centilitra</unitPattern>
+				<unitPattern count="many" case="dative">{0} centilitra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} centilitra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} centilitra</unitPattern>
+				<unitPattern count="many" case="locative">{0} centilitra</unitPattern>
 				<unitPattern count="other">{0} centilitrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centilitrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} centilitrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} centilitrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} centilitrami</unitPattern>
@@ -12101,25 +12101,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>mililitre</displayName>
 				<unitPattern count="one">{0} mililiter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mililiter</unitPattern>
 				<unitPattern count="one" case="dative">{0} mililitru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mililitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mililitrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} mililitri</unitPattern>
 				<unitPattern count="few">{0} mililitre</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mililitre</unitPattern>
 				<unitPattern count="few" case="dative">{0} mililitrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mililitrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} mililitrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} mililitroch</unitPattern>
 				<unitPattern count="many">{0} mililitra</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} mililitra</unitPattern>
+				<unitPattern count="many" case="dative">{0} mililitra</unitPattern>
+				<unitPattern count="many" case="genitive">{0} mililitra</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} mililitra</unitPattern>
+				<unitPattern count="many" case="locative">{0} mililitra</unitPattern>
 				<unitPattern count="other">{0} mililitrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mililitrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} mililitrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mililitrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} mililitrami</unitPattern>
@@ -12135,21 +12135,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} metrickou pintou</unitPattern>
 				<unitPattern count="one" case="locative">{0} metrickej pinte</unitPattern>
 				<unitPattern count="few">{0} metrické pinty</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metrické pinty</unitPattern>
 				<unitPattern count="few" case="dative">{0} metrickým pintám</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metrických pínt</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} metrickými pintami</unitPattern>
 				<unitPattern count="few" case="locative">{0} metrických pintách</unitPattern>
 				<unitPattern count="many">{0} metrickej pinty</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metrickej pinty</unitPattern>
+				<unitPattern count="many" case="dative">{0} metrickej pinty</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metrickej pinty</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metrickej pinty</unitPattern>
+				<unitPattern count="many" case="locative">{0} metrickej pinty</unitPattern>
 				<unitPattern count="other">{0} metrických pínt</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrických pínt</unitPattern>
 				<unitPattern count="other" case="dative">{0} metrickým pintám</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metrických pínt</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metrickými pintami</unitPattern>
 				<unitPattern count="other" case="locative">{0} metrických pintách</unitPattern>
 			</unit>
@@ -12157,27 +12157,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>metrické hrnčeky</displayName>
 				<unitPattern count="one">{0} metrický hrnček</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} metrický hrnček</unitPattern>
 				<unitPattern count="one" case="dative">{0} metrickému hrnčeku</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metrického hrnčeka</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrickým hrnčekom</unitPattern>
 				<unitPattern count="one" case="locative">{0} metrickom hrnčeku</unitPattern>
 				<unitPattern count="few">{0} metrické hrnčeky</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metrické hrnčeky</unitPattern>
 				<unitPattern count="few" case="dative">{0} metrickým hrnčekom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metrických hrnčekov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} metrickými hrnčekmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} metrických hrnčekoch</unitPattern>
 				<unitPattern count="many">{0} metrického hrnčeka</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} metrického hrnčeka</unitPattern>
+				<unitPattern count="many" case="dative">{0} metrického hrnčeka</unitPattern>
+				<unitPattern count="many" case="genitive">{0} metrického hrnčeka</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} metrického hrnčeka</unitPattern>
+				<unitPattern count="many" case="locative">{0} metrického hrnčeka</unitPattern>
 				<unitPattern count="other">{0} metrických hrnčekov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrických hrnčekov</unitPattern>
 				<unitPattern count="other" case="dative">{0} metrickým hrnčekom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metrických hrnčekov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metrickými hrnčekmi</unitPattern>
 				<unitPattern count="other" case="locative">{0} metrických hrnčekoch</unitPattern>
 			</unit>
@@ -12414,16 +12414,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -12927,9 +12927,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -12969,9 +12969,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
@@ -12983,16 +12983,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -13018,9 +13018,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -13170,9 +13170,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
 				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -13377,9 +13377,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="many">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -13398,9 +13398,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -13747,64 +13747,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
 				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -13834,18 +13834,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}{1}</compoundUnitPattern>
@@ -13865,135 +13865,135 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ot.</displayName>
+				<unitPattern count="one">{0} ot.</unitPattern>
+				<unitPattern count="few">{0} ot.</unitPattern>
+				<unitPattern count="many">{0} ot.</unitPattern>
+				<unitPattern count="other">{0} ot.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>rad</displayName>
 				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="few">{0} rad</unitPattern>
 				<unitPattern count="many">{0} rad</unitPattern>
 				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
 				<unitPattern count="many">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>′</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="many">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>″</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="many">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="many">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>ha</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="few">{0} ha</unitPattern>
+				<unitPattern count="many">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="many">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm²</displayName>
 				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="few">{0} cm²</unitPattern>
 				<unitPattern count="many">{0} cm²</unitPattern>
 				<unitPattern count="other">{0} cm²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="few">{0} mi²</unitPattern>
+				<unitPattern count="many">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>ac</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
+				<unitPattern count="few">{0} ac</unitPattern>
+				<unitPattern count="many">{0} ac</unitPattern>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd²</displayName>
 				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="few">{0} yd²</unitPattern>
 				<unitPattern count="many">{0} yd²</unitPattern>
 				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="few">{0} ft²</unitPattern>
+				<unitPattern count="many">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in²</displayName>
 				<unitPattern count="one">{0} in²</unitPattern>
 				<unitPattern count="few">{0} in²</unitPattern>
 				<unitPattern count="many">{0} in²</unitPattern>
 				<unitPattern count="other">{0} in²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dun.</displayName>
+				<unitPattern count="one">{0} dun.</unitPattern>
+				<unitPattern count="few">{0} dun.</unitPattern>
+				<unitPattern count="many">{0} dun.</unitPattern>
+				<unitPattern count="other">{0} dun.</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>kt</displayName>
 				<unitPattern count="one">{0} kt</unitPattern>
 				<unitPattern count="few">{0} kt</unitPattern>
 				<unitPattern count="many">{0} kt</unitPattern>
 				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="few">{0} mg/dl</unitPattern>
+				<unitPattern count="many">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/l</displayName>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="few">{0} mmol/l</unitPattern>
+				<unitPattern count="many">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>pol.</displayName>
@@ -14003,11 +14003,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pol.</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="many">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -14017,28 +14017,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="few">{0} ‰</unitPattern>
+				<unitPattern count="many">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="few">{0} ‱</unitPattern>
+				<unitPattern count="many">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="many">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>l/km</displayName>
 				<unitPattern count="one">{0} l/km</unitPattern>
 				<unitPattern count="few">{0} l/km</unitPattern>
 				<unitPattern count="many">{0} l/km</unitPattern>
@@ -14052,81 +14052,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpg</displayName>
 				<unitPattern count="one">{0} mpg</unitPattern>
 				<unitPattern count="few">{0} mpg</unitPattern>
 				<unitPattern count="many">{0} mpg</unitPattern>
 				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg brit.</displayName>
+				<unitPattern count="one">{0} mpg brit.</unitPattern>
+				<unitPattern count="few">{0} mpg brit.</unitPattern>
+				<unitPattern count="many">{0} mpg brit.</unitPattern>
+				<unitPattern count="other">{0} mpg brit.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="many">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="many">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="many">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="many">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="many">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="many">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="many">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="many">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="many">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
@@ -14136,7 +14136,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>bit</displayName>
 				<unitPattern count="one">{0} b</unitPattern>
 				<unitPattern count="few">{0} b</unitPattern>
 				<unitPattern count="many">{0} b</unitPattern>
@@ -14150,11 +14150,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} stor.</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>desaťr.</displayName>
+				<unitPattern count="one">{0} desaťr.</unitPattern>
+				<unitPattern count="few">{0} desaťr.</unitPattern>
+				<unitPattern count="many">{0} desaťr.</unitPattern>
+				<unitPattern count="other">{0} desaťr.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>r.</displayName>
@@ -14165,11 +14165,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/r.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>štvrťrok</displayName>
 				<unitPattern count="one">{0} štvrťrok</unitPattern>
 				<unitPattern count="few">{0} štvrťroky</unitPattern>
 				<unitPattern count="many">{0} štvrťroka</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} štvrťrokov</unitPattern>
 				<perUnitPattern>{0}/štvrťrok</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
@@ -14242,207 +14242,207 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="many">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="many">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="many">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="many">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="many">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="many">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="many">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="many">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="many">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="few">{0} kWh</unitPattern>
+				<unitPattern count="many">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="many">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} BTU</unitPattern>
+				<unitPattern count="few">{0} BTU</unitPattern>
+				<unitPattern count="many">{0} BTU</unitPattern>
+				<unitPattern count="other">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thm</displayName>
+				<unitPattern count="one">{0} thm</unitPattern>
+				<unitPattern count="few">{0} thm</unitPattern>
+				<unitPattern count="many">{0} thm</unitPattern>
+				<unitPattern count="other">{0} thm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="many">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="many">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="many">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="many">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="many">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="many">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="many">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="many">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="many">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mpx</displayName>
+				<unitPattern count="one">{0} Mpx</unitPattern>
+				<unitPattern count="few">{0} Mpx</unitPattern>
+				<unitPattern count="many">{0} Mpx</unitPattern>
+				<unitPattern count="other">{0} Mpx</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} dpcm</unitPattern>
+				<unitPattern count="few">{0} dpcm</unitPattern>
+				<unitPattern count="many">{0} dpcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpi</displayName>
 				<unitPattern count="one">{0} dpi</unitPattern>
 				<unitPattern count="few">{0} dpi</unitPattern>
 				<unitPattern count="many">{0} dpi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bod</displayName>
+				<unitPattern count="one">{0} bod</unitPattern>
+				<unitPattern count="few">{0} body</unitPattern>
+				<unitPattern count="many">{0} bodu</unitPattern>
+				<unitPattern count="other">{0} bodov</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -14555,18 +14555,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="many">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fth</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="few">{0} fth</unitPattern>
+				<unitPattern count="many">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>NM</displayName>
@@ -14590,39 +14590,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lx</displayName>
 				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="few">{0} lx</unitPattern>
 				<unitPattern count="many">{0} lx</unitPattern>
 				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="many">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="many">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -14706,74 +14706,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ct</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="many">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gran</displayName>
+				<unitPattern count="one">{0} gran</unitPattern>
+				<unitPattern count="few">{0} grany</unitPattern>
+				<unitPattern count="many">{0} granu</unitPattern>
+				<unitPattern count="other">{0} granov</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="few">{0} GW</unitPattern>
+				<unitPattern count="many">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="few">{0} MW</unitPattern>
 				<unitPattern count="many">{0} MW</unitPattern>
 				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="few">{0} kW</unitPattern>
+				<unitPattern count="many">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>W</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="few">{0} W</unitPattern>
+				<unitPattern count="many">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="few">{0} mW</unitPattern>
 				<unitPattern count="many">{0} mW</unitPattern>
 				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="one">{0} hp</unitPattern>
+				<unitPattern count="few">{0} hp</unitPattern>
+				<unitPattern count="many">{0} hp</unitPattern>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>mm Hg</displayName>
@@ -14791,17 +14791,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>inHg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="few">{0} inHg</unitPattern>
+				<unitPattern count="many">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="many">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -14811,18 +14811,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="many">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="many">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -14832,18 +14832,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="many">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="many">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -14902,79 +14902,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="many">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Nm</displayName>
+				<unitPattern count="one">{0} Nm</unitPattern>
+				<unitPattern count="few">{0} Nm</unitPattern>
+				<unitPattern count="many">{0} Nm</unitPattern>
+				<unitPattern count="other">{0} Nm</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="few">{0} km³</unitPattern>
+				<unitPattern count="many">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="few">{0} m³</unitPattern>
 				<unitPattern count="many">{0} m³</unitPattern>
 				<unitPattern count="other">{0} m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="few">{0} cm³</unitPattern>
 				<unitPattern count="many">{0} cm³</unitPattern>
 				<unitPattern count="other">{0} cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="few">{0} mi³</unitPattern>
+				<unitPattern count="many">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd³</displayName>
 				<unitPattern count="one">{0} yd³</unitPattern>
 				<unitPattern count="few">{0} yd³</unitPattern>
 				<unitPattern count="many">{0} yd³</unitPattern>
 				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft³</displayName>
 				<unitPattern count="one">{0} ft³</unitPattern>
 				<unitPattern count="few">{0} ft³</unitPattern>
 				<unitPattern count="many">{0} ft³</unitPattern>
 				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in³</displayName>
 				<unitPattern count="one">{0} in³</unitPattern>
 				<unitPattern count="few">{0} in³</unitPattern>
 				<unitPattern count="many">{0} in³</unitPattern>
 				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ml</displayName>
 				<unitPattern count="one">{0} Ml</unitPattern>
 				<unitPattern count="few">{0} Ml</unitPattern>
 				<unitPattern count="many">{0} Ml</unitPattern>
 				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>hl</displayName>
 				<unitPattern count="one">{0} hl</unitPattern>
 				<unitPattern count="few">{0} hl</unitPattern>
 				<unitPattern count="many">{0} hl</unitPattern>
@@ -14986,177 +14986,177 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="many">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0} dl</unitPattern>
 				<unitPattern count="few">{0} dl</unitPattern>
 				<unitPattern count="many">{0} dl</unitPattern>
 				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cl</displayName>
 				<unitPattern count="one">{0} cl</unitPattern>
 				<unitPattern count="few">{0} cl</unitPattern>
 				<unitPattern count="many">{0} cl</unitPattern>
 				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ml</displayName>
 				<unitPattern count="one">{0} ml</unitPattern>
 				<unitPattern count="few">{0} ml</unitPattern>
 				<unitPattern count="many">{0} ml</unitPattern>
 				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="many">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mc</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="few">{0} mc</unitPattern>
+				<unitPattern count="many">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ac ft</displayName>
 				<unitPattern count="one">{0} ac ft</unitPattern>
 				<unitPattern count="few">{0} ac ft</unitPattern>
 				<unitPattern count="many">{0} ac ft</unitPattern>
 				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="many">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">{0} gal</unitPattern>
 				<unitPattern count="few">{0} gal</unitPattern>
 				<unitPattern count="many">{0} gal</unitPattern>
 				<unitPattern count="other">{0} gal</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>brit. gal.</displayName>
+				<unitPattern count="one">{0} brit. gal.</unitPattern>
+				<unitPattern count="few">{0} brit. gal.</unitPattern>
+				<unitPattern count="many">{0} brit. gal.</unitPattern>
+				<unitPattern count="other">{0} brit. gal.</unitPattern>
+				<perUnitPattern>{0}/brit. gal.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt</displayName>
 				<unitPattern count="one">{0} qt</unitPattern>
 				<unitPattern count="few">{0} qt</unitPattern>
 				<unitPattern count="many">{0} qt</unitPattern>
 				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="few">{0} pt</unitPattern>
 				<unitPattern count="many">{0} pt</unitPattern>
 				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>c</displayName>
 				<unitPattern count="one">{0} c</unitPattern>
 				<unitPattern count="few">{0} c</unitPattern>
 				<unitPattern count="many">{0} c</unitPattern>
 				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz</displayName>
 				<unitPattern count="one">{0} fl oz</unitPattern>
 				<unitPattern count="few">{0} fl oz</unitPattern>
 				<unitPattern count="many">{0} fl oz</unitPattern>
 				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>brit. fl oz</displayName>
+				<unitPattern count="one">{0} brit. fl oz</unitPattern>
+				<unitPattern count="few">{0} brit. fl oz</unitPattern>
+				<unitPattern count="many">{0} brit. fl oz</unitPattern>
+				<unitPattern count="other">{0} brit. fl oz</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>tbsp</displayName>
 				<unitPattern count="one">{0} tbsp</unitPattern>
 				<unitPattern count="few">{0} tbsp</unitPattern>
 				<unitPattern count="many">{0} tbsp</unitPattern>
 				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>tsp</displayName>
 				<unitPattern count="one">{0} tsp</unitPattern>
 				<unitPattern count="few">{0} tsp</unitPattern>
 				<unitPattern count="many">{0} tsp</unitPattern>
 				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="many">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
+				<unitPattern count="many">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="few">{0} dstspn Imp</unitPattern>
+				<unitPattern count="many">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kvapky</displayName>
+				<unitPattern count="one">{0} kvapka</unitPattern>
+				<unitPattern count="few">{0} kvapky</unitPattern>
+				<unitPattern count="many">{0} kvapky</unitPattern>
+				<unitPattern count="other">{0} kvapiek</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dr</displayName>
+				<unitPattern count="one">{0} dr</unitPattern>
+				<unitPattern count="few">{0} dr</unitPattern>
+				<unitPattern count="many">{0} dr</unitPattern>
+				<unitPattern count="other">{0} dr</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>odmerky</displayName>
+				<unitPattern count="one">{0} odmerka</unitPattern>
+				<unitPattern count="few">{0} odmerky</unitPattern>
+				<unitPattern count="many">{0} odmerky</unitPattern>
+				<unitPattern count="other">{0} odmeriek</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>štipky</displayName>
+				<unitPattern count="one">{0} štipka</unitPattern>
+				<unitPattern count="few">{0} štipky</unitPattern>
+				<unitPattern count="many">{0} štipky</unitPattern>
+				<unitPattern count="other">{0} štipiek</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp</unitPattern>
+				<unitPattern count="few">{0} qt Imp</unitPattern>
+				<unitPattern count="many">{0} qt Imp</unitPattern>
+				<unitPattern count="other">{0} qt Imp</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>svetová strana</displayName>
@@ -15190,22 +15190,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} alebo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} alebo {1}</listPatternPart>
+			<listPatternPart type="2">{0} alebo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} alebo {1}</listPatternPart>
+			<listPatternPart type="2">{0} alebo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} a {1}</listPatternPart>
+			<listPatternPart type="2">{0} a {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -99,8 +99,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">čerokeščina</language>
 			<language type="chy">čejenščina</language>
 			<language type="ckb">soranska kurdščina</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">soranska kurdščina</language>
+			<language type="ckb" alt="variant">soranska kurdščina</language>
 			<language type="clc">čilkotinščina</language>
 			<language type="co">korziščina</language>
 			<language type="cop">koptščina</language>
@@ -569,9 +569,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="zh">kitajščina</language>
 			<language type="zh" alt="menu">kitajščina (mandarinščina)</language>
 			<language type="zh_Hans">poenostavljena kitajščina</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">poenostavljena kitajščina</language>
 			<language type="zh_Hant">tradicionalna kitajščina</language>
-			<language type="zh_Hant" alt="long">↑↑↑</language>
+			<language type="zh_Hant" alt="long">tradicionalna kitajščina</language>
 			<language type="zu">zulujščina</language>
 			<language type="zun">zunijščina</language>
 			<language type="zxx">brez jezikoslovne vsebine</language>
@@ -1921,7 +1921,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1929,7 +1929,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -7299,7 +7299,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>yobi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="one">kvadratno {0}</compoundUnitPattern1>
@@ -7313,8 +7313,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" gender="feminine" case="dative">kvadratni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">kvadratne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">kvadratno {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="locative">kvadratnem {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">kvadratno {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">kvadratnega {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="dative">kvadratnemu {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">kvadratnega {0}</compoundUnitPattern1>
@@ -7327,14 +7327,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="two" case="instrumental">kvadratnima {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" case="locative">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="feminine">kvadratni {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two" gender="feminine" case="dative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two" gender="feminine" case="accusative">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two" gender="feminine" case="dative">kvadratnima {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="feminine" case="genitive">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="feminine" case="instrumental">kvadratnima {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="feminine" case="locative">kvadratnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two" gender="masculine">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two" gender="masculine" case="accusative">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two" gender="masculine" case="dative">kvadratnima {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="masculine" case="genitive">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="masculine" case="instrumental">kvadratnima {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="masculine" case="locative">kvadratnih {0}</compoundUnitPattern1>
@@ -7350,30 +7350,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">kvadratnimi {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="locative">kvadratnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine">kvadratna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="accusative">kvadratne {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="dative">kvadratnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="genitive">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="instrumental">kvadratnimi {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="locative">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kvadratnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="dative">kvadratnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="genitive">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="instrumental">kvadratnimi {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="dative">kvadratnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">kvadratnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">kvadratnimi {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="locative">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">kvadratnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="dative">kvadratnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">kvadratnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">kvadratnimi {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="locative">kvadratnih {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1 count="one">kubično {0}</compoundUnitPattern1>
@@ -7388,7 +7388,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">kubične {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">kubično {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="locative">kubični {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">kubično {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">kubičnega {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="dative">kubičnemu {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">kubičnega {0}</compoundUnitPattern1>
@@ -7406,8 +7406,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="two" gender="feminine" case="genitive">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="feminine" case="instrumental">kubičnima {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="feminine" case="locative">kubičnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two" gender="masculine">kubični {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two" gender="masculine" case="accusative">kubični {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="masculine" case="dative">kubičnima {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="masculine" case="genitive">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="two" gender="masculine" case="instrumental">kubičnima {0}</compoundUnitPattern1>
@@ -7424,33 +7424,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">kubičnimi {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="locative">kubičnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine">kubična {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="accusative">kubične {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="dative">kubičnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="genitive">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="instrumental">kubičnimi {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="locative">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kubičnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="dative">kubičnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="genitive">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" case="instrumental">kubičnimi {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">kubičnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">kubičnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="dative">kubičnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">kubičnimi {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="locative">kubičnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">kubičnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="dative">kubičnim {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">kubičnih {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">kubičnimi {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="locative">kubičnih {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>masculine</gender>
@@ -7484,7 +7484,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>metri na kvadratno sekundo</displayName>
 				<unitPattern count="one">{0} meter na kvadratno sekundo</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} meter na kvadratno sekundo</unitPattern>
 				<unitPattern count="one" case="dative">{0} metru na kvadratno sekundo</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra na kvadratno sekundo</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom na kvadratno sekundo</unitPattern>
@@ -7499,10 +7499,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} metre na kvadratno sekundo</unitPattern>
 				<unitPattern count="few" case="dative">{0} metrom na kvadratno sekundo</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metrov na kvadratno sekundo</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metri na kvadratno sekundo</unitPattern>
 				<unitPattern count="few" case="locative">{0} metrih na kvadratno sekundo</unitPattern>
 				<unitPattern count="other">{0} metrov na kvadratno sekundo</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrov na kvadratno sekundo</unitPattern>
 				<unitPattern count="other" case="dative">{0} metrom na kvadratno sekundo</unitPattern>
 				<unitPattern count="other" case="genitive">{0} metrov na kvadratno sekundo</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metri na kvadratno sekundo</unitPattern>
@@ -7512,13 +7512,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>vrtljaj</displayName>
 				<unitPattern count="one">{0} vrtljaj</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} vrtljaj</unitPattern>
 				<unitPattern count="one" case="dative">{0} vrtljaju</unitPattern>
 				<unitPattern count="one" case="genitive">{0} vrtljaja</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} vrtljajem</unitPattern>
 				<unitPattern count="one" case="locative">{0} vrtljaju</unitPattern>
 				<unitPattern count="two">{0} vrtljaja</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} vrtljaja</unitPattern>
 				<unitPattern count="two" case="dative">{0} vrtljajema</unitPattern>
 				<unitPattern count="two" case="genitive">{0} vrtljajev</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} vrtljajema</unitPattern>
@@ -7530,7 +7530,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} vrtljaji</unitPattern>
 				<unitPattern count="few" case="locative">{0} vrtljajih</unitPattern>
 				<unitPattern count="other">{0} vrtljajev</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} vrtljajev</unitPattern>
 				<unitPattern count="other" case="dative">{0} vrtljajem</unitPattern>
 				<unitPattern count="other" case="genitive">{0} vrtljajev</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} vrtljaji</unitPattern>
@@ -7540,13 +7540,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>radian</displayName>
 				<unitPattern count="one">{0} radian</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} radian</unitPattern>
 				<unitPattern count="one" case="dative">{0} radianu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} radiana</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} radianom</unitPattern>
 				<unitPattern count="one" case="locative">{0} radianu</unitPattern>
 				<unitPattern count="two">{0} radiana</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} radiana</unitPattern>
 				<unitPattern count="two" case="dative">{0} radianoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} radianov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} radianoma</unitPattern>
@@ -7555,12 +7555,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} radiane</unitPattern>
 				<unitPattern count="few" case="dative">{0} radianom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} radianov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} radiani</unitPattern>
 				<unitPattern count="few" case="locative">{0} radianih</unitPattern>
 				<unitPattern count="other">{0} radianov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} radianov</unitPattern>
 				<unitPattern count="other" case="dative">{0} radianom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} radianov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} radiani</unitPattern>
 				<unitPattern count="other" case="locative">{0} radianih</unitPattern>
 			</unit>
@@ -7574,19 +7574,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} stopinjo</unitPattern>
 				<unitPattern count="one" case="locative">{0} stopinji</unitPattern>
 				<unitPattern count="two">{0} stopinji</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} stopinji</unitPattern>
 				<unitPattern count="two" case="dative">{0} stopinjama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} stopinj</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} stopinjama</unitPattern>
 				<unitPattern count="two" case="locative">{0} stopinjah</unitPattern>
 				<unitPattern count="few">{0} stopinje</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stopinje</unitPattern>
 				<unitPattern count="few" case="dative">{0} stopinjam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} stopinj</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} stopinjami</unitPattern>
 				<unitPattern count="few" case="locative">{0} stopinjah</unitPattern>
 				<unitPattern count="other">{0} stopinj</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stopinj</unitPattern>
 				<unitPattern count="other" case="dative">{0} stopinjam</unitPattern>
 				<unitPattern count="other" case="genitive">{0} stopinj</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} stopinjami</unitPattern>
@@ -7602,19 +7602,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kotno minuto</unitPattern>
 				<unitPattern count="one" case="locative">{0} kotni minuti</unitPattern>
 				<unitPattern count="two">{0} kotni minuti</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kotni minuti</unitPattern>
 				<unitPattern count="two" case="dative">{0} kotnima minutama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kotnih minut</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kotnima minutama</unitPattern>
 				<unitPattern count="two" case="locative">{0} kotnih minutah</unitPattern>
 				<unitPattern count="few">{0} kotne minute</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kotne minute</unitPattern>
 				<unitPattern count="few" case="dative">{0} kotnim minutam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kotnih minut</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kotnimi minutami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kotnih minutah</unitPattern>
 				<unitPattern count="other">{0} kotnih minut</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kotnih minut</unitPattern>
 				<unitPattern count="other" case="dative">{0} kotnim minutam</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kotnih minut</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kotnimi minutami</unitPattern>
@@ -7630,19 +7630,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kotno sekundo</unitPattern>
 				<unitPattern count="one" case="locative">{0} kotni sekundi</unitPattern>
 				<unitPattern count="two">{0} kotni sekundi</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kotni sekundi</unitPattern>
 				<unitPattern count="two" case="dative">{0} kotnima sekundama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kotnih sekund</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kotnima sekundama</unitPattern>
 				<unitPattern count="two" case="locative">{0} kotnih sekundah</unitPattern>
 				<unitPattern count="few">{0} kotne sekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kotne sekunde</unitPattern>
 				<unitPattern count="few" case="dative">{0} kotnim sekundam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kotnih sekund</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kotnimi sekundami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kotnih sekundah</unitPattern>
 				<unitPattern count="other">{0} kotnih sekund</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kotnih sekund</unitPattern>
 				<unitPattern count="other" case="dative">{0} kotnim sekundam</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kotnih sekund</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kotnimi sekundami</unitPattern>
@@ -7652,13 +7652,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kvadratni kilometri</displayName>
 				<unitPattern count="one">{0} kvadratni kilometer</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kvadratni kilometer</unitPattern>
 				<unitPattern count="one" case="dative">{0} kvadratnemu kilometru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kvadratnega kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kvadratnim kilometrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kvadratnem kilometru</unitPattern>
 				<unitPattern count="two">{0} kvadratna kilometra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kvadratna kilometra</unitPattern>
 				<unitPattern count="two" case="dative">{0} kvadratnima kilometroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kvadratnih kilometrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kvadratnima kilometroma</unitPattern>
@@ -7670,7 +7670,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kvadratnimi kilometri</unitPattern>
 				<unitPattern count="few" case="locative">{0} kvadratnih kilometrih</unitPattern>
 				<unitPattern count="other">{0} kvadratnih kilometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratnih kilometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kvadratnim kilometrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kvadratnih kilometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kvadratnimi kilometri</unitPattern>
@@ -7681,13 +7681,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>hektari</displayName>
 				<unitPattern count="one">{0} hektar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektar</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektarju</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektarjem</unitPattern>
 				<unitPattern count="one" case="locative">{0} hektarju</unitPattern>
 				<unitPattern count="two">{0} hektara</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} hektara</unitPattern>
 				<unitPattern count="two" case="dative">{0} hektarjema</unitPattern>
 				<unitPattern count="two" case="genitive">{0} hektarjev</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} hektarjema</unitPattern>
@@ -7709,7 +7709,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kvadratni metri</displayName>
 				<unitPattern count="one">{0} kvadratni meter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kvadratni meter</unitPattern>
 				<unitPattern count="one" case="dative">{0} kvadratnemu metru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kvadratnega metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kvadratnim metrom</unitPattern>
@@ -7727,7 +7727,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kvadratnimi metri</unitPattern>
 				<unitPattern count="few" case="locative">{0} kvadratnih metrih</unitPattern>
 				<unitPattern count="other">{0} kvadratnih metrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratnih metrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kvadratnim metrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kvadratnih metrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kvadratnimi metri</unitPattern>
@@ -7744,7 +7744,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kvadratnim centimetrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kvadratnem centimetru</unitPattern>
 				<unitPattern count="two">{0} kvadratna centimetra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kvadratna centimetra</unitPattern>
 				<unitPattern count="two" case="dative">{0} kvadratnima centimetroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kvadratnih centimetrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kvadratnima centimetroma</unitPattern>
@@ -7756,7 +7756,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kvadratnimi centimetri</unitPattern>
 				<unitPattern count="few" case="locative">{0} kvadratnih centimetrih</unitPattern>
 				<unitPattern count="other">{0} kvadratnih centimetrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratnih centimetrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kvadratnim centimetrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kvadratnih centimetrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kvadratnimi centimetri</unitPattern>
@@ -7803,7 +7803,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-dunam">
 				<displayName>dunumi</displayName>
 				<unitPattern count="one">{0} dunum</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="two">{0} dunuma</unitPattern>
 				<unitPattern count="few">{0} dunumi</unitPattern>
 				<unitPattern count="other">{0} dunumi</unitPattern>
 			</unit>
@@ -7811,13 +7811,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>karat</displayName>
 				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karat</unitPattern>
 				<unitPattern count="one" case="dative">{0} karatu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} karatom</unitPattern>
 				<unitPattern count="one" case="locative">{0} karatu</unitPattern>
 				<unitPattern count="two">{0} karata</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} karata</unitPattern>
 				<unitPattern count="two" case="dative">{0} karatoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} karatov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} karatoma</unitPattern>
@@ -7829,9 +7829,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} karati</unitPattern>
 				<unitPattern count="few" case="locative">{0} karatih</unitPattern>
 				<unitPattern count="other">{0} karatov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karatov</unitPattern>
 				<unitPattern count="other" case="dative">{0} karatom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karatov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} karati</unitPattern>
 				<unitPattern count="other" case="locative">{0} karatih</unitPattern>
 			</unit>
@@ -7846,13 +7846,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>milimol na liter</displayName>
 				<unitPattern count="one">{0} milimol na liter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milimol na liter</unitPattern>
 				<unitPattern count="one" case="dative">{0} milimolu na liter</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milimola na liter</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milimolom na liter</unitPattern>
 				<unitPattern count="one" case="locative">{0} milimolu na liter</unitPattern>
 				<unitPattern count="two">{0} milimola na liter</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} milimola na liter</unitPattern>
 				<unitPattern count="two" case="dative">{0} milimoloma na liter</unitPattern>
 				<unitPattern count="two" case="genitive">{0} milimolov na liter</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} milimoloma na liter</unitPattern>
@@ -7861,12 +7861,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} milimole na liter</unitPattern>
 				<unitPattern count="few" case="dative">{0} milimolom na liter</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milimolov na liter</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milimoli na liter</unitPattern>
 				<unitPattern count="few" case="locative">{0} milimolih na liter</unitPattern>
 				<unitPattern count="other">{0} milimolov na liter</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimolov na liter</unitPattern>
 				<unitPattern count="other" case="dative">{0} milimolom na liter</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimolov na liter</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} milimoli na liter</unitPattern>
 				<unitPattern count="other" case="locative">{0} milimolih na liter</unitPattern>
 			</unit>
@@ -7874,13 +7874,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>element</displayName>
 				<unitPattern count="one">{0} element</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} element</unitPattern>
 				<unitPattern count="one" case="dative">{0} elementu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} elementa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} elementom</unitPattern>
 				<unitPattern count="one" case="locative">{0} elementu</unitPattern>
 				<unitPattern count="two">{0} elementa</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} elementa</unitPattern>
 				<unitPattern count="two" case="dative">{0} elementoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} elementov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} elementoma</unitPattern>
@@ -7889,12 +7889,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} elemente</unitPattern>
 				<unitPattern count="few" case="dative">{0} elementom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} elementov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} elementi</unitPattern>
 				<unitPattern count="few" case="locative">{0} elementih</unitPattern>
 				<unitPattern count="other">{0} elementov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} elementov</unitPattern>
 				<unitPattern count="other" case="dative">{0} elementom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} elementov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} elementi</unitPattern>
 				<unitPattern count="other" case="locative">{0} elementih</unitPattern>
 			</unit>
@@ -7902,13 +7902,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>delci na milijon</displayName>
 				<unitPattern count="one">{0} delec na milijon</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} delec na milijon</unitPattern>
 				<unitPattern count="one" case="dative">{0} delcu na milijon</unitPattern>
 				<unitPattern count="one" case="genitive">{0} delca na milijon</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} delcem na milijon</unitPattern>
 				<unitPattern count="one" case="locative">{0} delcu na milijon</unitPattern>
 				<unitPattern count="two">{0} delca na milijon</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} delca na milijon</unitPattern>
 				<unitPattern count="two" case="dative">{0} delcema na milijon</unitPattern>
 				<unitPattern count="two" case="genitive">{0} delcev na milijon</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} delcema na milijon</unitPattern>
@@ -7917,10 +7917,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} delce na milijon</unitPattern>
 				<unitPattern count="few" case="dative">{0} delcem na milijon</unitPattern>
 				<unitPattern count="few" case="genitive">{0} delcev na milijon</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} delci na milijon</unitPattern>
 				<unitPattern count="few" case="locative">{0} delcih na milijon</unitPattern>
 				<unitPattern count="other">{0} delcev na milijon</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} delcev na milijon</unitPattern>
 				<unitPattern count="other" case="dative">{0} delcem na milijon</unitPattern>
 				<unitPattern count="other" case="genitive">{0} delcev na milijon</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} delci na milijon</unitPattern>
@@ -7930,13 +7930,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>odstotek</displayName>
 				<unitPattern count="one">{0} odstotek</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} odstotek</unitPattern>
 				<unitPattern count="one" case="dative">{0} odstotku</unitPattern>
 				<unitPattern count="one" case="genitive">{0} odstotka</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} odstotkom</unitPattern>
 				<unitPattern count="one" case="locative">{0} odstotku</unitPattern>
 				<unitPattern count="two">{0} odstotka</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} odstotka</unitPattern>
 				<unitPattern count="two" case="dative">{0} odstotkoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} odstotkov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} odstotkoma</unitPattern>
@@ -7948,7 +7948,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} odstotki</unitPattern>
 				<unitPattern count="few" case="locative">{0} odstotkih</unitPattern>
 				<unitPattern count="other">{0} odstotkov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} odstotkov</unitPattern>
 				<unitPattern count="other" case="dative">{0} odstotkom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} odstotkov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} odstotki</unitPattern>
@@ -7958,13 +7958,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>promile</displayName>
 				<unitPattern count="one">{0} promile</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} promile</unitPattern>
 				<unitPattern count="one" case="dative">{0} promilu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} promila</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} promilom</unitPattern>
 				<unitPattern count="one" case="locative">{0} promilu</unitPattern>
 				<unitPattern count="two">{0} promila</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} promila</unitPattern>
 				<unitPattern count="two" case="dative">{0} promiloma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} promilov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} promiloma</unitPattern>
@@ -7976,7 +7976,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} promili</unitPattern>
 				<unitPattern count="few" case="locative">{0} promilih</unitPattern>
 				<unitPattern count="other">{0} promilov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} promilov</unitPattern>
 				<unitPattern count="other" case="dative">{0} promilom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} promilov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} promili</unitPattern>
@@ -7992,19 +7992,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} desettisočino</unitPattern>
 				<unitPattern count="one" case="locative">{0} desettisočini</unitPattern>
 				<unitPattern count="two">{0} desettisočini</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} desettisočini</unitPattern>
 				<unitPattern count="two" case="dative">{0} desettisočinama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} desettisočin</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} desettisočinama</unitPattern>
 				<unitPattern count="two" case="locative">{0} desettisočinah</unitPattern>
 				<unitPattern count="few">{0} desettisočine</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} desettisočine</unitPattern>
 				<unitPattern count="few" case="dative">{0} desettisočinam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} desettisočin</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} desettisočinami</unitPattern>
 				<unitPattern count="few" case="locative">{0} desettisočinah</unitPattern>
 				<unitPattern count="other">{0} desettisočin</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} desettisočin</unitPattern>
 				<unitPattern count="other" case="dative">{0} desettisočinam</unitPattern>
 				<unitPattern count="other" case="genitive">{0} desettisočin</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} desettisočinami</unitPattern>
@@ -8014,13 +8014,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>moli</displayName>
 				<unitPattern count="one">{0} mol</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mol</unitPattern>
 				<unitPattern count="one" case="dative">{0} molu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mola</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} molom</unitPattern>
 				<unitPattern count="one" case="locative">{0} molu</unitPattern>
 				<unitPattern count="two">{0} mola</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} mola</unitPattern>
 				<unitPattern count="two" case="dative">{0} moloma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} molov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} moloma</unitPattern>
@@ -8032,9 +8032,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} moli</unitPattern>
 				<unitPattern count="few" case="locative">{0} molih</unitPattern>
 				<unitPattern count="other">{0} molov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} molov</unitPattern>
 				<unitPattern count="other" case="dative">{0} molom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} molov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} moli</unitPattern>
 				<unitPattern count="other" case="locative">{0} molih</unitPattern>
 			</unit>
@@ -8042,13 +8042,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>litri na kilometer</displayName>
 				<unitPattern count="one">{0} liter na kilometer</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} liter na kilometer</unitPattern>
 				<unitPattern count="one" case="dative">{0} litru na kilometer</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra na kilometer</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom na kilometer</unitPattern>
 				<unitPattern count="one" case="locative">{0} litru na kilometer</unitPattern>
 				<unitPattern count="two">{0} litra na kilometer</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} litra na kilometer</unitPattern>
 				<unitPattern count="two" case="dative">{0} litroma na kilometer</unitPattern>
 				<unitPattern count="two" case="genitive">{0} litrov na kilometer</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} litroma na kilometer</unitPattern>
@@ -8057,12 +8057,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} litre na kilometer</unitPattern>
 				<unitPattern count="few" case="dative">{0} litrom na kilometer</unitPattern>
 				<unitPattern count="few" case="genitive">{0} litrov na kilometer</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} litri na kilometer</unitPattern>
 				<unitPattern count="few" case="locative">{0} litrih na kilometer</unitPattern>
 				<unitPattern count="other">{0} litrov na kilometer</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litrov na kilometer</unitPattern>
 				<unitPattern count="other" case="dative">{0} litrom na kilometer</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litrov na kilometer</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} litri na kilometer</unitPattern>
 				<unitPattern count="other" case="locative">{0} litrih na kilometer</unitPattern>
 			</unit>
@@ -8070,13 +8070,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>litri na 100 kilometrov</displayName>
 				<unitPattern count="one">{0} liter na 100 kilometrov</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} liter na 100 kilometrov</unitPattern>
 				<unitPattern count="one" case="dative">{0} litru na 100 kilometrov</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra na 100 kilometrov</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom na 100 kilometrov</unitPattern>
 				<unitPattern count="one" case="locative">{0} litru na 100 kilometrov</unitPattern>
 				<unitPattern count="two">{0} litra na 100 kilometrov</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} litra na 100 kilometrov</unitPattern>
 				<unitPattern count="two" case="dative">{0} litroma na 100 kilometrov</unitPattern>
 				<unitPattern count="two" case="genitive">{0} litrov na 100 kilometrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} litroma na 100 kilometrov</unitPattern>
@@ -8088,9 +8088,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} litri na 100 kilometrov</unitPattern>
 				<unitPattern count="few" case="locative">{0} litrih na 100 kilometrov</unitPattern>
 				<unitPattern count="other">{0} litrov na 100 kilometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litrov na 100 kilometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} litrom na 100 kilometrov</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litrov na 100 kilometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} litri na 100 kilometrov</unitPattern>
 				<unitPattern count="other" case="locative">{0} litrih na 100 kilometrov</unitPattern>
 			</unit>
@@ -8112,13 +8112,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>petabajti</displayName>
 				<unitPattern count="one">{0} petabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} petabajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} petabajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} petabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} petabajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} petabajtu</unitPattern>
 				<unitPattern count="two">{0} petabajta</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} petabajta</unitPattern>
 				<unitPattern count="two" case="dative">{0} petabajtoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} petabajtov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} petabajtoma</unitPattern>
@@ -8130,9 +8130,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} petabajti</unitPattern>
 				<unitPattern count="few" case="locative">{0} petabajtih</unitPattern>
 				<unitPattern count="other">{0} petabajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} petabajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} petabajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} petabajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} petabajti</unitPattern>
 				<unitPattern count="other" case="locative">{0} petabajtih</unitPattern>
 			</unit>
@@ -8140,13 +8140,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>terabajti</displayName>
 				<unitPattern count="one">{0} terabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} terabajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} terabajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} terabajtu</unitPattern>
 				<unitPattern count="two">{0} terabajta</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} terabajta</unitPattern>
 				<unitPattern count="two" case="dative">{0} terabajtoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} terabajtov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} terabajtoma</unitPattern>
@@ -8155,12 +8155,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} terabajte</unitPattern>
 				<unitPattern count="few" case="dative">{0} terabajtom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} terabajtov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} terabajti</unitPattern>
 				<unitPattern count="few" case="locative">{0} terabajtih</unitPattern>
 				<unitPattern count="other">{0} terabajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} terabajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} terabajti</unitPattern>
 				<unitPattern count="other" case="locative">{0} terabajtih</unitPattern>
 			</unit>
@@ -8168,13 +8168,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>terabiti</displayName>
 				<unitPattern count="one">{0} terabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabit</unitPattern>
 				<unitPattern count="one" case="dative">{0} terabitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} terabitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} terabitu</unitPattern>
 				<unitPattern count="two">{0} terabita</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} terabita</unitPattern>
 				<unitPattern count="two" case="dative">{0} terabitoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} terabitov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} terabitoma</unitPattern>
@@ -8183,12 +8183,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} terabite</unitPattern>
 				<unitPattern count="few" case="dative">{0} terabitom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} terabitov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} terabiti</unitPattern>
 				<unitPattern count="few" case="locative">{0} terabitih</unitPattern>
 				<unitPattern count="other">{0} terabitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} terabitom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} terabiti</unitPattern>
 				<unitPattern count="other" case="locative">{0} terabitih</unitPattern>
 			</unit>
@@ -8196,13 +8196,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>gigabajti</displayName>
 				<unitPattern count="one">{0} gigabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigabajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigabajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} gigabajtu</unitPattern>
 				<unitPattern count="two">{0} gigabajta</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} gigabajta</unitPattern>
 				<unitPattern count="two" case="dative">{0} gigabajtoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} gigabajtov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} gigabajtoma</unitPattern>
@@ -8211,12 +8211,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} gigabajte</unitPattern>
 				<unitPattern count="few" case="dative">{0} gigabajtom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigabajtov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigabajti</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigabajtih</unitPattern>
 				<unitPattern count="other">{0} gigabajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} gigabajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} gigabajti</unitPattern>
 				<unitPattern count="other" case="locative">{0} gigabajtih</unitPattern>
 			</unit>
@@ -8224,13 +8224,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>gigabiti</displayName>
 				<unitPattern count="one">{0} gigabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabit</unitPattern>
 				<unitPattern count="one" case="dative">{0} gigabitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigabitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} gigabitu</unitPattern>
 				<unitPattern count="two">{0} gigabita</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} gigabita</unitPattern>
 				<unitPattern count="two" case="dative">{0} gigabitoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} gigabitov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} gigabitoma</unitPattern>
@@ -8239,12 +8239,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} gigabite</unitPattern>
 				<unitPattern count="few" case="dative">{0} gigabitom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} gigabitov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigabiti</unitPattern>
 				<unitPattern count="few" case="locative">{0} gigabitih</unitPattern>
 				<unitPattern count="other">{0} gigabitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} gigabitom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} gigabiti</unitPattern>
 				<unitPattern count="other" case="locative">{0} gigabitih</unitPattern>
 			</unit>
@@ -8252,13 +8252,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>megabajti</displayName>
 				<unitPattern count="one">{0} megabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} megabajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megabajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megabajtu</unitPattern>
 				<unitPattern count="two">{0} megabajta</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} megabajta</unitPattern>
 				<unitPattern count="two" case="dative">{0} megabajtoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} megabajtov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} megabajtoma</unitPattern>
@@ -8267,12 +8267,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} megabajte</unitPattern>
 				<unitPattern count="few" case="dative">{0} megabajtom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megabajtov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megabajti</unitPattern>
 				<unitPattern count="few" case="locative">{0} megabajtih</unitPattern>
 				<unitPattern count="other">{0} megabajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megabajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megabajti</unitPattern>
 				<unitPattern count="other" case="locative">{0} megabajtih</unitPattern>
 			</unit>
@@ -8280,13 +8280,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>megabiti</displayName>
 				<unitPattern count="one">{0} megabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabit</unitPattern>
 				<unitPattern count="one" case="dative">{0} megabitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megabitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megabitu</unitPattern>
 				<unitPattern count="two">{0} megabita</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} megabita</unitPattern>
 				<unitPattern count="two" case="dative">{0} megabitoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} megabitov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} megabitoma</unitPattern>
@@ -8298,9 +8298,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} megabiti</unitPattern>
 				<unitPattern count="few" case="locative">{0} megabitih</unitPattern>
 				<unitPattern count="other">{0} megabitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megabitom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megabiti</unitPattern>
 				<unitPattern count="other" case="locative">{0} megabitih</unitPattern>
 			</unit>
@@ -8308,13 +8308,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilobajti</displayName>
 				<unitPattern count="one">{0} kilobajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilobajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilobajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilobajtu</unitPattern>
 				<unitPattern count="two">{0} kilobajta</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kilobajta</unitPattern>
 				<unitPattern count="two" case="dative">{0} kilobajtoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kilobajtov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kilobajtoma</unitPattern>
@@ -8326,9 +8326,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilobajti</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilobajtih</unitPattern>
 				<unitPattern count="other">{0} kilobajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilobajtom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilobajti</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilobajtih</unitPattern>
 			</unit>
@@ -8336,13 +8336,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilobiti</displayName>
 				<unitPattern count="one">{0} kilobit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobit</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilobitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilobitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilobitu</unitPattern>
 				<unitPattern count="two">{0} kilobita</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kilobita</unitPattern>
 				<unitPattern count="two" case="dative">{0} kilobitoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kilobitov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kilobitoma</unitPattern>
@@ -8354,9 +8354,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilobiti</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilobitih</unitPattern>
 				<unitPattern count="other">{0} kilobitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilobitm</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilobiti</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilobitih</unitPattern>
 			</unit>
@@ -8364,13 +8364,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>bajt</displayName>
 				<unitPattern count="one">{0} bajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bajt</unitPattern>
 				<unitPattern count="one" case="dative">{0} bajtu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} bajtom</unitPattern>
 				<unitPattern count="one" case="locative">{0} bajtu</unitPattern>
 				<unitPattern count="two">{0} bajta</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} bajta</unitPattern>
 				<unitPattern count="two" case="dative">{0} bajtoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} bajtov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} bajtoma</unitPattern>
@@ -8382,7 +8382,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} bajti</unitPattern>
 				<unitPattern count="few" case="locative">{0} bajtih</unitPattern>
 				<unitPattern count="other">{0} bajtov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bajtov</unitPattern>
 				<unitPattern count="other" case="dative">{0} bajtom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} bajtov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} bajti</unitPattern>
@@ -8392,13 +8392,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>bit</displayName>
 				<unitPattern count="one">{0} bit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bit</unitPattern>
 				<unitPattern count="one" case="dative">{0} bitu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} bitom</unitPattern>
 				<unitPattern count="one" case="locative">{0} bitu</unitPattern>
 				<unitPattern count="two">{0} bita</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} bita</unitPattern>
 				<unitPattern count="two" case="dative">{0} bitoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} bitov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} bitoma</unitPattern>
@@ -8410,7 +8410,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} biti</unitPattern>
 				<unitPattern count="few" case="locative">{0} bitih</unitPattern>
 				<unitPattern count="other">{0} bitov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bitov</unitPattern>
 				<unitPattern count="other" case="dative">{0} bitom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} bitov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} biti</unitPattern>
@@ -8420,25 +8420,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>stoletja</displayName>
 				<unitPattern count="one">{0} stoletje</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} stoletje</unitPattern>
 				<unitPattern count="one" case="dative">{0} stoletju</unitPattern>
 				<unitPattern count="one" case="genitive">{0} stoletja</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stoletjem</unitPattern>
 				<unitPattern count="one" case="locative">{0} stoletju</unitPattern>
 				<unitPattern count="two">{0} stoletji</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} stoletji</unitPattern>
 				<unitPattern count="two" case="dative">{0} stoletjema</unitPattern>
 				<unitPattern count="two" case="genitive">{0} stoletij</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} stoletjema</unitPattern>
 				<unitPattern count="two" case="locative">{0} stoletjih</unitPattern>
 				<unitPattern count="few">{0} stoletja</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stoletja</unitPattern>
 				<unitPattern count="few" case="dative">{0} stoletjem</unitPattern>
 				<unitPattern count="few" case="genitive">{0} stoletij</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} stoletji</unitPattern>
 				<unitPattern count="few" case="locative">{0} stoletjih</unitPattern>
 				<unitPattern count="other">{0} stoletij</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stoletij</unitPattern>
 				<unitPattern count="other" case="dative">{0} stoletjem</unitPattern>
 				<unitPattern count="other" case="genitive">{0} stoletij</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} stoletji</unitPattern>
@@ -8476,13 +8476,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>neuter</gender>
 				<displayName>leta</displayName>
 				<unitPattern count="one">{0} leto</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} leto</unitPattern>
 				<unitPattern count="one" case="dative">{0} letu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} leta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} letom</unitPattern>
 				<unitPattern count="one" case="locative">{0} letu</unitPattern>
 				<unitPattern count="two">{0} leti</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} leti</unitPattern>
 				<unitPattern count="two" case="dative">{0} letoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} let</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} letoma</unitPattern>
@@ -8494,7 +8494,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} leti</unitPattern>
 				<unitPattern count="few" case="locative">{0} letih</unitPattern>
 				<unitPattern count="other">{0} let</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} let</unitPattern>
 				<unitPattern count="other" case="dative">{0} letom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} let</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} leti</unitPattern>
@@ -8505,7 +8505,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">neuter</gender>
 				<displayName draft="contributed">četrtletje</displayName>
 				<unitPattern count="one" draft="contributed">{0} četrtletje</unitPattern>
-				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">{0} četrtletje</unitPattern>
 				<unitPattern count="one" case="dative" draft="contributed">{0} četrtletju</unitPattern>
 				<unitPattern count="one" case="genitive" draft="contributed">{0} četrtletja</unitPattern>
 				<unitPattern count="one" case="instrumental" draft="contributed">{0} četrtletjem</unitPattern>
@@ -8534,13 +8534,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>meseci</displayName>
 				<unitPattern count="one">{0} mesec</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mesec</unitPattern>
 				<unitPattern count="one" case="dative">{0} mesecu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} meseca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mesecem</unitPattern>
 				<unitPattern count="one" case="locative">{0} mesecu</unitPattern>
 				<unitPattern count="two">{0} meseca</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} meseca</unitPattern>
 				<unitPattern count="two" case="dative">{0} mesecema</unitPattern>
 				<unitPattern count="two" case="genitive">{0} mesecev</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} mesecema</unitPattern>
@@ -8552,7 +8552,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} meseci</unitPattern>
 				<unitPattern count="few" case="locative">{0} mesecih</unitPattern>
 				<unitPattern count="other">{0} mesecev</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mesecev</unitPattern>
 				<unitPattern count="other" case="dative">{0} mesecem</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mesecev</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} meseci</unitPattern>
@@ -8563,13 +8563,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>tedni</displayName>
 				<unitPattern count="one">{0} teden</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} teden</unitPattern>
 				<unitPattern count="one" case="dative">{0} tednu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} tedna</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} tednom</unitPattern>
 				<unitPattern count="one" case="locative">{0} tednu</unitPattern>
 				<unitPattern count="two">{0} tedna</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} tedna</unitPattern>
 				<unitPattern count="two" case="dative">{0} tednoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} tednov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} tednoma</unitPattern>
@@ -8581,9 +8581,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} tedni</unitPattern>
 				<unitPattern count="few" case="locative">{0} tednih</unitPattern>
 				<unitPattern count="other">{0} tednov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} tednov</unitPattern>
 				<unitPattern count="other" case="dative">{0} tednom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} tednov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} tedni</unitPattern>
 				<unitPattern count="other" case="locative">{0} tednih</unitPattern>
 				<perUnitPattern>{0} na teden</perUnitPattern>
@@ -8592,25 +8592,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>dni</displayName>
 				<unitPattern count="one">{0} dan</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} dan</unitPattern>
 				<unitPattern count="one" case="dative">{0} dnevu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} dneva</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} dnevom</unitPattern>
 				<unitPattern count="one" case="locative">{0} dnevu</unitPattern>
 				<unitPattern count="two">{0} dneva</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} dneva</unitPattern>
 				<unitPattern count="two" case="dative">{0} dnema</unitPattern>
 				<unitPattern count="two" case="genitive">{0} dni</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} dnema</unitPattern>
 				<unitPattern count="two" case="locative">{0} dneh</unitPattern>
 				<unitPattern count="few">{0} dni</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} dni</unitPattern>
 				<unitPattern count="few" case="dative">{0} dnem</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive">{0} dni</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} dnevi</unitPattern>
 				<unitPattern count="few" case="locative">{0} dneh</unitPattern>
 				<unitPattern count="other">{0} dni</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dni</unitPattern>
 				<unitPattern count="other" case="dative">{0} dnem</unitPattern>
 				<unitPattern count="other" case="genitive">{0} dni</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} dnevi</unitPattern>
@@ -8619,7 +8619,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-hour">
 				<gender>feminine</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>ure</displayName>
 				<unitPattern count="one">{0} ura</unitPattern>
 				<unitPattern count="one" case="accusative">{0} uro</unitPattern>
 				<unitPattern count="one" case="dative">{0} uri</unitPattern>
@@ -8627,19 +8627,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} uro</unitPattern>
 				<unitPattern count="one" case="locative">{0} uri</unitPattern>
 				<unitPattern count="two">{0} uri</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} uri</unitPattern>
 				<unitPattern count="two" case="dative">{0} urama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} ur</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} urama</unitPattern>
 				<unitPattern count="two" case="locative">{0} urah</unitPattern>
 				<unitPattern count="few">{0} ure</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ure</unitPattern>
 				<unitPattern count="few" case="dative">{0} uram</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ur</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} urami</unitPattern>
 				<unitPattern count="few" case="locative">{0} urah</unitPattern>
 				<unitPattern count="other">{0} ur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ur</unitPattern>
 				<unitPattern count="other" case="dative">{0} uram</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ur</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} urami</unitPattern>
@@ -8656,19 +8656,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} minuto</unitPattern>
 				<unitPattern count="one" case="locative">{0} minuti</unitPattern>
 				<unitPattern count="two">{0} minuti</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} minuti</unitPattern>
 				<unitPattern count="two" case="dative">{0} minutama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} minut</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} minutama</unitPattern>
 				<unitPattern count="two" case="locative">{0} minutah</unitPattern>
 				<unitPattern count="few">{0} minute</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} minute</unitPattern>
 				<unitPattern count="few" case="dative">{0} minutam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} minut</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} minutami</unitPattern>
 				<unitPattern count="few" case="locative">{0} minutah</unitPattern>
 				<unitPattern count="other">{0} minut</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} minut</unitPattern>
 				<unitPattern count="other" case="dative">{0} minutam</unitPattern>
 				<unitPattern count="other" case="genitive">{0} minut</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} minutami</unitPattern>
@@ -8685,19 +8685,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} sekundo</unitPattern>
 				<unitPattern count="one" case="locative">{0} sekundi</unitPattern>
 				<unitPattern count="two">{0} sekundi</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} sekundi</unitPattern>
 				<unitPattern count="two" case="dative">{0} sekundama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} sekund</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} sekundama</unitPattern>
 				<unitPattern count="two" case="locative">{0} sekundah</unitPattern>
 				<unitPattern count="few">{0} sekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} sekunde</unitPattern>
 				<unitPattern count="few" case="dative">{0} sekundam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} sekund</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} sekundami</unitPattern>
 				<unitPattern count="few" case="locative">{0} sekundah</unitPattern>
 				<unitPattern count="other">{0} sekund</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sekund</unitPattern>
 				<unitPattern count="other" case="dative">{0} sekundam</unitPattern>
 				<unitPattern count="other" case="genitive">{0} sekund</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} sekundami</unitPattern>
@@ -8748,7 +8748,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two" case="instrumental">{0} mikrosekundama</unitPattern>
 				<unitPattern count="two" case="locative">{0} mikrosekundah</unitPattern>
 				<unitPattern count="few">{0} mikrosekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrosekunde</unitPattern>
 				<unitPattern count="few" case="dative">{0} mikrosekundam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} mikrosekund</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} mikrosekundami</unitPattern>
@@ -8792,13 +8792,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>amperi</displayName>
 				<unitPattern count="one">{0} amper</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} amper</unitPattern>
 				<unitPattern count="one" case="dative">{0} amperu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ampera</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} amperom</unitPattern>
 				<unitPattern count="one" case="locative">{0} amperu</unitPattern>
 				<unitPattern count="two">{0} ampera</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} ampera</unitPattern>
 				<unitPattern count="two" case="dative">{0} amperoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} amperov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} amperoma</unitPattern>
@@ -8807,12 +8807,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} ampere</unitPattern>
 				<unitPattern count="few" case="dative">{0} amperom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} amperov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} amperi</unitPattern>
 				<unitPattern count="few" case="locative">{0} amperih</unitPattern>
 				<unitPattern count="other">{0} amperov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} amperov</unitPattern>
 				<unitPattern count="other" case="dative">{0} amperom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} amperov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} amperi</unitPattern>
 				<unitPattern count="other" case="locative">{0} amperih</unitPattern>
 			</unit>
@@ -8820,13 +8820,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>miliamperi</displayName>
 				<unitPattern count="one">{0} miliamper</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miliamper</unitPattern>
 				<unitPattern count="one" case="dative">{0} miliamperu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miliampera</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} miliamperom</unitPattern>
 				<unitPattern count="one" case="locative">{0} miliamperu</unitPattern>
 				<unitPattern count="two">{0} miliampera</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} miliampera</unitPattern>
 				<unitPattern count="two" case="dative">{0} miliamperoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} miliamperov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} miliamperoma</unitPattern>
@@ -8835,12 +8835,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} miliampere</unitPattern>
 				<unitPattern count="few" case="dative">{0} miliamperom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} miliamperov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milliamperi</unitPattern>
 				<unitPattern count="few" case="locative">{0} miliamperih</unitPattern>
 				<unitPattern count="other">{0} miliamperov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miliamperov</unitPattern>
 				<unitPattern count="other" case="dative">{0} miliamperom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miliamperov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} miliamperi</unitPattern>
 				<unitPattern count="other" case="locative">{0} miliamperih</unitPattern>
 			</unit>
@@ -8854,7 +8854,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} ohmom</unitPattern>
 				<unitPattern count="one" case="locative">{0} ohmu</unitPattern>
 				<unitPattern count="two">{0} ohma</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} ohma</unitPattern>
 				<unitPattern count="two" case="dative">{0} ohmoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} ohmov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} ohmoma</unitPattern>
@@ -8866,7 +8866,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} ohmi</unitPattern>
 				<unitPattern count="few" case="locative">{0} ohmih</unitPattern>
 				<unitPattern count="other">{0} ohmov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ohmov</unitPattern>
 				<unitPattern count="other" case="dative">{0} ohmom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} ohmov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} ohmi</unitPattern>
@@ -8882,7 +8882,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} voltom</unitPattern>
 				<unitPattern count="one" case="locative">{0} voltu</unitPattern>
 				<unitPattern count="two">{0} volta</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} volta</unitPattern>
 				<unitPattern count="two" case="dative">{0} voltoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} voltov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} voltoma</unitPattern>
@@ -8896,7 +8896,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} voltov</unitPattern>
 				<unitPattern count="other" case="accusative">{0} voltov</unitPattern>
 				<unitPattern count="other" case="dative">{0} voltom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} voltov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} volti</unitPattern>
 				<unitPattern count="other" case="locative">{0} voltih</unitPattern>
 			</unit>
@@ -8917,21 +8917,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kalorijo</unitPattern>
 				<unitPattern count="one" case="locative">{0} kaloriji</unitPattern>
 				<unitPattern count="two">{0} kaloriji</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kaloriji</unitPattern>
 				<unitPattern count="two" case="dative">{0} kalorijama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kalorij</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kalorijama</unitPattern>
 				<unitPattern count="two" case="locative">{0} kalorijah</unitPattern>
 				<unitPattern count="few">{0} kalorije</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kalorije</unitPattern>
 				<unitPattern count="few" case="dative">{0} kalorijam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kalorij</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kalorijami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kalorijah</unitPattern>
 				<unitPattern count="other">{0} kalorij</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kalorij</unitPattern>
 				<unitPattern count="other" case="dative">{0} kalorijam</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kalorij</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kalorijami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kalorijah</unitPattern>
 			</unit>
@@ -9008,7 +9008,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kilovatno uro</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilovatni uri</unitPattern>
 				<unitPattern count="two">{0} kilovatni uri</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kilovatni uri</unitPattern>
 				<unitPattern count="two" case="dative">{0} kilovatnima urama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kilovatnih ur</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kilovatnima urama</unitPattern>
@@ -9020,7 +9020,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilovatnimi urami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilovatnih urah</unitPattern>
 				<unitPattern count="other">{0} kilovatnih ur</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovatnih ur</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilovatnim uram</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilovatnih ur</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilovatnimi urami</unitPattern>
@@ -9041,11 +9041,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} britanskih toplotnih enot</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>funti sile</displayName>
@@ -9064,7 +9064,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} newtonom</unitPattern>
 				<unitPattern count="one" case="locative">{0} newtonu</unitPattern>
 				<unitPattern count="two">{0} newtona</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} newtona</unitPattern>
 				<unitPattern count="two" case="dative">{0} newtonoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} newtonov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} newtonoma</unitPattern>
@@ -9076,7 +9076,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} newtoni</unitPattern>
 				<unitPattern count="few" case="locative">{0} newtonih</unitPattern>
 				<unitPattern count="other">{0} newtonov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} newtonov</unitPattern>
 				<unitPattern count="other" case="dative">{0} newtonom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} newtonov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} newtoni</unitPattern>
@@ -9092,21 +9092,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kilovatno uro na 100 kilometrov</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilovatni uri na 100 kilometrov</unitPattern>
 				<unitPattern count="two">{0} kilovatni uri na 100 kilometrov</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kilovatni uri na 100 kilometrov</unitPattern>
 				<unitPattern count="two" case="dative">{0} kilovatnima urama na 100 kilometrov</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kilovatnih ur na 100 kilometrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kilovatnima urama na 100 kilometrov</unitPattern>
 				<unitPattern count="two" case="locative">{0} kilovatnih urah na 100 kilometrov</unitPattern>
 				<unitPattern count="few">{0} kilovatne ure na 100 kilometrov</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilovatne ure na 100 kilometrov</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilovatnim uram na 100 kilometrov</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilovatnih ur na 100 kilometrov</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kilovatnimi urami na 100 kilometrov</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilovatnih urah na 100 kilometrov</unitPattern>
 				<unitPattern count="other">{0} kilovatnih ur na 100 kilometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovatnih ur na 100 kilometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilovatnim uram na 100 kilometrov</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilovatnih ur na 100 kilometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilovatnimi urami na 100 kilometrov</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilovatnih urah na 100 kilometrov</unitPattern>
 			</unit>
@@ -9224,8 +9224,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<gender>masculine</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="one" case="accusative">{0} ema</unitPattern>
 				<unitPattern count="one" case="dative">{0} emu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ema</unitPattern>
@@ -9335,25 +9335,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="locative">{0} slikovnih pikah na centimeter</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpcm</displayName>
 				<unitPattern count="one">{0} dpcm</unitPattern>
 				<unitPattern count="two">{0} dpcm</unitPattern>
 				<unitPattern count="few">{0} dpcm</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpi</displayName>
 				<unitPattern count="one">{0} dpi</unitPattern>
 				<unitPattern count="two">{0} dpi</unitPattern>
 				<unitPattern count="few">{0} dpi</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>pika</displayName>
@@ -9379,7 +9379,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kilometrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilometru</unitPattern>
 				<unitPattern count="two">{0} kilometra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kilometra</unitPattern>
 				<unitPattern count="two" case="dative">{0} kilometroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kilometrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kilometroma</unitPattern>
@@ -9402,13 +9402,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>metri</displayName>
 				<unitPattern count="one">{0} meter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} meter</unitPattern>
 				<unitPattern count="one" case="dative">{0} metru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} metru</unitPattern>
 				<unitPattern count="two">{0} metra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} metra</unitPattern>
 				<unitPattern count="two" case="dative">{0} metroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} metrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} metroma</unitPattern>
@@ -9420,7 +9420,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} metri</unitPattern>
 				<unitPattern count="few" case="locative">{0} metrih</unitPattern>
 				<unitPattern count="other">{0} metrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} metrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} metrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metri</unitPattern>
@@ -9437,7 +9437,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} decimetrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} decimetru</unitPattern>
 				<unitPattern count="two">{0} decimetra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} decimetra</unitPattern>
 				<unitPattern count="two" case="dative">{0} decimetroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} decimetrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} decimetroma</unitPattern>
@@ -9449,7 +9449,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} decimetri</unitPattern>
 				<unitPattern count="few" case="locative">{0} decimetrih</unitPattern>
 				<unitPattern count="other">{0} decimetrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decimetrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} decimetrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} decimetrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} decimetri</unitPattern>
@@ -9459,7 +9459,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>centimetri</displayName>
 				<unitPattern count="one">{0} centimeter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} centimeter</unitPattern>
 				<unitPattern count="one" case="dative">{0} centimetru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} centimetrom</unitPattern>
@@ -9477,7 +9477,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} centimetri</unitPattern>
 				<unitPattern count="few" case="locative">{0} centimetrih</unitPattern>
 				<unitPattern count="other">{0} centimetrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centimetrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} centimetrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} centimetrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} centimetri</unitPattern>
@@ -9494,7 +9494,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} milimetrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} milimetru</unitPattern>
 				<unitPattern count="two">{0} milimetra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} milimetra</unitPattern>
 				<unitPattern count="two" case="dative">{0} milimetroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} milimetrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} milimetroma</unitPattern>
@@ -9678,19 +9678,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} skandinavsko miljo</unitPattern>
 				<unitPattern count="one" case="locative">{0} skandinavski milji</unitPattern>
 				<unitPattern count="two">{0} skandinavski milji</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} skandinavski milji</unitPattern>
 				<unitPattern count="two" case="dative">{0} skandinavskima miljama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} skandinavskih milj</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} skandinavskima miljama</unitPattern>
 				<unitPattern count="two" case="locative">{0} skandinavskih miljah</unitPattern>
 				<unitPattern count="few">{0} skandinavske milje</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} skandinavske milje</unitPattern>
 				<unitPattern count="few" case="dative">{0} skandinavskim miljam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} skandinavskih milj</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} skandinavskimi miljami</unitPattern>
 				<unitPattern count="few" case="locative">{0} skandinavskih miljah</unitPattern>
 				<unitPattern count="other">{0} skandinavskih milj</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} skandinavskih milj</unitPattern>
 				<unitPattern count="other" case="dative">{0} skandinavskim miljam</unitPattern>
 				<unitPattern count="other" case="genitive">{0} skandinavskih milj</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} skandinavskimi miljami</unitPattern>
@@ -9714,13 +9714,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>luks</displayName>
 				<unitPattern count="one">{0} luks</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} luks</unitPattern>
 				<unitPattern count="one" case="dative">{0} luksu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} luksa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} luksom</unitPattern>
 				<unitPattern count="one" case="locative">{0} luksu</unitPattern>
 				<unitPattern count="two">{0} luksa</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} luksa</unitPattern>
 				<unitPattern count="two" case="dative">{0} luksoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} luksov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} luksoma</unitPattern>
@@ -9732,9 +9732,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} luksi</unitPattern>
 				<unitPattern count="few" case="locative">{0} luksih</unitPattern>
 				<unitPattern count="other">{0} luksov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} luksov</unitPattern>
 				<unitPattern count="other" case="dative">{0} luksom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} luksov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} luksi</unitPattern>
 				<unitPattern count="other" case="locative">{0} luksih</unitPattern>
 			</unit>
@@ -9748,21 +9748,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} kandelo</unitPattern>
 				<unitPattern count="one" case="locative">{0} kandeli</unitPattern>
 				<unitPattern count="two">{0} kandeli</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kandeli</unitPattern>
 				<unitPattern count="two" case="dative">{0} kandelama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kandel</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kandelama</unitPattern>
 				<unitPattern count="two" case="locative">{0} kandelah</unitPattern>
 				<unitPattern count="few">{0} kandele</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kandele</unitPattern>
 				<unitPattern count="few" case="dative">{0} kandelam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kandel</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} kandelami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kandelah</unitPattern>
 				<unitPattern count="other">{0} kandel</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kandel</unitPattern>
 				<unitPattern count="other" case="dative">{0} kandelam</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kandel</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kandelami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kandelah</unitPattern>
 			</unit>
@@ -9770,13 +9770,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>lumen</displayName>
 				<unitPattern count="one">{0} lumen</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} lumen</unitPattern>
 				<unitPattern count="one" case="dative">{0} lumnu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} lumna</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} lumnom</unitPattern>
 				<unitPattern count="one" case="locative">{0} lumnu</unitPattern>
 				<unitPattern count="two">{0} lumna</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} lumna</unitPattern>
 				<unitPattern count="two" case="dative">{0} lumnoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} lumnov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} lumnoma</unitPattern>
@@ -9788,7 +9788,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} lumni</unitPattern>
 				<unitPattern count="few" case="locative">{0} lumnih</unitPattern>
 				<unitPattern count="other">{0} lumnov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} lumnov</unitPattern>
 				<unitPattern count="other" case="dative">{0} lumnom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} lumnov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} lumni</unitPattern>
@@ -9811,21 +9811,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} metrično tono</unitPattern>
 				<unitPattern count="one" case="locative">{0} metrični toni</unitPattern>
 				<unitPattern count="two">{0} metrični toni</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} metrični toni</unitPattern>
 				<unitPattern count="two" case="dative">{0} metričnima tonama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} metričnih ton</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} metričnima tonama</unitPattern>
 				<unitPattern count="two" case="locative">{0} metričnih tonah</unitPattern>
 				<unitPattern count="few">{0} metrične tone</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metrične tone</unitPattern>
 				<unitPattern count="few" case="dative">{0} metričnim tonam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metričnih ton</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} metričnimi tonami</unitPattern>
 				<unitPattern count="few" case="locative">{0} metričnih tonah</unitPattern>
 				<unitPattern count="other">{0} metričnih ton</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metričnih ton</unitPattern>
 				<unitPattern count="other" case="dative">{0} metričnim tonam</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metričnih ton</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metričnimi tonami</unitPattern>
 				<unitPattern count="other" case="locative">{0} metričnih tonah</unitPattern>
 			</unit>
@@ -9833,13 +9833,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilogrami</displayName>
 				<unitPattern count="one">{0} kilogram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilogram</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilogramu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilograma</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilogramom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilogramu</unitPattern>
 				<unitPattern count="two">{0} kilograma</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kilograma</unitPattern>
 				<unitPattern count="two" case="dative">{0} kilogramoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kilogramov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kilogramoma</unitPattern>
@@ -9851,9 +9851,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilogrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilogramih</unitPattern>
 				<unitPattern count="other">{0} kilogramov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilogramov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilogramom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilogramov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilogrami</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilogramih</unitPattern>
 				<perUnitPattern>{0} na kilogram</perUnitPattern>
@@ -9862,13 +9862,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>grami</displayName>
 				<unitPattern count="one">{0} gram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gram</unitPattern>
 				<unitPattern count="one" case="dative">{0} gramu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} grama</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gramom</unitPattern>
 				<unitPattern count="one" case="locative">{0} gramu</unitPattern>
 				<unitPattern count="two">{0} grama</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} grama</unitPattern>
 				<unitPattern count="two" case="dative">{0} gramoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} gramov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} gramoma</unitPattern>
@@ -9880,9 +9880,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} grami</unitPattern>
 				<unitPattern count="few" case="locative">{0} gramih</unitPattern>
 				<unitPattern count="other">{0} gramov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gramov</unitPattern>
 				<unitPattern count="other" case="dative">{0} gramom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gramov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} grami</unitPattern>
 				<unitPattern count="other" case="locative">{0} gramih</unitPattern>
 				<perUnitPattern>{0} na gram</perUnitPattern>
@@ -9891,13 +9891,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>miligrami</displayName>
 				<unitPattern count="one">{0} miligram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miligram</unitPattern>
 				<unitPattern count="one" case="dative">{0} miligramu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miligrama</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} miligramom</unitPattern>
 				<unitPattern count="one" case="locative">{0} miligramu</unitPattern>
 				<unitPattern count="two">{0} miligrama</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} miligrama</unitPattern>
 				<unitPattern count="two" case="dative">{0} miligramoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} miligramov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} miligramoma</unitPattern>
@@ -9909,7 +9909,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} miligrami</unitPattern>
 				<unitPattern count="few" case="locative">{0} miligramih</unitPattern>
 				<unitPattern count="other">{0} miligramov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miligramov</unitPattern>
 				<unitPattern count="other" case="dative">{0} miligramom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} miligramov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} miligrami</unitPattern>
@@ -9919,13 +9919,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>mikrogrami</displayName>
 				<unitPattern count="one">{0} mikrogram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrogram</unitPattern>
 				<unitPattern count="one" case="dative">{0} mikrogramu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrograma</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mikrogramom</unitPattern>
 				<unitPattern count="one" case="locative">{0} mikrogramu</unitPattern>
 				<unitPattern count="two">{0} mikrograma</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} mikrograma</unitPattern>
 				<unitPattern count="two" case="dative">{0} mikrogramoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} mikrogramov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} mikrogramoma</unitPattern>
@@ -9984,13 +9984,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>karati</displayName>
 				<unitPattern count="one">{0} karat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} karat</unitPattern>
 				<unitPattern count="one" case="dative">{0} karatu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} karata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} karatom</unitPattern>
 				<unitPattern count="one" case="locative">{0} karatu</unitPattern>
 				<unitPattern count="two">{0} karata</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} karata</unitPattern>
 				<unitPattern count="two" case="dative">{0} karatoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} karatov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} karatoma</unitPattern>
@@ -10002,7 +10002,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} karati</unitPattern>
 				<unitPattern count="few" case="locative">{0} karatih</unitPattern>
 				<unitPattern count="other">{0} karatov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karatov</unitPattern>
 				<unitPattern count="other" case="dative">{0} karatom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} karatov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} karati</unitPattern>
@@ -10068,13 +10068,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>megavati</displayName>
 				<unitPattern count="one">{0} megavat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megavat</unitPattern>
 				<unitPattern count="one" case="dative">{0} megavatu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megavata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megavatom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megavatu</unitPattern>
 				<unitPattern count="two">{0} megavata</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} megavata</unitPattern>
 				<unitPattern count="two" case="dative">{0} megavatoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} megavatov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} megavatoma</unitPattern>
@@ -10086,9 +10086,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} megavati</unitPattern>
 				<unitPattern count="few" case="locative">{0} megavatih</unitPattern>
 				<unitPattern count="other">{0} megavatov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megavatov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megavatom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megavatov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megavati</unitPattern>
 				<unitPattern count="other" case="locative">{0} megavatih</unitPattern>
 			</unit>
@@ -10096,13 +10096,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilovati</displayName>
 				<unitPattern count="one">{0} kilovat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilovat</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilovatu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilovata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilovatom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilovatu</unitPattern>
 				<unitPattern count="two">{0} kilovata</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kilovata</unitPattern>
 				<unitPattern count="two" case="dative">{0} kilovatoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kilovatov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kilovatoma</unitPattern>
@@ -10111,10 +10111,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} kilovate</unitPattern>
 				<unitPattern count="few" case="dative">{0} kilovatom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} kilovatov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilovati</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilovatih</unitPattern>
 				<unitPattern count="other">{0} kilovatov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovatov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilovatom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilovatov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilovati</unitPattern>
@@ -10124,13 +10124,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>vati</displayName>
 				<unitPattern count="one">{0} vat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} vat</unitPattern>
 				<unitPattern count="one" case="dative">{0} vatu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} vata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} vatom</unitPattern>
 				<unitPattern count="one" case="locative">{0} vatu</unitPattern>
 				<unitPattern count="two">{0} vata</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} vata</unitPattern>
 				<unitPattern count="two" case="dative">{0} vatoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} vatov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} vatoma</unitPattern>
@@ -10139,12 +10139,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} vate</unitPattern>
 				<unitPattern count="few" case="dative">{0} vatom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} vatov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} vati</unitPattern>
 				<unitPattern count="few" case="locative">{0} vatih</unitPattern>
 				<unitPattern count="other">{0} vatov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} vatov</unitPattern>
 				<unitPattern count="other" case="dative">{0} vatom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} vatov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} vati</unitPattern>
 				<unitPattern count="other" case="locative">{0} vatih</unitPattern>
 			</unit>
@@ -10152,13 +10152,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>milivati</displayName>
 				<unitPattern count="one">{0} milivat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milivat</unitPattern>
 				<unitPattern count="one" case="dative">{0} milivatu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milivata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milivatom</unitPattern>
 				<unitPattern count="one" case="locative">{0} milivatu</unitPattern>
 				<unitPattern count="two">{0} milivata</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} milivata</unitPattern>
 				<unitPattern count="two" case="dative">{0} milivatoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} milivatov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} milivatoma</unitPattern>
@@ -10170,7 +10170,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} milivati</unitPattern>
 				<unitPattern count="few" case="locative">{0} milivatih</unitPattern>
 				<unitPattern count="other">{0} milivatov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milivatov</unitPattern>
 				<unitPattern count="other" case="dative">{0} milivatom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} milivatov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} milivati</unitPattern>
@@ -10207,14 +10207,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-bar">
 				<gender>masculine</gender>
 				<displayName>bari</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="one" case="accusative">{0} bar</unitPattern>
 				<unitPattern count="one" case="dative">{0} baru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} barom</unitPattern>
 				<unitPattern count="one" case="locative">{0} baru</unitPattern>
 				<unitPattern count="two">{0} bara</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} bara</unitPattern>
 				<unitPattern count="two" case="dative">{0} baroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} barov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} baroma</unitPattern>
@@ -10226,7 +10226,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} bari</unitPattern>
 				<unitPattern count="few" case="locative">{0} barih</unitPattern>
 				<unitPattern count="other">{0} barov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} barov</unitPattern>
 				<unitPattern count="other" case="dative">{0} barom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} barov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} bari</unitPattern>
@@ -10242,7 +10242,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} milibarom</unitPattern>
 				<unitPattern count="one" case="locative">{0} milibaru</unitPattern>
 				<unitPattern count="two">{0} milibara</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} milibara</unitPattern>
 				<unitPattern count="two" case="dative">{0} milibaroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} milibarov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} milibaroma</unitPattern>
@@ -10251,12 +10251,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} milibare</unitPattern>
 				<unitPattern count="few" case="dative">{0} milibarom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} milibarov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milibari</unitPattern>
 				<unitPattern count="few" case="locative">{0} milibarih</unitPattern>
 				<unitPattern count="other">{0} milibarov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milibarov</unitPattern>
 				<unitPattern count="other" case="dative">{0} milibarom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milibarov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} milibari</unitPattern>
 				<unitPattern count="other" case="locative">{0} milibarih</unitPattern>
 			</unit>
@@ -10270,7 +10270,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} atmosfero</unitPattern>
 				<unitPattern count="one" case="locative">{0} atmosferi</unitPattern>
 				<unitPattern count="two">{0} atmosferi</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} atmosferi</unitPattern>
 				<unitPattern count="two" case="dative">{0} atmosferama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} atmosfer</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} atmosferama</unitPattern>
@@ -10282,7 +10282,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} atmosferami</unitPattern>
 				<unitPattern count="few" case="locative">{0} atmosferah</unitPattern>
 				<unitPattern count="other">{0} atmosfer</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} atmosfer</unitPattern>
 				<unitPattern count="other" case="dative">{0} atmosferam</unitPattern>
 				<unitPattern count="other" case="genitive">{0} atmosfer</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} atmosferami</unitPattern>
@@ -10298,7 +10298,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} paskalom</unitPattern>
 				<unitPattern count="one" case="locative">{0} paskalu</unitPattern>
 				<unitPattern count="two">{0} paskala</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} paskala</unitPattern>
 				<unitPattern count="two" case="dative">{0} paskaloma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} paskalov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} paskaloma</unitPattern>
@@ -10310,7 +10310,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} paskali</unitPattern>
 				<unitPattern count="few" case="locative">{0} paskalih</unitPattern>
 				<unitPattern count="other">{0} paskalov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} paskalov</unitPattern>
 				<unitPattern count="other" case="dative">{0} paskalom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} paskalov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} paskali</unitPattern>
@@ -10320,13 +10320,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>hektopaskali</displayName>
 				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektopaskal</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektopaskalu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektopaskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektopaskalom</unitPattern>
 				<unitPattern count="one" case="locative">{0} hektopaskalu</unitPattern>
 				<unitPattern count="two">{0} hektopaskala</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} hektopaskala</unitPattern>
 				<unitPattern count="two" case="dative">{0} hektopaskaloma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} hektopaskalov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} hektopaskaloma</unitPattern>
@@ -10338,9 +10338,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} hektopaskali</unitPattern>
 				<unitPattern count="few" case="locative">{0} hektopaskalih</unitPattern>
 				<unitPattern count="other">{0} hektopaskalov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektopaskalov</unitPattern>
 				<unitPattern count="other" case="dative">{0} hektopaskalom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektopaskalov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} hektopaskali</unitPattern>
 				<unitPattern count="other" case="locative">{0} hektopaskalih</unitPattern>
 			</unit>
@@ -10348,13 +10348,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilopaskali</displayName>
 				<unitPattern count="one">{0} kilopaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilopaskal</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilopaskalu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilopaskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilopaskalom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilopaskalu</unitPattern>
 				<unitPattern count="two">{0} kilopaskala</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kilopaskala</unitPattern>
 				<unitPattern count="two" case="dative">{0} kilopaskaloma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kilopaskalov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kilopaskaloma</unitPattern>
@@ -10366,9 +10366,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilopaskali</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilopaskalih</unitPattern>
 				<unitPattern count="other">{0} kilopaskalov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilopaskalov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilopaskalom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilopaskalov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilopaskali</unitPattern>
 				<unitPattern count="other" case="locative">{0} kilopaskalih</unitPattern>
 			</unit>
@@ -10376,13 +10376,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>megapaskali</displayName>
 				<unitPattern count="one">{0} megapaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapaskal</unitPattern>
 				<unitPattern count="one" case="dative">{0} megapaskalu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megapaskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megapaskalom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megapaskalu</unitPattern>
 				<unitPattern count="two">{0} megapaskala</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} megapaskala</unitPattern>
 				<unitPattern count="two" case="dative">{0} megapaskaloma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} megapaskalov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} megapaskaloma</unitPattern>
@@ -10391,12 +10391,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} megapaskale</unitPattern>
 				<unitPattern count="few" case="dative">{0} megapaskalom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} megapaskalov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megapaskali</unitPattern>
 				<unitPattern count="few" case="locative">{0} megapaskalih</unitPattern>
 				<unitPattern count="other">{0} megapaskalov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapaskalov</unitPattern>
 				<unitPattern count="other" case="dative">{0} megapaskalom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapaskalov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} megapaskali</unitPattern>
 				<unitPattern count="other" case="locative">{0} megapaskalih</unitPattern>
 			</unit>
@@ -10404,13 +10404,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kilometri na uro</displayName>
 				<unitPattern count="one">{0} kilometer na uro</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilometer na uro</unitPattern>
 				<unitPattern count="one" case="dative">{0} kilometru na uro</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilometra na uro</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilometrom na uro</unitPattern>
 				<unitPattern count="one" case="locative">{0} kilometru na uro</unitPattern>
 				<unitPattern count="two">{0} kilometra na uro</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kilometra na uro</unitPattern>
 				<unitPattern count="two" case="dative">{0} kilometroma na uro</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kilometrov na uro</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kilometroma na uro</unitPattern>
@@ -10422,7 +10422,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kilometri na uro</unitPattern>
 				<unitPattern count="few" case="locative">{0} kilometrih na uro</unitPattern>
 				<unitPattern count="other">{0} kilometrov na uro</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometrov na uro</unitPattern>
 				<unitPattern count="other" case="dative">{0} kilometrom na uro</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kilometrov na uro</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kilometri na uro</unitPattern>
@@ -10450,9 +10450,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} metri na sekundo</unitPattern>
 				<unitPattern count="few" case="locative">{0} metrih na sekundo</unitPattern>
 				<unitPattern count="other">{0} metrov na sekundo</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metrov na sekundo</unitPattern>
 				<unitPattern count="other" case="dative">{0} metrom na sekundo</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metrov na sekundo</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metri na sekundo</unitPattern>
 				<unitPattern count="other" case="locative">{0} metrih na sekundo</unitPattern>
 			</unit>
@@ -10508,19 +10508,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} stopinjo Celzija</unitPattern>
 				<unitPattern count="one" case="locative">{0} stopinji Celzija</unitPattern>
 				<unitPattern count="two">{0} stopinji Celzija</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} stopinji Celzija</unitPattern>
 				<unitPattern count="two" case="dative">{0} stopinjama Celzija</unitPattern>
 				<unitPattern count="two" case="genitive">{0} stopinj Celzija</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} stopinjama Celzija</unitPattern>
 				<unitPattern count="two" case="locative">{0} stopinjah Celzija</unitPattern>
 				<unitPattern count="few">{0} stopinje Celzija</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stopinje Celzija</unitPattern>
 				<unitPattern count="few" case="dative">{0} stopinjam Celzija</unitPattern>
 				<unitPattern count="few" case="genitive">{0} stopinj Celzija</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} stopinjami Celzija</unitPattern>
 				<unitPattern count="few" case="locative">{0} stopinjah Celzija</unitPattern>
 				<unitPattern count="other">{0} stopinj Celzija</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stopinj Celzija</unitPattern>
 				<unitPattern count="other" case="dative">{0} stopinjam Celzija</unitPattern>
 				<unitPattern count="other" case="genitive">{0} stopinj Celzija</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} stopinjami Celzija</unitPattern>
@@ -10537,13 +10537,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kelvini</displayName>
 				<unitPattern count="one">{0} kelvin</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kelvin</unitPattern>
 				<unitPattern count="one" case="dative">{0} kelvinu</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kelvina</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kelvinom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kelvinu</unitPattern>
 				<unitPattern count="two">{0} kelvina</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kelvina</unitPattern>
 				<unitPattern count="two" case="dative">{0} kelvinoma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kelvinov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kelvinoma</unitPattern>
@@ -10555,7 +10555,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kelvini</unitPattern>
 				<unitPattern count="few" case="locative">{0} kelvinih</unitPattern>
 				<unitPattern count="other">{0} kelvinov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kelvinov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kelvinom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kelvinov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kelvini</unitPattern>
@@ -10572,13 +10572,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>newton metri</displayName>
 				<unitPattern count="one">{0} newton meter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} newton meter</unitPattern>
 				<unitPattern count="one" case="dative">{0} newton metru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} newton metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} newton metrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} newton metru</unitPattern>
 				<unitPattern count="two">{0} newton metra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} newton metra</unitPattern>
 				<unitPattern count="two" case="dative">{0} newton metroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} newton metrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} newton metroma</unitPattern>
@@ -10587,12 +10587,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="accusative">{0} newton metre</unitPattern>
 				<unitPattern count="few" case="dative">{0} newton metrom</unitPattern>
 				<unitPattern count="few" case="genitive">{0} newton metrov</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} newton metri</unitPattern>
 				<unitPattern count="few" case="locative">{0} newton metrih</unitPattern>
 				<unitPattern count="other">{0} newton metrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} newton metrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} newton metrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} newton metrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} newton metri</unitPattern>
 				<unitPattern count="other" case="locative">{0} newton metrih</unitPattern>
 			</unit>
@@ -10600,13 +10600,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kubični kilometri</displayName>
 				<unitPattern count="one">{0} kubični kilometer</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubični kilometer</unitPattern>
 				<unitPattern count="one" case="dative">{0} kubičnemu kilometru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubičnega kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubičnim kilometrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kubičnem kilometru</unitPattern>
 				<unitPattern count="two">{0} kubična kilometra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kubična kilometra</unitPattern>
 				<unitPattern count="two" case="dative">{0} kubičnima kilometroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kubičnih kilometrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kubičnima kilometroma</unitPattern>
@@ -10618,7 +10618,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kubičnimi kilometri</unitPattern>
 				<unitPattern count="few" case="locative">{0} kubičnih kilometrih</unitPattern>
 				<unitPattern count="other">{0} kubičnih kilometrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubičnih kilometrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kubičnim kilometrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kubičnih kilometrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kubičnimi kilometri</unitPattern>
@@ -10628,13 +10628,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kubični metri</displayName>
 				<unitPattern count="one">{0} kubični meter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubični meter</unitPattern>
 				<unitPattern count="one" case="dative">{0} kubičnemu metru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubičnega metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubičnim metrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kubičnem metru</unitPattern>
 				<unitPattern count="two">{0} kubična metra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kubična metra</unitPattern>
 				<unitPattern count="two" case="dative">{0} kubičnima metroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kubičnih metrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kubičnima metroma</unitPattern>
@@ -10646,7 +10646,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kubičnimi metri</unitPattern>
 				<unitPattern count="few" case="locative">{0} kubičnih metrih</unitPattern>
 				<unitPattern count="other">{0} kubičnih metrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubičnih metrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kubičnim metrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kubičnih metrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kubičnimi metri</unitPattern>
@@ -10657,13 +10657,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>kubični centimeter</displayName>
 				<unitPattern count="one">{0} kubični centimeter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubični centimeter</unitPattern>
 				<unitPattern count="one" case="dative">{0} kubičnemu centimetru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubičnega centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubičnim centimetrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} kubičnem centimetru</unitPattern>
 				<unitPattern count="two">{0} kubična centimetra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} kubična centimetra</unitPattern>
 				<unitPattern count="two" case="dative">{0} kubičnima centimetroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} kubičnih centimetrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} kubičnima centimetroma</unitPattern>
@@ -10675,7 +10675,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} kubičnimi centimetri</unitPattern>
 				<unitPattern count="few" case="locative">{0} kubičnih centimetrih</unitPattern>
 				<unitPattern count="other">{0} kubičnih centimetrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubičnih centimetrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} kubičnim centimetrom</unitPattern>
 				<unitPattern count="other" case="genitive">{0} kubičnih centimetrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} kubičnimi centimetri</unitPattern>
@@ -10714,13 +10714,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender draft="contributed">masculine</gender>
 				<displayName>megalitri</displayName>
 				<unitPattern count="one">{0} megaliter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megaliter</unitPattern>
 				<unitPattern count="one" case="dative">{0} megalitru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megalitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megalitrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} megalitru</unitPattern>
 				<unitPattern count="two">{0} megalitra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} megalitra</unitPattern>
 				<unitPattern count="two" case="dative">{0} megalitroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} megalitrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} megalitroma</unitPattern>
@@ -10742,13 +10742,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>hektolitri</displayName>
 				<unitPattern count="one">{0} hektoliter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektoliter</unitPattern>
 				<unitPattern count="one" case="dative">{0} hektolitru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektolitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektolitrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} hektolitru</unitPattern>
 				<unitPattern count="two">{0} hektolitra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} hektolitra</unitPattern>
 				<unitPattern count="two" case="dative">{0} hektolitrima</unitPattern>
 				<unitPattern count="two" case="genitive">{0} hektolitrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} hektolitroma</unitPattern>
@@ -10770,13 +10770,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>litri</displayName>
 				<unitPattern count="one">{0} liter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} liter</unitPattern>
 				<unitPattern count="one" case="dative">{0} litru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} litru</unitPattern>
 				<unitPattern count="two">{0} litra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} litra</unitPattern>
 				<unitPattern count="two" case="dative">{0} litroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} litrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} litroma</unitPattern>
@@ -10788,9 +10788,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} litri</unitPattern>
 				<unitPattern count="few" case="locative">{0} litrih</unitPattern>
 				<unitPattern count="other">{0} litrov</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litrov</unitPattern>
 				<unitPattern count="other" case="dative">{0} litrom</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litrov</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} litri</unitPattern>
 				<unitPattern count="other" case="locative">{0} litrih</unitPattern>
 				<perUnitPattern>{0} na liter</perUnitPattern>
@@ -10827,13 +10827,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>centilitri</displayName>
 				<unitPattern count="one">{0} centiliter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} centiliter</unitPattern>
 				<unitPattern count="one" case="dative">{0} centilitru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} centilitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} centilitrom</unitPattern>
 				<unitPattern count="one" case="locative">{0} centilitru</unitPattern>
 				<unitPattern count="two">{0} centilitra</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} centilitra</unitPattern>
 				<unitPattern count="two" case="dative">{0} centilitroma</unitPattern>
 				<unitPattern count="two" case="genitive">{0} centilitrov</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} centilitroma</unitPattern>
@@ -10855,7 +10855,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>mililitri</displayName>
 				<unitPattern count="one">{0} mililiter</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mililiter</unitPattern>
 				<unitPattern count="one" case="dative">{0} mililitru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mililitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mililitrom</unitPattern>
@@ -10883,27 +10883,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>feminine</gender>
 				<displayName>metrične pinte</displayName>
 				<unitPattern count="one">{0} metrična pinta</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} metrična pinta</unitPattern>
 				<unitPattern count="one" case="dative">{0} metrični pinti</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metrične pinte</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrično pinto</unitPattern>
 				<unitPattern count="one" case="locative">{0} metrični pinti</unitPattern>
 				<unitPattern count="two">{0} metrični pinti</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} metrični pinti</unitPattern>
 				<unitPattern count="two" case="dative">{0} metričnima pintama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} metričnih pint</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} metričnima pintama</unitPattern>
 				<unitPattern count="two" case="locative">{0} metričnih pintah</unitPattern>
 				<unitPattern count="few">{0} metrične pinte</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metrične pinte</unitPattern>
 				<unitPattern count="few" case="dative">{0} metričnim pintam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metričnih pint</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} metričnimi pintami</unitPattern>
 				<unitPattern count="few" case="locative">{0} metričnih pintah</unitPattern>
 				<unitPattern count="other">{0} metričnih pint</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metričnih pint</unitPattern>
 				<unitPattern count="other" case="dative">{0} metričnim pintam</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metričnih pint</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} metričnimi pintami</unitPattern>
 				<unitPattern count="other" case="locative">{0} metričnih pintah</unitPattern>
 			</unit>
@@ -10917,13 +10917,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} metrično skodelico</unitPattern>
 				<unitPattern count="one" case="locative">{0} metrični skodelici</unitPattern>
 				<unitPattern count="two">{0} metrični skodelici</unitPattern>
-				<unitPattern count="two" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="two" case="accusative">{0} metrični skodelici</unitPattern>
 				<unitPattern count="two" case="dative">{0} metričnima skodelicama</unitPattern>
 				<unitPattern count="two" case="genitive">{0} metričnih skodelic</unitPattern>
 				<unitPattern count="two" case="instrumental">{0} metričnima skodelicama</unitPattern>
 				<unitPattern count="two" case="locative">{0} metričnih skodelicah</unitPattern>
 				<unitPattern count="few">{0} metrične skodelice</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metrične skodelice</unitPattern>
 				<unitPattern count="few" case="dative">{0} metričnim skodelicam</unitPattern>
 				<unitPattern count="few" case="genitive">{0} metričnih skodelic</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} metričnimi skodelicami</unitPattern>
@@ -11168,16 +11168,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -11660,9 +11660,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>US therm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
 				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
@@ -11681,9 +11681,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -11716,51 +11716,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="two">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
@@ -11938,16 +11938,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -12131,9 +12131,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>bar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="two">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -12152,9 +12152,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>Pa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
 				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -12525,40 +12525,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -12567,7 +12567,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
 				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
@@ -12588,138 +12588,138 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="two">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="two">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="two">{0} G</unitPattern>
+				<unitPattern count="few">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="two">{0} m/s²</unitPattern>
+				<unitPattern count="few">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>vrt</displayName>
+				<unitPattern count="one">{0} vrt</unitPattern>
+				<unitPattern count="two">{0} vrt</unitPattern>
+				<unitPattern count="few">{0} vrt</unitPattern>
+				<unitPattern count="other">{0} vrt</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="two">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="one" draft="contributed">{0} °</unitPattern>
 				<unitPattern count="two" draft="contributed">{0} °</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} °</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} °</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>′</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="two">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>″</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="two">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="two">{0} km²</unitPattern>
+				<unitPattern count="few">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ha</displayName>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="two">{0} ha</unitPattern>
+				<unitPattern count="few">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="two">{0} m²</unitPattern>
+				<unitPattern count="few">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="two">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="two">{0} mi²</unitPattern>
+				<unitPattern count="few">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>aker</displayName>
+				<unitPattern count="one">{0} ac</unitPattern>
+				<unitPattern count="two">{0} ac</unitPattern>
+				<unitPattern count="few">{0} ac</unitPattern>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="two">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="two">{0} ft²</unitPattern>
+				<unitPattern count="few">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="two">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunum</displayName>
@@ -12729,25 +12729,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dunumi</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="two">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dl</displayName>
+				<unitPattern count="one">{0} mg/dl</unitPattern>
+				<unitPattern count="two">{0} mg/dl</unitPattern>
+				<unitPattern count="few">{0} mg/dl</unitPattern>
+				<unitPattern count="other">{0} mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/l</displayName>
+				<unitPattern count="one">{0} mmol/l</unitPattern>
+				<unitPattern count="two">{0} mmol/l</unitPattern>
+				<unitPattern count="few">{0} mmol/l</unitPattern>
+				<unitPattern count="other">{0} mmol/l</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>element</displayName>
@@ -12757,11 +12757,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} elementov</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="two">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -12771,32 +12771,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} %</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>promile</displayName>
+				<unitPattern count="one">{0} ‰</unitPattern>
+				<unitPattern count="two">{0} ‰</unitPattern>
+				<unitPattern count="few">{0} ‰</unitPattern>
+				<unitPattern count="other">{0} ‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0} ‱</unitPattern>
+				<unitPattern count="two">{0} ‱</unitPattern>
+				<unitPattern count="few">{0} ‱</unitPattern>
+				<unitPattern count="other">{0} ‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="two">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="two">{0} l/km</unitPattern>
+				<unitPattern count="few">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -12806,95 +12806,95 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="two">{0} mpg</unitPattern>
+				<unitPattern count="few">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="one">{0} mpg Imp.</unitPattern>
+				<unitPattern count="two">{0} mpg Imp.</unitPattern>
+				<unitPattern count="few">{0} mpg Imp.</unitPattern>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="two">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="two">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="two">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="two">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="two">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="two">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="two">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="two">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="two">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<displayName>bajt</displayName>
+				<unitPattern count="one">{0} bajt</unitPattern>
+				<unitPattern count="two">{0} bajta</unitPattern>
+				<unitPattern count="few">{0} bajti</unitPattern>
 				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="two">{0} bita</unitPattern>
+				<unitPattern count="few">{0} biti</unitPattern>
+				<unitPattern count="other">{0} bitov</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>st.</displayName>
@@ -12932,7 +12932,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>tednov</displayName>
@@ -12956,15 +12956,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} h</unitPattern>
 				<unitPattern count="few">{0} h</unitPattern>
 				<unitPattern count="other">{0} h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>min</displayName>
 				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="two">{0} min</unitPattern>
 				<unitPattern count="few">{0} min</unitPattern>
 				<unitPattern count="other">{0} min</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
@@ -12972,7 +12972,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} s</unitPattern>
 				<unitPattern count="few">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -12982,221 +12982,221 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="two">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="two">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="two">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="two">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="two">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="two">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="two">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="two">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="two">{0} Cal</unitPattern>
+				<unitPattern count="few">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="two">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="two">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="two">{0} kWh</unitPattern>
+				<unitPattern count="few">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="two">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="two">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="two">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="two">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="two">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="two">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="two">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="two">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="two">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="two">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} em</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="two">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="two">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="two">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="two">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpcm</displayName>
 				<unitPattern count="one">{0} dpcm</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ppcm</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpi</displayName>
 				<unitPattern count="one" draft="contributed">{0} dpi</unitPattern>
-				<unitPattern count="two" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="two" draft="contributed">{0} ppi</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pika</displayName>
+				<unitPattern count="one">{0} pika</unitPattern>
+				<unitPattern count="two">{0} piki</unitPattern>
+				<unitPattern count="few">{0} pike</unitPattern>
+				<unitPattern count="other">{0} pik</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="two">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -13204,7 +13204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} km</unitPattern>
 				<unitPattern count="few">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
@@ -13212,14 +13212,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="two">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
@@ -13227,7 +13227,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} cm</unitPattern>
 				<unitPattern count="few">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -13237,62 +13237,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="two">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="two">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="two">{0} pm</unitPattern>
 				<unitPattern count="few">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi</displayName>
 				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="two">{0} mi</unitPattern>
 				<unitPattern count="few">{0} mi</unitPattern>
 				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd</displayName>
 				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="two">{0} yd</unitPattern>
 				<unitPattern count="few">{0} yd</unitPattern>
 				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft</displayName>
 				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="two">{0} ft</unitPattern>
 				<unitPattern count="few">{0} ft</unitPattern>
 				<unitPattern count="other">{0} ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in</displayName>
 				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="two">{0} in</unitPattern>
 				<unitPattern count="few">{0} in</unitPattern>
 				<unitPattern count="other">{0} in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="two">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName draft="contributed">sv. let</displayName>
@@ -13309,81 +13309,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ae</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>furlongi</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="two">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>sežnji</displayName>
 				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="two">{0} fth</unitPattern>
 				<unitPattern count="few">{0} fth</unitPattern>
 				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="two">{0} nmi</unitPattern>
+				<unitPattern count="few">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="two">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="two">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="two">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="two">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="two">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="two">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="two">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="two">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
@@ -13391,7 +13391,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} kg</unitPattern>
 				<unitPattern count="few">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
@@ -13399,205 +13399,205 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} g</unitPattern>
 				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="two">{0} mg</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="two">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sh tn</displayName>
+				<unitPattern count="one">{0} sh tn</unitPattern>
+				<unitPattern count="two">{0} sh tn</unitPattern>
+				<unitPattern count="few">{0} sh tn</unitPattern>
+				<unitPattern count="other">{0} sh tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>stone</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="two">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="two">{0} lb</unitPattern>
 				<unitPattern count="few">{0} lb</unitPattern>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="two">{0} oz</unitPattern>
 				<unitPattern count="few">{0} oz</unitPattern>
 				<unitPattern count="other">{0} oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="two">{0} oz t</unitPattern>
+				<unitPattern count="few">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>CD</displayName>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="two">{0} CD</unitPattern>
+				<unitPattern count="few">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="two">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="two">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="two">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gran</displayName>
+				<unitPattern count="one">{0} gran</unitPattern>
+				<unitPattern count="two">{0} grana</unitPattern>
+				<unitPattern count="few">{0} grani</unitPattern>
+				<unitPattern count="other">{0} granov</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="two">{0} GW</unitPattern>
+				<unitPattern count="few">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="two">{0} MW</unitPattern>
+				<unitPattern count="few">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="two">{0} kW</unitPattern>
+				<unitPattern count="few">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>W</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="two">{0} W</unitPattern>
+				<unitPattern count="few">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="two">{0} mW</unitPattern>
+				<unitPattern count="few">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>KM</displayName>
 				<unitPattern count="one">{0} KM</unitPattern>
 				<unitPattern count="two">{0} KM</unitPattern>
 				<unitPattern count="few">{0} KM</unitPattern>
 				<unitPattern count="other">{0} KM</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="two">{0} mmHg</unitPattern>
+				<unitPattern count="few">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="two">{0} psi</unitPattern>
+				<unitPattern count="few">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="two">{0} inHg</unitPattern>
 				<unitPattern count="few">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="two">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="two">{0} mbar</unitPattern>
 				<unitPattern count="few">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="two">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="two">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="two">{0} hPa</unitPattern>
 				<unitPattern count="few">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="two">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="two">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -13607,32 +13607,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="two">{0} m/s</unitPattern>
 				<unitPattern count="few">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/h</displayName>
 				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="two">{0} mi/h</unitPattern>
 				<unitPattern count="few">{0} mi/h</unitPattern>
 				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="two">{0} kn</unitPattern>
+				<unitPattern count="few">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="two">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -13642,97 +13642,97 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0} °F</unitPattern>
 				<unitPattern count="two">{0} °F</unitPattern>
 				<unitPattern count="few">{0} °F</unitPattern>
 				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="two">{0} K</unitPattern>
+				<unitPattern count="few">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="two">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="two">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="two">{0} km³</unitPattern>
+				<unitPattern count="few">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="two">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="two">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="two">{0} mi³</unitPattern>
+				<unitPattern count="few">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="two">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="two">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="two">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="two">{0} Ml</unitPattern>
+				<unitPattern count="few">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hl</displayName>
+				<unitPattern count="one">{0} hl</unitPattern>
+				<unitPattern count="two">{0} hl</unitPattern>
+				<unitPattern count="few">{0} hl</unitPattern>
+				<unitPattern count="other">{0} hl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
@@ -13740,128 +13740,128 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="two">{0} l</unitPattern>
 				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="two">{0} dl</unitPattern>
+				<unitPattern count="few">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cl</displayName>
+				<unitPattern count="one">{0} cl</unitPattern>
+				<unitPattern count="two">{0} cl</unitPattern>
+				<unitPattern count="few">{0} cl</unitPattern>
+				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="two">{0} ml</unitPattern>
+				<unitPattern count="few">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="two">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>m. skod.</displayName>
 				<unitPattern count="one">{0} m. sk.</unitPattern>
 				<unitPattern count="two">{0} m. sk.</unitPattern>
 				<unitPattern count="few">{0} m. sk.</unitPattern>
 				<unitPattern count="other">{0} m. sk.</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="two">{0} ac ft</unitPattern>
+				<unitPattern count="few">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bušel</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="two">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="two">{0} gal</unitPattern>
+				<unitPattern count="few">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>imp. gal</displayName>
+				<unitPattern count="one">{0} imp. gal</unitPattern>
+				<unitPattern count="two">{0} imp. gal</unitPattern>
+				<unitPattern count="few">{0} imp. gal</unitPattern>
+				<unitPattern count="other">{0} imp. gal</unitPattern>
+				<perUnitPattern>{0}/imp. gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="two">{0} qt</unitPattern>
+				<unitPattern count="few">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="two">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="two">{0} c</unitPattern>
+				<unitPattern count="few">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="two">{0} fl oz</unitPattern>
+				<unitPattern count="few">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp. fl. oz.</displayName>
+				<unitPattern count="one">{0} imp. fl. oz.</unitPattern>
+				<unitPattern count="two">{0} imp. fl. oz.</unitPattern>
+				<unitPattern count="few">{0} imp. fl. oz.</unitPattern>
+				<unitPattern count="other">{0} imp. fl. oz.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>žlica</displayName>
+				<unitPattern count="one">{0} žlica</unitPattern>
+				<unitPattern count="two">{0} žlici</unitPattern>
+				<unitPattern count="few">{0} žlice</unitPattern>
+				<unitPattern count="other">{0} žlic</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>žlička</displayName>
+				<unitPattern count="one">{0} žlička</unitPattern>
+				<unitPattern count="two">{0} žlički</unitPattern>
+				<unitPattern count="few">{0} žličke</unitPattern>
+				<unitPattern count="other">{0} žličk</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="two">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>des. žl.</displayName>
@@ -13878,39 +13878,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} imp. des. žl.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kapljica</displayName>
+				<unitPattern count="one">{0} kapljica</unitPattern>
+				<unitPattern count="two">{0} kapljici</unitPattern>
+				<unitPattern count="few">{0} kapljice</unitPattern>
+				<unitPattern count="other">{0} kapljic</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tekoča drahma</displayName>
+				<unitPattern count="one">{0} tekoča drahma</unitPattern>
+				<unitPattern count="two">{0} tekoči drahmi</unitPattern>
+				<unitPattern count="few">{0} tekoče drahme</unitPattern>
+				<unitPattern count="other">{0} tekočih drahm</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>šilce</displayName>
+				<unitPattern count="one">{0} šilce</unitPattern>
+				<unitPattern count="two">{0} šilca</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} šilci</unitPattern>
+				<unitPattern count="other">{0} šilcev</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ščepec</displayName>
+				<unitPattern count="one">{0} ščepec</unitPattern>
+				<unitPattern count="two">{0} ščepca</unitPattern>
+				<unitPattern count="few">{0} ščepci</unitPattern>
+				<unitPattern count="other">{0} ščepcev</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. qt</displayName>
+				<unitPattern count="one">{0} imp. qt</unitPattern>
+				<unitPattern count="two">{0} imp. qt</unitPattern>
+				<unitPattern count="few">{0} imp. qt</unitPattern>
+				<unitPattern count="other">{0} imp. qt</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>smer</displayName>
@@ -13944,26 +13944,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ali {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ali {1}</listPatternPart>
+			<listPatternPart type="2">{0} ali {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ali {1}</listPatternPart>
+			<listPatternPart type="2">{0} ali {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} in {1}</listPatternPart>
+			<listPatternPart type="2">{0} in {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} in {1}</listPatternPart>
 			<listPatternPart type="2">{0} in {1}</listPatternPart>
 		</listPattern>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -78,7 +78,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">Jerookee</language>
 			<language type="chy">Cheyenne</language>
 			<language type="ckb">Bartamaha Kurdish</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">Bartamaha Kurdish</language>
 			<language type="ckb" alt="variant">Kurdi, Sorani</language>
 			<language type="clc">Chilcotin</language>
 			<language type="co">Korsikan</language>
@@ -453,11 +453,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="yue" alt="menu">Shiinays, Cantonese</language>
 			<language type="zgh">Morokaanka Tamasayt Rasmiga</language>
 			<language type="zh">Shiinaha Mandarin</language>
-			<language type="zh" alt="menu">↑↑↑</language>
+			<language type="zh" alt="menu">Shiinaha Mandarin</language>
 			<language type="zh_Hans">Shiinaha Rasmiga ah</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">Shiinaha Rasmiga ah</language>
 			<language type="zh_Hant">Shiinahii Hore</language>
-			<language type="zh_Hant" alt="long">↑↑↑</language>
+			<language type="zh_Hant" alt="long">Shiinahii Hore</language>
 			<language type="zu">Zuulu</language>
 			<language type="zun">Zuni</language>
 			<language type="zxx">Luuqad Looma Hayo</language>
@@ -915,7 +915,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tuniisiya</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turki</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turki</territory>
 			<territory type="TT">Tirinidaad &amp; Tobago</territory>
 			<territory type="TV">Tufaalu</territory>
 			<territory type="TW">Taywaan</territory>
@@ -925,7 +925,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UM">Jasiiradaha ka baxsan Maraykanka</territory>
 			<territory type="UN">Qaramada Midoobay</territory>
 			<territory type="US">Maraykanka</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">Maraykanka</territory>
 			<territory type="UY">Uruguwaay</territory>
 			<territory type="UZ">Usbakistan</territory>
 			<territory type="VA">Faatikaan</territory>
@@ -1199,237 +1199,237 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="buddhist">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">BE</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">BE</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>M/d/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">M/d/y GGGGG – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, M/d/y GGGGG – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1452,18 +1452,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Bisha12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Bisha Koobaad</month>
@@ -1482,18 +1482,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Bisha1</month>
+							<month type="2">Bisha2</month>
+							<month type="3">Bisha3</month>
+							<month type="4">Bisha4</month>
+							<month type="5">Bisha5</month>
+							<month type="6">Bisha6</month>
+							<month type="7">Bisha7</month>
+							<month type="8">Bisha8</month>
+							<month type="9">Bisha9</month>
+							<month type="10">Bisha10</month>
+							<month type="11">Bisha11</month>
+							<month type="12">Bisha12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -1528,10 +1528,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
 							<monthPattern type="leap">↑↑↑</monthPattern>
@@ -1544,13 +1544,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthPatternContext>
 					<monthPatternContext type="stand-alone">
 						<monthPatternWidth type="abbreviated">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="narrow">
 							<monthPattern type="leap">↑↑↑</monthPattern>
 						</monthPatternWidth>
 						<monthPatternWidth type="wide">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}bis</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 				</monthPatterns>
@@ -1558,7 +1558,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<cyclicNameSet type="dayParts">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="9">↑↑↑</cyclicName>
+								<cyclicName type="9">shen</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -1594,9 +1594,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 								<cyclicName type="1">guga ayaa bilaabmaya</cyclicName>
 								<cyclicName type="2">biyaha roobka</cyclicName>
 								<cyclicName type="3">cayayaan kacay</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
+								<cyclicName type="4">guga ekuinikis</cyclicName>
 								<cyclicName type="5">dhalaalya cad na</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
+								<cyclicName type="6">hadhuudha roobka</cyclicName>
 								<cyclicName type="7">kulka ayaa bilaabmaya</cyclicName>
 								<cyclicName type="8">hadhuudh buuxda</cyclicName>
 								<cyclicName type="9">hadhuudh ku jirta dhagaha</cyclicName>
@@ -1604,11 +1604,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 								<cyclicName type="11">kuleeyl yar</cyclicName>
 								<cyclicName type="12">kulayl weeyn</cyclicName>
 								<cyclicName type="13">deyrta ayaa bilaameeysa</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
+								<cyclicName type="14">dhamaadka kulaylka</cyclicName>
+								<cyclicName type="15">dhado cad</cyclicName>
+								<cyclicName type="16">ekuinokiska daayrta</cyclicName>
+								<cyclicName type="17">dhado qaboow</cyclicName>
+								<cyclicName type="18">baraf soo dhacaya</cyclicName>
 								<cyclicName type="19">kulka ayaa bilaabmaya</cyclicName>
 								<cyclicName type="20">barafka yar</cyclicName>
 								<cyclicName type="21">baraf weeyn</cyclicName>
@@ -1617,30 +1617,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 								<cyclicName type="24">qaboow weeyn</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
+								<cyclicName type="1">guga ayaa bilaabmaya</cyclicName>
+								<cyclicName type="2">biyaha roobka</cyclicName>
 								<cyclicName type="3">cayayaan lakiciyay</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
+								<cyclicName type="4">guga ekuinikis</cyclicName>
+								<cyclicName type="5">dhalaalaya cad na</cyclicName>
+								<cyclicName type="6">hadhuudha roobka</cyclicName>
+								<cyclicName type="7">jiilaalka ayaa bilaabmaya</cyclicName>
+								<cyclicName type="8">hadhuudh buuxda</cyclicName>
+								<cyclicName type="9">hadhuudh dhagta kujirta</cyclicName>
 								<cyclicName type="10">xaalada kulka</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="11">kulayl yar</cyclicName>
+								<cyclicName type="12">kulayl weeyn</cyclicName>
+								<cyclicName type="13">daayrta ayaa bilaabmaysa</cyclicName>
+								<cyclicName type="14">dhamaadka kulaylka</cyclicName>
+								<cyclicName type="15">dhado cad</cyclicName>
+								<cyclicName type="16">ekuinokiska daayrta</cyclicName>
+								<cyclicName type="17">dhado qaboow</cyclicName>
+								<cyclicName type="18">baraf soo dhacaya</cyclicName>
+								<cyclicName type="19">qaboowbaha ayaa bilaabmaya</cyclicName>
+								<cyclicName type="20">baraf yar</cyclicName>
+								<cyclicName type="21">baraf weeyn</cyclicName>
+								<cyclicName type="22">qorax qabow</cyclicName>
+								<cyclicName type="23">qaboow yar</cyclicName>
+								<cyclicName type="24">qaboow weeyn</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -1892,19 +1892,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -1927,240 +1927,240 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 						<era type="1">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>M/d/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">M/d/y GGGGG – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, M/d/y GGGGG – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2169,102 +2169,102 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Bisha1</month>
+							<month type="2">Bisha2</month>
+							<month type="3">Bisha3</month>
+							<month type="4">Bisha4</month>
+							<month type="5">Bisha5</month>
+							<month type="6">Bisha6</month>
+							<month type="7">Bisha7</month>
+							<month type="8">Bisha8</month>
+							<month type="9">Bisha9</month>
+							<month type="10">Bisha10</month>
+							<month type="11">Bisha11</month>
+							<month type="12">Bisha12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Bisha Koobaad</month>
+							<month type="2">bisha labaad</month>
+							<month type="3">bisha saddexaad</month>
+							<month type="4">bisha afaraad</month>
+							<month type="5">bisha shanaad</month>
+							<month type="6">bisha lixaad</month>
+							<month type="7">bisha todobaad</month>
+							<month type="8">bisha siddedad</month>
+							<month type="9">bisha sagaalad</month>
+							<month type="10">bisha tobnaad</month>
+							<month type="11">bisha kow iyo tobnaad</month>
+							<month type="12">bisha laba iyo tobnaad</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Bisha1</month>
+							<month type="2">Bisha2</month>
+							<month type="3">Bisha3</month>
+							<month type="4">Bisha4</month>
+							<month type="5">Bisha5</month>
+							<month type="6">Bisha6</month>
+							<month type="7">Bisha7</month>
+							<month type="8">Bisha8</month>
+							<month type="9">Bisha9</month>
+							<month type="10">Bisha10</month>
+							<month type="11">Bisha11</month>
+							<month type="12">Bisha12</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Bisha Koobaad</month>
+							<month type="2">Bisha Labaad</month>
+							<month type="3">Bisha Sadexaad</month>
+							<month type="4">Bisha Afraad</month>
+							<month type="5">Bisha Shanaad</month>
+							<month type="6">Bisha Lixaad</month>
+							<month type="7">Bisha Todabaad</month>
+							<month type="8">Bisha Sideedaad</month>
+							<month type="9">Bisha Sagaalaad</month>
+							<month type="10">Bisha Tobnaad</month>
+							<month type="11">Bisha Kow iyo Tobnaad</month>
+							<month type="12">Bisha laba iyo Tobnaad</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<monthPatterns>
 					<monthPatternContext type="format">
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 					<monthPatternContext type="stand-alone">
 						<monthPatternWidth type="narrow">
-							<monthPattern type="leap">↑↑↑</monthPattern>
+							<monthPattern type="leap">{0}b</monthPattern>
 						</monthPatternWidth>
 					</monthPatternContext>
 				</monthPatterns>
@@ -2272,146 +2272,146 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<cyclicNameSet type="dayParts">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
+								<cyclicName type="3">yin</cyclicName>
+								<cyclicName type="4">mao</cyclicName>
+								<cyclicName type="5">chen</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="solarTerms">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">guga ayaa bilaabmaya</cyclicName>
+								<cyclicName type="2">biyaha roobka</cyclicName>
+								<cyclicName type="3">xayayaan lakiciyay</cyclicName>
+								<cyclicName type="4">guga ekuinikis</cyclicName>
+								<cyclicName type="5">dhalaalaya cad na</cyclicName>
+								<cyclicName type="6">hadhuudha roobka</cyclicName>
+								<cyclicName type="7">jiilaalka ayaa bilaabmaya</cyclicName>
+								<cyclicName type="8">hadhuudh buuxda</cyclicName>
+								<cyclicName type="9">hadhuudh dhagta kujirta</cyclicName>
+								<cyclicName type="10">xaalka kulka</cyclicName>
+								<cyclicName type="11">kulayl yar</cyclicName>
+								<cyclicName type="12">kulayl weeyn</cyclicName>
+								<cyclicName type="13">daayrta ayaa bilaabmaysa</cyclicName>
+								<cyclicName type="14">dhamaadka kulaylka</cyclicName>
+								<cyclicName type="15">dhado cad</cyclicName>
+								<cyclicName type="16">ekuinokiska daayrta</cyclicName>
+								<cyclicName type="17">dhado qaboow</cyclicName>
+								<cyclicName type="18">baraf soo dhacaya</cyclicName>
+								<cyclicName type="19">qaboowbaha ayaa bilaabmaya</cyclicName>
+								<cyclicName type="20">baraf yar</cyclicName>
+								<cyclicName type="21">baraf weeyn</cyclicName>
+								<cyclicName type="22">qorax qabow</cyclicName>
+								<cyclicName type="23">qaboow yar</cyclicName>
+								<cyclicName type="24">qaboow weeyn</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">guga ayaa bilaabmaya</cyclicName>
+								<cyclicName type="2">biyaha roobka</cyclicName>
+								<cyclicName type="3">cayayaan kacay</cyclicName>
+								<cyclicName type="4">guga ekuinikis</cyclicName>
+								<cyclicName type="5">dhalaalya cad na</cyclicName>
+								<cyclicName type="6">hadhuudha roobka</cyclicName>
+								<cyclicName type="7">kulka ayaa bilaabmaya</cyclicName>
+								<cyclicName type="8">hadhuudh buuxda</cyclicName>
+								<cyclicName type="9">hadhuudh ku jirta dhagaha</cyclicName>
+								<cyclicName type="10">xaalada kulka</cyclicName>
+								<cyclicName type="11">kuleeyl yar</cyclicName>
+								<cyclicName type="12">kulayl weeyn</cyclicName>
+								<cyclicName type="13">deyrta ayaa bilaameeysa</cyclicName>
+								<cyclicName type="14">dhamaadka kulaylka</cyclicName>
+								<cyclicName type="15">dhado cad</cyclicName>
+								<cyclicName type="16">ekuinokiska daayrta</cyclicName>
+								<cyclicName type="17">dhado qaboow</cyclicName>
+								<cyclicName type="18">baraf soo dhacaya</cyclicName>
+								<cyclicName type="19">kulka ayaa bilaabmaya</cyclicName>
+								<cyclicName type="20">barafka yar</cyclicName>
+								<cyclicName type="21">baraf weeyn</cyclicName>
+								<cyclicName type="22">xaalada qaboobaha</cyclicName>
+								<cyclicName type="23">qaboow weeyn</cyclicName>
+								<cyclicName type="24">qaboow weeyn</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
-								<cyclicName type="13">↑↑↑</cyclicName>
-								<cyclicName type="14">↑↑↑</cyclicName>
-								<cyclicName type="15">↑↑↑</cyclicName>
-								<cyclicName type="16">↑↑↑</cyclicName>
-								<cyclicName type="17">↑↑↑</cyclicName>
-								<cyclicName type="18">↑↑↑</cyclicName>
-								<cyclicName type="19">↑↑↑</cyclicName>
-								<cyclicName type="20">↑↑↑</cyclicName>
-								<cyclicName type="21">↑↑↑</cyclicName>
-								<cyclicName type="22">↑↑↑</cyclicName>
-								<cyclicName type="23">↑↑↑</cyclicName>
-								<cyclicName type="24">↑↑↑</cyclicName>
+								<cyclicName type="1">guga ayaa bilaabmaya</cyclicName>
+								<cyclicName type="2">biyaha roobka</cyclicName>
+								<cyclicName type="3">cayayaan lakiciyay</cyclicName>
+								<cyclicName type="4">guga ekuinikis</cyclicName>
+								<cyclicName type="5">dhalaalaya cad na</cyclicName>
+								<cyclicName type="6">hadhuudha roobka</cyclicName>
+								<cyclicName type="7">jiilaalka ayaa bilaabmaya</cyclicName>
+								<cyclicName type="8">hadhuudh buuxda</cyclicName>
+								<cyclicName type="9">hadhuudh dhagta kujirta</cyclicName>
+								<cyclicName type="10">xaalada kulka</cyclicName>
+								<cyclicName type="11">kulayl yar</cyclicName>
+								<cyclicName type="12">kulayl weeyn</cyclicName>
+								<cyclicName type="13">daayrta ayaa bilaabmaysa</cyclicName>
+								<cyclicName type="14">dhamaadka kulaylka</cyclicName>
+								<cyclicName type="15">dhado cad</cyclicName>
+								<cyclicName type="16">ekuinokiska daayrta</cyclicName>
+								<cyclicName type="17">dhado qaboow</cyclicName>
+								<cyclicName type="18">baraf soo dhacaya</cyclicName>
+								<cyclicName type="19">qaboowbaha ayaa bilaabmaya</cyclicName>
+								<cyclicName type="20">baraf yar</cyclicName>
+								<cyclicName type="21">baraf weeyn</cyclicName>
+								<cyclicName type="22">qorax qabow</cyclicName>
+								<cyclicName type="23">qaboow yar</cyclicName>
+								<cyclicName type="24">qaboow weeyn</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="years">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="12">yi-hai</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="zodiacs">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">Jiir</cyclicName>
+								<cyclicName type="2">Dibi</cyclicName>
+								<cyclicName type="3">Shabeel</cyclicName>
+								<cyclicName type="4">Bakeeyle</cyclicName>
+								<cyclicName type="5">Masduullaa</cyclicName>
+								<cyclicName type="6">Mas</cyclicName>
+								<cyclicName type="7">Faras</cyclicName>
+								<cyclicName type="8">Ri</cyclicName>
+								<cyclicName type="9">Daanyeer</cyclicName>
+								<cyclicName type="10">Diiq</cyclicName>
+								<cyclicName type="11">Eey</cyclicName>
+								<cyclicName type="12">Doofaar</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">Jiir</cyclicName>
+								<cyclicName type="2">Dibi</cyclicName>
+								<cyclicName type="3">Shabeel</cyclicName>
+								<cyclicName type="4">Bakeeyle</cyclicName>
+								<cyclicName type="5">Masduullaa</cyclicName>
+								<cyclicName type="6">Mas</cyclicName>
+								<cyclicName type="7">Faras</cyclicName>
+								<cyclicName type="8">Ri</cyclicName>
+								<cyclicName type="9">Daanyeer</cyclicName>
+								<cyclicName type="10">Diiq</cyclicName>
+								<cyclicName type="11">Eey</cyclicName>
+								<cyclicName type="12">Doofaar</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
-								<cyclicName type="3">↑↑↑</cyclicName>
-								<cyclicName type="4">↑↑↑</cyclicName>
-								<cyclicName type="5">↑↑↑</cyclicName>
-								<cyclicName type="6">↑↑↑</cyclicName>
-								<cyclicName type="7">↑↑↑</cyclicName>
-								<cyclicName type="8">↑↑↑</cyclicName>
-								<cyclicName type="9">↑↑↑</cyclicName>
-								<cyclicName type="10">↑↑↑</cyclicName>
-								<cyclicName type="11">↑↑↑</cyclicName>
-								<cyclicName type="12">↑↑↑</cyclicName>
+								<cyclicName type="1">Jiir</cyclicName>
+								<cyclicName type="2">Dibi</cyclicName>
+								<cyclicName type="3">Shabeel</cyclicName>
+								<cyclicName type="4">Bakeeyle</cyclicName>
+								<cyclicName type="5">Masduullaa</cyclicName>
+								<cyclicName type="6">Mas</cyclicName>
+								<cyclicName type="7">Faras</cyclicName>
+								<cyclicName type="8">Ri</cyclicName>
+								<cyclicName type="9">daanyeer</cyclicName>
+								<cyclicName type="10">Diiq</cyclicName>
+								<cyclicName type="11">Eey</cyclicName>
+								<cyclicName type="12">Doofaar</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2419,184 +2419,184 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>r(U) MMMM d, EEEE</pattern>
+							<datetimeSkeleton>rMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>r(U) MMMM d</pattern>
+							<datetimeSkeleton>rMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>r MMM d</pattern>
+							<datetimeSkeleton>rMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>r-MM-dd</pattern>
+							<datetimeSkeleton>rMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">r U</dateFormatItem>
+						<dateFormatItem id="GyMMM">r MMM</dateFormatItem>
+						<dateFormatItem id="GyMMMd">r MMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">r MMM d, E</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">MM-dd</dateFormatItem>
+						<dateFormatItem id="MEd">MM-dd, E</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">MMM d, E</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="UM">U MM</dateFormatItem>
+						<dateFormatItem id="UMd">U MM-d</dateFormatItem>
+						<dateFormatItem id="UMMM">U MMM</dateFormatItem>
+						<dateFormatItem id="UMMMd">U MMM d</dateFormatItem>
+						<dateFormatItem id="y">r(U)</dateFormatItem>
+						<dateFormatItem id="yMd">r-MM-dd</dateFormatItem>
+						<dateFormatItem id="yyyy">r(U)</dateFormatItem>
+						<dateFormatItem id="yyyyM">r-MM</dateFormatItem>
+						<dateFormatItem id="yyyyMd">r-MM-dd</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">r-MM-dd, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">r MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">r MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">r MMM d, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">r(U) MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">r(U) QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">r(U) QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM–MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">LLL–LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">U–U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">U MMM–MMM</greatestDifference>
+							<greatestDifference id="y">U MMM – U MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">U MMM d–d</greatestDifference>
+							<greatestDifference id="M">U MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">U MMM d – U MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">U MMM d, E – U MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">U MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y">U MMMM – U MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2620,19 +2620,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="13">Pagumen</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Meskerem</month>
@@ -2700,240 +2700,240 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 						<era type="1">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
+						<era type="0">ERA0</era>
+						<era type="1">ERA1</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>M/d/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">M/d/y GGGGG – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, M/d/y GGGGG – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2941,13 +2941,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="ethiopic-amete-alem">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">ERA0</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">ERA0</era>
 					</eraNarrow>
 				</eras>
 			</calendar>
@@ -3230,13 +3230,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="3">M</month>
 							<month type="4">A</month>
 							<month type="5">M</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="6">J</month>
+							<month type="7">L</month>
+							<month type="8">O</month>
+							<month type="9">S</month>
+							<month type="10">O</month>
+							<month type="11">N</month>
+							<month type="12">D</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Bisha Koobaad</month>
@@ -3266,7 +3266,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="9">Seb</month>
 							<month type="10">Okt</month>
 							<month type="11">Nof</month>
-							<month type="12">↑↑↑</month>
+							<month type="12">Dis</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">J</month>
@@ -3316,16 +3316,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="wed">A</day>
 							<day type="thu">Kh</day>
 							<day type="fri">J</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">Axd</day>
 							<day type="mon">Isn</day>
 							<day type="tue">Tldo</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="wed">Arbc</day>
+							<day type="thu">Khms</day>
+							<day type="fri">Jmc</day>
+							<day type="sat">Sbti</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">Axad</day>
@@ -3342,9 +3342,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sun">Axd</day>
 							<day type="mon">Isn</day>
 							<day type="tue">Tldo</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
+							<day type="wed">Arbc</day>
+							<day type="thu">Khms</day>
+							<day type="fri">Jmc</day>
 							<day type="sat">Sbti</day>
 						</dayWidth>
 						<dayWidth type="narrow">
@@ -3361,9 +3361,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon">Isn</day>
 							<day type="tue">Tldo</day>
 							<day type="wed">Arbaco</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="thu">Khms</day>
+							<day type="fri">Jmc</day>
+							<day type="sat">Sbti</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">Axad</day>
@@ -3385,10 +3385,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">R4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">1</quarter>
+							<quarter type="2">2</quarter>
+							<quarter type="3">3</quarter>
+							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1">Rubaca 1aad</quarter>
@@ -3440,7 +3440,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="am">AM</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="pm">GD</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">GH</dayPeriod>
@@ -3463,7 +3463,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">B</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">KTM</era>
 						<era type="1">A</era>
 						<era type="1" alt="variant">CE</era>
 					</eraNarrow>
@@ -3756,36 +3756,36 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tishri</month>
+							<month type="2">Heshvan</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
+							<month type="5">Shevat</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
+							<month type="9">Iyar</month>
+							<month type="10">Sivan</month>
+							<month type="11">Tamuz</month>
+							<month type="12">Av</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="7" yeartype="leap">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -3806,20 +3806,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tishri</month>
+							<month type="2">Heshvan</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
+							<month type="5">Shevat</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
+							<month type="9">Iyar</month>
+							<month type="10">Sivan</month>
+							<month type="11">Tamuz</month>
+							<month type="12">Av</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -3838,57 +3838,57 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="13">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="7" yeartype="leap">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-							<month type="13">↑↑↑</month>
+							<month type="1">Tishri</month>
+							<month type="2">Heshvan</month>
+							<month type="3">Kislev</month>
+							<month type="4">Tevet</month>
+							<month type="5">Shevat</month>
+							<month type="6">Adar I</month>
+							<month type="7">Adar</month>
+							<month type="7" yeartype="leap">Adar II</month>
+							<month type="8">Nisan</month>
+							<month type="9">Iyar</month>
+							<month type="10">Sivan</month>
+							<month type="11">Tamuz</month>
+							<month type="12">Av</month>
+							<month type="13">Elul</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AM</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AM</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>M/d/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
@@ -3920,180 +3920,180 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">M/d/y GGGGG – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, M/d/y GGGGG – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4102,32 +4102,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Chaitra</month>
+							<month type="2">Vaisakha</month>
+							<month type="3">Jyaistha</month>
+							<month type="4">Asadha</month>
+							<month type="5">Sravana</month>
+							<month type="6">Bhadra</month>
+							<month type="7">Asvina</month>
+							<month type="8">Kartika</month>
+							<month type="9">Agrahayana</month>
+							<month type="10">Pausa</month>
+							<month type="11">Magha</month>
+							<month type="12">Phalguna</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -4146,18 +4146,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Chaitra</month>
+							<month type="2">Vaisakha</month>
+							<month type="3">Jyaistha</month>
+							<month type="4">Asadha</month>
+							<month type="5">Sravana</month>
+							<month type="6">Bhadra</month>
+							<month type="7">Asvina</month>
+							<month type="8">Kartika</month>
+							<month type="9">Agrahayana</month>
+							<month type="10">Pausa</month>
+							<month type="11">Magha</month>
+							<month type="12">Phalguna</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -4174,55 +4174,55 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Chaitra</month>
+							<month type="2">Vaisakha</month>
+							<month type="3">Jyaistha</month>
+							<month type="4">Asadha</month>
+							<month type="5">Sravana</month>
+							<month type="6">Bhadra</month>
+							<month type="7">Asvina</month>
+							<month type="8">Kartika</month>
+							<month type="9">Agrahayana</month>
+							<month type="10">Pausa</month>
+							<month type="11">Magha</month>
+							<month type="12">Phalguna</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">Saka</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">Saka</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>M/d/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
@@ -4254,180 +4254,180 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">M/d/y GGGGG – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, M/d/y GGGGG – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4450,6 +4450,50 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">Muxarram</month>
+							<month type="2">Safar</month>
+							<month type="3">Rabic al-awwal</month>
+							<month type="4">Rabic al-thani</month>
+							<month type="5">Jumada al-awwal</month>
+							<month type="6">jumada al-thani</month>
+							<month type="7">↑↑↑</month>
+							<month type="8">Shacban</month>
+							<month type="9">↑↑↑</month>
+							<month type="10">↑↑↑</month>
+							<month type="11">Dul al-qacda</month>
+							<month type="12">Dul xijjah</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">Mux.</month>
+							<month type="2">Saf.</month>
+							<month type="3">Rab. I</month>
+							<month type="4">Rab. II</month>
+							<month type="5">Jum. I</month>
+							<month type="6">Jum. II</month>
+							<month type="7">Raj.</month>
+							<month type="8">Sha.</month>
+							<month type="9">Ram.</month>
+							<month type="10">Shaw.</month>
+							<month type="11">Dul-Q.</month>
+							<month type="12">Dul-X.</month>
+						</monthWidth>
+						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
 							<month type="2">↑↑↑</month>
 							<month type="3">↑↑↑</month>
@@ -4470,54 +4514,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="4">Rabic al-thani</month>
 							<month type="5">Jumada al-awwal</month>
 							<month type="6">jumada al-thani</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">Rajab</month>
 							<month type="8">Shacban</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">Dul al-qacda</month>
-							<month type="12">Dul xijjah</month>
-						</monthWidth>
-					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">Mux.</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">Dul-Q.</month>
-							<month type="12">Dul-X.</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">Muxarram</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">Rabic al-awwal</month>
-							<month type="4">Rabic al-thani</month>
-							<month type="5">Jumada al-awwal</month>
-							<month type="6">jumada al-thani</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">Shacban</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
+							<month type="9">Ramadan</month>
+							<month type="10">Shawwal</month>
 							<month type="11">Dul al-qacdah</month>
 							<month type="12">Dul xijjah</month>
 						</monthWidth>
@@ -4537,226 +4537,226 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>M/d/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
 						<dateFormatItem id="GyMd">M/d/y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">M/d/y GGGGG – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, M/d/y GGGGG – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4764,243 +4764,243 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="japanese">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="2">↑↑↑</era>
-						<era type="3">↑↑↑</era>
-						<era type="4">↑↑↑</era>
-						<era type="5">↑↑↑</era>
-						<era type="6">↑↑↑</era>
-						<era type="7">↑↑↑</era>
-						<era type="8">↑↑↑</era>
-						<era type="9">↑↑↑</era>
-						<era type="10">↑↑↑</era>
-						<era type="11">↑↑↑</era>
-						<era type="12">↑↑↑</era>
-						<era type="13">↑↑↑</era>
-						<era type="14">↑↑↑</era>
-						<era type="15">↑↑↑</era>
-						<era type="16">↑↑↑</era>
-						<era type="17">↑↑↑</era>
-						<era type="18">↑↑↑</era>
-						<era type="19">↑↑↑</era>
-						<era type="20">↑↑↑</era>
-						<era type="21">↑↑↑</era>
-						<era type="22">↑↑↑</era>
-						<era type="23">↑↑↑</era>
-						<era type="24">↑↑↑</era>
-						<era type="25">↑↑↑</era>
-						<era type="26">↑↑↑</era>
-						<era type="27">↑↑↑</era>
-						<era type="28">↑↑↑</era>
-						<era type="29">↑↑↑</era>
-						<era type="30">↑↑↑</era>
-						<era type="31">↑↑↑</era>
-						<era type="32">↑↑↑</era>
-						<era type="33">↑↑↑</era>
-						<era type="34">↑↑↑</era>
-						<era type="35">↑↑↑</era>
-						<era type="36">↑↑↑</era>
-						<era type="37">↑↑↑</era>
-						<era type="38">↑↑↑</era>
-						<era type="39">↑↑↑</era>
-						<era type="40">↑↑↑</era>
-						<era type="41">↑↑↑</era>
-						<era type="42">↑↑↑</era>
-						<era type="43">↑↑↑</era>
-						<era type="44">↑↑↑</era>
-						<era type="45">↑↑↑</era>
-						<era type="46">↑↑↑</era>
-						<era type="47">↑↑↑</era>
-						<era type="48">↑↑↑</era>
-						<era type="49">↑↑↑</era>
-						<era type="50">↑↑↑</era>
-						<era type="51">↑↑↑</era>
-						<era type="52">↑↑↑</era>
-						<era type="53">↑↑↑</era>
-						<era type="54">↑↑↑</era>
-						<era type="55">↑↑↑</era>
-						<era type="56">↑↑↑</era>
-						<era type="57">↑↑↑</era>
-						<era type="58">↑↑↑</era>
-						<era type="59">↑↑↑</era>
-						<era type="60">↑↑↑</era>
-						<era type="61">↑↑↑</era>
-						<era type="62">↑↑↑</era>
-						<era type="63">↑↑↑</era>
-						<era type="64">↑↑↑</era>
-						<era type="65">↑↑↑</era>
-						<era type="66">↑↑↑</era>
-						<era type="67">↑↑↑</era>
-						<era type="68">↑↑↑</era>
-						<era type="69">↑↑↑</era>
-						<era type="70">↑↑↑</era>
-						<era type="71">↑↑↑</era>
-						<era type="72">↑↑↑</era>
-						<era type="73">↑↑↑</era>
-						<era type="74">↑↑↑</era>
-						<era type="75">↑↑↑</era>
-						<era type="76">↑↑↑</era>
-						<era type="77">↑↑↑</era>
-						<era type="78">↑↑↑</era>
-						<era type="79">↑↑↑</era>
-						<era type="80">↑↑↑</era>
-						<era type="81">↑↑↑</era>
-						<era type="82">↑↑↑</era>
-						<era type="83">↑↑↑</era>
-						<era type="84">↑↑↑</era>
-						<era type="85">↑↑↑</era>
-						<era type="86">↑↑↑</era>
-						<era type="87">↑↑↑</era>
-						<era type="88">↑↑↑</era>
-						<era type="89">↑↑↑</era>
-						<era type="90">↑↑↑</era>
-						<era type="91">↑↑↑</era>
-						<era type="92">↑↑↑</era>
-						<era type="93">↑↑↑</era>
-						<era type="94">↑↑↑</era>
-						<era type="95">↑↑↑</era>
-						<era type="96">↑↑↑</era>
-						<era type="97">↑↑↑</era>
-						<era type="98">↑↑↑</era>
-						<era type="99">↑↑↑</era>
-						<era type="100">↑↑↑</era>
-						<era type="101">↑↑↑</era>
-						<era type="102">↑↑↑</era>
-						<era type="103">↑↑↑</era>
-						<era type="104">↑↑↑</era>
-						<era type="105">↑↑↑</era>
-						<era type="106">↑↑↑</era>
-						<era type="107">↑↑↑</era>
-						<era type="108">↑↑↑</era>
-						<era type="109">↑↑↑</era>
-						<era type="110">↑↑↑</era>
-						<era type="111">↑↑↑</era>
-						<era type="112">↑↑↑</era>
-						<era type="113">↑↑↑</era>
-						<era type="114">↑↑↑</era>
-						<era type="115">↑↑↑</era>
-						<era type="116">↑↑↑</era>
-						<era type="117">↑↑↑</era>
-						<era type="118">↑↑↑</era>
-						<era type="119">↑↑↑</era>
-						<era type="120">↑↑↑</era>
-						<era type="121">↑↑↑</era>
-						<era type="122">↑↑↑</era>
-						<era type="123">↑↑↑</era>
-						<era type="124">↑↑↑</era>
-						<era type="125">↑↑↑</era>
-						<era type="126">↑↑↑</era>
-						<era type="127">↑↑↑</era>
-						<era type="128">↑↑↑</era>
-						<era type="129">↑↑↑</era>
-						<era type="130">↑↑↑</era>
-						<era type="131">↑↑↑</era>
-						<era type="132">↑↑↑</era>
-						<era type="133">↑↑↑</era>
-						<era type="134">↑↑↑</era>
-						<era type="135">↑↑↑</era>
-						<era type="136">↑↑↑</era>
-						<era type="137">↑↑↑</era>
-						<era type="138">↑↑↑</era>
-						<era type="139">↑↑↑</era>
-						<era type="140">↑↑↑</era>
-						<era type="141">↑↑↑</era>
-						<era type="142">↑↑↑</era>
-						<era type="143">↑↑↑</era>
-						<era type="144">↑↑↑</era>
-						<era type="145">↑↑↑</era>
-						<era type="146">↑↑↑</era>
-						<era type="147">↑↑↑</era>
-						<era type="148">↑↑↑</era>
-						<era type="149">↑↑↑</era>
-						<era type="150">↑↑↑</era>
-						<era type="151">↑↑↑</era>
-						<era type="152">↑↑↑</era>
-						<era type="153">↑↑↑</era>
-						<era type="154">↑↑↑</era>
-						<era type="155">↑↑↑</era>
-						<era type="156">↑↑↑</era>
-						<era type="157">↑↑↑</era>
-						<era type="158">↑↑↑</era>
-						<era type="159">↑↑↑</era>
-						<era type="160">↑↑↑</era>
-						<era type="161">↑↑↑</era>
-						<era type="162">↑↑↑</era>
-						<era type="163">↑↑↑</era>
-						<era type="164">↑↑↑</era>
-						<era type="165">↑↑↑</era>
-						<era type="166">↑↑↑</era>
-						<era type="167">↑↑↑</era>
-						<era type="168">↑↑↑</era>
-						<era type="169">↑↑↑</era>
-						<era type="170">↑↑↑</era>
-						<era type="171">↑↑↑</era>
-						<era type="172">↑↑↑</era>
-						<era type="173">↑↑↑</era>
-						<era type="174">↑↑↑</era>
-						<era type="175">↑↑↑</era>
-						<era type="176">↑↑↑</era>
-						<era type="177">↑↑↑</era>
-						<era type="178">↑↑↑</era>
-						<era type="179">↑↑↑</era>
-						<era type="180">↑↑↑</era>
-						<era type="181">↑↑↑</era>
-						<era type="182">↑↑↑</era>
-						<era type="183">↑↑↑</era>
-						<era type="184">↑↑↑</era>
-						<era type="185">↑↑↑</era>
-						<era type="186">↑↑↑</era>
-						<era type="187">↑↑↑</era>
-						<era type="188">↑↑↑</era>
-						<era type="189">↑↑↑</era>
-						<era type="190">↑↑↑</era>
-						<era type="191">↑↑↑</era>
-						<era type="192">↑↑↑</era>
-						<era type="193">↑↑↑</era>
-						<era type="194">↑↑↑</era>
-						<era type="195">↑↑↑</era>
-						<era type="196">↑↑↑</era>
-						<era type="197">↑↑↑</era>
-						<era type="198">↑↑↑</era>
-						<era type="199">↑↑↑</era>
-						<era type="200">↑↑↑</era>
-						<era type="201">↑↑↑</era>
-						<era type="202">↑↑↑</era>
-						<era type="203">↑↑↑</era>
-						<era type="204">↑↑↑</era>
-						<era type="205">↑↑↑</era>
-						<era type="206">↑↑↑</era>
-						<era type="207">↑↑↑</era>
-						<era type="208">↑↑↑</era>
-						<era type="209">↑↑↑</era>
-						<era type="210">↑↑↑</era>
-						<era type="211">↑↑↑</era>
-						<era type="212">↑↑↑</era>
-						<era type="213">↑↑↑</era>
-						<era type="214">↑↑↑</era>
-						<era type="215">↑↑↑</era>
-						<era type="216">↑↑↑</era>
-						<era type="217">↑↑↑</era>
-						<era type="218">↑↑↑</era>
-						<era type="219">↑↑↑</era>
-						<era type="220">↑↑↑</era>
-						<era type="221">↑↑↑</era>
-						<era type="222">↑↑↑</era>
-						<era type="223">↑↑↑</era>
-						<era type="224">↑↑↑</era>
-						<era type="225">↑↑↑</era>
-						<era type="226">↑↑↑</era>
-						<era type="227">↑↑↑</era>
-						<era type="228">↑↑↑</era>
-						<era type="229">↑↑↑</era>
-						<era type="230">↑↑↑</era>
-						<era type="231">↑↑↑</era>
-						<era type="232">↑↑↑</era>
-						<era type="233">↑↑↑</era>
-						<era type="234">↑↑↑</era>
-						<era type="235">↑↑↑</era>
-						<era type="236">↑↑↑</era>
+						<era type="0">Taika (645–650)</era>
+						<era type="1">Hakuchi (650–671)</era>
+						<era type="2">Hakuhō (672–686)</era>
+						<era type="3">Shuchō (686–701)</era>
+						<era type="4">Taihō (701–704)</era>
+						<era type="5">Keiun (704–708)</era>
+						<era type="6">Wadō (708–715)</era>
+						<era type="7">Reiki (715–717)</era>
+						<era type="8">Yōrō (717–724)</era>
+						<era type="9">Jinki (724–729)</era>
+						<era type="10">Tenpyō (729–749)</era>
+						<era type="11">Tenpyō-kampō (749–749)</era>
+						<era type="12">Tenpyō-shōhō (749–757)</era>
+						<era type="13">Tenpyō-hōji (757–765)</era>
+						<era type="14">Tenpyō-jingo (765–767)</era>
+						<era type="15">Jingo-keiun (767–770)</era>
+						<era type="16">Hōki (770–780)</era>
+						<era type="17">Ten-ō (781–782)</era>
+						<era type="18">Enryaku (782–806)</era>
+						<era type="19">Daidō (806–810)</era>
+						<era type="20">Kōnin (810–824)</era>
+						<era type="21">Tenchō (824–834)</era>
+						<era type="22">Jōwa (834–848)</era>
+						<era type="23">Kajō (848–851)</era>
+						<era type="24">Ninju (851–854)</era>
+						<era type="25">Saikō (854–857)</era>
+						<era type="26">Ten-an (857–859)</era>
+						<era type="27">Jōgan (859–877)</era>
+						<era type="28">Gangyō (877–885)</era>
+						<era type="29">Ninna (885–889)</era>
+						<era type="30">Kanpyō (889–898)</era>
+						<era type="31">Shōtai (898–901)</era>
+						<era type="32">Engi (901–923)</era>
+						<era type="33">Enchō (923–931)</era>
+						<era type="34">Jōhei (931–938)</era>
+						<era type="35">Tengyō (938–947)</era>
+						<era type="36">Tenryaku (947–957)</era>
+						<era type="37">Tentoku (957–961)</era>
+						<era type="38">Ōwa (961–964)</era>
+						<era type="39">Kōhō (964–968)</era>
+						<era type="40">Anna (968–970)</era>
+						<era type="41">Tenroku (970–973)</era>
+						<era type="42">Ten’en (973–976)</era>
+						<era type="43">Jōgen (976–978)</era>
+						<era type="44">Tengen (978–983)</era>
+						<era type="45">Eikan (983–985)</era>
+						<era type="46">Kanna (985–987)</era>
+						<era type="47">Eien (987–989)</era>
+						<era type="48">Eiso (989–990)</era>
+						<era type="49">Shōryaku (990–995)</era>
+						<era type="50">Chōtoku (995–999)</era>
+						<era type="51">Chōhō (999–1004)</era>
+						<era type="52">Kankō (1004–1012)</era>
+						<era type="53">Chōwa (1012–1017)</era>
+						<era type="54">Kannin (1017–1021)</era>
+						<era type="55">Jian (1021–1024)</era>
+						<era type="56">Manju (1024–1028)</era>
+						<era type="57">Chōgen (1028–1037)</era>
+						<era type="58">Chōryaku (1037–1040)</era>
+						<era type="59">Chōkyū (1040–1044)</era>
+						<era type="60">Kantoku (1044–1046)</era>
+						<era type="61">Eishō (1046–1053)</era>
+						<era type="62">Tengi (1053–1058)</era>
+						<era type="63">Kōhei (1058–1065)</era>
+						<era type="64">Jiryaku (1065–1069)</era>
+						<era type="65">Enkyū (1069–1074)</era>
+						<era type="66">Shōho (1074–1077)</era>
+						<era type="67">Shōryaku (1077–1081)</era>
+						<era type="68">Eihō (1081–1084)</era>
+						<era type="69">Ōtoku (1084–1087)</era>
+						<era type="70">Kanji (1087–1094)</era>
+						<era type="71">Kahō (1094–1096)</era>
+						<era type="72">Eichō (1096–1097)</era>
+						<era type="73">Jōtoku (1097–1099)</era>
+						<era type="74">Kōwa (1099–1104)</era>
+						<era type="75">Chōji (1104–1106)</era>
+						<era type="76">Kashō (1106–1108)</era>
+						<era type="77">Tennin (1108–1110)</era>
+						<era type="78">Ten-ei (1110–1113)</era>
+						<era type="79">Eikyū (1113–1118)</era>
+						<era type="80">Gen’ei (1118–1120)</era>
+						<era type="81">Hōan (1120–1124)</era>
+						<era type="82">Tenji (1124–1126)</era>
+						<era type="83">Daiji (1126–1131)</era>
+						<era type="84">Tenshō (1131–1132)</era>
+						<era type="85">Chōshō (1132–1135)</era>
+						<era type="86">Hōen (1135–1141)</era>
+						<era type="87">Eiji (1141–1142)</era>
+						<era type="88">Kōji (1142–1144)</era>
+						<era type="89">Ten’yō (1144–1145)</era>
+						<era type="90">Kyūan (1145–1151)</era>
+						<era type="91">Ninpei (1151–1154)</era>
+						<era type="92">Kyūju (1154–1156)</era>
+						<era type="93">Hōgen (1156–1159)</era>
+						<era type="94">Heiji (1159–1160)</era>
+						<era type="95">Eiryaku (1160–1161)</era>
+						<era type="96">Ōho (1161–1163)</era>
+						<era type="97">Chōkan (1163–1165)</era>
+						<era type="98">Eiman (1165–1166)</era>
+						<era type="99">Nin’an (1166–1169)</era>
+						<era type="100">Kaō (1169–1171)</era>
+						<era type="101">Shōan (1171–1175)</era>
+						<era type="102">Angen (1175–1177)</era>
+						<era type="103">Jishō (1177–1181)</era>
+						<era type="104">Yōwa (1181–1182)</era>
+						<era type="105">Juei (1182–1184)</era>
+						<era type="106">Genryaku (1184–1185)</era>
+						<era type="107">Bunji (1185–1190)</era>
+						<era type="108">Kenkyū (1190–1199)</era>
+						<era type="109">Shōji (1199–1201)</era>
+						<era type="110">Kennin (1201–1204)</era>
+						<era type="111">Genkyū (1204–1206)</era>
+						<era type="112">Ken’ei (1206–1207)</era>
+						<era type="113">Jōgen (1207–1211)</era>
+						<era type="114">Kenryaku (1211–1213)</era>
+						<era type="115">Kenpō (1213–1219)</era>
+						<era type="116">Jōkyū (1219–1222)</era>
+						<era type="117">Jōō (1222–1224)</era>
+						<era type="118">Gennin (1224–1225)</era>
+						<era type="119">Karoku (1225–1227)</era>
+						<era type="120">Antei (1227–1229)</era>
+						<era type="121">Kanki (1229–1232)</era>
+						<era type="122">Jōei (1232–1233)</era>
+						<era type="123">Tenpuku (1233–1234)</era>
+						<era type="124">Bunryaku (1234–1235)</era>
+						<era type="125">Katei (1235–1238)</era>
+						<era type="126">Ryakunin (1238–1239)</era>
+						<era type="127">En’ō (1239–1240)</era>
+						<era type="128">Ninji (1240–1243)</era>
+						<era type="129">Kangen (1243–1247)</era>
+						<era type="130">Hōji (1247–1249)</era>
+						<era type="131">Kenchō (1249–1256)</era>
+						<era type="132">Kōgen (1256–1257)</era>
+						<era type="133">Shōka (1257–1259)</era>
+						<era type="134">Shōgen (1259–1260)</era>
+						<era type="135">Bun’ō (1260–1261)</era>
+						<era type="136">Kōchō (1261–1264)</era>
+						<era type="137">Bun’ei (1264–1275)</era>
+						<era type="138">Kenji (1275–1278)</era>
+						<era type="139">Kōan (1278–1288)</era>
+						<era type="140">Shōō (1288–1293)</era>
+						<era type="141">Einin (1293–1299)</era>
+						<era type="142">Shōan (1299–1302)</era>
+						<era type="143">Kengen (1302–1303)</era>
+						<era type="144">Kagen (1303–1306)</era>
+						<era type="145">Tokuji (1306–1308)</era>
+						<era type="146">Enkyō (1308–1311)</era>
+						<era type="147">Ōchō (1311–1312)</era>
+						<era type="148">Shōwa (1312–1317)</era>
+						<era type="149">Bunpō (1317–1319)</era>
+						<era type="150">Genō (1319–1321)</era>
+						<era type="151">Genkō (1321–1324)</era>
+						<era type="152">Shōchū (1324–1326)</era>
+						<era type="153">Karyaku (1326–1329)</era>
+						<era type="154">Gentoku (1329–1331)</era>
+						<era type="155">Genkō (1331–1334)</era>
+						<era type="156">Kenmu (1334–1336)</era>
+						<era type="157">Engen (1336–1340)</era>
+						<era type="158">Kōkoku (1340–1346)</era>
+						<era type="159">Shōhei (1346–1370)</era>
+						<era type="160">Kentoku (1370–1372)</era>
+						<era type="161">Bunchū (1372–1375)</era>
+						<era type="162">Tenju (1375–1379)</era>
+						<era type="163">Kōryaku (1379–1381)</era>
+						<era type="164">Kōwa (1381–1384)</era>
+						<era type="165">Genchū (1384–1392)</era>
+						<era type="166">Meitoku (1384–1387)</era>
+						<era type="167">Kakei (1387–1389)</era>
+						<era type="168">Kōō (1389–1390)</era>
+						<era type="169">Meitoku (1390–1394)</era>
+						<era type="170">Ōei (1394–1428)</era>
+						<era type="171">Shōchō (1428–1429)</era>
+						<era type="172">Eikyō (1429–1441)</era>
+						<era type="173">Kakitsu (1441–1444)</era>
+						<era type="174">Bun’an (1444–1449)</era>
+						<era type="175">Hōtoku (1449–1452)</era>
+						<era type="176">Kyōtoku (1452–1455)</era>
+						<era type="177">Kōshō (1455–1457)</era>
+						<era type="178">Chōroku (1457–1460)</era>
+						<era type="179">Kanshō (1460–1466)</era>
+						<era type="180">Bunshō (1466–1467)</era>
+						<era type="181">Ōnin (1467–1469)</era>
+						<era type="182">Bunmei (1469–1487)</era>
+						<era type="183">Chōkyō (1487–1489)</era>
+						<era type="184">Entoku (1489–1492)</era>
+						<era type="185">Meiō (1492–1501)</era>
+						<era type="186">Bunki (1501–1504)</era>
+						<era type="187">Eishō (1504–1521)</era>
+						<era type="188">Taiei (1521–1528)</era>
+						<era type="189">Kyōroku (1528–1532)</era>
+						<era type="190">Tenbun (1532–1555)</era>
+						<era type="191">Kōji (1555–1558)</era>
+						<era type="192">Eiroku (1558–1570)</era>
+						<era type="193">Genki (1570–1573)</era>
+						<era type="194">Tenshō (1573–1592)</era>
+						<era type="195">Bunroku (1592–1596)</era>
+						<era type="196">Keichō (1596–1615)</era>
+						<era type="197">Genna (1615–1624)</era>
+						<era type="198">Kan’ei (1624–1644)</era>
+						<era type="199">Shōho (1644–1648)</era>
+						<era type="200">Keian (1648–1652)</era>
+						<era type="201">Jōō (1652–1655)</era>
+						<era type="202">Meireki (1655–1658)</era>
+						<era type="203">Manji (1658–1661)</era>
+						<era type="204">Kanbun (1661–1673)</era>
+						<era type="205">Enpō (1673–1681)</era>
+						<era type="206">Tenna (1681–1684)</era>
+						<era type="207">Jōkyō (1684–1688)</era>
+						<era type="208">Genroku (1688–1704)</era>
+						<era type="209">Hōei (1704–1711)</era>
+						<era type="210">Shōtoku (1711–1716)</era>
+						<era type="211">Kyōhō (1716–1736)</era>
+						<era type="212">Genbun (1736–1741)</era>
+						<era type="213">Kanpō (1741–1744)</era>
+						<era type="214">Enkyō (1744–1748)</era>
+						<era type="215">Kan’en (1748–1751)</era>
+						<era type="216">Hōreki (1751–1764)</era>
+						<era type="217">Meiwa (1764–1772)</era>
+						<era type="218">An’ei (1772–1781)</era>
+						<era type="219">Tenmei (1781–1789)</era>
+						<era type="220">Kansei (1789–1801)</era>
+						<era type="221">Kyōwa (1801–1804)</era>
+						<era type="222">Bunka (1804–1818)</era>
+						<era type="223">Bunsei (1818–1830)</era>
+						<era type="224">Tenpō (1830–1844)</era>
+						<era type="225">Kōka (1844–1848)</era>
+						<era type="226">Kaei (1848–1854)</era>
+						<era type="227">Ansei (1854–1860)</era>
+						<era type="228">Man’en (1860–1861)</era>
+						<era type="229">Bunkyū (1861–1864)</era>
+						<era type="230">Genji (1864–1865)</era>
+						<era type="231">Keiō (1865–1868)</era>
+						<era type="232">Meiji</era>
+						<era type="233">Taishō</era>
+						<era type="234">Shōwa</era>
+						<era type="235">Heisei</era>
+						<era type="236">Reiwa</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
@@ -5484,225 +5484,225 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>M/d/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">M/d/y GGGGG – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, M/d/y GGGGG – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5711,18 +5711,62 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Janaayo</month>
+							<month type="2">Feebraayo</month>
+							<month type="3">Maarso</month>
+							<month type="4">Abril</month>
+							<month type="5">Maayo</month>
+							<month type="6">Juun</month>
+							<month type="7">Luuliyo</month>
+							<month type="8">Agoosto</month>
+							<month type="9">Sabteembar</month>
+							<month type="10">Oktoobar</month>
+							<month type="11">Noofeembar</month>
+							<month type="12">Diiseembar</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">Janaayo</month>
+							<month type="2">Feebraayo</month>
+							<month type="3">Maarso</month>
+							<month type="4">Abril</month>
+							<month type="5">Maayo</month>
+							<month type="6">Juun</month>
+							<month type="7">Luuliyo</month>
+							<month type="8">Agoosto</month>
+							<month type="9">Sabteembar</month>
+							<month type="10">Oktoobar</month>
+							<month type="11">Noofeembar</month>
+							<month type="12">Diiseembar</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">Janaayo</month>
+							<month type="2">Feebraayo</month>
+							<month type="3">Maarso</month>
+							<month type="4">Abril</month>
+							<month type="5">Maayo</month>
+							<month type="6">Juun</month>
+							<month type="7">Luuliyo</month>
+							<month type="8">Agoosto</month>
+							<month type="9">Sabteembar</month>
+							<month type="10">Oktoobar</month>
+							<month type="11">Noofeembar</month>
+							<month type="12">Diiseembar</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -5753,284 +5797,240 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Diiseembar</month>
 						</monthWidth>
 					</monthContext>
-					<monthContext type="stand-alone">
-						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
-						</monthWidth>
-					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">AP</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">AP</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>M/d/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">M/d/y GGGGG – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, M/d/y GGGGG – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -6047,231 +6047,231 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">Kahor R.O.C.</era>
-						<era type="1">↑↑↑</era>
+						<era type="1">Minguo</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>MMM d, y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>M/d/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d, E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">M/d/y GGGGG – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, M/d/y GGGGG – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -6303,9 +6303,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>snd</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Sannadkii hore</relative>
+				<relative type="0">Sannadkan</relative>
+				<relative type="1">Sannadka danbe</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} snd</relativeTimePattern>
 					<relativeTimePattern count="other">{0} snd</relativeTimePattern>
@@ -6318,15 +6318,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="year-narrow">
 				<displayName>Snd</displayName>
 				<relative type="-1">Sannadkii la soo dhaafay</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">Sannadkan</relative>
 				<relative type="1">Sannadka xiga</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} snd</relativeTimePattern>
+					<relativeTimePattern count="other">{0} snd</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} snd khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Snd khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -6346,7 +6346,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="quarter-short">
 				<displayName>rbc</displayName>
 				<relative type="-1">Rubucii ugu dambeeyay</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">Rubucan</relative>
 				<relative type="1">Rubuca xiga</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} rbc</relativeTimePattern>
@@ -6359,16 +6359,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="quarter-narrow">
 				<displayName>rbc</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Rubucii ugu dambeeyay</relative>
+				<relative type="0">Rubucan</relative>
+				<relative type="1">Rubuca xiga</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} rbc</relativeTimePattern>
+					<relativeTimePattern count="other">{0} rbc</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} rbc khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} rbc khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -6386,12 +6386,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Bil</displayName>
+				<relative type="-1">Bishii hore</relative>
+				<relative type="0">Bishan</relative>
+				<relative type="1">Bisha danbe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bil</relativeTimePattern>
 					<relativeTimePattern count="other">{0} bil</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
@@ -6401,16 +6401,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>bil</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Bishii hore</relative>
+				<relative type="0">Bishan</relative>
+				<relative type="1">Bisha danbe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bil</relativeTimePattern>
+					<relativeTimePattern count="other">{0} bil</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} bil khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} bil khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -6430,9 +6430,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>tdbd</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Toddobaadkii hore</relative>
+				<relative type="0">Usbuucan</relative>
+				<relative type="1">Toddobaadka danbe</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} tdbd</relativeTimePattern>
 					<relativeTimePattern count="other">{0} tdbd</relativeTimePattern>
@@ -6445,16 +6445,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>tdbd</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">Toddobaadkii hore</relative>
 				<relative type="0">Toddobaadkan</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">Toddobaadka danbe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} tdbd</relativeTimePattern>
+					<relativeTimePattern count="other">{0} tdbd</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} tdbd khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} tdbd khr</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>Tdbdka {0}</relativePeriod>
 			</field>
@@ -6462,10 +6462,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Toddobaadka Bisha</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Toddobaadka Bisha</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Toddobaadka Bisha</displayName>
 			</field>
 			<field type="day">
 				<displayName>maalin</displayName>
@@ -6483,9 +6483,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>mln</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Shalay</relative>
+				<relative type="0">Maanta</relative>
+				<relative type="1">Berri</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} mln</relativeTimePattern>
 					<relativeTimePattern count="other">{0} mlmd</relativeTimePattern>
@@ -6497,16 +6497,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>mln</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Shalay</relative>
+				<relative type="0">Maanta</relative>
+				<relative type="1">Berri</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} mln</relativeTimePattern>
+					<relativeTimePattern count="other">{0} mlmd</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} mln khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} mlmd khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
@@ -6516,7 +6516,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>mlnta sndka</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>mlnta sndka</displayName>
 			</field>
 			<field type="weekday">
 				<displayName>maalinta toddobaadka</displayName>
@@ -6550,16 +6550,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Axadii hore</relative>
+				<relative type="0">Axadan</relative>
+				<relative type="1">Axada danbe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">Axad</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Axadood</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Axad kahor</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Axadood kahor</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
@@ -6567,12 +6567,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">axadan</relative>
 				<relative type="1">axada xigta</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">Axad</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Axadood</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Axad kahor</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Axadood kahor</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -6602,16 +6602,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">Isnti hre</relative>
+				<relative type="0">Isntn</relative>
 				<relative type="1">Isnta dbe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Isn</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Isn</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Isn khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Isn khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -6680,16 +6680,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Arbcdi hre</relative>
+				<relative type="0">Arbcdn</relative>
+				<relative type="1">Arbcda dbe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Arbc</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Arbc</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Arbc khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Arbc khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -6719,16 +6719,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Khmsti hre</relative>
+				<relative type="0">Khmstn</relative>
+				<relative type="1">Khmsta dbe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} khms</relativeTimePattern>
+					<relativeTimePattern count="other">{0} khms</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} khms khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} khms khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -6758,16 +6758,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Jmchi hre</relative>
+				<relative type="0">Jmchn</relative>
+				<relative type="1">Jmcha dbe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Jmc</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Jmc</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Jmc khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} jmc khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -6797,16 +6797,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Sbtdi hre</relative>
+				<relative type="0">Sbtdn</relative>
+				<relative type="1">Sbtda dbe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Sbti</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Sbti</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Sbti khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Sbti khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
@@ -6832,7 +6832,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-short">
 				<displayName>scd</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">Saacadan</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} scd</relativeTimePattern>
 					<relativeTimePattern count="other">{0} scd</relativeTimePattern>
@@ -6844,14 +6844,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-narrow">
 				<displayName>scd</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">Saacadan</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} scd</relativeTimePattern>
+					<relativeTimePattern count="other">{0} scd</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} scd khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} scd khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
@@ -6868,26 +6868,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-short">
 				<displayName>dqqd</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">Daqiiqadan</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} dqqd</relativeTimePattern>
 					<relativeTimePattern count="other">{0} dqqd</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} dqqd khr</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} daqiiqadood kahor</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>dqqd</displayName>
+				<relative type="0">Daqiiqadan</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dqqd</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dqqd</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} dqqd khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} daqiiqadood kahor</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -6915,15 +6915,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>ilbrqsi</displayName>
+				<relative type="0">Iminka</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ilbrqsi</relativeTimePattern>
+					<relativeTimePattern count="other">{0} ilbrqsi</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ilbrqsi khr</relativeTimePattern>
+					<relativeTimePattern count="other">{0} ilbrqsi khr</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
@@ -9198,18 +9198,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</otherNumberingSystems>
 		<minimumGroupingDigits draft="contributed">↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
@@ -9240,270 +9240,270 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="beng">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="brah">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="cakm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="cham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="deva">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="fullwide">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>(^)</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="gong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="gonm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="gujr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="guru">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="hanidec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="java">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="kali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="khmr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="knda">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-		</symbols>
-		<symbols numberSystem="lana">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
+			<perMille>‰</perMille>
 			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="beng">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="brah">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="cakm">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="cham">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="deva">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="fullwide">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>(^)</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="gong">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="gonm">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="gujr">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="guru">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="hanidec">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="java">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="kali">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="khmr">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="knda">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
+		</symbols>
+		<symbols numberSystem="lana">
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>NaN</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal draft="contributed">↑↑↑</decimal>
@@ -9521,478 +9521,478 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>(^)</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>(^)</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
-			<nan>↑↑↑</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
+			<nan>MaL</nan>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<infinity>↑↑↑</infinity>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="adlm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arab">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="arabext">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="bali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="beng">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="brah">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cakm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="cham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="deva">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="fullwide">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gonm">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="gujr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="guru">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="hanidec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="java">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="kali">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="khmr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="knda">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lana">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="lanatham">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="laoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -10032,17 +10032,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
 				<decimalFormat>
-					<pattern type="1000" count="one">↑↑↑</pattern>
+					<pattern type="1000" count="one">0K</pattern>
 					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
+					<pattern type="10000" count="one">00K</pattern>
 					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
+					<pattern type="100000" count="one">000K</pattern>
 					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000" count="one">0M</pattern>
 					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000" count="one">00M</pattern>
 					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000" count="one">000M</pattern>
 					<pattern type="100000000" count="other">↑↑↑</pattern>
 					<pattern type="1000000000" count="one">0B</pattern>
 					<pattern type="1000000000" count="other">0B</pattern>
@@ -10050,11 +10050,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000000000" count="other">00B</pattern>
 					<pattern type="100000000000" count="one">000B</pattern>
 					<pattern type="100000000000" count="other">000B</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one">0T</pattern>
 					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one">00T</pattern>
 					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one">000T</pattern>
 					<pattern type="100000000000000" count="other">↑↑↑</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
@@ -10062,315 +10062,315 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<decimalFormats numberSystem="lepc">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="limb">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mlym">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mong">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mtei">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="mymrshan">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="nkoo">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="olck">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="orya">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="osma">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="rohg">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="saur">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="shrd">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sora">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="sund">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="takr">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="talu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tamldec">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="telu">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="thai">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="tibt">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<decimalFormats numberSystem="vaii">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
 		<scientificFormats numberSystem="adlm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arab">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="arabext">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="bali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="beng">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="brah">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cakm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="cham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="deva">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="fullwide">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gonm">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="gujr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="guru">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="hanidec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="java">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="kali">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="khmr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="knda">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lana">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="lanatham">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="laoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -10384,168 +10384,168 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<scientificFormats numberSystem="lepc">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="limb">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mlym">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mong">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mtei">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="mymrshan">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="nkoo">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="olck">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="orya">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="osma">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="rohg">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="saur">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="shrd">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sora">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="sund">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="takr">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="talu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tamldec">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="telu">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="thai">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="tibt">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<scientificFormats numberSystem="vaii">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<percentFormats numberSystem="adlm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -10559,140 +10559,140 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="arabext">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="bali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="beng">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="brah">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cakm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="cham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="deva">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="fullwide">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gonm">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="gujr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="guru">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="hanidec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="java">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="kali">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="khmr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="knda">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lana">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="lanatham">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="laoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -10706,175 +10706,175 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<percentFormats numberSystem="lepc">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="limb">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mlym">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mong">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mtei">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="mymrshan">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="nkoo">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="olck">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="orya">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="osma">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="rohg">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="saur">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="shrd">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sora">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="sund">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="takr">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="talu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tamldec">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="telu">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="thai">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="tibt">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<percentFormats numberSystem="vaii">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -10882,249 +10882,249 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
@@ -11192,284 +11192,284 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">
@@ -11565,7 +11565,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="BAD">
 				<displayName>Diinaarka BBosnia-Hersogofina 1.00 konfatibal maakta Bosnia-Hersogofina 1 konfatibal maaka Bosnia-Hersogofina (1992–1994)</displayName>
 				<displayName count="one">Diinaarka BBosnia-Hersogofina (1992–1994)</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Diinaarka BBosnia-Hersogofina 1.00 konfatibal maakta Bosnia-Hersogofina 1 konfatibal maaka Bosnia-Hersogofina (1992–1994)</displayName>
 			</currency>
 			<currency type="BAM">
 				<displayName>Konfatibal Maakta Bosnia-Hersogofina</displayName>
@@ -11609,7 +11609,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="BMD">
 				<displayName>Doolarka Barmuuda</displayName>
 				<displayName count="one">doolarka Barmuuda</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Doolarka Barmuuda</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -11671,7 +11671,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName count="one">rubalka Belarus</displayName>
 				<displayName count="other">rubalka Belarus</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">BYN</symbol>
 			</currency>
 			<currency type="BZD">
 				<displayName>Doolarka Beelisa</displayName>
@@ -11894,7 +11894,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="HKD">
 				<displayName>Doolarka Hoon Koon</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Doolarada Hoon Koon</displayName>
 				<displayName count="other">Doolarada Hoon Koon</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -12215,7 +12215,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="NIO">
 				<displayName>Kordobada Nikargow</displayName>
 				<displayName count="one">Kordobada Nikargow</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Kordobada Nikargow</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -12367,7 +12367,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="SHP">
 				<displayName>Bowndka St Helen</displayName>
 				<displayName count="one">bowndka St Helen</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Bowndka St Helen</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -12379,8 +12379,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="SOS">
 				<displayName>Shilingka Soomaaliya</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Shilingka Soomaaliya</displayName>
+				<displayName count="other">Shilingka Soomaaliya</displayName>
 				<symbol>S</symbol>
 			</currency>
 			<currency type="SRD">
@@ -12594,136 +12594,136 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 		</currencies>
 		<miscPatterns numberSystem="adlm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arab">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="arabext">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="bali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="beng">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="brah">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cakm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="cham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="deva">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="fullwide">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gonm">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="gujr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="guru">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="hanidec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="java">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="kali">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="khmr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="knda">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lana">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lanatham">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="laoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="latn">
 			<pattern type="approximately">↑↑↑</pattern>
@@ -12732,142 +12732,142 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="lepc">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="limb">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mlym">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mong">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mtei">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="mymrshan">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="nkoo">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="olck">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="orya">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="osma">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="rohg">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="saur">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="shrd">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sora">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="sund">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="takr">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="talu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tamldec">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="telu">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="thai">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="tibt">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="vaii">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
-			<pattern type="atMost">↑↑↑</pattern>
-			<pattern type="range">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">≥{0}</pattern>
+			<pattern type="atMost">≤{0}</pattern>
+			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one" draft="contributed">{0} maalin</pluralMinimalPairs>
@@ -12884,46 +12884,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>senti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
 				<unitPrefixPattern>peta{0}</unitPrefixPattern>
@@ -12938,31 +12938,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>yotta{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
 				<unitPrefixPattern>dheer{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="one">laba-jibaar {0}</compoundUnitPattern1>
@@ -12973,7 +12973,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">saddex-jibaar {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>cadaadis dib ku riixaya</displayName>
@@ -13182,8 +13182,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-bit">
 				<displayName>bitis</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>qarni</displayName>
@@ -13193,7 +13193,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-decade">
 				<displayName>rubuc qarni</displayName>
 				<unitPattern count="one">rubuc qarni</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>Sannado</displayName>
@@ -13209,7 +13209,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-month">
 				<displayName>Bilo</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bil</unitPattern>
 				<unitPattern count="other">{0} bilood</unitPattern>
 				<perUnitPattern>{0} bishiiba</perUnitPattern>
 			</unit>
@@ -13232,9 +13232,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} saacadiiba</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>daqiiqad</displayName>
 				<unitPattern count="one">{0} daqiiqad</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} daqiiqo</unitPattern>
 				<perUnitPattern>{0} daqiiqadiiba</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -13269,7 +13269,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} miliambeer</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>ohmis</displayName>
 				<unitPattern count="one">{0} ohm</unitPattern>
 				<unitPattern count="other">{0} ohm</unitPattern>
 			</unit>
@@ -13319,9 +13319,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} halbeega kulaylka ee Biritishka</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>rodol xoog</displayName>
@@ -13329,7 +13329,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} rodolo xoog</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>nuyuuton</displayName>
 				<unitPattern count="one">{0} nuyuuton</unitPattern>
 				<unitPattern count="other">{0} nuyuuton</unitPattern>
 			</unit>
@@ -13359,29 +13359,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} haart</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dhibco halkii sentimitir</displayName>
@@ -13394,14 +13394,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} dhibic injigiiba</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>Kiilo mitir</displayName>
@@ -13484,14 +13484,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} unuga xidigiska</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>Nuutikal meyl</displayName>
@@ -13509,7 +13509,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} dhibco</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>raadiyas qoraxeed</displayName>
 				<unitPattern count="one">{0} raadiyas qoraxeed</unitPattern>
 				<unitPattern count="other">{0} raadiyas qoraxeed</unitPattern>
 			</unit>
@@ -13519,14 +13519,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} laks</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>iftiinnada qorraxda</displayName>
@@ -13566,9 +13566,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} tan</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>bownd</displayName>
@@ -13608,9 +13608,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} cufka qorraxda</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>gigawaatis</displayName>
@@ -13658,9 +13658,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} Inji maakuri ah</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>milibaaris</displayName>
@@ -13673,9 +13673,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} hawada agagaarka</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hektobaskalis</displayName>
@@ -13713,9 +13713,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} nott</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>degriis Selsiyaas</displayName>
@@ -13883,19 +13883,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} foosto</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>drop</displayName>
+				<unitPattern count="one">{0} drop</unitPattern>
+				<unitPattern count="other">{0} drop</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>dram</displayName>
@@ -13903,19 +13903,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="one">{0} pinch</unitPattern>
+				<unitPattern count="other">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>afarta Jiho</displayName>
@@ -14015,12 +14015,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -14028,7 +14028,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>cadaadis dib ku riixaya</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
@@ -14063,7 +14063,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -14074,19 +14074,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>mitir jibaaran</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>meyl jibaaran</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} my²</unitPattern>
 				<unitPattern count="other">{0} my²</unitPattern>
 				<perUnitPattern>{0}/my²</perUnitPattern>
 			</unit>
@@ -14097,17 +14097,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yaardi jibaaran</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>fiit jibaaran</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>injis²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -14128,7 +14128,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-item">
@@ -14143,12 +14143,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>boqolkiiba</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>baarmiil</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
@@ -14163,7 +14163,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litar/km</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L/km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
@@ -14173,7 +14173,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>meyl/gal</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpg US</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
@@ -14188,42 +14188,42 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TBeyt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} TB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>Tbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Tb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName>GBeyt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName>Gbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Gb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>MBeyt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName>Mbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Mb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName>kBeyt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kB</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName>kbit</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-byte">
@@ -14233,7 +14233,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-bit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bit</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -14243,7 +14243,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-decade">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dec</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -14296,7 +14296,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>milisek</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
@@ -14311,27 +14311,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>ambs</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>miliambs</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>ohmis</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>fooltis</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>kilokalooris</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Kkal</unitPattern>
 				<unitPattern count="other">{0} Kkal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
@@ -14346,12 +14346,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kiilojuul</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>juules</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
@@ -14371,7 +14371,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
@@ -14391,47 +14391,47 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -14445,24 +14445,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} dhbi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -14473,23 +14473,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>μmitir</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
@@ -14504,18 +14504,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-yard">
 				<displayName>yaardi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>injis</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -14536,12 +14536,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -14561,22 +14561,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>raadiyas qoraxeed</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>laks</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -14586,39 +14586,39 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>garaam</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>tan</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -14645,7 +14645,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
@@ -14660,32 +14660,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>waat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
@@ -14710,12 +14710,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
@@ -14725,7 +14725,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -14765,22 +14765,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>deg. C</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°C</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>deg. F</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
@@ -14795,18 +14795,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -14817,27 +14817,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>yaardi³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>fiit³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>inji³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ML</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-liter">
@@ -14848,7 +14848,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
@@ -14858,7 +14858,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
@@ -14878,7 +14878,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>cabirka bushels</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -14915,7 +14915,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>imb. owniska dareeraha</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} own dr imb.</unitPattern>
 				<unitPattern count="other">{0} own dr imb.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -14935,37 +14935,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} drop</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>dareere dram</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pinch</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -14978,199 +14978,199 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cadaadis dib ku riixaya</displayName>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mitir/ilbrqsi²</displayName>
+				<unitPattern count="one">{0} m/i²</unitPattern>
+				<unitPattern count="other">{0} m/i²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>wreg</displayName>
+				<unitPattern count="one">{0} wreg</unitPattern>
+				<unitPattern count="other">{0} wreg</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>raadiyan</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>digrii</displayName>
+				<unitPattern count="one">{0} dig</unitPattern>
+				<unitPattern count="other">{0} dig</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arkmnt</displayName>
+				<unitPattern count="one">{0} arkmnt</unitPattern>
+				<unitPattern count="other">{0} arkmnt</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>aarkseken</displayName>
+				<unitPattern count="one">{0} aarkseken</unitPattern>
+				<unitPattern count="other">{0} aarkseken</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hektar</displayName>
+				<unitPattern count="one">{0} hk</unitPattern>
+				<unitPattern count="other">{0} hk</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mitir jibaaran</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>meyl jibaaran</displayName>
+				<unitPattern count="one">{0} my²</unitPattern>
+				<unitPattern count="other">{0} my²</unitPattern>
+				<perUnitPattern>{0}/my²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>aakre</displayName>
+				<unitPattern count="one">{0} ak</unitPattern>
+				<unitPattern count="other">{0} ak</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fiit jibaaran</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>injis²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunaam</displayName>
+				<unitPattern count="one">{0} dunaam</unitPattern>
+				<unitPattern count="other">{0} dunaam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karaat</displayName>
+				<unitPattern count="one">{0} kr</unitPattern>
+				<unitPattern count="other">{0} kr</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>mg/dL</displayName>
@@ -15178,9 +15178,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>shay</displayName>
@@ -15194,28 +15194,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}%</unitPattern>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>baarmiil</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bermiraad</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mool</displayName>
+				<unitPattern count="one">{0} mool</unitPattern>
+				<unitPattern count="other">{0} mool</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>litar/km</displayName>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -15223,74 +15223,74 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>meyl/gal</displayName>
+				<unitPattern count="one">{0} mpg US</unitPattern>
+				<unitPattern count="other">{0} mpg US</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>meyl/gal imb.</displayName>
+				<unitPattern count="one">{0} mg Imb.</unitPattern>
+				<unitPattern count="other">{0} mg Imb.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BBeyt</displayName>
+				<unitPattern count="one">{0} BB</unitPattern>
+				<unitPattern count="other">{0} BB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TBeyt</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tbit</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GBeyt</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gbit</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MBeyt</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mbit</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kBeyt</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kbit</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>beyt</displayName>
+				<unitPattern count="one">{0} beyt</unitPattern>
+				<unitPattern count="other">{0} beyt</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>q</displayName>
+				<unitPattern count="one">{0} q</unitPattern>
+				<unitPattern count="other">{0} q</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<displayName>toban sano</displayName>
@@ -15301,7 +15301,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>snd</displayName>
 				<unitPattern count="one">{0}s</unitPattern>
 				<unitPattern count="other">{0}s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sk</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>Rubac</displayName>
@@ -15313,7 +15313,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Bil</displayName>
 				<unitPattern count="one">{0}b</unitPattern>
 				<unitPattern count="other">{0}b</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/bsh</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>t</displayName>
@@ -15329,21 +15329,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-hour">
 				<displayName>scd</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} scd</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} scdi</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>dqqd</displayName>
 				<unitPattern count="one">{0}d</unitPattern>
 				<unitPattern count="other">{0}d</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} dqqdb</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ilbrqsi</displayName>
 				<unitPattern count="one">{0}il</unitPattern>
 				<unitPattern count="other">{0}il</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ilbrgba</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>mlsek</displayName>
@@ -15351,89 +15351,89 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mykseken</displayName>
+				<unitPattern count="one">{0} myks</unitPattern>
+				<unitPattern count="other">{0} myks</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nanosek</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ambs</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miliambs</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohmis</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fooltis</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilokalooris</displayName>
+				<unitPattern count="one">{0} Kkal</unitPattern>
+				<unitPattern count="other">{0} Kkal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kal</displayName>
+				<unitPattern count="one">{0} kal</unitPattern>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kal</displayName>
+				<unitPattern count="one">{0} Kal</unitPattern>
+				<unitPattern count="other">{0} Kal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kiilojuul</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>juules</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>KW-saacad</displayName>
+				<unitPattern count="one">{0} KWs</unitPattern>
+				<unitPattern count="other">{0} KWs</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Elektarofoolt</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>HKB</displayName>
+				<unitPattern count="one">{0} Hkb</unitPattern>
+				<unitPattern count="other">{0} Hkb</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rodol xoog</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nuyuuton</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/100km</displayName>
@@ -15441,59 +15441,59 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dhsm</displayName>
+				<unitPattern count="one">dhsm</unitPattern>
+				<unitPattern count="other">{0} dhsm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dhbi</displayName>
+				<unitPattern count="one">{0} dhbi</unitPattern>
+				<unitPattern count="other">{0} dhbi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>dhibic</displayName>
@@ -15506,119 +15506,119 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km</displayName>
 				<unitPattern count="one">{0}km</unitPattern>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0}dm</unitPattern>
+				<unitPattern count="other">{0}dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm</displayName>
 				<unitPattern count="one">{0}cm</unitPattern>
 				<unitPattern count="other">{0}cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mm</displayName>
 				<unitPattern count="one">{0}mm</unitPattern>
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μmitir</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bm</displayName>
+				<unitPattern count="one">{0} bm</unitPattern>
+				<unitPattern count="other">{0} bm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>meyl</displayName>
+				<unitPattern count="one">{0} my</unitPattern>
+				<unitPattern count="other">{0} my</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yaardi</displayName>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>injis</displayName>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bs</displayName>
+				<unitPattern count="one">{0} bs</unitPattern>
+				<unitPattern count="other">{0} bs</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ux</displayName>
+				<unitPattern count="one">{0} ux</unitPattern>
+				<unitPattern count="other">{0} ux</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmy</displayName>
+				<unitPattern count="one">{0} nmy</unitPattern>
+				<unitPattern count="other">{0} nmy</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smy</displayName>
+				<unitPattern count="one">{0} smy</unitPattern>
+				<unitPattern count="other">{0} smy</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dhibco</displayName>
+				<unitPattern count="one">{0} dhbc</unitPattern>
+				<unitPattern count="other">{0} dhbc</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>raadiyas qoraxeed</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>laks</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>cd</displayName>
@@ -15631,83 +15631,83 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>iftiinada qorraxda</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
+				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>garaam</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tan</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>bownd</displayName>
+				<unitPattern count="one">{0} bw</unitPattern>
+				<unitPattern count="other">{0} bw</unitPattern>
+				<perUnitPattern>{0}/bw</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ow</displayName>
+				<unitPattern count="one">{0} ow</unitPattern>
+				<unitPattern count="other">{0} ow</unitPattern>
+				<perUnitPattern>{0}/ow</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>torooy ow</displayName>
+				<unitPattern count="one">{0} ow t</unitPattern>
+				<unitPattern count="other">{0} ow t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karaats</displayName>
+				<unitPattern count="one">{0} KT</unitPattern>
+				<unitPattern count="other">{0} KT</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dalton</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cufk Dhulka</displayName>
+				<unitPattern count="one">{0} CDh</unitPattern>
+				<unitPattern count="other">{0} CDh</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>xufka qorraxda</displayName>
+				<unitPattern count="one">{0} CQ</unitPattern>
+				<unitPattern count="other">{0} CQ</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>gr</displayName>
@@ -15715,34 +15715,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>waat</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hb</displayName>
+				<unitPattern count="one">{0} hb</unitPattern>
+				<unitPattern count="other">{0} hb</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>mmHg</displayName>
@@ -15760,39 +15760,39 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ha</displayName>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hBa</displayName>
+				<unitPattern count="one">{0} hBa</unitPattern>
+				<unitPattern count="other">{0} hBa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kBa</displayName>
+				<unitPattern count="one">{0} kBa</unitPattern>
+				<unitPattern count="other">{0} kBa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mba</displayName>
+				<unitPattern count="one">{0} Mba</unitPattern>
+				<unitPattern count="other">{0} Mba</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/s</displayName>
@@ -15800,39 +15800,39 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} km/s</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mitir/ilbrqsi</displayName>
+				<unitPattern count="one">{0} m/i</unitPattern>
+				<unitPattern count="other">{0} m/i</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>meyl saacadiiba</displayName>
+				<unitPattern count="one">{0} my/s</unitPattern>
+				<unitPattern count="other">{0} my/s</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nt</displayName>
+				<unitPattern count="one">{0} nt</unitPattern>
+				<unitPattern count="other">{0} nt</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°C</unitPattern>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>deg. F</displayName>
+				<unitPattern count="one">{0}°F</unitPattern>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>lbf⋅ft</displayName>
@@ -15840,149 +15840,149 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>my³</displayName>
+				<unitPattern count="one">{0} my³</unitPattern>
+				<unitPattern count="other">{0} my³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yaardi³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fiit³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inji³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litar</displayName>
 				<unitPattern count="one">{0}L</unitPattern>
 				<unitPattern count="other">{0}L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sL</displayName>
+				<unitPattern count="one">{0} sL</unitPattern>
+				<unitPattern count="other">{0} sL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbt</displayName>
+				<unitPattern count="one">{0} mbt</unitPattern>
+				<unitPattern count="other">{0} mbt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>mkoob</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mk</unitPattern>
+				<unitPattern count="other">{0} mk</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>akr ft</displayName>
+				<unitPattern count="one">{0} akr ft</unitPattern>
+				<unitPattern count="other">{0} akr ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>cabirka bushel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>imb. gal</displayName>
+				<unitPattern count="one">{0} gal Imb.</unitPattern>
+				<unitPattern count="other">{0} gal Imb,</unitPattern>
+				<perUnitPattern>{0}/gal Imb.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kts</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bint</displayName>
+				<unitPattern count="one">{0} bt</unitPattern>
+				<unitPattern count="other">{0} bt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>koob</displayName>
+				<unitPattern count="one">{0} k</unitPattern>
+				<unitPattern count="other">{0} k</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>own dr</displayName>
+				<unitPattern count="one">{0} own dr</unitPattern>
+				<unitPattern count="other">{0} own dr</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imb. owniska dareeraha</displayName>
+				<unitPattern count="one">{0} own dr imb.</unitPattern>
+				<unitPattern count="other">{0} own dr imb.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mlqcd</displayName>
+				<unitPattern count="one">{0} mlqcd</unitPattern>
+				<unitPattern count="other">{0} mlqcd</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mlqcd sh</displayName>
+				<unitPattern count="one">{0} mlqcd sh</unitPattern>
+				<unitPattern count="other">{0} mlqcd sh</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>foosto</displayName>
+				<unitPattern count="one">{0} fsto</unitPattern>
+				<unitPattern count="other">{0} fsto</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dsp</displayName>
@@ -16051,16 +16051,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} ama {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ama {1}</listPatternPart>
+			<listPatternPart type="2">{0} ama {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ama {1}</listPatternPart>
+			<listPatternPart type="2">{0} ama {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -16069,26 +16069,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} &amp; {1}</listPatternPart>
 			<listPatternPart type="2">{0} &amp; {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0} iyo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -82,8 +82,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">çerokisht</language>
 			<language type="chy">çejenisht</language>
 			<language type="ckb">kurdishte qendrore</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">kurdishte qendrore</language>
+			<language type="ckb" alt="variant">kurdishte qendrore</language>
 			<language type="clc">çilkotinisht</language>
 			<language type="co">korsikisht</language>
 			<language type="crg">miçifisht</language>
@@ -938,7 +938,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunizi</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turqi</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turqi</territory>
 			<territory type="TT">Trinidad e Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tajvan</territory>
@@ -2369,9 +2369,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>ditë</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">dje</relative>
+				<relative type="0">sot</relative>
+				<relative type="1">nesër</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">pas {0} dite</relativeTimePattern>
 					<relativeTimePattern count="other">pas {0} ditësh</relativeTimePattern>
@@ -2383,9 +2383,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>ditë</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">dje</relative>
+				<relative type="0">sot</relative>
+				<relative type="1">nesër</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">pas {0} dite</relativeTimePattern>
 					<relativeTimePattern count="other">pas {0} ditësh</relativeTimePattern>
@@ -2718,7 +2718,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>orë</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">këtë orë</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">pas {0} ore</relativeTimePattern>
 					<relativeTimePattern count="other">pas {0} orësh</relativeTimePattern>
@@ -2730,7 +2730,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-narrow">
 				<displayName>orë</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">këtë orë</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">pas {0} ore</relativeTimePattern>
 					<relativeTimePattern count="other">pas {0} orësh</relativeTimePattern>
@@ -2754,7 +2754,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>min</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">këtë minutë</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">pas {0} min</relativeTimePattern>
 					<relativeTimePattern count="other">pas {0} min</relativeTimePattern>
@@ -2766,7 +2766,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>min</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">këtë minutë</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">pas {0} min</relativeTimePattern>
 					<relativeTimePattern count="other">pas {0} min</relativeTimePattern>
@@ -2790,7 +2790,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>sek</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">tani</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">pas {0} sek</relativeTimePattern>
 					<relativeTimePattern count="other">pas {0} sek</relativeTimePattern>
@@ -2802,7 +2802,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>sek</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">tani</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">pas {0} sek</relativeTimePattern>
 					<relativeTimePattern count="other">pas {0} sek</relativeTimePattern>
@@ -6433,7 +6433,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0} kub</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-forcë</displayName>
@@ -6944,14 +6944,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} njësi astronomike</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">fur</displayName>
+				<unitPattern count="one" draft="contributed">{0} fur</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName draft="contributed">fth</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} fth</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>milje nautike</displayName>
@@ -7026,9 +7026,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} tonë</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">st</displayName>
+				<unitPattern count="one" draft="contributed">{0} st</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>paund</displayName>
@@ -7119,7 +7119,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>bare</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bare</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -7133,9 +7133,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} atmosferë</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hektopaskal</displayName>
@@ -7343,19 +7343,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fuçi</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">dstspn</displayName>
+				<unitPattern count="one" draft="contributed">{0} dstspn</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">dstspn Imp</displayName>
+				<unitPattern count="one" draft="contributed">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">drop</displayName>
+				<unitPattern count="one" draft="contributed">{0} drop</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} drop</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>drahma të lëngshme</displayName>
@@ -7363,19 +7363,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} drahma të lëngshme</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">jigger</displayName>
+				<unitPattern count="one" draft="contributed">{0} jigger</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">pinch</displayName>
+				<unitPattern count="one" draft="contributed">{0} pinch</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">qt Imp</displayName>
+				<unitPattern count="one" draft="contributed">{0} qt Imp.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>drejtimi kardinal</displayName>
@@ -7475,12 +7475,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7613,12 +7613,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7821,12 +7821,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -7836,12 +7836,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -7871,47 +7871,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -7996,12 +7996,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fth</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -8021,7 +8021,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -8031,17 +8031,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8078,7 +8078,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -8105,17 +8105,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8170,7 +8170,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -8185,7 +8185,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8195,12 +8195,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -8245,12 +8245,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -8338,7 +8338,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName draft="contributed">bushelë</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} bu</unitPattern>
 				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -8375,7 +8375,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -8390,42 +8390,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} drop</unitPattern>
 				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} dram fl</unitPattern>
 				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} jigger</unitPattern>
 				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} pinch</unitPattern>
 				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -8438,104 +8438,104 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>
@@ -9511,22 +9511,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} ose {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ose {1}</listPatternPart>
+			<listPatternPart type="2">{0} ose {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ose {1}</listPatternPart>
+			<listPatternPart type="2">{0} ose {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} dhe {1}</listPatternPart>
+			<listPatternPart type="2">{0} dhe {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -9752,10 +9752,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {surname}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{title} {given} {surname}</namePattern>
@@ -9767,13 +9767,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{title} {given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {surname}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
 			<namePattern>{title} {given} {surname}</namePattern>
@@ -9785,10 +9785,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{title} {given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{title} {surname}, {given} {given2-initial}, {credentials}</namePattern>
@@ -9809,7 +9809,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}, {given} {given2-initial}, {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{title} {surname}, {given}</namePattern>
@@ -9827,7 +9827,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}, {given} {given2-initial}, {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
 			<namePattern>{title} {surname}, {given}</namePattern>
@@ -9851,13 +9851,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{title} {surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname-core}, {given} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{title} {surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname-core}, {given} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
 			<namePattern>{title} {surname}, {given-informal}</namePattern>

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -100,8 +100,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">чероки</language>
 			<language type="chy">чејенски</language>
 			<language type="ckb">централни курдски</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">централни курдски</language>
+			<language type="ckb" alt="variant">централни курдски</language>
 			<language type="clc">чилкотин</language>
 			<language type="co">корзикански</language>
 			<language type="cop">коптски</language>
@@ -943,7 +943,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">Науру</territory>
 			<territory type="NU">Ниуе</territory>
 			<territory type="NZ">Нови Зеланд</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Нови Зеланд</territory>
 			<territory type="OM">Оман</territory>
 			<territory type="PA">Панама</territory>
 			<territory type="PE">Перу</territory>
@@ -1003,7 +1003,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Тунис</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Турска</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Турска</territory>
 			<territory type="TT">Тринидад и Тобаго</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тајван</territory>
@@ -1348,7 +1348,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1356,7 +1356,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1364,7 +1364,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1372,7 +1372,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1921,7 +1921,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1929,7 +1929,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1937,7 +1937,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1945,7 +1945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2218,18 +2218,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">Зул-х.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Мухарем</month>
@@ -2248,18 +2248,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Мух.</month>
+							<month type="2">Саф.</month>
+							<month type="3">Реб. 1</month>
+							<month type="4">Реб. 2</month>
+							<month type="5">Џум. 1</month>
+							<month type="6">Џум. 2</month>
+							<month type="7">Реџ.</month>
+							<month type="8">Ша.</month>
+							<month type="9">Рам.</month>
+							<month type="10">Ше.</month>
+							<month type="11">Зул-к.</month>
+							<month type="12">Зул-х.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -2299,54 +2299,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, d. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d.M.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d.</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">d.M.y. GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d.M.</dateFormatItem>
+						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
+						<dateFormatItem id="y">y. G</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M.y. GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ, y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y. G</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -2792,10 +2792,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>мес.</displayName>
+				<relative type="-1">прошлог мес.</relative>
+				<relative type="0">овог мес.</relative>
+				<relative type="1">следећег мес.</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">за {0} м.</relativeTimePattern>
 					<relativeTimePattern count="few">за {0} м.</relativeTimePattern>
@@ -2842,7 +2842,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relativePeriod>недеља која почиње {0}.</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>нед.</displayName>
 				<relative type="-1">прошле н.</relative>
 				<relative type="0">ове н.</relative>
 				<relative type="1">следеће н.</relative>
@@ -2979,9 +2979,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">пр. нед.</relative>
 				<relative type="0">у нед</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">сл. нед.</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">за {0} недељу</relativeTimePattern>
 					<relativeTimePattern count="few">за {0} недеље</relativeTimePattern>
@@ -8041,80 +8041,80 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>квадратни {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">квадратни {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="instrumental">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">квадратни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">квадратни {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">квадратна {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="instrumental">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">квадратна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">квадратна {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">квадратних {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">квадратних {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>кубни {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">кубни {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="instrumental">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">кубни {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">кубни {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">кубна {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="instrumental">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">кубна {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">кубна {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">кубних {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">кубних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">кубних {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}-{1}</compoundUnitPattern>
@@ -8127,29 +8127,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} ге силе</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ге силом</unitPattern>
 				<unitPattern count="few">{0} ге сила</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ге сила</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ге сила</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} ге сила</unitPattern>
 				<unitPattern count="other">{0} ге сила</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ге сила</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ге сила</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ге сила</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>inanimate</gender>
 				<displayName>метри у секунди на квадрат</displayName>
 				<unitPattern count="one">{0} метар у секунди на квадрат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} метар у секунди на квадрат</unitPattern>
 				<unitPattern count="one" case="genitive">{0} метра у секунди на квадрат</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} метром у секунди на квадрат</unitPattern>
 				<unitPattern count="few">{0} метра у секунди на квадрат</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метра у секунди на квадрат</unitPattern>
+				<unitPattern count="few" case="genitive">{0} метра у секунди на квадрат</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} метра у секунди на квадрат</unitPattern>
 				<unitPattern count="other">{0} метара у секунди на квадрат</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метара у секунди на квадрат</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метара у секунди на квадрат</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метара у секунди на квадрат</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>inanimate</gender>
@@ -8159,13 +8159,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} обртаја</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} обртајем</unitPattern>
 				<unitPattern count="few">{0} обртаја</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} обртаја</unitPattern>
+				<unitPattern count="few" case="genitive">{0} обртаја</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} обртаја</unitPattern>
 				<unitPattern count="other">{0} обртаја</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} обртаја</unitPattern>
+				<unitPattern count="other" case="genitive">{0} обртаја</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} обртаја</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>inanimate</gender>
@@ -8175,13 +8175,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} радијана</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} радијаном</unitPattern>
 				<unitPattern count="few">{0} радијана</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} радијана</unitPattern>
+				<unitPattern count="few" case="genitive">{0} радијана</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} радијана</unitPattern>
 				<unitPattern count="other">{0} радијана</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} радијана</unitPattern>
+				<unitPattern count="other" case="genitive">{0} радијана</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} радијана</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>inanimate</gender>
@@ -8191,13 +8191,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} степена</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} степеном</unitPattern>
 				<unitPattern count="few">{0} степена</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} степена</unitPattern>
+				<unitPattern count="few" case="genitive">{0} степена</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} степена</unitPattern>
 				<unitPattern count="other">{0} степени</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} степени</unitPattern>
+				<unitPattern count="other" case="genitive">{0} степени</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} степени</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>inanimate</gender>
@@ -8207,13 +8207,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} лучног минута</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} лучним минутом</unitPattern>
 				<unitPattern count="few">{0} лучна минута</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} лучна минута</unitPattern>
+				<unitPattern count="few" case="genitive">{0} лучна минута</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} лучна минута</unitPattern>
 				<unitPattern count="other">{0} лучних минута</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} лучних минута</unitPattern>
+				<unitPattern count="other" case="genitive">{0} лучних минута</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} лучних минута</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>feminine</gender>
@@ -8223,29 +8223,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} лучне секунде</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} лучном секундом</unitPattern>
 				<unitPattern count="few">{0} лучне секунде</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} лучне секунде</unitPattern>
+				<unitPattern count="few" case="genitive">{0} лучне секунде</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} лучне секунде</unitPattern>
 				<unitPattern count="other">{0} лучних секунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} лучних секунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} лучних секунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} лучних секунди</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>inanimate</gender>
 				<displayName>квадратни километри</displayName>
 				<unitPattern count="one">{0} квадратни километар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} квадратни километар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} квадратна километра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} квадратним километром</unitPattern>
 				<unitPattern count="few">{0} квадратна километра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратна километра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} квадратна километра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} квадратна километра</unitPattern>
 				<unitPattern count="other">{0} квадратних километара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратних километара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратних километара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратних километара</unitPattern>
 				<perUnitPattern>{0} по квадратном километру</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
@@ -8256,46 +8256,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} хектара</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} хектаром</unitPattern>
 				<unitPattern count="few">{0} хектара</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} хектара</unitPattern>
+				<unitPattern count="few" case="genitive">{0} хектара</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} хектара</unitPattern>
 				<unitPattern count="other">{0} хектара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} хектара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} хектара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} хектара</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>inanimate</gender>
 				<displayName>квадратни метри</displayName>
 				<unitPattern count="one">{0} квадратни метар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} квадратни метар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} квадратна метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} квадратним метром</unitPattern>
 				<unitPattern count="few">{0} квадратна метра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратна метра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} квадратна метра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} квадратна метра</unitPattern>
 				<unitPattern count="other">{0} квадратних метара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратних метара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратних метара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратних метара</unitPattern>
 				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<gender>inanimate</gender>
 				<displayName>квадратни центиметри</displayName>
 				<unitPattern count="one">{0} квадратни центиметар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} квадратни центиметар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} квадратног центиметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} квадратним центиметром</unitPattern>
 				<unitPattern count="few">{0} квадратна центиметра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратна центиметра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} квадратна центиметра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} квадратна центиметра</unitPattern>
 				<unitPattern count="other">{0} квадратних центиметара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратних центиметара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратних центиметара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратних центиметара</unitPattern>
 				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -8344,13 +8344,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} карата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} каратом</unitPattern>
 				<unitPattern count="few">{0} карата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} карата</unitPattern>
+				<unitPattern count="few" case="genitive">{0} карата</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} карата</unitPattern>
 				<unitPattern count="other">{0} карата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} карата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} карата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} карата</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>милиграми по децилитру</displayName>
@@ -8362,17 +8362,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>милимол по литри</displayName>
 				<unitPattern count="one">{0} милимол по литри</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} милимол по литри</unitPattern>
 				<unitPattern count="one" case="genitive">{0} милимола по литри</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} милимолом по литри</unitPattern>
 				<unitPattern count="few">{0} милимола по литри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} милимола по литри</unitPattern>
+				<unitPattern count="few" case="genitive">{0} милимола по литри</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} милимола по литри</unitPattern>
 				<unitPattern count="other">{0} милимола по литри</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} милимола по литри</unitPattern>
+				<unitPattern count="other" case="genitive">{0} милимола по литри</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} милимола по литри</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>feminine</gender>
@@ -8382,13 +8382,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} ставке</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ставком</unitPattern>
 				<unitPattern count="few">{0} ставке</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ставке</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ставке</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} ставке</unitPattern>
 				<unitPattern count="other">{0} ставки</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ставки</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ставки</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ставки</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>feminine</gender>
@@ -8398,13 +8398,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} честице на милион</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} честицом на милион</unitPattern>
 				<unitPattern count="few">{0} честице на милион</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} честице на милион</unitPattern>
+				<unitPattern count="few" case="genitive">{0} честице на милион</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} честице на милион</unitPattern>
 				<unitPattern count="other">{0} честица на милион</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} честица на милион</unitPattern>
+				<unitPattern count="other" case="genitive">{0} честица на милион</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} честица на милион</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>inanimate</gender>
@@ -8414,13 +8414,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} процента</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} процентом</unitPattern>
 				<unitPattern count="few">{0} процената</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} процената</unitPattern>
+				<unitPattern count="few" case="genitive">{0} процената</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} процената</unitPattern>
 				<unitPattern count="other">{0} процената</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} процената</unitPattern>
+				<unitPattern count="other" case="genitive">{0} процената</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} процената</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>inanimate</gender>
@@ -8430,29 +8430,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} промила</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} промилом</unitPattern>
 				<unitPattern count="few">{0} промила</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} промила</unitPattern>
+				<unitPattern count="few" case="genitive">{0} промила</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} промила</unitPattern>
 				<unitPattern count="other">{0} промила</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} промила</unitPattern>
+				<unitPattern count="other" case="genitive">{0} промила</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} промила</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">{0}‱</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="one" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="one" case="instrumental">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="few" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="few" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="few" case="instrumental">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
+				<unitPattern count="other" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="other" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="other" case="instrumental">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>inanimate</gender>
@@ -8462,45 +8462,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} мола</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} молом</unitPattern>
 				<unitPattern count="few">{0} мола</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мола</unitPattern>
+				<unitPattern count="few" case="genitive">{0} мола</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} мола</unitPattern>
 				<unitPattern count="other">{0} мола</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мола</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мола</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мола</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>inanimate</gender>
 				<displayName>литри по километру</displayName>
 				<unitPattern count="one">{0} литар по километру</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} литар по километру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} литра по километру</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} литром по километру</unitPattern>
 				<unitPattern count="few">{0} литра по километру</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} литра по километру</unitPattern>
+				<unitPattern count="few" case="genitive">{0} литра по километру</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} литра по километру</unitPattern>
 				<unitPattern count="other">{0} литара по километру</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} литара по километру</unitPattern>
+				<unitPattern count="other" case="genitive">{0} литара по километру</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} литара по километру</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>inanimate</gender>
 				<displayName>литри на 100 километара</displayName>
 				<unitPattern count="one">{0} литар на 100 километара</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} литар на 100 километара</unitPattern>
 				<unitPattern count="one" case="genitive">{0} литра на 100 километара</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} литром на 100 километара</unitPattern>
 				<unitPattern count="few">{0} литра на 100 километара</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} литра на 100 километара</unitPattern>
+				<unitPattern count="few" case="genitive">{0} литра на 100 километара</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} литра на 100 километара</unitPattern>
 				<unitPattern count="other">{0} литара на 100 километара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} литара на 100 километара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} литара на 100 километара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} литара на 100 километара</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>миља по галону</displayName>
@@ -8518,29 +8518,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>петабајти</displayName>
 				<unitPattern count="one">{0} петабајт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} петабајт</unitPattern>
 				<unitPattern count="one" case="genitive">{0} петабајта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} петабајтом</unitPattern>
 				<unitPattern count="few">{0} петабајта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} петабајта</unitPattern>
+				<unitPattern count="few" case="genitive">{0} петабајта</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} петабајта</unitPattern>
 				<unitPattern count="other">{0} петабајтова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} петабајтова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} петабајтова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} петабајтова</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>inanimate</gender>
 				<displayName>терабајти</displayName>
 				<unitPattern count="one">{0} терабајт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} терабајт</unitPattern>
 				<unitPattern count="one" case="genitive">{0} терабајта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} терабајтом</unitPattern>
 				<unitPattern count="few">{0} терабајта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} терабајта</unitPattern>
+				<unitPattern count="few" case="genitive">{0} терабајта</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} терабајта</unitPattern>
 				<unitPattern count="other">{0} терабајта</unitPattern>
 				<unitPattern count="other" case="accusative">{0} терабајтова</unitPattern>
 				<unitPattern count="other" case="genitive">{0} терабајтова</unitPattern>
@@ -8550,113 +8550,113 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>терабитови</displayName>
 				<unitPattern count="one">{0} терабит</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} терабит</unitPattern>
 				<unitPattern count="one" case="genitive">{0} терабита</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} терабитом</unitPattern>
 				<unitPattern count="few">{0} терабита</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} терабита</unitPattern>
+				<unitPattern count="few" case="genitive">{0} терабита</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} терабита</unitPattern>
 				<unitPattern count="other">{0} терабитова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} терабитова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} терабитова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} терабитова</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>inanimate</gender>
 				<displayName>гигабајти</displayName>
 				<unitPattern count="one">{0} гигабајт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гигабајт</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гигабајта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гигабајтом</unitPattern>
 				<unitPattern count="few">{0} гигабајта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гигабајта</unitPattern>
+				<unitPattern count="few" case="genitive">{0} гигабајта</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} гигабајта</unitPattern>
 				<unitPattern count="other">{0} гигабајтова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гигабајтова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гигабајтова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гигабајтова</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>inanimate</gender>
 				<displayName>гигабитови</displayName>
 				<unitPattern count="one">{0} гигабит</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гигабит</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гигабита</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гигабитом</unitPattern>
 				<unitPattern count="few">{0} гигабита</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гигабита</unitPattern>
+				<unitPattern count="few" case="genitive">{0} гигабита</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} гигабита</unitPattern>
 				<unitPattern count="other">{0} гигабитова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гигабитова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гигабитова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гигабитова</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>inanimate</gender>
 				<displayName>мегабајти</displayName>
 				<unitPattern count="one">{0} мегабајт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегабајт</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегабајта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегабајтом</unitPattern>
 				<unitPattern count="few">{0} мегабајта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегабајта</unitPattern>
+				<unitPattern count="few" case="genitive">{0} мегабајта</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} мегабајта</unitPattern>
 				<unitPattern count="other">{0} мегабајтова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегабајтова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегабајтова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегабајтова</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>inanimate</gender>
 				<displayName>мегабитови</displayName>
 				<unitPattern count="one">{0} мегабит</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегабит</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегабита</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегабитом</unitPattern>
 				<unitPattern count="few">{0} мегабита</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегабита</unitPattern>
+				<unitPattern count="few" case="genitive">{0} мегабита</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} мегабита</unitPattern>
 				<unitPattern count="other">{0} мегабитова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегабитова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегабитова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегабитова</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>inanimate</gender>
 				<displayName>килобајти</displayName>
 				<unitPattern count="one">{0} килобајт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} килобајт</unitPattern>
 				<unitPattern count="one" case="genitive">{0} килобајта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} килобајтом</unitPattern>
 				<unitPattern count="few">{0} килобајта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} килобајта</unitPattern>
+				<unitPattern count="few" case="genitive">{0} килобајта</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} килобајта</unitPattern>
 				<unitPattern count="other">{0} килобајтова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килобајтова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килобајтова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килобајтова</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>inanimate</gender>
 				<displayName>килобитови</displayName>
 				<unitPattern count="one">{0} килобит</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} килобит</unitPattern>
 				<unitPattern count="one" case="genitive">{0} килобита</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} килобитом</unitPattern>
 				<unitPattern count="few">{0} килобита</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} килобита</unitPattern>
+				<unitPattern count="few" case="genitive">{0} килобита</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} килобита</unitPattern>
 				<unitPattern count="other">{0} килобитова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килобитова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килобитова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килобитова</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>inanimate</gender>
@@ -8666,13 +8666,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} бајта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} бајтом</unitPattern>
 				<unitPattern count="few">{0} бајта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} бајта</unitPattern>
+				<unitPattern count="few" case="genitive">{0} бајта</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} бајта</unitPattern>
 				<unitPattern count="other">{0} бајтова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} бајтова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} бајтова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} бајтова</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>inanimate</gender>
@@ -8682,13 +8682,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} бита</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} битом</unitPattern>
 				<unitPattern count="few">{0} бита</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} бита</unitPattern>
+				<unitPattern count="few" case="genitive">{0} бита</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} бита</unitPattern>
 				<unitPattern count="other">{0} битова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} битова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} битова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} битова</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>inanimate</gender>
@@ -8698,13 +8698,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} века</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} веком</unitPattern>
 				<unitPattern count="few">{0} века</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} века</unitPattern>
+				<unitPattern count="few" case="genitive">{0} века</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} века</unitPattern>
 				<unitPattern count="other">{0} векова</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} векова</unitPattern>
+				<unitPattern count="other" case="genitive">{0} векова</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} векова</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>feminine</gender>
@@ -8718,9 +8718,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="genitive">{0} деценије</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} деценије</unitPattern>
 				<unitPattern count="other">{0} деценија</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} деценија</unitPattern>
+				<unitPattern count="other" case="genitive">{0} деценија</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} деценија</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>feminine</gender>
@@ -8730,13 +8730,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} године</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} годином</unitPattern>
 				<unitPattern count="few">{0} године</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} године</unitPattern>
+				<unitPattern count="few" case="genitive">{0} године</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} године</unitPattern>
 				<unitPattern count="other">{0} година</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} година</unitPattern>
+				<unitPattern count="other" case="genitive">{0} година</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} година</unitPattern>
 				<perUnitPattern>{0} годишње</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -8764,13 +8764,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} месеца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} месецом</unitPattern>
 				<unitPattern count="few">{0} месеца</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} месеца</unitPattern>
+				<unitPattern count="few" case="genitive">{0} месеца</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} месеца</unitPattern>
 				<unitPattern count="other">{0} месеци</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} месеци</unitPattern>
+				<unitPattern count="other" case="genitive">{0} месеци</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} месеци</unitPattern>
 				<perUnitPattern>{0} месечно</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
@@ -8781,13 +8781,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} недеље</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} недељом</unitPattern>
 				<unitPattern count="few">{0} недеље</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} недеље</unitPattern>
+				<unitPattern count="few" case="genitive">{0} недеље</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} недеље</unitPattern>
 				<unitPattern count="other">{0} недеља</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} недеља</unitPattern>
+				<unitPattern count="other" case="genitive">{0} недеља</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} недеља</unitPattern>
 				<perUnitPattern>{0} недељно</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
@@ -8798,13 +8798,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} дана</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} даном</unitPattern>
 				<unitPattern count="few">{0} дана</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} дана</unitPattern>
+				<unitPattern count="few" case="genitive">{0} дана</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} дана</unitPattern>
 				<unitPattern count="other">{0} дана</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} дана</unitPattern>
+				<unitPattern count="other" case="genitive">{0} дана</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} дана</unitPattern>
 				<perUnitPattern>{0}/дневно</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -8815,13 +8815,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} сата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} сатом</unitPattern>
 				<unitPattern count="few">{0} сата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} сата</unitPattern>
+				<unitPattern count="few" case="genitive">{0} сата</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} сата</unitPattern>
 				<unitPattern count="other">{0} сати</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} сати</unitPattern>
+				<unitPattern count="other" case="genitive">{0} сати</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} сати</unitPattern>
 				<perUnitPattern>{0}/сат</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -8832,13 +8832,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} минута</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} минутом</unitPattern>
 				<unitPattern count="few">{0} минута</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} минута</unitPattern>
+				<unitPattern count="few" case="genitive">{0} минута</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} минута</unitPattern>
 				<unitPattern count="other">{0} минута</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} минута</unitPattern>
+				<unitPattern count="other" case="genitive">{0} минута</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} минута</unitPattern>
 				<perUnitPattern>{0} у минуту</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -8849,30 +8849,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} секунде</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} секундом</unitPattern>
 				<unitPattern count="few">{0} секунде</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} секунде</unitPattern>
+				<unitPattern count="few" case="genitive">{0} секунде</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} секунде</unitPattern>
 				<unitPattern count="other">{0} секунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} секунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} секунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} секунди</unitPattern>
 				<perUnitPattern>{0}/у секунди</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<gender>feminine</gender>
 				<displayName>милисекунде</displayName>
 				<unitPattern count="one">{0} милисекунда</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} милисекунда</unitPattern>
 				<unitPattern count="one" case="genitive">{0} милисекунде</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} милисекундом</unitPattern>
 				<unitPattern count="few">{0} милисекунде</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} милисекунде</unitPattern>
+				<unitPattern count="few" case="genitive">{0} милисекунде</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} милисекунде</unitPattern>
 				<unitPattern count="other">{0} милисекунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} милисекунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} милисекунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} милисекунди</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>feminine</gender>
@@ -8882,13 +8882,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} микросекунде</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} микросекундом</unitPattern>
 				<unitPattern count="few">{0} микросекунде</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} микросекунде</unitPattern>
+				<unitPattern count="few" case="genitive">{0} микросекунде</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} микросекунде</unitPattern>
 				<unitPattern count="other">{0} микросекунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} микросекунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} микросекунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} микросекунди</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>feminine</gender>
@@ -8898,13 +8898,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} наносекунде</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} наносекундом</unitPattern>
 				<unitPattern count="few">{0} наносекунде</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} наносекунде</unitPattern>
+				<unitPattern count="few" case="genitive">{0} наносекунде</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} наносекунде</unitPattern>
 				<unitPattern count="other">{0} наносекунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} наносекунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} наносекунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} наносекунди</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>inanimate</gender>
@@ -8914,29 +8914,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} ампера</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ампером</unitPattern>
 				<unitPattern count="few">{0} ампера</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ампера</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ампера</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} ампера</unitPattern>
 				<unitPattern count="other">{0} ампера</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ампера</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ампера</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ампера</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>inanimate</gender>
 				<displayName>милиампери</displayName>
 				<unitPattern count="one">{0} милиампер</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} милиампер</unitPattern>
 				<unitPattern count="one" case="genitive">{0} милиампера</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} милиампером</unitPattern>
 				<unitPattern count="few">{0} милиампера</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} милиампера</unitPattern>
+				<unitPattern count="few" case="genitive">{0} милиампера</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} милиампера</unitPattern>
 				<unitPattern count="other">{0} милиампера</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} милиампера</unitPattern>
+				<unitPattern count="other" case="genitive">{0} милиампера</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} милиампера</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>inanimate</gender>
@@ -8946,13 +8946,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} ома</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} омом</unitPattern>
 				<unitPattern count="few">{0} ома</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ома</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ома</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} ома</unitPattern>
 				<unitPattern count="other">{0} ома</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ома</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ома</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ома</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>inanimate</gender>
@@ -8962,13 +8962,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} волта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} волтом</unitPattern>
 				<unitPattern count="few">{0} волта</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} волта</unitPattern>
+				<unitPattern count="few" case="genitive">{0} волта</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} волта</unitPattern>
 				<unitPattern count="other">{0} волти</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} волти</unitPattern>
+				<unitPattern count="other" case="genitive">{0} волти</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} волти</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>килокалорије</displayName>
@@ -8984,13 +8984,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} калорије</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} калоријом</unitPattern>
 				<unitPattern count="few">{0} калорије</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} калорије</unitPattern>
+				<unitPattern count="few" case="genitive">{0} калорије</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} калорије</unitPattern>
 				<unitPattern count="other">{0} калорија</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} калорија</unitPattern>
+				<unitPattern count="other" case="genitive">{0} калорија</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} калорија</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>Калорије</displayName>
@@ -9002,17 +9002,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>килоџули</displayName>
 				<unitPattern count="one">{0} килоџул</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} килоџул</unitPattern>
 				<unitPattern count="one" case="genitive">{0} килоџула</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} килоџулом</unitPattern>
 				<unitPattern count="few">{0} килоџула</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} килоџула</unitPattern>
+				<unitPattern count="few" case="genitive">{0} килоџула</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} килоџула</unitPattern>
 				<unitPattern count="other">{0} килоџула</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килоџула</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килоџула</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килоџула</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>inanimate</gender>
@@ -9022,29 +9022,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} џула</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} џулом</unitPattern>
 				<unitPattern count="few">{0} џула</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} џула</unitPattern>
+				<unitPattern count="few" case="genitive">{0} џула</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} џула</unitPattern>
 				<unitPattern count="other">{0} џула</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} џула</unitPattern>
+				<unitPattern count="other" case="genitive">{0} џула</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} џула</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>inanimate</gender>
 				<displayName>киловат-сати</displayName>
 				<unitPattern count="one">{0} киловат-сат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} киловат-сат</unitPattern>
 				<unitPattern count="one" case="genitive">{0} киловат-сата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} киловат-сатом</unitPattern>
 				<unitPattern count="few">{0} киловат-сата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} киловат-сата</unitPattern>
+				<unitPattern count="few" case="genitive">{0} киловат-сата</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} киловат-сата</unitPattern>
 				<unitPattern count="other">{0} киловат-сати</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} киловат-сати</unitPattern>
+				<unitPattern count="other" case="genitive">{0} киловат-сати</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} киловат-сати</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>електронволти</displayName>
@@ -9054,9 +9054,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>Британска термална јединица</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>US therms</displayName>
@@ -9078,77 +9078,77 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} њутна</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} њутном</unitPattern>
 				<unitPattern count="few">{0} њутна</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} њутна</unitPattern>
+				<unitPattern count="few" case="genitive">{0} њутна</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} њутна</unitPattern>
 				<unitPattern count="other">{0} њутна</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} њутна</unitPattern>
+				<unitPattern count="other" case="genitive">{0} њутна</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} њутна</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>inanimate</gender>
 				<displayName>гигахерци</displayName>
 				<unitPattern count="one">{0} гигахерц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гигахерц</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гигахерца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гигахерцом</unitPattern>
 				<unitPattern count="few">{0} гигахерца</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гигахерца</unitPattern>
+				<unitPattern count="few" case="genitive">{0} гигахерца</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} гигахерца</unitPattern>
 				<unitPattern count="other">{0} гигахерца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гигахерца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гигахерца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гигахерца</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>inanimate</gender>
 				<displayName>мегахерци</displayName>
 				<unitPattern count="one">{0} мегахерц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегахерц</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегахерца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегахерцом</unitPattern>
 				<unitPattern count="few">{0} мегахерца</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегахерца</unitPattern>
+				<unitPattern count="few" case="genitive">{0} мегахерца</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} мегахерца</unitPattern>
 				<unitPattern count="other">{0} мегахерца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегахерца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегахерца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегахерца</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>inanimate</gender>
 				<displayName>килохерци</displayName>
 				<unitPattern count="one">{0} килохерц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} килохерц</unitPattern>
 				<unitPattern count="one" case="genitive">{0} килохерца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} килохерцом</unitPattern>
 				<unitPattern count="few">{0} килохерца</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} килохерца</unitPattern>
+				<unitPattern count="few" case="genitive">{0} килохерца</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} килохерца</unitPattern>
 				<unitPattern count="other">{0} килохерца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килохерца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килохерца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килохерца</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>inanimate</gender>
@@ -9158,33 +9158,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} херца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} херцом</unitPattern>
 				<unitPattern count="few">{0} херца</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} херца</unitPattern>
+				<unitPattern count="few" case="genitive">{0} херца</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} херца</unitPattern>
 				<unitPattern count="other">{0} херца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} херца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} херца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} херца</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="accusative">{0} em</unitPattern>
+				<unitPattern count="one" case="genitive">{0} em</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="few" case="accusative">{0} em</unitPattern>
+				<unitPattern count="few" case="genitive">{0} em</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="accusative">{0} em</unitPattern>
+				<unitPattern count="other" case="genitive">{0} em</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="one">{0} пиксел</unitPattern>
 				<unitPattern count="one" case="accusative">{0} пиксел</unitPattern>
 				<unitPattern count="one" case="genitive">{0} пиксела</unitPattern>
@@ -9216,7 +9216,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0} пиксел на центиметар</unitPattern>
 				<unitPattern count="one" case="accusative">{0} пиксел на центиметар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} пиксела на центиметар</unitPattern>
@@ -9231,28 +9231,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="instrumental">{0} пиксела на центиметар</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>тачка</displayName>
 				<unitPattern count="one">{0} тачка</unitPattern>
 				<unitPattern count="few">{0} тачке</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} тачака</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>полупречник Земље</displayName>
@@ -9264,17 +9264,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>километри</displayName>
 				<unitPattern count="one">{0} километар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} километар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} километра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} километром</unitPattern>
 				<unitPattern count="few">{0} километра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} километра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} километра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} километра</unitPattern>
 				<unitPattern count="other">{0} километара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} километара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} километара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} километара</unitPattern>
 				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
@@ -9285,36 +9285,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} метром</unitPattern>
 				<unitPattern count="few">{0} метра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} метра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} метра</unitPattern>
 				<unitPattern count="other">{0} метара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метара</unitPattern>
 				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<gender>inanimate</gender>
 				<displayName>дециметри</displayName>
 				<unitPattern count="one">{0} дециметар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} дециметар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} дециметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} дециметром</unitPattern>
 				<unitPattern count="few">{0} дециметра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} дециметра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} дециметра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} дециметра</unitPattern>
 				<unitPattern count="other">{0} дециметара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} дециметара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} дециметара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} дециметара</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>inanimate</gender>
 				<displayName>центиметри</displayName>
 				<unitPattern count="one">{0} центиметар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} центиметар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} центиметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} центиметром</unitPattern>
 				<unitPattern count="few">{0} центиметра</unitPattern>
@@ -9322,74 +9322,74 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="genitive">{0} центиметра</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} центиметра</unitPattern>
 				<unitPattern count="other">{0} центиметара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} центиметара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} центиметара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} центиметара</unitPattern>
 				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<gender>inanimate</gender>
 				<displayName>милиметри</displayName>
 				<unitPattern count="one">{0} милиметар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} милиметар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} милиметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} милиметром</unitPattern>
 				<unitPattern count="few">{0} милиметра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} милиметра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} милиметра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} милиметра</unitPattern>
 				<unitPattern count="other">{0} милиметара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} милиметара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} милиметара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} милиметара</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>inanimate</gender>
 				<displayName>микрометри</displayName>
 				<unitPattern count="one">{0} микрометар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} микрометар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} микрометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} микрометром</unitPattern>
 				<unitPattern count="few">{0} микрометра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} микрометра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} микрометра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} микрометра</unitPattern>
 				<unitPattern count="other">{0} микрометара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} микрометара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} микрометара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} микрометара</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>inanimate</gender>
 				<displayName>нанометри</displayName>
 				<unitPattern count="one">{0} нанометар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} нанометар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} нанометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} нанометром</unitPattern>
 				<unitPattern count="few">{0} нанометра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} нанометра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} нанометра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} нанометра</unitPattern>
 				<unitPattern count="other">{0} нанометара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} нанометара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} нанометара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} нанометара</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>inanimate</gender>
 				<displayName>пикометри</displayName>
 				<unitPattern count="one">{0} пикометар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} пикометар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} пикометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} пикометром</unitPattern>
 				<unitPattern count="few">{0} пикометра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} пикометра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} пикометра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} пикометра</unitPattern>
 				<unitPattern count="other">{0} пикометара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} пикометара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} пикометара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} пикометара</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>миље</displayName>
@@ -9461,13 +9461,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} скандинавске миље</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} скандинавском миљом</unitPattern>
 				<unitPattern count="few">{0} скандинавске миље</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} скандинавске миље</unitPattern>
+				<unitPattern count="few" case="genitive">{0} скандинавске миље</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} скандинавске миље</unitPattern>
 				<unitPattern count="other">{0} скандинавских миља</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} скандинавских миља</unitPattern>
+				<unitPattern count="other" case="genitive">{0} скандинавских миља</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} скандинавских миља</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pt</displayName>
@@ -9489,13 +9489,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} лукса</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} луксом</unitPattern>
 				<unitPattern count="few">{0} лукса</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} лукса</unitPattern>
+				<unitPattern count="few" case="genitive">{0} лукса</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} лукса</unitPattern>
 				<unitPattern count="other">{0} лукса</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} лукса</unitPattern>
+				<unitPattern count="other" case="genitive">{0} лукса</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} лукса</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
@@ -9505,13 +9505,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} канделе</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} канделом</unitPattern>
 				<unitPattern count="few">{0} канделе</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} канделе</unitPattern>
+				<unitPattern count="few" case="genitive">{0} канделе</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} канделе</unitPattern>
 				<unitPattern count="other">{0} кандела</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кандела</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кандела</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кандела</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>inanimate</gender>
@@ -9521,19 +9521,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} лумена</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} луменом</unitPattern>
 				<unitPattern count="few">{0} лумена</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} лумена</unitPattern>
+				<unitPattern count="few" case="genitive">{0} лумена</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} лумена</unitPattern>
 				<unitPattern count="other">{0} лумена</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} лумена</unitPattern>
+				<unitPattern count="other" case="genitive">{0} лумена</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} лумена</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<gender>feminine</gender>
@@ -9543,13 +9543,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} метричке тоне</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} метричком тоном</unitPattern>
 				<unitPattern count="few">{0} метричке тоне</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метричке тоне</unitPattern>
+				<unitPattern count="few" case="genitive">{0} метричке тоне</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} метричке тоне</unitPattern>
 				<unitPattern count="other">{0} метричких тона</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метричких тона</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метричких тона</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метричких тона</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>inanimate</gender>
@@ -9559,13 +9559,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} килограма</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} килограмом</unitPattern>
 				<unitPattern count="few">{0} килограма</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} килограма</unitPattern>
+				<unitPattern count="few" case="genitive">{0} килограма</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} килограма</unitPattern>
 				<unitPattern count="other">{0} килограма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килограма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килограма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килограма</unitPattern>
 				<perUnitPattern>{0} по килограму</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
@@ -9576,46 +9576,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} грама</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} грамом</unitPattern>
 				<unitPattern count="few">{0} грама</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} грама</unitPattern>
+				<unitPattern count="few" case="genitive">{0} грама</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} грама</unitPattern>
 				<unitPattern count="other">{0} грама</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} грама</unitPattern>
+				<unitPattern count="other" case="genitive">{0} грама</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} грама</unitPattern>
 				<perUnitPattern>{0} по граму</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<gender>inanimate</gender>
 				<displayName>милиграми</displayName>
 				<unitPattern count="one">{0} милиграм</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} милиграм</unitPattern>
 				<unitPattern count="one" case="genitive">{0} милиграма</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} милиграмом</unitPattern>
 				<unitPattern count="few">{0} милиграма</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} милиграма</unitPattern>
+				<unitPattern count="few" case="genitive">{0} милиграма</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} милиграма</unitPattern>
 				<unitPattern count="other">{0} милиграма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} милиграма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} милиграма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} милиграма</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>inanimate</gender>
 				<displayName>микрограми</displayName>
 				<unitPattern count="one">{0} микрограм</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} микрограм</unitPattern>
 				<unitPattern count="one" case="genitive">{0} микрограма</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} микрограмом</unitPattern>
 				<unitPattern count="few">{0} микрограма</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} микрограма</unitPattern>
+				<unitPattern count="few" case="genitive">{0} микрограма</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} микрограма</unitPattern>
 				<unitPattern count="other">{0} микрограма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} микрограма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} микрограма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} микрограма</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>тоне</displayName>
@@ -9657,13 +9657,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} карата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} каратом</unitPattern>
 				<unitPattern count="few">{0} карата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} карата</unitPattern>
+				<unitPattern count="few" case="genitive">{0} карата</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} карата</unitPattern>
 				<unitPattern count="other">{0} карата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} карата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} карата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} карата</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>далтони</displayName>
@@ -9693,49 +9693,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>гигавати</displayName>
 				<unitPattern count="one">{0} гигават</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гигават</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гигавата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гигаватом</unitPattern>
 				<unitPattern count="few">{0} гигавата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гигавата</unitPattern>
+				<unitPattern count="few" case="genitive">{0} гигавата</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} гигавата</unitPattern>
 				<unitPattern count="other">{0} гигавати</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гигавати</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гигавати</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гигавати</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>inanimate</gender>
 				<displayName>мегавати</displayName>
 				<unitPattern count="one">{0} мегават</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегават</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегавата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегаватом</unitPattern>
 				<unitPattern count="few">{0} мегавата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегавата</unitPattern>
+				<unitPattern count="few" case="genitive">{0} мегавата</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} мегавата</unitPattern>
 				<unitPattern count="other">{0} мегавати</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегавати</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегавати</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегавати</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>inanimate</gender>
 				<displayName>киловати</displayName>
 				<unitPattern count="one">{0} киловат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} киловат</unitPattern>
 				<unitPattern count="one" case="genitive">{0} киловата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} киловатом</unitPattern>
 				<unitPattern count="few">{0} киловата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} киловата</unitPattern>
+				<unitPattern count="few" case="genitive">{0} киловата</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} киловата</unitPattern>
 				<unitPattern count="other">{0} киловати</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} киловати</unitPattern>
+				<unitPattern count="other" case="genitive">{0} киловати</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} киловати</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>inanimate</gender>
@@ -9745,29 +9745,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} вата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ватом</unitPattern>
 				<unitPattern count="few">{0} вата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} вата</unitPattern>
+				<unitPattern count="few" case="genitive">{0} вата</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} вата</unitPattern>
 				<unitPattern count="other">{0} вати</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} вати</unitPattern>
+				<unitPattern count="other" case="genitive">{0} вати</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} вати</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>inanimate</gender>
 				<displayName>миливати</displayName>
 				<unitPattern count="one">{0} миливат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} миливат</unitPattern>
 				<unitPattern count="one" case="genitive">{0} миливата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} миливатом</unitPattern>
 				<unitPattern count="few">{0} миливата</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} миливата</unitPattern>
+				<unitPattern count="few" case="genitive">{0} миливата</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} миливата</unitPattern>
 				<unitPattern count="other">{0} миливати</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} миливати</unitPattern>
+				<unitPattern count="other" case="genitive">{0} миливати</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} миливати</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>коњске снаге</displayName>
@@ -9801,29 +9801,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} бара</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} баром</unitPattern>
 				<unitPattern count="few">{0} бара</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} бара</unitPattern>
+				<unitPattern count="few" case="genitive">{0} бара</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} бара</unitPattern>
 				<unitPattern count="other">{0} бара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} бара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} бара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} бара</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>inanimate</gender>
 				<displayName>милибари</displayName>
 				<unitPattern count="one">{0} милибар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} милибар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} милибара</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} милибаром</unitPattern>
 				<unitPattern count="few">{0} милибара</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} милибара</unitPattern>
+				<unitPattern count="few" case="genitive">{0} милибара</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} милибара</unitPattern>
 				<unitPattern count="other">{0} милибара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} милибара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} милибара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} милибара</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>feminine</gender>
@@ -9833,13 +9833,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} атмосфере</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} атмосфером</unitPattern>
 				<unitPattern count="few">{0} атмосфере</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} атмосфере</unitPattern>
+				<unitPattern count="few" case="genitive">{0} атмосфере</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} атмосфере</unitPattern>
 				<unitPattern count="other">{0} атмосфера</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} атмосфера</unitPattern>
+				<unitPattern count="other" case="genitive">{0} атмосфера</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} атмосфера</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>inanimate</gender>
@@ -9849,93 +9849,93 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} паскала</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} паскалом</unitPattern>
 				<unitPattern count="few">{0} паскала</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} паскала</unitPattern>
+				<unitPattern count="few" case="genitive">{0} паскала</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} паскала</unitPattern>
 				<unitPattern count="other">{0} паскала</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} паскала</unitPattern>
+				<unitPattern count="other" case="genitive">{0} паскала</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} паскала</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>inanimate</gender>
 				<displayName>хектопаскали</displayName>
 				<unitPattern count="one">{0} хектопаскал</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} хектопаскал</unitPattern>
 				<unitPattern count="one" case="genitive">{0} хектопаскала</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} хектопаскалом</unitPattern>
 				<unitPattern count="few">{0} хектопаскала</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} хектопаскала</unitPattern>
+				<unitPattern count="few" case="genitive">{0} хектопаскала</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} хектопаскала</unitPattern>
 				<unitPattern count="other">{0} хектопаскала</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} хектопаскала</unitPattern>
+				<unitPattern count="other" case="genitive">{0} хектопаскала</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} хектопаскала</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>inanimate</gender>
 				<displayName>килопаскали</displayName>
 				<unitPattern count="one">{0} килопаскал</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} килопаскал</unitPattern>
 				<unitPattern count="one" case="genitive">{0} килопаскала</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} килопаскалом</unitPattern>
 				<unitPattern count="few">{0} килопаскала</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} килопаскала</unitPattern>
+				<unitPattern count="few" case="genitive">{0} килопаскала</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} килопаскала</unitPattern>
 				<unitPattern count="other">{0} килопаскала</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} килопаскала</unitPattern>
+				<unitPattern count="other" case="genitive">{0} килопаскала</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} килопаскала</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>inanimate</gender>
 				<displayName>мегапаскали</displayName>
 				<unitPattern count="one">{0} мегапаскал</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегапаскал</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегапаскала</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегапаскалом</unitPattern>
 				<unitPattern count="few">{0} мегапаскала</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегапаскала</unitPattern>
+				<unitPattern count="few" case="genitive">{0} мегапаскала</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} мегапаскала</unitPattern>
 				<unitPattern count="other">{0} мегапаскала</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегапаскала</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегапаскала</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегапаскала</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>inanimate</gender>
 				<displayName>километри на сат</displayName>
 				<unitPattern count="one">{0} километар на сат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} километар на сат</unitPattern>
 				<unitPattern count="one" case="genitive">{0} километра на сат</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} километром на сат</unitPattern>
 				<unitPattern count="few">{0} километра на сат</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} километра на сат</unitPattern>
+				<unitPattern count="few" case="genitive">{0} километра на сат</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} километра на сат</unitPattern>
 				<unitPattern count="other">{0} километара на сат</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} километара на сат</unitPattern>
+				<unitPattern count="other" case="genitive">{0} километара на сат</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} километара на сат</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>inanimate</gender>
 				<displayName>метри у секунди</displayName>
 				<unitPattern count="one">{0} метар у секунди</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} метар у секунди</unitPattern>
 				<unitPattern count="one" case="genitive">{0} метра у секунди</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} метром у секунди</unitPattern>
 				<unitPattern count="few">{0} метра у секунди</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метра у секунди</unitPattern>
+				<unitPattern count="few" case="genitive">{0} метра у секунди</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} метра у секунди</unitPattern>
 				<unitPattern count="other">{0} метара у секунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метара у секунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метара у секунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метара у секунди</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>миље на сат</displayName>
@@ -9953,17 +9953,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0}°</unitPattern>
+				<unitPattern count="one" case="genitive">{0}°</unitPattern>
+				<unitPattern count="one" case="instrumental">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0}°</unitPattern>
+				<unitPattern count="few" case="genitive">{0}°</unitPattern>
+				<unitPattern count="few" case="instrumental">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0}°</unitPattern>
+				<unitPattern count="other" case="genitive">{0}°</unitPattern>
+				<unitPattern count="other" case="instrumental">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<gender>inanimate</gender>
@@ -9973,13 +9973,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} степена Целзијуса</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} степеном Целзијуса</unitPattern>
 				<unitPattern count="few">{0} степена Целзијуса</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} степена Целзијуса</unitPattern>
+				<unitPattern count="few" case="genitive">{0} степена Целзијуса</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} степена Целзијуса</unitPattern>
 				<unitPattern count="other">{0} степени Целзијуса</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} степени Целзијуса</unitPattern>
+				<unitPattern count="other" case="genitive">{0} степени Целзијуса</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} степени Целзијуса</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>степени Фаренхајта</displayName>
@@ -9995,13 +9995,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} келвина</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} келвином</unitPattern>
 				<unitPattern count="few">{0} келвина</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} келвина</unitPattern>
+				<unitPattern count="few" case="genitive">{0} келвина</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} келвина</unitPattern>
 				<unitPattern count="other">{0} келвина</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} келвина</unitPattern>
+				<unitPattern count="other" case="genitive">{0} келвина</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} келвина</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>фунта-стопе</displayName>
@@ -10013,66 +10013,66 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>њутн-метри</displayName>
 				<unitPattern count="one">{0} њутн-метар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} њутн-метар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} њутн-метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} њутн-метром</unitPattern>
 				<unitPattern count="few">{0} њутн-метра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} њутн-метра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} њутн-метра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} њутн-метра</unitPattern>
 				<unitPattern count="other">{0} њутн-метара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} њутн-метара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} њутн-метара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} њутн-метара</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>inanimate</gender>
 				<displayName>кубни километри</displayName>
 				<unitPattern count="one">{0} кубни километар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кубни километар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кубног километра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кубним километром</unitPattern>
 				<unitPattern count="few">{0} кубна километра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубна километра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} кубна километра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} кубна километра</unitPattern>
 				<unitPattern count="other">{0} кубних километара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубних километара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубних километара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубних километара</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>inanimate</gender>
 				<displayName>кубни метри</displayName>
 				<unitPattern count="one">{0} кубни метар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кубни метар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кубног метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кубним метром</unitPattern>
 				<unitPattern count="few">{0} кубна метра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубна метра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} кубна метра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} кубна метра</unitPattern>
 				<unitPattern count="other">{0} кубних метара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубних метара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубних метара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубних метара</unitPattern>
 				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<gender>inanimate</gender>
 				<displayName>кубни центиметри</displayName>
 				<unitPattern count="one">{0} кубни центиметар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кубни центиметар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кубног центиметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кубним центиметром</unitPattern>
 				<unitPattern count="few">{0} кубна центиметра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубна центиметра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} кубна центиметра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} кубна центиметра</unitPattern>
 				<unitPattern count="other">{0} кубних центиметара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубних центиметара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубних центиметара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубних центиметара</unitPattern>
 				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -10103,33 +10103,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>inanimate</gender>
 				<displayName>мегалитри</displayName>
 				<unitPattern count="one">{0} мегалитар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегалитар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегалитра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегалитром</unitPattern>
 				<unitPattern count="few">{0} мегалитра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегалитра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} мегалитра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} мегалитра</unitPattern>
 				<unitPattern count="other">{0} мегалитара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегалитара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегалитара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегалитара</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>inanimate</gender>
 				<displayName>хектолитри</displayName>
 				<unitPattern count="one">{0} хектолитар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} хектолитар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} хектолитра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} хектолитром</unitPattern>
 				<unitPattern count="few">{0} хектолитра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} хектолитра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} хектолитра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} хектолитра</unitPattern>
 				<unitPattern count="other">{0} хектолитара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} хектолитара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} хектолитара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} хектолитара</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>inanimate</gender>
@@ -10139,62 +10139,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} литра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} литром</unitPattern>
 				<unitPattern count="few">{0} литра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} литра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} литра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} литра</unitPattern>
 				<unitPattern count="other">{0} литара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} литара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} литара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} литара</unitPattern>
 				<perUnitPattern>{0} по литри</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<gender>inanimate</gender>
 				<displayName>децилитри</displayName>
 				<unitPattern count="one">{0} децилитар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} децилитар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} децилитра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} децилитром</unitPattern>
 				<unitPattern count="few">{0} децилитра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} децилитра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} децилитра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} децилитра</unitPattern>
 				<unitPattern count="other">{0} децилитара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} децилитара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} децилитара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} децилитара</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>inanimate</gender>
 				<displayName>центилитри</displayName>
 				<unitPattern count="one">{0} центилитар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} центилитар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} центилитра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} центилитром</unitPattern>
 				<unitPattern count="few">{0} центилитра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} центилитра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} центилитра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} центилитра</unitPattern>
 				<unitPattern count="other">{0} центилитара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} центилитара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} центилитара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} центилитара</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>inanimate</gender>
 				<displayName>милилитри</displayName>
 				<unitPattern count="one">{0} милилитар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} милилитар</unitPattern>
 				<unitPattern count="one" case="genitive">{0} милилитра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} милилитром</unitPattern>
 				<unitPattern count="few">{0} милилитра</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} милилитра</unitPattern>
+				<unitPattern count="few" case="genitive">{0} милилитра</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} милилитра</unitPattern>
 				<unitPattern count="other">{0} милилитара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} милилитара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} милилитара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} милилитара</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>feminine</gender>
@@ -10204,13 +10204,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} метричке пинте</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} метричком пинтом</unitPattern>
 				<unitPattern count="few">{0} метричке пинте</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метричке пинте</unitPattern>
+				<unitPattern count="few" case="genitive">{0} метричке пинте</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} метричке пинте</unitPattern>
 				<unitPattern count="other">{0} метричких пинти</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метричких пинти</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метричких пинти</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метричких пинти</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>feminine</gender>
@@ -10220,13 +10220,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="genitive">{0} метричке шоље</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} метричком шољом</unitPattern>
 				<unitPattern count="few">{0} метричке шоље</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метричке шоље</unitPattern>
+				<unitPattern count="few" case="genitive">{0} метричке шоље</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} метричке шоље</unitPattern>
 				<unitPattern count="other">{0} метричких шоља</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метричких шоља</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метричких шоља</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метричких шоља</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>акер стопе</displayName>
@@ -10448,8 +10448,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10606,14 +10606,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -10860,8 +10860,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -10872,20 +10872,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>њутн</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -10914,44 +10914,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
@@ -11063,7 +11063,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>фурлонзи</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="few">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
@@ -11093,8 +11093,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -11105,20 +11105,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -11161,8 +11161,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -11193,26 +11193,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>грејн</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="few">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -11301,14 +11301,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -11361,14 +11361,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -11472,8 +11472,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -11516,8 +11516,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="few">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -11534,20 +11534,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="few">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -11558,26 +11558,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>драм течности</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="few">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>џигер</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="few">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>прстохват</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pinch</unitPattern>
+				<unitPattern count="few">{0} pinch</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="few">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -11590,231 +11590,231 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>ге сила</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="few">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="few">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="few">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>степени</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>лучни мин</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>лучне сек</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>квадратни километри</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>хектари</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="few">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>квадратни метри</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="few">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>акери</displayName>
 				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="few">{0} ac</unitPattern>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>квадратне стопе</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="few">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дунами</displayName>
+				<unitPattern count="one">{0} дунам</unitPattern>
+				<unitPattern count="few">{0} дунама</unitPattern>
+				<unitPattern count="other">{0} дунама</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="few">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="few">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>ставка</displayName>
@@ -11823,10 +11823,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ставки</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -11835,28 +11835,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>промил</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="few">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="few">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -11865,10 +11865,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="few">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg Imp</displayName>
@@ -11877,89 +11877,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mpg Imp</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бајт</displayName>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="few">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>бит</displayName>
+				<unitPattern count="one">{0} b</unitPattern>
+				<unitPattern count="few">{0} b</unitPattern>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>в.</displayName>
+				<unitPattern count="one">{0} в</unitPattern>
+				<unitPattern count="few">{0} в</unitPattern>
+				<unitPattern count="other">{0} в</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>дец.</displayName>
+				<unitPattern count="one">{0} дец.</unitPattern>
+				<unitPattern count="few">{0} дец.</unitPattern>
+				<unitPattern count="other">{0} дец.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>г.</displayName>
 				<unitPattern count="one">{0} г</unitPattern>
 				<unitPattern count="few">{0} г</unitPattern>
 				<unitPattern count="other">{0} г</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/год</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>кв</displayName>
@@ -11973,42 +11973,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} м</unitPattern>
 				<unitPattern count="few">{0} м</unitPattern>
 				<unitPattern count="other">{0} м</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/м</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>н.</displayName>
 				<unitPattern count="one">{0} н</unitPattern>
 				<unitPattern count="few">{0} н</unitPattern>
 				<unitPattern count="other">{0} н</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/н</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>д</displayName>
 				<unitPattern count="one">{0} д</unitPattern>
 				<unitPattern count="few">{0} д</unitPattern>
 				<unitPattern count="other">{0} д</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/д</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ч</displayName>
 				<unitPattern count="one">{0} ч</unitPattern>
 				<unitPattern count="few">{0} ч</unitPattern>
 				<unitPattern count="other">{0} ч</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ч</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>мин</displayName>
 				<unitPattern count="one">{0} м</unitPattern>
 				<unitPattern count="few">{0} м</unitPattern>
 				<unitPattern count="other">{0} м</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/мин</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>с</displayName>
 				<unitPattern count="one">{0} с</unitPattern>
 				<unitPattern count="few">{0} с</unitPattern>
 				<unitPattern count="other">{0} с</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/с</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -12017,217 +12017,217 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="few">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="few">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>електронволт</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therms</unitPattern>
+				<unitPattern count="other">{0} US therms</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>њутн</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>тачка</displayName>
+				<unitPattern count="one">{0} тачка</unitPattern>
+				<unitPattern count="few">{0} тачке</unitPattern>
+				<unitPattern count="other">{0} тачака</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="few">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="few">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -12236,25 +12236,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>пикометри</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="few">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>миље</displayName>
 				<unitPattern count="one">{0} миља</unitPattern>
 				<unitPattern count="few">{0} миље</unitPattern>
 				<unitPattern count="other">{0} миља</unitPattern>
@@ -12270,282 +12270,282 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="few">{0} ft</unitPattern>
 				<unitPattern count="other">{0} ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>in</displayName>
 				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="few">{0} in</unitPattern>
 				<unitPattern count="other">{0} in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>парсеци</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>светлосне год.</displayName>
 				<unitPattern count="one">{0} ly</unitPattern>
 				<unitPattern count="few">{0} ly</unitPattern>
 				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ај</displayName>
+				<unitPattern count="one">{0} ај</unitPattern>
+				<unitPattern count="few">{0} ај</unitPattern>
+				<unitPattern count="other">{0} ај</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>фурлонзи</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>хв</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="few">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="few">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="few">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="few">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="few">{0} lb</unitPattern>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0} унца</unitPattern>
 				<unitPattern count="few">{0} унце</unitPattern>
 				<unitPattern count="other">{0} унци</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="few">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>карати</displayName>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="few">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>грејн</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="few">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="few">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="few">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="few">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="few">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="few">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0} кс</unitPattern>
 				<unitPattern count="few">{0} кс</unitPattern>
 				<unitPattern count="other">{0} кс</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="one">{0} mm Hg</unitPattern>
+				<unitPattern count="few">{0} mm Hg</unitPattern>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="few">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="few">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="few">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="few">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -12554,28 +12554,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>метри у секунди</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="few">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>миље на сат</displayName>
 				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="few">{0} mi/h</unitPattern>
 				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="few">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -12584,140 +12584,140 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>степени Фаренхајта</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="few">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="few">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="few">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="few">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="few">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="few">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="few">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="few">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="few">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="few">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="few">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>Imp gal</displayName>
@@ -12727,28 +12727,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/gal Imp</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="few">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>шоље</displayName>
+				<unitPattern count="one">{0} ш.</unitPattern>
+				<unitPattern count="few">{0} ш.</unitPattern>
+				<unitPattern count="other">{0} ш.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="few">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>Imp fl oz</displayName>
@@ -12757,61 +12757,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl oz Imp</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>каш.</displayName>
+				<unitPattern count="one">{0} каш.</unitPattern>
+				<unitPattern count="few">{0} каш.</unitPattern>
+				<unitPattern count="other">{0} каш.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кашич.</displayName>
+				<unitPattern count="one">{0} кашич.</unitPattern>
+				<unitPattern count="few">{0} кашич.</unitPattern>
+				<unitPattern count="other">{0} кашич.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="few">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>кап</displayName>
+				<unitPattern count="one">{0} кап</unitPattern>
+				<unitPattern count="few">{0} капи</unitPattern>
+				<unitPattern count="other">{0} капи</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>драм течности</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="few">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>џигер</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="few">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>прстохват</displayName>
 				<unitPattern count="one">{0} pn</unitPattern>
 				<unitPattern count="few">{0} pn</unitPattern>
 				<unitPattern count="other">{0} pn</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt Imp</displayName>
 				<unitPattern count="one">{0} qt Imp</unitPattern>
 				<unitPattern count="few">{0} qt Imp</unitPattern>
 				<unitPattern count="other">{0} qt Imp</unitPattern>
@@ -12848,22 +12848,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} или {1}</listPatternPart>
+			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} или {1}</listPatternPart>
+			<listPatternPart type="2">{0} или {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} и {1}</listPatternPart>
+			<listPatternPart type="2">{0} и {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -99,8 +99,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">čeroki</language>
 			<language type="chy">čejenski</language>
 			<language type="ckb">centralni kurdski</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">centralni kurdski</language>
+			<language type="ckb" alt="variant">centralni kurdski</language>
 			<language type="clc">čilkotin</language>
 			<language type="co">korzikanski</language>
 			<language type="cop">koptski</language>
@@ -941,7 +941,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">Novi Zeland</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Novi Zeland</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -1001,7 +1001,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunis</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turska</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turska</territory>
 			<territory type="TT">Trinidad i Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tajvan</territory>
@@ -1346,7 +1346,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1354,7 +1354,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1362,7 +1362,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1370,7 +1370,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1919,7 +1919,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1927,7 +1927,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1935,7 +1935,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1943,7 +1943,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2216,18 +2216,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Zul-h.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Muharem</month>
@@ -2246,18 +2246,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Muh.</month>
+							<month type="2">Saf.</month>
+							<month type="3">Reb. 1</month>
+							<month type="4">Reb. 2</month>
+							<month type="5">Džum. 1</month>
+							<month type="6">Džum. 2</month>
+							<month type="7">Redž.</month>
+							<month type="8">Ša.</month>
+							<month type="9">Ram.</month>
+							<month type="10">Še.</month>
+							<month type="11">Zul-k.</month>
+							<month type="12">Zul-h.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -2297,54 +2297,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, d. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d. MMMM y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d.MM.y. G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d.M.y. GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d.</dateFormatItem>
+						<dateFormatItem id="Gy">y. G</dateFormatItem>
+						<dateFormatItem id="GyMd">d.M.y. GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d.M.</dateFormatItem>
+						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d. MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d. MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, d. MMMM</dateFormatItem>
+						<dateFormatItem id="y">y. G</dateFormatItem>
+						<dateFormatItem id="yyyy">y. G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M.y. GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d.M.y. GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d.M.y. GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d. MMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ, y. G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y. G</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -2790,10 +2790,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>mes.</displayName>
+				<relative type="-1">prošlog mes.</relative>
+				<relative type="0">ovog mes.</relative>
+				<relative type="1">sledećeg mes.</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} m.</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} m.</relativeTimePattern>
@@ -2840,7 +2840,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativePeriod>nedelja koja počinje {0}.</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ned.</displayName>
 				<relative type="-1">prošle n.</relative>
 				<relative type="0">ove n.</relative>
 				<relative type="1">sledeće n.</relative>
@@ -2977,9 +2977,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">pr. ned.</relative>
 				<relative type="0">u ned</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">sl. ned.</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">za {0} nedelju</relativeTimePattern>
 					<relativeTimePattern count="few">za {0} nedelje</relativeTimePattern>
@@ -8036,80 +8036,80 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>kvadratni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kvadratni {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="instrumental">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">kvadratni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">kvadratni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">kvadratna {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="instrumental">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">kvadratna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">kvadratna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kvadratnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">kvadratnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">kvadratnih {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>kubni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kubni {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="instrumental">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="accusative">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="accusative">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="genitive">kubni {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="inanimate" case="instrumental">kubni {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">kubna {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="genitive">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="instrumental">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="accusative">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="genitive">kubna {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="inanimate" case="instrumental">kubna {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kubnih {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="accusative">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="genitive">kubnih {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="inanimate" case="instrumental">kubnih {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}-{1}</compoundUnitPattern>
@@ -8122,29 +8122,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} ge sile</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ge silom</unitPattern>
 				<unitPattern count="few">{0} ge sila</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ge sila</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ge sila</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} ge sila</unitPattern>
 				<unitPattern count="other">{0} ge sila</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ge sila</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ge sila</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ge sila</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>inanimate</gender>
 				<displayName>metri u sekundi na kvadrat</displayName>
 				<unitPattern count="one">{0} metar u sekundi na kvadrat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} metar u sekundi na kvadrat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra u sekundi na kvadrat</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom u sekundi na kvadrat</unitPattern>
 				<unitPattern count="few">{0} metra u sekundi na kvadrat</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metra u sekundi na kvadrat</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metra u sekundi na kvadrat</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metra u sekundi na kvadrat</unitPattern>
 				<unitPattern count="other">{0} metara u sekundi na kvadrat</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metara u sekundi na kvadrat</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metara u sekundi na kvadrat</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metara u sekundi na kvadrat</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>inanimate</gender>
@@ -8154,13 +8154,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} obrtaja</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} obrtajem</unitPattern>
 				<unitPattern count="few">{0} obrtaja</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} obrtaja</unitPattern>
+				<unitPattern count="few" case="genitive">{0} obrtaja</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} obrtaja</unitPattern>
 				<unitPattern count="other">{0} obrtaja</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} obrtaja</unitPattern>
+				<unitPattern count="other" case="genitive">{0} obrtaja</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} obrtaja</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>inanimate</gender>
@@ -8170,13 +8170,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} radijana</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} radijanom</unitPattern>
 				<unitPattern count="few">{0} radijana</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} radijana</unitPattern>
+				<unitPattern count="few" case="genitive">{0} radijana</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} radijana</unitPattern>
 				<unitPattern count="other">{0} radijana</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} radijana</unitPattern>
+				<unitPattern count="other" case="genitive">{0} radijana</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} radijana</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>inanimate</gender>
@@ -8186,13 +8186,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} stepena</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stepenom</unitPattern>
 				<unitPattern count="few">{0} stepena</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stepena</unitPattern>
+				<unitPattern count="few" case="genitive">{0} stepena</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} stepena</unitPattern>
 				<unitPattern count="other">{0} stepeni</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stepeni</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stepeni</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stepeni</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>inanimate</gender>
@@ -8202,13 +8202,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} lučnog minuta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} lučnim minutom</unitPattern>
 				<unitPattern count="few">{0} lučna minuta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} lučna minuta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} lučna minuta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} lučna minuta</unitPattern>
 				<unitPattern count="other">{0} lučnih minuta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} lučnih minuta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} lučnih minuta</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} lučnih minuta</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>feminine</gender>
@@ -8218,29 +8218,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} lučne sekunde</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} lučnom sekundom</unitPattern>
 				<unitPattern count="few">{0} lučne sekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} lučne sekunde</unitPattern>
+				<unitPattern count="few" case="genitive">{0} lučne sekunde</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} lučne sekunde</unitPattern>
 				<unitPattern count="other">{0} lučnih sekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} lučnih sekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} lučnih sekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} lučnih sekundi</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>inanimate</gender>
 				<displayName>kvadratni kilometri</displayName>
 				<unitPattern count="one">{0} kvadratni kilometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kvadratni kilometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kvadratna kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kvadratnim kilometrom</unitPattern>
 				<unitPattern count="few">{0} kvadratna kilometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kvadratna kilometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kvadratna kilometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kvadratna kilometra</unitPattern>
 				<unitPattern count="other">{0} kvadratnih kilometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratnih kilometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kvadratnih kilometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kvadratnih kilometara</unitPattern>
 				<perUnitPattern>{0} po kvadratnom kilometru</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
@@ -8251,46 +8251,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} hektara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektarom</unitPattern>
 				<unitPattern count="few">{0} hektara</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektara</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hektara</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} hektara</unitPattern>
 				<unitPattern count="other">{0} hektara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektara</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>inanimate</gender>
 				<displayName>kvadratni metri</displayName>
 				<unitPattern count="one">{0} kvadratni metar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kvadratni metar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kvadratna metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kvadratnim metrom</unitPattern>
 				<unitPattern count="few">{0} kvadratna metra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kvadratna metra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kvadratna metra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kvadratna metra</unitPattern>
 				<unitPattern count="other">{0} kvadratnih metara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratnih metara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kvadratnih metara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kvadratnih metara</unitPattern>
 				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<gender>inanimate</gender>
 				<displayName>kvadratni centimetri</displayName>
 				<unitPattern count="one">{0} kvadratni centimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kvadratni centimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kvadratnog centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kvadratnim centimetrom</unitPattern>
 				<unitPattern count="few">{0} kvadratna centimetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kvadratna centimetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kvadratna centimetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kvadratna centimetra</unitPattern>
 				<unitPattern count="other">{0} kvadratnih centimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kvadratnih centimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kvadratnih centimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kvadratnih centimetara</unitPattern>
 				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -8339,13 +8339,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} karata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} karatom</unitPattern>
 				<unitPattern count="few">{0} karata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} karata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} karata</unitPattern>
 				<unitPattern count="other">{0} karata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karata</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} karata</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>miligrami po decilitru</displayName>
@@ -8357,17 +8357,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<gender>inanimate</gender>
 				<displayName>milimol po litri</displayName>
 				<unitPattern count="one">{0} milimol po litri</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milimol po litri</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milimola po litri</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milimolom po litri</unitPattern>
 				<unitPattern count="few">{0} milimola po litri</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milimola po litri</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milimola po litri</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milimola po litri</unitPattern>
 				<unitPattern count="other">{0} milimola po litri</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimola po litri</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimola po litri</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milimola po litri</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>feminine</gender>
@@ -8377,13 +8377,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} stavke</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stavkom</unitPattern>
 				<unitPattern count="few">{0} stavke</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stavke</unitPattern>
+				<unitPattern count="few" case="genitive">{0} stavke</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} stavke</unitPattern>
 				<unitPattern count="other">{0} stavki</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stavki</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stavki</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stavki</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>feminine</gender>
@@ -8393,13 +8393,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} čestice na milion</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} česticom na milion</unitPattern>
 				<unitPattern count="few">{0} čestice na milion</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} čestice na milion</unitPattern>
+				<unitPattern count="few" case="genitive">{0} čestice na milion</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} čestice na milion</unitPattern>
 				<unitPattern count="other">{0} čestica na milion</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} čestica na milion</unitPattern>
+				<unitPattern count="other" case="genitive">{0} čestica na milion</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} čestica na milion</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>inanimate</gender>
@@ -8409,13 +8409,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} procenta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} procentom</unitPattern>
 				<unitPattern count="few">{0} procenata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} procenata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} procenata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} procenata</unitPattern>
 				<unitPattern count="other">{0} procenata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} procenata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} procenata</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} procenata</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>inanimate</gender>
@@ -8425,29 +8425,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} promila</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} promilom</unitPattern>
 				<unitPattern count="few">{0} promila</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} promila</unitPattern>
+				<unitPattern count="few" case="genitive">{0} promila</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} promila</unitPattern>
 				<unitPattern count="other">{0} promila</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} promila</unitPattern>
+				<unitPattern count="other" case="genitive">{0} promila</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} promila</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">{0}‱</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="one" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="one" case="instrumental">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="few" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="few" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="few" case="instrumental">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
+				<unitPattern count="other" case="accusative">{0}‱</unitPattern>
+				<unitPattern count="other" case="genitive">{0}‱</unitPattern>
+				<unitPattern count="other" case="instrumental">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<gender>inanimate</gender>
@@ -8457,45 +8457,45 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} mola</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} molom</unitPattern>
 				<unitPattern count="few">{0} mola</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mola</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mola</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mola</unitPattern>
 				<unitPattern count="other">{0} mola</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mola</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mola</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mola</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>inanimate</gender>
 				<displayName>litri po kilometru</displayName>
 				<unitPattern count="one">{0} litar po kilometru</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} litar po kilometru</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra po kilometru</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom po kilometru</unitPattern>
 				<unitPattern count="few">{0} litra po kilometru</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litra po kilometru</unitPattern>
+				<unitPattern count="few" case="genitive">{0} litra po kilometru</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} litra po kilometru</unitPattern>
 				<unitPattern count="other">{0} litara po kilometru</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litara po kilometru</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litara po kilometru</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litara po kilometru</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>inanimate</gender>
 				<displayName>litri na 100 kilometara</displayName>
 				<unitPattern count="one">{0} litar na 100 kilometara</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} litar na 100 kilometara</unitPattern>
 				<unitPattern count="one" case="genitive">{0} litra na 100 kilometara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom na 100 kilometara</unitPattern>
 				<unitPattern count="few">{0} litra na 100 kilometara</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litra na 100 kilometara</unitPattern>
+				<unitPattern count="few" case="genitive">{0} litra na 100 kilometara</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} litra na 100 kilometara</unitPattern>
 				<unitPattern count="other">{0} litara na 100 kilometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litara na 100 kilometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litara na 100 kilometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litara na 100 kilometara</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>milja po galonu</displayName>
@@ -8513,29 +8513,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<gender>inanimate</gender>
 				<displayName>petabajti</displayName>
 				<unitPattern count="one">{0} petabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} petabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} petabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} petabajtom</unitPattern>
 				<unitPattern count="few">{0} petabajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} petabajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} petabajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} petabajta</unitPattern>
 				<unitPattern count="other">{0} petabajtova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} petabajtova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} petabajtova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} petabajtova</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>inanimate</gender>
 				<displayName>terabajti</displayName>
 				<unitPattern count="one">{0} terabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} terabajtom</unitPattern>
 				<unitPattern count="few">{0} terabajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} terabajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} terabajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} terabajta</unitPattern>
 				<unitPattern count="other">{0} terabajta</unitPattern>
 				<unitPattern count="other" case="accusative">{0} terabajtova</unitPattern>
 				<unitPattern count="other" case="genitive">{0} terabajtova</unitPattern>
@@ -8545,113 +8545,113 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<gender>inanimate</gender>
 				<displayName>terabitovi</displayName>
 				<unitPattern count="one">{0} terabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} terabit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} terabita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} terabitom</unitPattern>
 				<unitPattern count="few">{0} terabita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} terabita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} terabita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} terabita</unitPattern>
 				<unitPattern count="other">{0} terabitova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} terabitova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} terabitova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} terabitova</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>inanimate</gender>
 				<displayName>gigabajti</displayName>
 				<unitPattern count="one">{0} gigabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigabajtom</unitPattern>
 				<unitPattern count="few">{0} gigabajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigabajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigabajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigabajta</unitPattern>
 				<unitPattern count="other">{0} gigabajtova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabajtova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabajtova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigabajtova</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>inanimate</gender>
 				<displayName>gigabitovi</displayName>
 				<unitPattern count="one">{0} gigabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigabit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigabita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigabitom</unitPattern>
 				<unitPattern count="few">{0} gigabita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigabita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigabita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigabita</unitPattern>
 				<unitPattern count="other">{0} gigabitova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigabitova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigabitova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigabitova</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>inanimate</gender>
 				<displayName>megabajti</displayName>
 				<unitPattern count="one">{0} megabajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megabajtom</unitPattern>
 				<unitPattern count="few">{0} megabajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megabajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megabajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megabajta</unitPattern>
 				<unitPattern count="other">{0} megabajtova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabajtova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabajtova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megabajtova</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>inanimate</gender>
 				<displayName>megabitovi</displayName>
 				<unitPattern count="one">{0} megabit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megabit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megabita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megabitom</unitPattern>
 				<unitPattern count="few">{0} megabita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megabita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megabita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megabita</unitPattern>
 				<unitPattern count="other">{0} megabitova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megabitova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megabitova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megabitova</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>inanimate</gender>
 				<displayName>kilobajti</displayName>
 				<unitPattern count="one">{0} kilobajt</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobajt</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilobajtom</unitPattern>
 				<unitPattern count="few">{0} kilobajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilobajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilobajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilobajta</unitPattern>
 				<unitPattern count="other">{0} kilobajtova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobajtova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobajtova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilobajtova</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>inanimate</gender>
 				<displayName>kilobitovi</displayName>
 				<unitPattern count="one">{0} kilobit</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilobit</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilobita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilobitom</unitPattern>
 				<unitPattern count="few">{0} kilobita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilobita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilobita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilobita</unitPattern>
 				<unitPattern count="other">{0} kilobitova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilobitova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilobitova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilobitova</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>inanimate</gender>
@@ -8661,13 +8661,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} bajta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} bajtom</unitPattern>
 				<unitPattern count="few">{0} bajta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bajta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} bajta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} bajta</unitPattern>
 				<unitPattern count="other">{0} bajtova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bajtova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bajtova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} bajtova</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>inanimate</gender>
@@ -8677,13 +8677,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} bita</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} bitom</unitPattern>
 				<unitPattern count="few">{0} bita</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bita</unitPattern>
+				<unitPattern count="few" case="genitive">{0} bita</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} bita</unitPattern>
 				<unitPattern count="other">{0} bitova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bitova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bitova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} bitova</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>inanimate</gender>
@@ -8693,13 +8693,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} veka</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} vekom</unitPattern>
 				<unitPattern count="few">{0} veka</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} veka</unitPattern>
+				<unitPattern count="few" case="genitive">{0} veka</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} veka</unitPattern>
 				<unitPattern count="other">{0} vekova</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} vekova</unitPattern>
+				<unitPattern count="other" case="genitive">{0} vekova</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} vekova</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>feminine</gender>
@@ -8713,9 +8713,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few" case="genitive">{0} decenije</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} decenije</unitPattern>
 				<unitPattern count="other">{0} decenija</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decenija</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decenija</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} decenija</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>feminine</gender>
@@ -8725,13 +8725,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} godine</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} godinom</unitPattern>
 				<unitPattern count="few">{0} godine</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} godine</unitPattern>
+				<unitPattern count="few" case="genitive">{0} godine</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} godine</unitPattern>
 				<unitPattern count="other">{0} godina</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} godina</unitPattern>
+				<unitPattern count="other" case="genitive">{0} godina</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} godina</unitPattern>
 				<perUnitPattern>{0} godišnje</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -8759,13 +8759,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} meseca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mesecom</unitPattern>
 				<unitPattern count="few">{0} meseca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} meseca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} meseca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} meseca</unitPattern>
 				<unitPattern count="other">{0} meseci</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} meseci</unitPattern>
+				<unitPattern count="other" case="genitive">{0} meseci</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} meseci</unitPattern>
 				<perUnitPattern>{0} mesečno</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
@@ -8776,13 +8776,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} nedelje</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} nedeljom</unitPattern>
 				<unitPattern count="few">{0} nedelje</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} nedelje</unitPattern>
+				<unitPattern count="few" case="genitive">{0} nedelje</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} nedelje</unitPattern>
 				<unitPattern count="other">{0} nedelja</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nedelja</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nedelja</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} nedelja</unitPattern>
 				<perUnitPattern>{0} nedeljno</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
@@ -8793,13 +8793,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} dana</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} danom</unitPattern>
 				<unitPattern count="few">{0} dana</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} dana</unitPattern>
+				<unitPattern count="few" case="genitive">{0} dana</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} dana</unitPattern>
 				<unitPattern count="other">{0} dana</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} dana</unitPattern>
+				<unitPattern count="other" case="genitive">{0} dana</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} dana</unitPattern>
 				<perUnitPattern>{0}/dnevno</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -8810,13 +8810,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} sata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} satom</unitPattern>
 				<unitPattern count="few">{0} sata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} sata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} sata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} sata</unitPattern>
 				<unitPattern count="other">{0} sati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} sati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} sati</unitPattern>
 				<perUnitPattern>{0}/sat</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -8827,13 +8827,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} minuta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} minutom</unitPattern>
 				<unitPattern count="few">{0} minuta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} minuta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} minuta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} minuta</unitPattern>
 				<unitPattern count="other">{0} minuta</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} minuta</unitPattern>
+				<unitPattern count="other" case="genitive">{0} minuta</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} minuta</unitPattern>
 				<perUnitPattern>{0} u minutu</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -8844,30 +8844,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} sekunde</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} sekundom</unitPattern>
 				<unitPattern count="few">{0} sekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} sekunde</unitPattern>
+				<unitPattern count="few" case="genitive">{0} sekunde</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} sekunde</unitPattern>
 				<unitPattern count="other">{0} sekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} sekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} sekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} sekundi</unitPattern>
 				<perUnitPattern>{0}/u sekundi</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<gender>feminine</gender>
 				<displayName>milisekunde</displayName>
 				<unitPattern count="one">{0} milisekunda</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milisekunda</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milisekunde</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milisekundom</unitPattern>
 				<unitPattern count="few">{0} milisekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milisekunde</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milisekunde</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milisekunde</unitPattern>
 				<unitPattern count="other">{0} milisekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milisekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milisekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milisekundi</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>feminine</gender>
@@ -8877,13 +8877,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} mikrosekunde</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mikrosekundom</unitPattern>
 				<unitPattern count="few">{0} mikrosekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrosekunde</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mikrosekunde</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mikrosekunde</unitPattern>
 				<unitPattern count="other">{0} mikrosekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrosekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrosekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mikrosekundi</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>feminine</gender>
@@ -8893,13 +8893,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} nanosekunde</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} nanosekundom</unitPattern>
 				<unitPattern count="few">{0} nanosekunde</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} nanosekunde</unitPattern>
+				<unitPattern count="few" case="genitive">{0} nanosekunde</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} nanosekunde</unitPattern>
 				<unitPattern count="other">{0} nanosekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanosekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nanosekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} nanosekundi</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>inanimate</gender>
@@ -8909,29 +8909,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} ampera</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} amperom</unitPattern>
 				<unitPattern count="few">{0} ampera</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ampera</unitPattern>
+				<unitPattern count="few" case="genitive">{0} ampera</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} ampera</unitPattern>
 				<unitPattern count="other">{0} ampera</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ampera</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ampera</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ampera</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>inanimate</gender>
 				<displayName>miliamperi</displayName>
 				<unitPattern count="one">{0} miliamper</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miliamper</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miliampera</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} miliamperom</unitPattern>
 				<unitPattern count="few">{0} miliampera</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} miliampera</unitPattern>
+				<unitPattern count="few" case="genitive">{0} miliampera</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} miliampera</unitPattern>
 				<unitPattern count="other">{0} miliampera</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miliampera</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miliampera</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} miliampera</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>inanimate</gender>
@@ -8941,13 +8941,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} oma</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} omom</unitPattern>
 				<unitPattern count="few">{0} oma</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} oma</unitPattern>
+				<unitPattern count="few" case="genitive">{0} oma</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} oma</unitPattern>
 				<unitPattern count="other">{0} oma</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} oma</unitPattern>
+				<unitPattern count="other" case="genitive">{0} oma</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} oma</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>inanimate</gender>
@@ -8957,13 +8957,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} volta</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} voltom</unitPattern>
 				<unitPattern count="few">{0} volta</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} volta</unitPattern>
+				<unitPattern count="few" case="genitive">{0} volta</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} volta</unitPattern>
 				<unitPattern count="other">{0} volti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} volti</unitPattern>
+				<unitPattern count="other" case="genitive">{0} volti</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} volti</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>kilokalorije</displayName>
@@ -8979,13 +8979,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} kalorije</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kalorijom</unitPattern>
 				<unitPattern count="few">{0} kalorije</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kalorije</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kalorije</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kalorije</unitPattern>
 				<unitPattern count="other">{0} kalorija</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kalorija</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kalorija</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kalorija</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>Kalorije</displayName>
@@ -8997,17 +8997,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<gender>inanimate</gender>
 				<displayName>kilodžuli</displayName>
 				<unitPattern count="one">{0} kilodžul</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilodžul</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilodžula</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilodžulom</unitPattern>
 				<unitPattern count="few">{0} kilodžula</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilodžula</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilodžula</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilodžula</unitPattern>
 				<unitPattern count="other">{0} kilodžula</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilodžula</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilodžula</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilodžula</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>inanimate</gender>
@@ -9017,29 +9017,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} džula</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} džulom</unitPattern>
 				<unitPattern count="few">{0} džula</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} džula</unitPattern>
+				<unitPattern count="few" case="genitive">{0} džula</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} džula</unitPattern>
 				<unitPattern count="other">{0} džula</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} džula</unitPattern>
+				<unitPattern count="other" case="genitive">{0} džula</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} džula</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>inanimate</gender>
 				<displayName>kilovat-sati</displayName>
 				<unitPattern count="one">{0} kilovat-sat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilovat-sat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilovat-sata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilovat-satom</unitPattern>
 				<unitPattern count="few">{0} kilovat-sata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilovat-sata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilovat-sata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilovat-sata</unitPattern>
 				<unitPattern count="other">{0} kilovat-sati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovat-sati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilovat-sati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilovat-sati</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronvolti</displayName>
@@ -9049,9 +9049,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>Britanska termalna jedinica</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>US therms</displayName>
@@ -9073,77 +9073,77 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} njutna</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} njutnom</unitPattern>
 				<unitPattern count="few">{0} njutna</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} njutna</unitPattern>
+				<unitPattern count="few" case="genitive">{0} njutna</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} njutna</unitPattern>
 				<unitPattern count="other">{0} njutna</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} njutna</unitPattern>
+				<unitPattern count="other" case="genitive">{0} njutna</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} njutna</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kWh/100km</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>inanimate</gender>
 				<displayName>gigaherci</displayName>
 				<unitPattern count="one">{0} gigaherc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigaherc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigaherca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigahercom</unitPattern>
 				<unitPattern count="few">{0} gigaherca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigaherca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigaherca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigaherca</unitPattern>
 				<unitPattern count="other">{0} gigaherca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigaherca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigaherca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigaherca</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>inanimate</gender>
 				<displayName>megaherci</displayName>
 				<unitPattern count="one">{0} megaherc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megaherc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megaherca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megahercom</unitPattern>
 				<unitPattern count="few">{0} megaherca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megaherca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megaherca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megaherca</unitPattern>
 				<unitPattern count="other">{0} megaherca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megaherca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megaherca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megaherca</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>inanimate</gender>
 				<displayName>kiloherci</displayName>
 				<unitPattern count="one">{0} kiloherc</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kiloherc</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kiloherca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilohercom</unitPattern>
 				<unitPattern count="few">{0} kiloherca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kiloherca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kiloherca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kiloherca</unitPattern>
 				<unitPattern count="other">{0} kiloherca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kiloherca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kiloherca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kiloherca</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>inanimate</gender>
@@ -9153,33 +9153,33 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} herca</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hercom</unitPattern>
 				<unitPattern count="few">{0} herca</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} herca</unitPattern>
+				<unitPattern count="few" case="genitive">{0} herca</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} herca</unitPattern>
 				<unitPattern count="other">{0} herca</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} herca</unitPattern>
+				<unitPattern count="other" case="genitive">{0} herca</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} herca</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="one" case="accusative">{0} em</unitPattern>
+				<unitPattern count="one" case="genitive">{0} em</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="few" case="accusative">{0} em</unitPattern>
+				<unitPattern count="few" case="genitive">{0} em</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
+				<unitPattern count="other" case="accusative">{0} em</unitPattern>
+				<unitPattern count="other" case="genitive">{0} em</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="one">{0} piksel</unitPattern>
 				<unitPattern count="one" case="accusative">{0} piksel</unitPattern>
 				<unitPattern count="one" case="genitive">{0} piksela</unitPattern>
@@ -9211,7 +9211,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>inanimate</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">{0} piksel na centimetar</unitPattern>
 				<unitPattern count="one" case="accusative">{0} piksel na centimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} piksela na centimetar</unitPattern>
@@ -9226,28 +9226,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" case="instrumental">{0} piksela na centimetar</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>tačka</displayName>
 				<unitPattern count="one">{0} tačka</unitPattern>
 				<unitPattern count="few">{0} tačke</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} tačaka</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>poluprečnik Zemlje</displayName>
@@ -9259,17 +9259,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<gender>inanimate</gender>
 				<displayName>kilometri</displayName>
 				<unitPattern count="one">{0} kilometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilometrom</unitPattern>
 				<unitPattern count="few">{0} kilometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilometra</unitPattern>
 				<unitPattern count="other">{0} kilometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilometara</unitPattern>
 				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
@@ -9280,36 +9280,36 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom</unitPattern>
 				<unitPattern count="few">{0} metra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metra</unitPattern>
 				<unitPattern count="other">{0} metara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metara</unitPattern>
 				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<gender>inanimate</gender>
 				<displayName>decimetri</displayName>
 				<unitPattern count="one">{0} decimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} decimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} decimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} decimetrom</unitPattern>
 				<unitPattern count="few">{0} decimetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} decimetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} decimetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} decimetra</unitPattern>
 				<unitPattern count="other">{0} decimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} decimetara</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>inanimate</gender>
 				<displayName>centimetri</displayName>
 				<unitPattern count="one">{0} centimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} centimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} centimetrom</unitPattern>
 				<unitPattern count="few">{0} centimetra</unitPattern>
@@ -9317,74 +9317,74 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="few" case="genitive">{0} centimetra</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} centimetra</unitPattern>
 				<unitPattern count="other">{0} centimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centimetara</unitPattern>
 				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<gender>inanimate</gender>
 				<displayName>milimetri</displayName>
 				<unitPattern count="one">{0} milimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milimetrom</unitPattern>
 				<unitPattern count="few">{0} milimetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milimetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milimetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milimetra</unitPattern>
 				<unitPattern count="other">{0} milimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milimetara</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>inanimate</gender>
 				<displayName>mikrometri</displayName>
 				<unitPattern count="one">{0} mikrometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mikrometrom</unitPattern>
 				<unitPattern count="few">{0} mikrometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mikrometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mikrometra</unitPattern>
 				<unitPattern count="other">{0} mikrometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mikrometara</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>inanimate</gender>
 				<displayName>nanometri</displayName>
 				<unitPattern count="one">{0} nanometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} nanometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} nanometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} nanometrom</unitPattern>
 				<unitPattern count="few">{0} nanometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} nanometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} nanometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} nanometra</unitPattern>
 				<unitPattern count="other">{0} nanometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} nanometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} nanometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} nanometara</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>inanimate</gender>
 				<displayName>pikometri</displayName>
 				<unitPattern count="one">{0} pikometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} pikometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} pikometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} pikometrom</unitPattern>
 				<unitPattern count="few">{0} pikometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} pikometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} pikometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} pikometra</unitPattern>
 				<unitPattern count="other">{0} pikometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} pikometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} pikometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} pikometara</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>milje</displayName>
@@ -9456,13 +9456,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} skandinavske milje</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} skandinavskom miljom</unitPattern>
 				<unitPattern count="few">{0} skandinavske milje</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} skandinavske milje</unitPattern>
+				<unitPattern count="few" case="genitive">{0} skandinavske milje</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} skandinavske milje</unitPattern>
 				<unitPattern count="other">{0} skandinavskih milja</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} skandinavskih milja</unitPattern>
+				<unitPattern count="other" case="genitive">{0} skandinavskih milja</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} skandinavskih milja</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pt</displayName>
@@ -9484,13 +9484,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} luksa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} luksom</unitPattern>
 				<unitPattern count="few">{0} luksa</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} luksa</unitPattern>
+				<unitPattern count="few" case="genitive">{0} luksa</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} luksa</unitPattern>
 				<unitPattern count="other">{0} luksa</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} luksa</unitPattern>
+				<unitPattern count="other" case="genitive">{0} luksa</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} luksa</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
@@ -9500,13 +9500,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} kandele</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kandelom</unitPattern>
 				<unitPattern count="few">{0} kandele</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kandele</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kandele</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kandele</unitPattern>
 				<unitPattern count="other">{0} kandela</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kandela</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kandela</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kandela</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>inanimate</gender>
@@ -9516,19 +9516,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} lumena</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} lumenom</unitPattern>
 				<unitPattern count="few">{0} lumena</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} lumena</unitPattern>
+				<unitPattern count="few" case="genitive">{0} lumena</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} lumena</unitPattern>
 				<unitPattern count="other">{0} lumena</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} lumena</unitPattern>
+				<unitPattern count="other" case="genitive">{0} lumena</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} lumena</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<gender>feminine</gender>
@@ -9538,13 +9538,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} metričke tone</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metričkom tonom</unitPattern>
 				<unitPattern count="few">{0} metričke tone</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metričke tone</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metričke tone</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metričke tone</unitPattern>
 				<unitPattern count="other">{0} metričkih tona</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metričkih tona</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metričkih tona</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metričkih tona</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>inanimate</gender>
@@ -9554,13 +9554,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} kilograma</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilogramom</unitPattern>
 				<unitPattern count="few">{0} kilograma</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilograma</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilograma</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilograma</unitPattern>
 				<unitPattern count="other">{0} kilograma</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilograma</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilograma</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilograma</unitPattern>
 				<perUnitPattern>{0} po kilogramu</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
@@ -9571,46 +9571,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} grama</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gramom</unitPattern>
 				<unitPattern count="few">{0} grama</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} grama</unitPattern>
+				<unitPattern count="few" case="genitive">{0} grama</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} grama</unitPattern>
 				<unitPattern count="other">{0} grama</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} grama</unitPattern>
+				<unitPattern count="other" case="genitive">{0} grama</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} grama</unitPattern>
 				<perUnitPattern>{0} po gramu</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<gender>inanimate</gender>
 				<displayName>miligrami</displayName>
 				<unitPattern count="one">{0} miligram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} miligram</unitPattern>
 				<unitPattern count="one" case="genitive">{0} miligrama</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} miligramom</unitPattern>
 				<unitPattern count="few">{0} miligrama</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} miligrama</unitPattern>
+				<unitPattern count="few" case="genitive">{0} miligrama</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} miligrama</unitPattern>
 				<unitPattern count="other">{0} miligrama</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} miligrama</unitPattern>
+				<unitPattern count="other" case="genitive">{0} miligrama</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} miligrama</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>inanimate</gender>
 				<displayName>mikrogrami</displayName>
 				<unitPattern count="one">{0} mikrogram</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mikrogram</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mikrograma</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mikrogramom</unitPattern>
 				<unitPattern count="few">{0} mikrograma</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mikrograma</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mikrograma</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mikrograma</unitPattern>
 				<unitPattern count="other">{0} mikrograma</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mikrograma</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mikrograma</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mikrograma</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>tone</displayName>
@@ -9652,13 +9652,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} karata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} karatom</unitPattern>
 				<unitPattern count="few">{0} karata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} karata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} karata</unitPattern>
 				<unitPattern count="other">{0} karata</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} karata</unitPattern>
+				<unitPattern count="other" case="genitive">{0} karata</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} karata</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>daltoni</displayName>
@@ -9688,49 +9688,49 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<gender>inanimate</gender>
 				<displayName>gigavati</displayName>
 				<unitPattern count="one">{0} gigavat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} gigavat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} gigavata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} gigavatom</unitPattern>
 				<unitPattern count="few">{0} gigavata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} gigavata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} gigavata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} gigavata</unitPattern>
 				<unitPattern count="other">{0} gigavati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} gigavati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigavati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} gigavati</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>inanimate</gender>
 				<displayName>megavati</displayName>
 				<unitPattern count="one">{0} megavat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megavat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megavata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megavatom</unitPattern>
 				<unitPattern count="few">{0} megavata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megavata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megavata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megavata</unitPattern>
 				<unitPattern count="other">{0} megavati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megavati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megavati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megavati</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>inanimate</gender>
 				<displayName>kilovati</displayName>
 				<unitPattern count="one">{0} kilovat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilovat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilovata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilovatom</unitPattern>
 				<unitPattern count="few">{0} kilovata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilovata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilovata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilovata</unitPattern>
 				<unitPattern count="other">{0} kilovati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilovati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilovati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilovati</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>inanimate</gender>
@@ -9740,29 +9740,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} vata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} vatom</unitPattern>
 				<unitPattern count="few">{0} vata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} vata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} vata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} vata</unitPattern>
 				<unitPattern count="other">{0} vati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} vati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} vati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} vati</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>inanimate</gender>
 				<displayName>milivati</displayName>
 				<unitPattern count="one">{0} milivat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milivat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milivata</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milivatom</unitPattern>
 				<unitPattern count="few">{0} milivata</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milivata</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milivata</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milivata</unitPattern>
 				<unitPattern count="other">{0} milivati</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milivati</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milivati</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milivati</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>konjske snage</displayName>
@@ -9796,29 +9796,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} bara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} barom</unitPattern>
 				<unitPattern count="few">{0} bara</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} bara</unitPattern>
+				<unitPattern count="few" case="genitive">{0} bara</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} bara</unitPattern>
 				<unitPattern count="other">{0} bara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} bara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} bara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} bara</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>inanimate</gender>
 				<displayName>milibari</displayName>
 				<unitPattern count="one">{0} milibar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} milibar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} milibara</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} milibarom</unitPattern>
 				<unitPattern count="few">{0} milibara</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} milibara</unitPattern>
+				<unitPattern count="few" case="genitive">{0} milibara</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} milibara</unitPattern>
 				<unitPattern count="other">{0} milibara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} milibara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} milibara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} milibara</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>feminine</gender>
@@ -9828,13 +9828,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} atmosfere</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} atmosferom</unitPattern>
 				<unitPattern count="few">{0} atmosfere</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} atmosfere</unitPattern>
+				<unitPattern count="few" case="genitive">{0} atmosfere</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} atmosfere</unitPattern>
 				<unitPattern count="other">{0} atmosfera</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} atmosfera</unitPattern>
+				<unitPattern count="other" case="genitive">{0} atmosfera</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} atmosfera</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>inanimate</gender>
@@ -9844,93 +9844,93 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} paskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} paskalom</unitPattern>
 				<unitPattern count="few">{0} paskala</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} paskala</unitPattern>
+				<unitPattern count="few" case="genitive">{0} paskala</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} paskala</unitPattern>
 				<unitPattern count="other">{0} paskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} paskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} paskala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} paskala</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>inanimate</gender>
 				<displayName>hektopaskali</displayName>
 				<unitPattern count="one">{0} hektopaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektopaskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektopaskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektopaskalom</unitPattern>
 				<unitPattern count="few">{0} hektopaskala</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektopaskala</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hektopaskala</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} hektopaskala</unitPattern>
 				<unitPattern count="other">{0} hektopaskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektopaskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektopaskala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>inanimate</gender>
 				<displayName>kilopaskali</displayName>
 				<unitPattern count="one">{0} kilopaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilopaskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilopaskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilopaskalom</unitPattern>
 				<unitPattern count="few">{0} kilopaskala</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilopaskala</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilopaskala</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilopaskala</unitPattern>
 				<unitPattern count="other">{0} kilopaskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilopaskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilopaskala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilopaskala</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>inanimate</gender>
 				<displayName>megapaskali</displayName>
 				<unitPattern count="one">{0} megapaskal</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megapaskal</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megapaskala</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megapaskalom</unitPattern>
 				<unitPattern count="few">{0} megapaskala</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megapaskala</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megapaskala</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megapaskala</unitPattern>
 				<unitPattern count="other">{0} megapaskala</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megapaskala</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megapaskala</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megapaskala</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>inanimate</gender>
 				<displayName>kilometri na sat</displayName>
 				<unitPattern count="one">{0} kilometar na sat</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kilometar na sat</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kilometra na sat</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kilometrom na sat</unitPattern>
 				<unitPattern count="few">{0} kilometra na sat</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kilometra na sat</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kilometra na sat</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kilometra na sat</unitPattern>
 				<unitPattern count="other">{0} kilometara na sat</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kilometara na sat</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilometara na sat</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kilometara na sat</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>inanimate</gender>
 				<displayName>metri u sekundi</displayName>
 				<unitPattern count="one">{0} metar u sekundi</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} metar u sekundi</unitPattern>
 				<unitPattern count="one" case="genitive">{0} metra u sekundi</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metrom u sekundi</unitPattern>
 				<unitPattern count="few">{0} metra u sekundi</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metra u sekundi</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metra u sekundi</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metra u sekundi</unitPattern>
 				<unitPattern count="other">{0} metara u sekundi</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metara u sekundi</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metara u sekundi</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metara u sekundi</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>milje na sat</displayName>
@@ -9948,17 +9948,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<gender>inanimate</gender>
 				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0}°</unitPattern>
+				<unitPattern count="one" case="genitive">{0}°</unitPattern>
+				<unitPattern count="one" case="instrumental">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0}°</unitPattern>
+				<unitPattern count="few" case="genitive">{0}°</unitPattern>
+				<unitPattern count="few" case="instrumental">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0}°</unitPattern>
+				<unitPattern count="other" case="genitive">{0}°</unitPattern>
+				<unitPattern count="other" case="instrumental">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<gender>inanimate</gender>
@@ -9968,13 +9968,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} stepena Celzijusa</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} stepenom Celzijusa</unitPattern>
 				<unitPattern count="few">{0} stepena Celzijusa</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} stepena Celzijusa</unitPattern>
+				<unitPattern count="few" case="genitive">{0} stepena Celzijusa</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} stepena Celzijusa</unitPattern>
 				<unitPattern count="other">{0} stepeni Celzijusa</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} stepeni Celzijusa</unitPattern>
+				<unitPattern count="other" case="genitive">{0} stepeni Celzijusa</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} stepeni Celzijusa</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>stepeni Farenhajta</displayName>
@@ -9990,13 +9990,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} kelvina</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kelvinom</unitPattern>
 				<unitPattern count="few">{0} kelvina</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kelvina</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kelvina</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kelvina</unitPattern>
 				<unitPattern count="other">{0} kelvina</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kelvina</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kelvina</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kelvina</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>funta-stope</displayName>
@@ -10008,66 +10008,66 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<gender>inanimate</gender>
 				<displayName>njutn-metri</displayName>
 				<unitPattern count="one">{0} njutn-metar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} njutn-metar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} njutn-metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} njutn-metrom</unitPattern>
 				<unitPattern count="few">{0} njutn-metra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} njutn-metra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} njutn-metra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} njutn-metra</unitPattern>
 				<unitPattern count="other">{0} njutn-metara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} njutn-metara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} njutn-metara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} njutn-metara</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>inanimate</gender>
 				<displayName>kubni kilometri</displayName>
 				<unitPattern count="one">{0} kubni kilometar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubni kilometar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubnog kilometra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubnim kilometrom</unitPattern>
 				<unitPattern count="few">{0} kubna kilometra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kubna kilometra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kubna kilometra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kubna kilometra</unitPattern>
 				<unitPattern count="other">{0} kubnih kilometara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubnih kilometara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubnih kilometara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kubnih kilometara</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>inanimate</gender>
 				<displayName>kubni metri</displayName>
 				<unitPattern count="one">{0} kubni metar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubni metar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubnog metra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubnim metrom</unitPattern>
 				<unitPattern count="few">{0} kubna metra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kubna metra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kubna metra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kubna metra</unitPattern>
 				<unitPattern count="other">{0} kubnih metara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubnih metara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubnih metara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kubnih metara</unitPattern>
 				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<gender>inanimate</gender>
 				<displayName>kubni centimetri</displayName>
 				<unitPattern count="one">{0} kubni centimetar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} kubni centimetar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} kubnog centimetra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} kubnim centimetrom</unitPattern>
 				<unitPattern count="few">{0} kubna centimetra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} kubna centimetra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} kubna centimetra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} kubna centimetra</unitPattern>
 				<unitPattern count="other">{0} kubnih centimetara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} kubnih centimetara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kubnih centimetara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} kubnih centimetara</unitPattern>
 				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -10098,33 +10098,33 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<gender>inanimate</gender>
 				<displayName>megalitri</displayName>
 				<unitPattern count="one">{0} megalitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} megalitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} megalitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} megalitrom</unitPattern>
 				<unitPattern count="few">{0} megalitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} megalitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} megalitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} megalitra</unitPattern>
 				<unitPattern count="other">{0} megalitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} megalitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megalitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} megalitara</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>inanimate</gender>
 				<displayName>hektolitri</displayName>
 				<unitPattern count="one">{0} hektolitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} hektolitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} hektolitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} hektolitrom</unitPattern>
 				<unitPattern count="few">{0} hektolitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} hektolitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} hektolitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} hektolitra</unitPattern>
 				<unitPattern count="other">{0} hektolitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} hektolitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hektolitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} hektolitara</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>inanimate</gender>
@@ -10134,62 +10134,62 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} litra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} litrom</unitPattern>
 				<unitPattern count="few">{0} litra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} litra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} litra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} litra</unitPattern>
 				<unitPattern count="other">{0} litara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} litara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} litara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} litara</unitPattern>
 				<perUnitPattern>{0} po litri</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<gender>inanimate</gender>
 				<displayName>decilitri</displayName>
 				<unitPattern count="one">{0} decilitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} decilitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} decilitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} decilitrom</unitPattern>
 				<unitPattern count="few">{0} decilitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} decilitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} decilitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} decilitra</unitPattern>
 				<unitPattern count="other">{0} decilitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} decilitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} decilitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} decilitara</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>inanimate</gender>
 				<displayName>centilitri</displayName>
 				<unitPattern count="one">{0} centilitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} centilitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} centilitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} centilitrom</unitPattern>
 				<unitPattern count="few">{0} centilitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} centilitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} centilitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} centilitra</unitPattern>
 				<unitPattern count="other">{0} centilitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} centilitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} centilitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} centilitara</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>inanimate</gender>
 				<displayName>mililitri</displayName>
 				<unitPattern count="one">{0} mililitar</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} mililitar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mililitra</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} mililitrom</unitPattern>
 				<unitPattern count="few">{0} mililitra</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} mililitra</unitPattern>
+				<unitPattern count="few" case="genitive">{0} mililitra</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} mililitra</unitPattern>
 				<unitPattern count="other">{0} mililitara</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} mililitara</unitPattern>
+				<unitPattern count="other" case="genitive">{0} mililitara</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} mililitara</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>feminine</gender>
@@ -10199,13 +10199,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} metričke pinte</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metričkom pintom</unitPattern>
 				<unitPattern count="few">{0} metričke pinte</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metričke pinte</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metričke pinte</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metričke pinte</unitPattern>
 				<unitPattern count="other">{0} metričkih pinti</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metričkih pinti</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metričkih pinti</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metričkih pinti</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>feminine</gender>
@@ -10215,13 +10215,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one" case="genitive">{0} metričke šolje</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} metričkom šoljom</unitPattern>
 				<unitPattern count="few">{0} metričke šolje</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} metričke šolje</unitPattern>
+				<unitPattern count="few" case="genitive">{0} metričke šolje</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} metričke šolje</unitPattern>
 				<unitPattern count="other">{0} metričkih šolja</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} metričkih šolja</unitPattern>
+				<unitPattern count="other" case="genitive">{0} metričkih šolja</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} metričkih šolja</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>aker stope</displayName>
@@ -10443,8 +10443,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10601,14 +10601,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -10855,8 +10855,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -10867,20 +10867,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>njutn</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -10909,44 +10909,44 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
@@ -11058,7 +11058,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-furlong">
 				<displayName>furlonzi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="few">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
@@ -11088,8 +11088,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -11100,20 +11100,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -11156,8 +11156,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -11188,26 +11188,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>grejn</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="few">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -11296,14 +11296,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -11356,14 +11356,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -11467,8 +11467,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -11511,8 +11511,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="few">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -11529,20 +11529,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="few">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
@@ -11553,26 +11553,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-dram">
 				<displayName>dram tečnosti</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="few">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>džiger</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="few">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>prstohvat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pinch</unitPattern>
+				<unitPattern count="few">{0} pinch</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="few">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -11585,231 +11585,231 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>ge sila</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="few">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="few">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="few">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="few">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>stepeni</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>lučni min</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="few">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>lučne sek</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="few">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kvadratni kilometri</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="few">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektari</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="few">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>kvadratni metri</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="few">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="few">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="few">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>akeri</displayName>
 				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="few">{0} ac</unitPattern>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="few">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kvadratne stope</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="few">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="few">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunami</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="few">{0} dunama</unitPattern>
+				<unitPattern count="other">{0} dunama</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="few">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="few">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="few">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>stavka</displayName>
@@ -11818,10 +11818,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} stavki</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="few">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -11830,28 +11830,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>promil</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="few">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="few">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="few">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -11860,10 +11860,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="few">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg Imp</displayName>
@@ -11872,89 +11872,89 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} mpg Imp</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="few">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="few">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="few">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="few">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="few">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="few">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="few">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="few">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="few">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bajt</displayName>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="few">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} b</unitPattern>
+				<unitPattern count="few">{0} b</unitPattern>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>v.</displayName>
+				<unitPattern count="one">{0} v</unitPattern>
+				<unitPattern count="few">{0} v</unitPattern>
+				<unitPattern count="other">{0} v</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec.</displayName>
+				<unitPattern count="one">{0} dec.</unitPattern>
+				<unitPattern count="few">{0} dec.</unitPattern>
+				<unitPattern count="other">{0} dec.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>g.</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/god</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>kv</displayName>
@@ -11968,42 +11968,42 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>n.</displayName>
 				<unitPattern count="one">{0} n</unitPattern>
 				<unitPattern count="few">{0} n</unitPattern>
 				<unitPattern count="other">{0} n</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/n</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>d</displayName>
 				<unitPattern count="one">{0} d</unitPattern>
 				<unitPattern count="few">{0} d</unitPattern>
 				<unitPattern count="other">{0} d</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>č</displayName>
 				<unitPattern count="one">{0} č</unitPattern>
 				<unitPattern count="few">{0} č</unitPattern>
 				<unitPattern count="other">{0} č</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/č</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>s</displayName>
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="few">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -12012,217 +12012,217 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="few">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="few">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="few">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="few">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="few">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>V</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="few">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="few">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="few">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="few">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="few">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="few">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="few">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>elektronvolt</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="few">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="few">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="few">{0} US therms</unitPattern>
+				<unitPattern count="other">{0} US therms</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="few">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>njutn</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="few">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="few">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="few">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="few">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="few">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="few">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="few">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="few">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="few">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tačka</displayName>
+				<unitPattern count="one">{0} tačka</unitPattern>
+				<unitPattern count="few">{0} tačke</unitPattern>
+				<unitPattern count="other">{0} tačaka</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="few">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="few">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="few">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="few">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -12231,25 +12231,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="few">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="few">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pikometri</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="few">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>milje</displayName>
 				<unitPattern count="one">{0} milja</unitPattern>
 				<unitPattern count="few">{0} milje</unitPattern>
 				<unitPattern count="other">{0} milja</unitPattern>
@@ -12265,282 +12265,282 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="few">{0} ft</unitPattern>
 				<unitPattern count="other">{0} ft</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>in</displayName>
 				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="few">{0} in</unitPattern>
 				<unitPattern count="other">{0} in</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>parseci</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="few">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>svetlosne god.</displayName>
 				<unitPattern count="one">{0} ly</unitPattern>
 				<unitPattern count="few">{0} ly</unitPattern>
 				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>aj</displayName>
+				<unitPattern count="one">{0} aj</unitPattern>
+				<unitPattern count="few">{0} aj</unitPattern>
+				<unitPattern count="other">{0} aj</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>furlonzi</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="few">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hv</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="few">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="few">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="few">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="few">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="few">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="few">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="few">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="few">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="few">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="few">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="few">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="few">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>lb</displayName>
 				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="few">{0} lb</unitPattern>
 				<unitPattern count="other">{0} lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="one">{0} unca</unitPattern>
 				<unitPattern count="few">{0} unce</unitPattern>
 				<unitPattern count="other">{0} unci</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="few">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karati</displayName>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="few">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="few">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grejn</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="few">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="few">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="few">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="few">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="few">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="few">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0} ks</unitPattern>
 				<unitPattern count="few">{0} ks</unitPattern>
 				<unitPattern count="other">{0} ks</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="one">{0} mm Hg</unitPattern>
+				<unitPattern count="few">{0} mm Hg</unitPattern>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="few">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="few">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="few">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="few">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="few">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="few">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="few">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="few">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="few">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -12549,28 +12549,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>metri u sekundi</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="few">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>milje na sat</displayName>
 				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="few">{0} mi/h</unitPattern>
 				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="few">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="few">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -12579,140 +12579,140 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>stepeni Farenhajta</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="few">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="few">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="few">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="few">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="few">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="few">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="few">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="few">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="few">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="few">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="few">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="few">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="few">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="few">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="few">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="few">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="few">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="few">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="few">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="few">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="few">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="few">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>Imp gal</displayName>
@@ -12722,28 +12722,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/gal Imp</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="few">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="few">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>šolje</displayName>
+				<unitPattern count="one">{0} š.</unitPattern>
+				<unitPattern count="few">{0} š.</unitPattern>
+				<unitPattern count="other">{0} š.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="few">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>Imp fl oz</displayName>
@@ -12752,61 +12752,61 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} fl oz Imp</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kaš.</displayName>
+				<unitPattern count="one">{0} kaš.</unitPattern>
+				<unitPattern count="few">{0} kaš.</unitPattern>
+				<unitPattern count="other">{0} kaš.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kašič.</displayName>
+				<unitPattern count="one">{0} kašič.</unitPattern>
+				<unitPattern count="few">{0} kašič.</unitPattern>
+				<unitPattern count="other">{0} kašič.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="few">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="few">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="few">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kap</displayName>
+				<unitPattern count="one">{0} kap</unitPattern>
+				<unitPattern count="few">{0} kapi</unitPattern>
+				<unitPattern count="other">{0} kapi</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram tečnosti</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="few">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>džiger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="few">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>prstohvat</displayName>
 				<unitPattern count="one">{0} pn</unitPattern>
 				<unitPattern count="few">{0} pn</unitPattern>
 				<unitPattern count="other">{0} pn</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt Imp</displayName>
 				<unitPattern count="one">{0} qt Imp</unitPattern>
 				<unitPattern count="few">{0} qt Imp</unitPattern>
 				<unitPattern count="other">{0} qt Imp</unitPattern>
@@ -12843,22 +12843,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} ili {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ili {1}</listPatternPart>
+			<listPatternPart type="2">{0} ili {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ili {1}</listPatternPart>
+			<listPatternPart type="2">{0} ili {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} i {1}</listPatternPart>
+			<listPatternPart type="2">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/su.xml
+++ b/common/main/su.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -203,7 +203,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="2">Péb</month>
 							<month type="3">Mar</month>
 							<month type="4">Apr</month>
-							<month type="5">↑↑↑</month>
+							<month type="5">Méi</month>
 							<month type="6">Jun</month>
 							<month type="7">Jul</month>
 							<month type="8">Ags</month>
@@ -243,18 +243,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Jan</month>
+							<month type="2">Péb</month>
+							<month type="3">Mar</month>
+							<month type="4">Apr</month>
+							<month type="5">Méi</month>
+							<month type="6">Jun</month>
+							<month type="7">Jul</month>
+							<month type="8">Ags</month>
+							<month type="9">Sép</month>
+							<month type="10">Okt</month>
+							<month type="11">Nop</month>
+							<month type="12">Dés</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">J</month>
@@ -272,17 +272,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Januari</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="2">Pébruari</month>
+							<month type="3">Maret</month>
+							<month type="4">April</month>
+							<month type="5">Méi</month>
+							<month type="6">Juni</month>
+							<month type="7">Juli</month>
+							<month type="8">Agustus</month>
+							<month type="9">Séptémber</month>
+							<month type="10">Oktober</month>
+							<month type="11">Nopémber</month>
+							<month type="12">Désémber</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -355,10 +355,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">K4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">1</quarter>
+							<quarter type="2">2</quarter>
+							<quarter type="3">3</quarter>
+							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1">kuartal ka-1</quarter>
@@ -391,8 +391,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dayPeriods>
 					<dayPeriodContext type="format">
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -541,10 +541,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>éra</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>éra</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>éra</displayName>
 			</field>
 			<field type="year">
 				<displayName>taun</displayName>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -126,7 +126,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chy">cheyenne</language>
 			<language type="ckb">soranisk kurdiska</language>
 			<language type="ckb" alt="menu">kurdiska (sorani)</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="variant">soranisk kurdiska</language>
 			<language type="clc">chilcotin</language>
 			<language type="co">korsikanska</language>
 			<language type="cop">koptiska</language>
@@ -1146,7 +1146,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="SX">Sint Maarten</territory>
 			<territory type="SY">Syrien</territory>
 			<territory type="SZ">Eswatini</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
+			<territory type="SZ" alt="variant">Eswatini</territory>
 			<territory type="TA">Tristan da Cunha</territory>
 			<territory type="TC">Turks- och Caicosöarna</territory>
 			<territory type="TD">Tchad</territory>
@@ -1161,7 +1161,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisien</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkiet</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkiet</territory>
 			<territory type="TT">Trinidad och Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1565,20 +1565,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">EEEE d MMMM y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">d MMMM y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
-							<datetimeSkeleton draft="contributed">↑↑↑</datetimeSkeleton>
+							<pattern draft="contributed">d MMM y G</pattern>
+							<datetimeSkeleton draft="contributed">GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
@@ -1591,72 +1591,72 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="contributed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="contributed">E d</dateFormatItem>
+						<dateFormatItem id="Gy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd" draft="contributed">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd" draft="contributed">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M" draft="contributed">L</dateFormatItem>
+						<dateFormatItem id="Md" draft="contributed">d/M</dateFormatItem>
+						<dateFormatItem id="MEd" draft="contributed">E d/M</dateFormatItem>
+						<dateFormatItem id="MMd" draft="contributed">d/M</dateFormatItem>
 						<dateFormatItem id="MMdd" draft="contributed">d/M</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="contributed">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="contributed">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd" draft="contributed">d MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd" draft="contributed">E d MMMM</dateFormatItem>
+						<dateFormatItem id="y" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyy" draft="contributed">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM" draft="contributed">y-MM G</dateFormatItem>
+						<dateFormatItem id="yyyyMd" draft="contributed">y-MM-dd G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd" draft="contributed">E y-MM-dd G</dateFormatItem>
 						<dateFormatItem id="yyyyMM" draft="contributed">y-MM G</dateFormatItem>
-						<dateFormatItem id="yyyyMMM" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyMMM" draft="contributed">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd" draft="contributed">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd" draft="contributed">E d MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM" draft="contributed">MMMM y G</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ" draft="contributed">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ" draft="contributed">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G–y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
 							<greatestDifference id="G" draft="contributed">y-MM GGGGG – y-MM GGGGG</greatestDifference>
@@ -1676,78 +1676,78 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y" draft="contributed">E y-MM-dd – E y-MM-dd GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y G – d MMM d y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a v</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h:mm–h:mm a v</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d/M–d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d/M – E d/M</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d/M – E d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E d – E d MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E d MMM – E d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y–y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
 							<greatestDifference id="M" draft="contributed">y-MM – MM GGGGG</greatestDifference>
@@ -1764,13 +1764,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y" draft="contributed">E y-MM-dd – E y-MM-dd GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM–MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d–d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM–d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y–d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
 							<greatestDifference id="d" draft="contributed">E d MMM–E d MMM y G</greatestDifference>
@@ -1778,8 +1778,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y" draft="contributed">E d MMM y–E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMMM–MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1802,18 +1802,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12" draft="contributed">12:e mån</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">1</month>
+							<month type="2" draft="contributed">2</month>
+							<month type="3" draft="contributed">3</month>
+							<month type="4" draft="contributed">4</month>
+							<month type="5" draft="contributed">5</month>
+							<month type="6" draft="contributed">6</month>
+							<month type="7" draft="contributed">7</month>
+							<month type="8" draft="contributed">8</month>
+							<month type="9" draft="contributed">9</month>
+							<month type="10" draft="contributed">10</month>
+							<month type="11" draft="contributed">11</month>
+							<month type="12" draft="contributed">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1" draft="contributed">första månaden</month>
@@ -1860,18 +1860,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12" draft="contributed">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">första månaden</month>
+							<month type="2" draft="contributed">andra månaden</month>
+							<month type="3" draft="contributed">tredje månaden</month>
+							<month type="4" draft="contributed">fjärde månaden</month>
+							<month type="5" draft="contributed">femte månaden</month>
+							<month type="6" draft="contributed">sjätte månaden</month>
+							<month type="7" draft="contributed">sjunde månaden</month>
+							<month type="8" draft="contributed">åttonde månaden</month>
+							<month type="9" draft="contributed">nionde månaden</month>
+							<month type="10" draft="contributed">tionde månaden</month>
+							<month type="11" draft="contributed">elfte månaden</month>
+							<month type="12" draft="contributed">tolfte månaden</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -2142,7 +2142,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2334,7 +2334,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2342,7 +2342,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2640,12 +2640,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">lör</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
+							<day type="sun">S</day>
+							<day type="mon">M</day>
+							<day type="tue">T</day>
 							<day type="wed">O</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
+							<day type="thu">T</day>
+							<day type="fri">F</day>
 							<day type="sat">L</day>
 						</dayWidth>
 						<dayWidth type="short">
@@ -2784,8 +2784,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
 							<dayPeriod type="midnight">midnatt</dayPeriod>
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">fm</dayPeriod>
+							<dayPeriod type="pm">em</dayPeriod>
 							<dayPeriod type="morning1">morgon</dayPeriod>
 							<dayPeriod type="morning2">förm.</dayPeriod>
 							<dayPeriod type="afternoon1">efterm.</dayPeriod>
@@ -2916,7 +2916,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2924,7 +2924,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3214,11 +3214,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
 							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
@@ -3349,12 +3349,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3623,13 +3623,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dateTimeFormatLength>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3711,13 +3711,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4070,9 +4070,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mån. förra veckan</relative>
+				<relative type="0">mån. denna vecka</relative>
+				<relative type="1">mån. nästa vecka</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">+{0} må.</relativeTimePattern>
 					<relativeTimePattern count="other">+{0} må.</relativeTimePattern>
@@ -6763,16 +6763,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator alt="variant" draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<plusSign draft="contributed">↑↑↑</plusSign>
+			<decimal draft="contributed">,</decimal>
+			<plusSign draft="contributed">+</plusSign>
 		</symbols>
 		<symbols numberSystem="olck">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
-			<timeSeparator alt="variant" draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
+			<timeSeparator alt="variant" draft="contributed">.</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<perMille draft="contributed">↑↑↑</perMille>
+			<percentSign draft="contributed">%</percentSign>
+			<perMille draft="contributed">‰</perMille>
 		</symbols>
 		<decimalFormats numberSystem="latn">
 			<decimalFormatLength>
@@ -7307,7 +7307,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="CNH">
 				<displayName>kinesisk yuan (offshore)</displayName>
 				<displayName count="one">kinesisk yuan (offshore)</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">kinesisk yuan (offshore)</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CNX">
@@ -8245,7 +8245,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">rysk rubel (1991–1998)</displayName>
 				<displayName count="other">ryska rubel (1991–1998)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">RUR</symbol>
 			</currency>
 			<currency type="RWF">
 				<displayName>rwandisk franc</displayName>
@@ -8544,7 +8544,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currency type="UYW">
 				<displayName>uruguayansk indexenhet för nominell lön</displayName>
 				<displayName count="one">uruguayansk indexenhet för nominell lön</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">uruguayansk indexenhet för nominell lön</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="UZS">
@@ -8926,24 +8926,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>kvadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kvadrat{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="common">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="common" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="common">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="common" case="genitive">kvadrat{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kvadrat{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="common">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="common" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="common">kvadrat{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="common" case="genitive">kvadrat{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">kubik{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="common">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="common" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="genitive">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="common">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="common" case="genitive">kubik{0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">kubik{0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="common">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="common" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="common">kubik{0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="common" case="genitive">kubik{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}-{1}</compoundUnitPattern>
@@ -9070,9 +9070,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} per kvadrattum</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<gender>common</gender>
@@ -9137,10 +9137,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="one" case="genitive">{0} mols</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 				<unitPattern count="other" case="genitive">{0} mols</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -9461,7 +9461,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} British thermal units</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>am. therm</displayName>
 				<unitPattern count="one">{0} am. therm</unitPattern>
 				<unitPattern count="other">{0} am. therms</unitPattern>
 			</unit>
@@ -9480,43 +9480,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100 km</displayName>
 				<unitPattern count="one">{0} kWh/100 km</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} kWh/100 km</unitPattern>
 				<unitPattern count="other">{0} kWh/100 km</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kWh/100 km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>common</gender>
 				<displayName>gigahertz</displayName>
 				<unitPattern count="one">{0} gigahertz</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} gigahertz</unitPattern>
 				<unitPattern count="other">{0} gigahertz</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} gigahertz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>common</gender>
 				<displayName>megahertz</displayName>
 				<unitPattern count="one">{0} megahertz</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} megahertz</unitPattern>
 				<unitPattern count="other">{0} megahertz</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} megahertz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>common</gender>
 				<displayName>kilohertz</displayName>
 				<unitPattern count="one">{0} kilohertz</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} kilohertz</unitPattern>
 				<unitPattern count="other">{0} kilohertz</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} kilohertz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>common</gender>
 				<displayName>hertz</displayName>
 				<unitPattern count="one">{0} hertz</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} hertz</unitPattern>
 				<unitPattern count="other">{0} hertz</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} hertz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>common</gender>
@@ -9567,7 +9567,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>punkt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} punkter</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
@@ -9708,7 +9708,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="genitive">{0} mils</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>punkter</displayName>
 				<unitPattern count="one">{0} pkt</unitPattern>
 				<unitPattern count="other">{0} pkt</unitPattern>
 			</unit>
@@ -9722,9 +9722,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>common</gender>
 				<displayName>lux</displayName>
 				<unitPattern count="one">{0} lux</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} lux</unitPattern>
 				<unitPattern count="other">{0} lux</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} lux</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>common</gender>
@@ -9847,7 +9847,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-grain">
 				<gender>neuter</gender>
-				<displayName>↑↑↑</displayName>
+				<displayName>grain</displayName>
 				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">{0} grains</unitPattern>
 			</unit>
@@ -9913,10 +9913,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<gender>common</gender>
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="one" case="genitive">{0} bars</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 				<unitPattern count="other" case="genitive">{0} bars</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -10006,9 +10006,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>common</gender>
 				<displayName>grader Celsius</displayName>
 				<unitPattern count="one">{0} grad Celsius</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} grad Celsius</unitPattern>
 				<unitPattern count="other">{0} grader Celsius</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} grader Celsius</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<gender>common</gender>
@@ -10201,7 +10201,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-fluid-ounce-imperial">
 				<gender>neuter</gender>
 				<displayName>Br. flytande uns</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} br. fl oz</unitPattern>
 				<unitPattern count="other">{0} br. flytande uns</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -10218,8 +10218,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>fat</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fat</unitPattern>
+				<unitPattern count="other">{0} fat</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<gender>common</gender>
@@ -10254,8 +10254,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-pinch">
 				<gender>common</gender>
 				<displayName>nypa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nypa</unitPattern>
+				<unitPattern count="other">{0} nypa</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<gender>common</gender>
@@ -10361,12 +10361,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -10459,7 +10459,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -10504,7 +10504,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -10707,12 +10707,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -10722,12 +10722,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>pound-force</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -10747,7 +10747,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>kHz</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
@@ -10762,7 +10762,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
@@ -10792,12 +10792,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>pixlar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10907,7 +10907,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -10917,7 +10917,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
@@ -10927,7 +10927,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -10991,22 +10991,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -11056,7 +11056,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -11071,7 +11071,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -11081,12 +11081,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -11131,7 +11131,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -11209,7 +11209,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
@@ -11281,7 +11281,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>des.sked</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dsk</unitPattern>
 				<unitPattern count="other">{0} dsk</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
@@ -11336,16 +11336,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
 				<unitPrefixPattern>z{0}</unitPrefixPattern>
@@ -11354,13 +11354,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
 				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
 				<unitPrefixPattern>M{0}</unitPrefixPattern>
@@ -11378,50 +11378,50 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName draft="contributed">G</displayName>
@@ -11485,7 +11485,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mi²</displayName>
 				<unitPattern count="one">{0}mi²</unitPattern>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>eng. tunnland</displayName>
@@ -11509,7 +11509,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/tum²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>dunam</displayName>
 				<unitPattern count="one">{0}dunam</unitPattern>
 				<unitPattern count="other">{0}dunam</unitPattern>
 			</unit>
@@ -11519,12 +11519,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg/dl</displayName>
 				<unitPattern count="one">{0}mg/dl</unitPattern>
 				<unitPattern count="other">{0}mg/dl</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mmol/l</displayName>
 				<unitPattern count="one">{0}mmol/l</unitPattern>
 				<unitPattern count="other">{0}mmol/l</unitPattern>
 			</unit>
@@ -11549,12 +11549,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="one">{0}mol</unitPattern>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
@@ -11569,7 +11569,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpg</displayName>
 				<unitPattern count="one">{0}mpg</unitPattern>
 				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
@@ -11579,12 +11579,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mpg UK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">PB</displayName>
 				<unitPattern count="one">{0}PB</unitPattern>
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">TB</displayName>
 				<unitPattern count="one">{0}TB</unitPattern>
 				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
@@ -11594,7 +11594,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">GB</displayName>
 				<unitPattern count="one">{0}GB</unitPattern>
 				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
@@ -11604,7 +11604,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">MB</displayName>
 				<unitPattern count="one">{0}MB</unitPattern>
 				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
@@ -11614,7 +11614,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">kB</displayName>
 				<unitPattern count="one">{0}kB</unitPattern>
 				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
@@ -11639,7 +11639,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}årh</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>årt</displayName>
 				<unitPattern count="one">{0}årt</unitPattern>
 				<unitPattern count="other">{0}årt</unitPattern>
 			</unit>
@@ -11757,27 +11757,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>eV</displayName>
 				<unitPattern count="one">{0}eV</unitPattern>
 				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>BTU</displayName>
 				<unitPattern count="one">{0}Btu</unitPattern>
 				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>am. therm</displayName>
 				<unitPattern count="one">{0} am. therm</unitPattern>
 				<unitPattern count="other">{0} am. therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>pound-force</displayName>
 				<unitPattern count="one">{0}lbf</unitPattern>
 				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>newton</displayName>
 				<unitPattern count="one">{0}N</unitPattern>
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
@@ -11808,36 +11808,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>fyrkant</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} fyrkant</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} fyrkant</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">px</displayName>
+				<unitPattern count="one" draft="contributed">{0} px</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mpx</displayName>
 				<unitPattern count="one">{0}mpx</unitPattern>
 				<unitPattern count="other">{0}mpx</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">px/cm</displayName>
 				<unitPattern count="one">{0}px/cm</unitPattern>
 				<unitPattern count="other">{0}px/cm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">px/tum</displayName>
+				<unitPattern count="one" draft="contributed">{0} px/tum</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} px/tum</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">d/cm</displayName>
 				<unitPattern count="one">{0}d/cm</unitPattern>
 				<unitPattern count="other">{0}d/cm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">d/tum</displayName>
 				<unitPattern count="one">{0}d/tum</unitPattern>
 				<unitPattern count="other">{0}d/tum</unitPattern>
 			</unit>
@@ -11847,7 +11847,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pkt</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one">{0}R⊕</unitPattern>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
@@ -11891,8 +11891,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-picometer">
 				<displayName>pm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>mi</displayName>
@@ -11901,7 +11901,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-yard">
 				<displayName>yd</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">{0}yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
@@ -11957,7 +11957,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pkt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R☉</displayName>
 				<unitPattern count="one">{0}R☉</unitPattern>
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
@@ -11967,17 +11967,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}lux</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="one">{0}cd</unitPattern>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>L☉</displayName>
 				<unitPattern count="one">{0}L☉</unitPattern>
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
@@ -12019,24 +12019,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} eng. s:n</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>pund</displayName>
 				<unitPattern count="one">{0}lb</unitPattern>
 				<unitPattern count="other">{0}lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/pund</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>uns</displayName>
 				<unitPattern count="one">{0}uns</unitPattern>
 				<unitPattern count="other">{0}uns</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/uns</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>ozt</displayName>
 				<unitPattern count="one">{0}ozt</unitPattern>
 				<unitPattern count="other">{0}ozt</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>karat</displayName>
 				<unitPattern count="one">{0}ct</unitPattern>
 				<unitPattern count="other">{0}ct</unitPattern>
 			</unit>
@@ -12046,22 +12046,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M⊕</displayName>
 				<unitPattern count="one">{0}M⊕</unitPattern>
 				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M☉</displayName>
 				<unitPattern count="one">{0}M☉</unitPattern>
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>grain</displayName>
 				<unitPattern count="one">{0}gr</unitPattern>
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="one">{0}GW</unitPattern>
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
@@ -12096,7 +12096,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 				<unitPattern count="one">{0}psi</unitPattern>
 				<unitPattern count="other">{0}psi</unitPattern>
 			</unit>
@@ -12106,7 +12106,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="one">{0}bar</unitPattern>
 				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
@@ -12121,7 +12121,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="one">{0}Pa</unitPattern>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
@@ -12131,12 +12131,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="one">{0}kPa</unitPattern>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="one">{0}MPa</unitPattern>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
@@ -12181,12 +12181,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="one">{0}lbf⋅ft</unitPattern>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Nm</displayName>
 				<unitPattern count="one">{0}Nm</unitPattern>
 				<unitPattern count="other">{0}Nm</unitPattern>
 			</unit>
@@ -12228,12 +12228,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}tum³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ml</displayName>
 				<unitPattern count="one">{0}Ml</unitPattern>
 				<unitPattern count="other">{0}Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>hl</displayName>
 				<unitPattern count="one">{0}hl</unitPattern>
 				<unitPattern count="other">{0}hl</unitPattern>
 			</unit>
@@ -12241,20 +12241,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>liter</displayName>
 				<unitPattern count="one">{0}l</unitPattern>
 				<unitPattern count="other">{0}l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0}dl</unitPattern>
 				<unitPattern count="other">{0}dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cl</displayName>
 				<unitPattern count="one">{0}cl</unitPattern>
 				<unitPattern count="other">{0}cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ml</displayName>
 				<unitPattern count="one">{0}ml</unitPattern>
 				<unitPattern count="other">{0}ml</unitPattern>
 			</unit>
@@ -12279,10 +12279,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}skäppor</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">{0}gal</unitPattern>
 				<unitPattern count="other">{0}gal</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>Br. gal</displayName>
@@ -12291,7 +12291,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/br. gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>quart</displayName>
 				<unitPattern count="one">{0}qt</unitPattern>
 				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
@@ -12301,12 +12301,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>koppar</displayName>
 				<unitPattern count="one">{0}kopp</unitPattern>
 				<unitPattern count="other">{0}koppar</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz</displayName>
 				<unitPattern count="one">{0}fl oz</unitPattern>
 				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
@@ -12326,7 +12326,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}tsk</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
+				<displayName>fat</displayName>
 				<unitPattern count="one">{0}fat</unitPattern>
 				<unitPattern count="other">{0}fat</unitPattern>
 			</unit>
@@ -12336,7 +12336,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dsk</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>br. dsk</displayName>
 				<unitPattern count="one">{0}br.dsk</unitPattern>
 				<unitPattern count="other">{0}br.dsk</unitPattern>
 			</unit>
@@ -12356,12 +12356,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mätglas</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>nypa</displayName>
 				<unitPattern count="one">{0}nypa</unitPattern>
 				<unitPattern count="other">{0}nypor</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>br. qt</displayName>
 				<unitPattern count="one">{0}br.qt</unitPattern>
 				<unitPattern count="other">{0}br.qt</unitPattern>
 			</unit>
@@ -12400,20 +12400,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} eller {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} eller {1}</listPatternPart>
+			<listPatternPart type="2">{0} eller {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} eller {1}</listPatternPart>
+			<listPatternPart type="2">{0} eller {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -12656,7 +12656,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
@@ -12695,7 +12695,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname}, {given} {given2-initial}, {credentials}</namePattern>
@@ -12710,7 +12710,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
 			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -94,8 +94,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">Kicherokee</language>
 			<language type="chy">Kicheyeni</language>
 			<language type="ckb">Kikurdi cha Sorani</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">Kikurdi cha Sorani</language>
+			<language type="ckb" alt="variant">Kikurdi cha Sorani</language>
 			<language type="clc">Kichikotini</language>
 			<language type="co">Kikosikani</language>
 			<language type="cop">Kikhufti</language>
@@ -851,7 +851,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Uturuki</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Uturuki</territory>
 			<territory type="TT">Trinidad na Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Taiwan</territory>
@@ -1937,9 +1937,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-short">
 				<displayName>mwaka</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mwaka uliopita</relative>
+				<relative type="0">mwaka huu</relative>
+				<relative type="1">mwaka ujao</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">baada ya mwaka {0}</relativeTimePattern>
 					<relativeTimePattern count="other">baada ya miaka {0}</relativeTimePattern>
@@ -1951,9 +1951,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="year-narrow">
 				<displayName>mwaka</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mwaka uliopita</relative>
+				<relative type="0">mwaka huu</relative>
+				<relative type="1">mwaka ujao</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">baada ya mwaka {0}</relativeTimePattern>
 					<relativeTimePattern count="other">baada ya miaka {0}</relativeTimePattern>
@@ -2015,9 +2015,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-short">
 				<displayName>mwezi</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mwezi uliopita</relative>
+				<relative type="0">mwezi huu</relative>
+				<relative type="1">mwezi ujao</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">baada ya mwezi {0}</relativeTimePattern>
 					<relativeTimePattern count="other">baada ya miezi {0}</relativeTimePattern>
@@ -2029,9 +2029,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="month-narrow">
 				<displayName>mwezi</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">mwezi uliopita</relative>
+				<relative type="0">mwezi huu</relative>
+				<relative type="1">mwezi ujao</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">baada ya mwezi {0}</relativeTimePattern>
 					<relativeTimePattern count="other">baada ya miezi {0}</relativeTimePattern>
@@ -2058,9 +2058,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-short">
 				<displayName>wiki</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">wiki iliyopita</relative>
+				<relative type="0">wiki hii</relative>
+				<relative type="1">wiki ijayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">baada ya wiki {0}</relativeTimePattern>
 					<relativeTimePattern count="other">baada ya wiki {0}</relativeTimePattern>
@@ -2073,9 +2073,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="week-narrow">
 				<displayName>wiki</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">wiki iliyopita</relative>
+				<relative type="0">wiki hii</relative>
+				<relative type="1">wiki ijayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">baada ya wiki {0}</relativeTimePattern>
 					<relativeTimePattern count="other">baada ya wiki {0}</relativeTimePattern>
@@ -5488,7 +5488,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>Loti ya Lesoto</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">Loti za Lesoto</displayName>
 				<displayName count="other">Loti za Lesoto</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -6135,7 +6135,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0} mchemraba</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>mvuto wa graviti</displayName>
@@ -7177,12 +7177,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7236,7 +7236,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>mita za mraba</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">m² {0}</unitPattern>
 				<unitPattern count="other">m² {0}</unitPattern>
 				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
@@ -7315,7 +7315,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>permyriadi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -7597,12 +7597,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">ppi {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="one">dpcm {0}</unitPattern>
 				<unitPattern count="other">dpcm {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="one">dpi {0}</unitPattern>
 				<unitPattern count="other">dpi {0}</unitPattern>
 			</unit>
@@ -8227,132 +8227,132 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>mvuto wa graviti</displayName>
 				<unitPattern count="one">G {0}</unitPattern>
 				<unitPattern count="other">G {0}</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mita kwa kila sekunde mraba</displayName>
+				<unitPattern count="one">m {0}/s²</unitPattern>
+				<unitPattern count="other">m {0}/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
+				<displayName>mzunguko</displayName>
 				<unitPattern count="one">raundi {0}</unitPattern>
 				<unitPattern count="other">raundi {0}</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>radiani</displayName>
+				<unitPattern count="one">radiani {0}</unitPattern>
+				<unitPattern count="other">radiani {0}</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>digrii</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>dakika</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>sekunde</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kilomita za mraba</displayName>
 				<unitPattern count="one">km² {0}</unitPattern>
 				<unitPattern count="other">km² {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hekta</displayName>
 				<unitPattern count="one">ha {0}</unitPattern>
 				<unitPattern count="other">ha {0}</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mita za mraba</displayName>
 				<unitPattern count="one">m² {0}</unitPattern>
 				<unitPattern count="other">m² {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sentimita za mraba</displayName>
+				<unitPattern count="one">cm² {0}</unitPattern>
+				<unitPattern count="other">cm² {0}</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>maili za mraba</displayName>
 				<unitPattern count="one">mi² {0}</unitPattern>
 				<unitPattern count="other">mi² {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ekari</displayName>
 				<unitPattern count="one">Ekari {0}</unitPattern>
 				<unitPattern count="other">Ekari {0}</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yadi za mraba</displayName>
+				<unitPattern count="one">yd² {0}</unitPattern>
+				<unitPattern count="other">yd² {0}</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>futi za mraba</displayName>
 				<unitPattern count="one">ft² {0}</unitPattern>
 				<unitPattern count="other">ft² {0}</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>inchi za mraba</displayName>
+				<unitPattern count="one">in² {0}</unitPattern>
+				<unitPattern count="other">in² {0}</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunamu</displayName>
+				<unitPattern count="one">dunamu {0}</unitPattern>
+				<unitPattern count="other">dunamu {0}</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karati</displayName>
+				<unitPattern count="one">karati {0}</unitPattern>
+				<unitPattern count="other">karati {0}</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>mmol/L</displayName>
 				<unitPattern count="one">mmol {0}/L</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mmol {0}/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>kipengee</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kipengee {0}</unitPattern>
+				<unitPattern count="other">vipengee {0}</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ppm {0}</unitPattern>
+				<unitPattern count="other">ppm {0}</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>asilimia</displayName>
@@ -8360,24 +8360,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">asilimia {0}</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kwa elfu</displayName>
+				<unitPattern count="one">{0} kwa elfu</unitPattern>
+				<unitPattern count="other">{0} kwa elfu</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>permyriadi</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>moli</displayName>
+				<unitPattern count="one">moli {0}</unitPattern>
+				<unitPattern count="other">moli {0}</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lita kwa kila kilomita</displayName>
+				<unitPattern count="one">lita {0} kwa kilomita</unitPattern>
+				<unitPattern count="other">lita {0} kwa kilomita</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>lita kwa kilomita 100</displayName>
@@ -8386,84 +8386,84 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mpg {0}</unitPattern>
+				<unitPattern count="other">mpg {0}</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="one">mpg Imp. {0}</unitPattern>
+				<unitPattern count="other">mpg Imp. {0}</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>petabaiti</displayName>
+				<unitPattern count="one">PB {0}</unitPattern>
+				<unitPattern count="other">PB {0}</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>terabaiti</displayName>
+				<unitPattern count="one">terabaiti {0}</unitPattern>
+				<unitPattern count="other">terabaiti {0}</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>terabiti</displayName>
+				<unitPattern count="one">terabiti {0}</unitPattern>
+				<unitPattern count="other">terabiti {0}</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">GB {0}</unitPattern>
+				<unitPattern count="other">GB {0}</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gigabiti</displayName>
+				<unitPattern count="one">gigabiti {0}</unitPattern>
+				<unitPattern count="other">gigabiti {0}</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">MB {0}</unitPattern>
+				<unitPattern count="other">MB {0}</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">megabiti {0}</unitPattern>
+				<unitPattern count="other">megabiti {0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilobaiti</displayName>
+				<unitPattern count="one">kilobaiti {0}</unitPattern>
+				<unitPattern count="other">kilobaiti {0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilobiti</displayName>
+				<unitPattern count="one">kilobiti {0}</unitPattern>
+				<unitPattern count="other">kilobiti {0}</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>baiti</displayName>
+				<unitPattern count="one">baiti {0}</unitPattern>
+				<unitPattern count="other">baiti {0}</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>biti</displayName>
+				<unitPattern count="one">biti {0}</unitPattern>
+				<unitPattern count="other">biti {0}</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karne</displayName>
+				<unitPattern count="one">karne {0}</unitPattern>
+				<unitPattern count="other">karne {0}</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miongo</displayName>
+				<unitPattern count="one">mwongo {0}</unitPattern>
+				<unitPattern count="other">miongo {0}</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>mwaka</displayName>
 				<unitPattern count="one">mwaka {0}</unitPattern>
 				<unitPattern count="other">miaka {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa mwaka</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>robo</displayName>
@@ -8475,31 +8475,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>mwezi</displayName>
 				<unitPattern count="one">mwezi {0}</unitPattern>
 				<unitPattern count="other">miezi {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa mwezi</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>wiki</displayName>
 				<unitPattern count="one">wiki {0}</unitPattern>
 				<unitPattern count="other">wiki {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa wiki</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>siku</displayName>
 				<unitPattern count="one">siku {0}</unitPattern>
 				<unitPattern count="other">siku {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa siku</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>saa</displayName>
 				<unitPattern count="one">saa {0}</unitPattern>
 				<unitPattern count="other">saa {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa saa</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>dakika</displayName>
 				<unitPattern count="one">dak {0}</unitPattern>
 				<unitPattern count="other">dak {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa kila dakika</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>sekunde</displayName>
@@ -8513,89 +8513,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">ms {0}</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mikrosekunde</displayName>
+				<unitPattern count="one">mikrosekunde {0}</unitPattern>
+				<unitPattern count="other">mikrosekunde {0}</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nanosekunde</displayName>
+				<unitPattern count="one">nanosekunde {0}</unitPattern>
+				<unitPattern count="other">nanosekunde {0}</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ampea</displayName>
+				<unitPattern count="one">ampea {0}</unitPattern>
+				<unitPattern count="other">ampea {0}</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miliampea</displayName>
+				<unitPattern count="one">mA {0}</unitPattern>
+				<unitPattern count="other">mA {0}</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>volti</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">volti {0}</unitPattern>
+				<unitPattern count="other">volti {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilokalori</displayName>
+				<unitPattern count="one">kilokalori {0}</unitPattern>
+				<unitPattern count="other">kilokalori {0}</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kalori</displayName>
+				<unitPattern count="one">kalori {0}</unitPattern>
+				<unitPattern count="other">kalori {0}</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kalori</displayName>
+				<unitPattern count="one">kalori {0}</unitPattern>
+				<unitPattern count="other">kalori {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilojuli</displayName>
+				<unitPattern count="one">kilojuli {0}</unitPattern>
+				<unitPattern count="other">kilojuli {0}</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jouli</displayName>
+				<unitPattern count="one">jouli {0}</unitPattern>
+				<unitPattern count="other">jouli {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilowati kwa saa</displayName>
+				<unitPattern count="one">kWh {0}</unitPattern>
+				<unitPattern count="other">kWh {0}</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>elektrovolti</displayName>
+				<unitPattern count="one">eV {0}</unitPattern>
+				<unitPattern count="other">eV {0}</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">Btu {0}</unitPattern>
+				<unitPattern count="other">Btu {0}</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kipimo cha gesi, Marekani</displayName>
+				<unitPattern count="one">kipimo {0} cha gesi, US</unitPattern>
+				<unitPattern count="other">vipimo {0} vya gesi, US</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>paunikani</displayName>
+				<unitPattern count="one">lbf {0}</unitPattern>
+				<unitPattern count="other">lbf {0}</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">N {0}</unitPattern>
+				<unitPattern count="other">N {0}</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWh/km 100</displayName>
@@ -8603,92 +8603,92 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">kWh {0} kwa km 100</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gigahezi</displayName>
+				<unitPattern count="one">gigahezi {0}</unitPattern>
+				<unitPattern count="other">gigahezi {0}</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megahezi</displayName>
+				<unitPattern count="one">megahezi {0}</unitPattern>
+				<unitPattern count="other">megahezi {0}</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilohezi</displayName>
+				<unitPattern count="one">kilohezi {0}</unitPattern>
+				<unitPattern count="other">kilohezi {0}</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hezi</displayName>
+				<unitPattern count="one">hezi {0}</unitPattern>
+				<unitPattern count="other">hezi {0}</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">em {0}</unitPattern>
+				<unitPattern count="other">em {0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pikseli</displayName>
+				<unitPattern count="one">px {0}</unitPattern>
+				<unitPattern count="other">px {0}</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">MP {0}</unitPattern>
+				<unitPattern count="other">MP {0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">ppcm {0}</unitPattern>
+				<unitPattern count="other">ppcm {0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">ppi {0}</unitPattern>
+				<unitPattern count="other">ppi {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">dpcm {0}</unitPattern>
+				<unitPattern count="other">dpcm {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">dpi {0}</unitPattern>
+				<unitPattern count="other">dpi {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kitone</displayName>
+				<unitPattern count="one">kitone {0}</unitPattern>
+				<unitPattern count="other">vitone {0}</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">R⊕ {0}</unitPattern>
+				<unitPattern count="other">R⊕ {0}</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">km {0}</unitPattern>
 				<unitPattern count="other">km {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa kila kilomita</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>mita</displayName>
 				<unitPattern count="one">mita {0}</unitPattern>
 				<unitPattern count="other">mita {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa kila mita</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>desimita</displayName>
+				<unitPattern count="one">desimita {0}</unitPattern>
+				<unitPattern count="other">desimita {0}</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>sentimita</displayName>
 				<unitPattern count="one">cm {0}</unitPattern>
 				<unitPattern count="other">cm {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa kila sentimita</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>milimita</displayName>
@@ -8696,198 +8696,198 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">mm {0}</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mikromita</displayName>
+				<unitPattern count="one">mikromita {0}</unitPattern>
+				<unitPattern count="other">mikromita {0}</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nanomita</displayName>
+				<unitPattern count="one">nanomita {0}</unitPattern>
+				<unitPattern count="other">nanomita {0}</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pikomita</displayName>
 				<unitPattern count="one">pm {0}</unitPattern>
 				<unitPattern count="other">pm {0}</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>maili</displayName>
 				<unitPattern count="one">maili {0}</unitPattern>
 				<unitPattern count="other">maili {0}</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yadi</displayName>
 				<unitPattern count="one">yadi {0}</unitPattern>
 				<unitPattern count="other">yadi {0}</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>futi</displayName>
 				<unitPattern count="one">futi {0}</unitPattern>
 				<unitPattern count="other">futi {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa kila futi</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>inchi</displayName>
 				<unitPattern count="one">inchi {0}</unitPattern>
 				<unitPattern count="other">inchi {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa kila inchi</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kila sekunde</displayName>
+				<unitPattern count="one">pc {0}</unitPattern>
+				<unitPattern count="other">pc {0}</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>miaka ya mwanga</displayName>
 				<unitPattern count="one">ly {0}</unitPattern>
 				<unitPattern count="other">ly {0}</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>vipimo vya astronomia</displayName>
+				<unitPattern count="one">au {0}</unitPattern>
+				<unitPattern count="other">au {0}</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>furlong</displayName>
+				<unitPattern count="one">fur {0}</unitPattern>
+				<unitPattern count="other">fur {0}</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fathom</displayName>
+				<unitPattern count="one">fth {0}</unitPattern>
+				<unitPattern count="other">fth {0}</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>maili za kibaharia</displayName>
+				<unitPattern count="one">maili {0} ya kibaharia</unitPattern>
+				<unitPattern count="other">maili {0} za kibaharia</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">smi {0}</unitPattern>
+				<unitPattern count="other">smi {0}</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pointi</displayName>
+				<unitPattern count="one">pointi {0}</unitPattern>
+				<unitPattern count="other">pointi {0}</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">R☉ {0}</unitPattern>
+				<unitPattern count="other">R☉ {0}</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="one">lx {0}</unitPattern>
+				<unitPattern count="other">lx {0}</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">cd {0}</unitPattern>
+				<unitPattern count="other">cd {0}</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">lm {0}</unitPattern>
+				<unitPattern count="other">lm {0}</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">L☉ {0}</unitPattern>
+				<unitPattern count="other">L☉ {0}</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tani mita</displayName>
+				<unitPattern count="one">tani mita {0}</unitPattern>
+				<unitPattern count="other">tani mita {0}</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kilogramu</displayName>
 				<unitPattern count="one">kg {0}</unitPattern>
 				<unitPattern count="other">kg {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gramu</displayName>
 				<unitPattern count="one">gramu {0}</unitPattern>
 				<unitPattern count="other">gramu {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa kila gramu</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miligramu</displayName>
+				<unitPattern count="one">mg {0}</unitPattern>
+				<unitPattern count="other">mg {0}</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mikrogramu</displayName>
+				<unitPattern count="one">mikrogramu {0}</unitPattern>
+				<unitPattern count="other">mikrogramu {0}</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tani fupi</displayName>
+				<unitPattern count="one">tani fupi {0}</unitPattern>
+				<unitPattern count="other">tani fupi {0}</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mawe</displayName>
+				<unitPattern count="one">st {0}</unitPattern>
+				<unitPattern count="other">st {0}</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>ratili</displayName>
 				<unitPattern count="one">Ratili {0}</unitPattern>
 				<unitPattern count="other">Ratili {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>aunsi</displayName>
 				<unitPattern count="one">Aunsi {0}</unitPattern>
 				<unitPattern count="other">Aunsi {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tola aunsi</displayName>
+				<unitPattern count="one">tola aunsi {0}</unitPattern>
+				<unitPattern count="other">tola aunsi {0}</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karati</displayName>
+				<unitPattern count="one">karati {0}</unitPattern>
+				<unitPattern count="other">karati {0}</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>daltoni</displayName>
+				<unitPattern count="one">Da {0}</unitPattern>
+				<unitPattern count="other">Da {0}</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>uzito wa dunia</displayName>
+				<unitPattern count="one">M⊕ {0}</unitPattern>
+				<unitPattern count="other">M⊕ {0}</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>uzito wa jua</displayName>
+				<unitPattern count="one">M☉ {0}</unitPattern>
+				<unitPattern count="other">M☉ {0}</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nafaka</displayName>
+				<unitPattern count="one">nafaka {0}</unitPattern>
+				<unitPattern count="other">nafaka {0}</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gigawati</displayName>
+				<unitPattern count="one">gigawati {0}</unitPattern>
+				<unitPattern count="other">gigawati {0}</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megawati</displayName>
+				<unitPattern count="one">megawati {0}</unitPattern>
+				<unitPattern count="other">megawati {0}</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kilowati</displayName>
 				<unitPattern count="one">kW {0}</unitPattern>
 				<unitPattern count="other">kW {0}</unitPattern>
 			</unit>
@@ -8897,64 +8897,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">Wati {0}</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miliwati</displayName>
+				<unitPattern count="one">miliwati {0}</unitPattern>
+				<unitPattern count="other">miliwati {0}</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>kipimo cha hospawa</displayName>
 				<unitPattern count="one">hp {0}</unitPattern>
 				<unitPattern count="other">hp {0}</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milimita za zebaki</displayName>
+				<unitPattern count="one">mmHg {0}</unitPattern>
+				<unitPattern count="other">mmHg {0}</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pauni kwa kila inchi mraba</displayName>
+				<unitPattern count="one">psi {0}</unitPattern>
+				<unitPattern count="other">psi {0}</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inchi za zebaki</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bari</displayName>
+				<unitPattern count="one">bari {0}</unitPattern>
+				<unitPattern count="other">bari {0}</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>kipimo cha milibari</displayName>
 				<unitPattern count="one">mbar {0}</unitPattern>
 				<unitPattern count="other">mbar {0}</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">atm {0}</unitPattern>
+				<unitPattern count="other">atm {0}</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">Pa {0}</unitPattern>
+				<unitPattern count="other">Pa {0}</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektopaskali</displayName>
 				<unitPattern count="one">hPa {0}</unitPattern>
 				<unitPattern count="other">hPa {0}</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">kPa {0}</unitPattern>
+				<unitPattern count="other">kPa {0}</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">MPa {0}</unitPattern>
+				<unitPattern count="other">MPa {0}</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>kilomita kwa saa</displayName>
@@ -8962,24 +8962,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">km {0}/saa</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>mita kwa kila sekunde</displayName>
 				<unitPattern count="one">m {0}/s</unitPattern>
 				<unitPattern count="other">m {0}/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>maili kwa kila saa</displayName>
 				<unitPattern count="one">mi {0}/saa</unitPattern>
 				<unitPattern count="other">mi {0}/saa</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>noti</displayName>
+				<unitPattern count="one">noti {0}</unitPattern>
+				<unitPattern count="other">noti {0}</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -8987,199 +8987,199 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>nyuzi za farenheiti</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">lbf⋅ft {0}</unitPattern>
+				<unitPattern count="other">lbf⋅ft {0}</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">N⋅m {0}</unitPattern>
+				<unitPattern count="other">N⋅m {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kilomita za ujazo</displayName>
 				<unitPattern count="one">km³ {0}</unitPattern>
 				<unitPattern count="other">km³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mita za ujazo</displayName>
+				<unitPattern count="one">m³ {0}</unitPattern>
+				<unitPattern count="other">mita {0} za ujazo</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sentimita za ujazo</displayName>
+				<unitPattern count="one">cm³ {0}</unitPattern>
+				<unitPattern count="other">cm³ {0}</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>maili za ujazo</displayName>
 				<unitPattern count="one">mi³ {0}</unitPattern>
 				<unitPattern count="other">mi³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yadi za ujazo</displayName>
+				<unitPattern count="one">yd³ {0}</unitPattern>
+				<unitPattern count="other">yd³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>futi za ujazo</displayName>
+				<unitPattern count="one">ft³ {0}</unitPattern>
+				<unitPattern count="other">ft³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inchi za ujazo</displayName>
+				<unitPattern count="one">in³ {0}</unitPattern>
+				<unitPattern count="other">in³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megalita</displayName>
+				<unitPattern count="one">megalita {0}</unitPattern>
+				<unitPattern count="other">megalita {0}</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hektolita</displayName>
+				<unitPattern count="one">hektolita {0}</unitPattern>
+				<unitPattern count="other">hektolita {0}</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>lita</displayName>
 				<unitPattern count="one">lita {0}</unitPattern>
 				<unitPattern count="other">lita {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} kwa kila lita</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>desilita</displayName>
+				<unitPattern count="one">desilita {0}</unitPattern>
+				<unitPattern count="other">desilita {0}</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sentilita</displayName>
+				<unitPattern count="one">sentilita {0}</unitPattern>
+				<unitPattern count="other">sentilita {0}</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mililita</displayName>
+				<unitPattern count="one">mililita {0}</unitPattern>
+				<unitPattern count="other">mililita {0}</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>painti za mizani</displayName>
+				<unitPattern count="one">mpt {0}</unitPattern>
+				<unitPattern count="other">mpt {0}</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>vikombe vya mizani</displayName>
+				<unitPattern count="one">mc {0}</unitPattern>
+				<unitPattern count="other">vikombe {0} vya mizani</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ekari futi</displayName>
+				<unitPattern count="one">ekari futi {0}</unitPattern>
+				<unitPattern count="other">ekari futi {0}</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>busheli</displayName>
+				<unitPattern count="one">bu {0}</unitPattern>
+				<unitPattern count="other">bu {0}</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>galoni</displayName>
+				<unitPattern count="one">galoni {0}</unitPattern>
+				<unitPattern count="other">galoni {0}</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="one">gal Imp. {0}</unitPattern>
+				<unitPattern count="other">gal Imp. {0}</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kwati</displayName>
+				<unitPattern count="one">kwati {0}</unitPattern>
+				<unitPattern count="other">kwati {0}</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>painti</displayName>
+				<unitPattern count="one">painti {0}</unitPattern>
+				<unitPattern count="other">painti {0}</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>vikombe</displayName>
+				<unitPattern count="one">kikombe {0}</unitPattern>
+				<unitPattern count="other">vikombe {0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>aunsi za ujazo</displayName>
+				<unitPattern count="one">fl oz {0}</unitPattern>
+				<unitPattern count="other">fl oz {0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="one">fl oz Imp. {0}</unitPattern>
+				<unitPattern count="other">fl oz Imp. {0}</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>vijiko vikubwa</displayName>
+				<unitPattern count="one">tbsp {0}</unitPattern>
+				<unitPattern count="other">tbsp {0}</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>vijiko vidogo</displayName>
+				<unitPattern count="one">tsp {0}</unitPattern>
+				<unitPattern count="other">tsp {0}</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pipa</displayName>
+				<unitPattern count="one">pipa {0}</unitPattern>
+				<unitPattern count="other">mapipa {0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">dstspn {0}</unitPattern>
+				<unitPattern count="other">dstspn {0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">dstspn Imp {0}</unitPattern>
+				<unitPattern count="other">dstspn Imp {0}</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tone</displayName>
+				<unitPattern count="one">tone {0}</unitPattern>
+				<unitPattern count="other">matone {0}</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ujazo wa dramu</displayName>
+				<unitPattern count="one">ujazo wa dramu {0}</unitPattern>
+				<unitPattern count="other">ujazo wa dramu {0}</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>toti</displayName>
+				<unitPattern count="one">toti {0}</unitPattern>
+				<unitPattern count="other">toti {0}</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mfinyo kwa vidole</displayName>
+				<unitPattern count="one">mfinyo {0} kwa vidole</unitPattern>
+				<unitPattern count="other">mifinyo {0} kwa vidole</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">qt Imp. {0}</unitPattern>
+				<unitPattern count="other">qt Imp. {0}</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>mwelekeo</displayName>
@@ -9215,7 +9215,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<listPattern type="or-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0}, au {1}</listPatternPart>
 			<listPatternPart type="2">{0} au {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
@@ -9225,9 +9225,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} au {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} na {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
@@ -9457,7 +9457,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -9478,7 +9478,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
 			<namePattern>{title} {surname}</namePattern>

--- a/common/main/syr.xml
+++ b/common/main/syr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -231,7 +231,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="FR">ܦܪܢܣܐ</territory>
 			<territory type="GA">ܓܒܘܢ</territory>
 			<territory type="GB">ܡܠܟܘܬܐ ܡܚܝܕܬܐ</territory>
-			<territory type="GB" alt="short">↑↑↑</territory>
+			<territory type="GB" alt="short">ܡܠܟܘܬܐ ܡܚܝܕܬܐ</territory>
 			<territory type="GD">ܓܪܝܢܐܕܐ</territory>
 			<territory type="GE">ܓܘܪܓܝܐ</territory>
 			<territory type="GF">ܓܘܝܐܢܐ ܦܪܢܣܝܬܐ</territory>
@@ -387,7 +387,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">ܬܘܢܣ</territory>
 			<territory type="TO">ܬܘܢܓܐ</territory>
 			<territory type="TR">ܬܘܪܟܝܐ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ܬܘܪܟܝܐ</territory>
 			<territory type="TT">ܬܪܝܢܝܕܐܕ ܘܬܘܒܐܓܘ</territory>
 			<territory type="TV">ܬܘܒܐܠܘ</territory>
 			<territory type="TW">ܬܐܝܘܐܢ</territory>
@@ -397,7 +397,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UM" draft="unconfirmed">ܓܙܝܪ̈ܐ ܪ̈ܚܝܩܐ ܕܐܘܚܕ̈ܢܐ ܡܚܝܕ̈ܐ</territory>
 			<territory type="UN">ܐܡ̈ܘܬܐ ܡܚܝ̈ܕܬܐ</territory>
 			<territory type="US">ܐܘܚܕ̈ܢܐ ܡܚܝܕ̈ܐ</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">ܐܘܚܕ̈ܢܐ ܡܚܝܕ̈ܐ</territory>
 			<territory type="UY">ܐܘܪܘܓܘܐܝ</territory>
 			<territory type="UZ">ܐܘܙܒܟܣܬܐܢ</territory>
 			<territory type="VA">ܡܕܝܢܬܐ ܕܘܛܝܩܢ</territory>
@@ -585,7 +585,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -593,7 +593,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -601,7 +601,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -609,7 +609,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -757,14 +757,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
 							<month type="1">ܟܢ܊ ܒ</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
+							<month type="2">ܫܒܛ</month>
+							<month type="3">ܐܕܪ</month>
+							<month type="4">ܢܝܣܢ</month>
+							<month type="5">ܐܝܪ</month>
+							<month type="6">ܚܙܝܪܢ</month>
+							<month type="7">ܬܡܘܙ</month>
+							<month type="8">ܐܒ</month>
+							<month type="9">ܐܝܠܘܠ</month>
 							<month type="10">ܬܫ܊ ܐ</month>
 							<month type="11">ܬܫ܊ ܒ</month>
 							<month type="12">ܟܢ܊ ܐ</month>
@@ -801,14 +801,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
 							<month type="1">ܟܢ܊ ܒ</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
+							<month type="2">ܫܒܛ</month>
+							<month type="3">ܐܕܪ</month>
+							<month type="4">ܢܝܣܢ</month>
+							<month type="5">ܐܝܪ</month>
+							<month type="6">ܚܙܝܪܢ</month>
+							<month type="7">ܬܡܘܙ</month>
+							<month type="8">ܐܒ</month>
+							<month type="9">ܐܝܠܘܠ</month>
 							<month type="10">ܬܫ܊ ܐ</month>
 							<month type="11">ܬܫ܊ ܒ</month>
 							<month type="12">ܟܢ܊ ܐ</month>
@@ -829,14 +829,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">ܟܢܘܢ ܐܚܪܝܐ</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
+							<month type="2">ܫܒܛ</month>
+							<month type="3">ܐܕܪ</month>
+							<month type="4">ܢܝܣܢ</month>
+							<month type="5">ܐܝܪ</month>
+							<month type="6">ܚܙܝܪܢ</month>
+							<month type="7">ܬܡܘܙ</month>
+							<month type="8">ܐܒ</month>
+							<month type="9">ܐܝܠܘܠ</month>
 							<month type="10">ܬܫܪܝܢ ܩܕܡܝܐ</month>
 							<month type="11">ܬܫܪܝܼܢ ܐܚܪܝܐ</month>
 							<month type="12">ܟܢܘܢ ܩܕܡܝܐ</month>
@@ -846,13 +846,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">ܚܕܒܫܒܐ</day>
+							<day type="mon">ܬܪܝܢܒܫܒܐ</day>
+							<day type="tue">ܬܠܬܒܫܒܐ</day>
+							<day type="wed">ܐܪܒܥܒܫܒܐ</day>
+							<day type="thu">ܚܡܫܒܫܒܐ</day>
+							<day type="fri">ܥܪܘܒܬܐ</day>
+							<day type="sat">ܫܒܬܐ</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">ܐ</day>
@@ -890,7 +890,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="wed">ܐܪܒܥ</day>
 							<day type="thu">ܚܡܫ</day>
 							<day type="fri">ܥܪܘ</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">ܫܒܬܐ</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">ܐ</day>
@@ -916,7 +916,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="tue">ܬܠܬܒܫܒܐ</day>
 							<day type="wed">ܐܪܒܥܒܫܒܐ</day>
 							<day type="thu">ܚܡܫܒܫܒܐ</day>
-							<day type="fri">↑↑↑</day>
+							<day type="fri">ܥܪܘܒܬܐ</day>
 							<day type="sat">ܫܒܬܐ</day>
 						</dayWidth>
 					</dayContext>
@@ -944,10 +944,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">ܪܘܒܥܐ ܐ</quarter>
+							<quarter type="2">ܪܘܒܥܐ ܒ</quarter>
+							<quarter type="3">ܪܘܒܥܐ ܓ</quarter>
+							<quarter type="4">ܪܘܒܥܐ ܕ</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">ܐ</quarter>
@@ -980,8 +980,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">ܩܛ</dayPeriod>
+							<dayPeriod type="pm">ܒܛ</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="am">ܩܛ</dayPeriod>
@@ -1007,10 +1007,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<era type="1" alt="variant">܏ܕܚ</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">܏ܩܡ</era>
 						<era type="0" alt="variant">܏ܩܕܚ</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1">܏ܫܡ</era>
+						<era type="1" alt="variant">܏ܕܚ</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -1071,7 +1071,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1079,7 +1079,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1087,7 +1087,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1095,7 +1095,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1302,10 +1302,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ܕܪܐ</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܕܪܐ</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܕܪܐ</displayName>
 			</field>
 			<field type="year">
 				<displayName>ܫܢܬܐ</displayName>
@@ -1323,30 +1323,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>ܫܢ܊</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܐܫܬܩܕܝ</relative>
+				<relative type="0">ܗܕܐ ܫܢܬܐ</relative>
+				<relative type="1">ܫܢܬܐ ܐܚܪܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܫܢܝ̈ܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܫܢܝ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܫܢܝ̈ܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܫܢܝ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>ܫܢ܊</displayName>
+				<relative type="-1">ܐܫܬܩܕܝ</relative>
+				<relative type="0">ܗܕܐ ܫܢܬܐ</relative>
+				<relative type="1">ܫܢܬܐ ܐܚܪܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܫܢܝ̈ܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܫܢܝ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܫܢܝ̈ܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܫܢܝ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -1364,31 +1364,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>ܪܘܒܥܐ ܕܫܢܬܐ</displayName>
+				<relative type="-1">ܪܘܒܥܐ ܕܥܒܪ</relative>
+				<relative type="0">ܗܢܐ ܪܘܒܥܐ</relative>
+				<relative type="1">ܪܘܒܥܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܪܘܒܥܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܪ̈ܘܒܥܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܪܘܒܥܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܪ̈ܘܒܥܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>ܪܘܒܥܐ ܕܫܢܬܐ</displayName>
+				<relative type="-1">ܪܘܒܥܐ ܕܥܒܪ</relative>
+				<relative type="0">ܗܢܐ ܪܘܒܥܐ</relative>
+				<relative type="1">ܪܘܒܥܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܪܘܒܥܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܪ̈ܘܒܥܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܪܘܒܥܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܪ̈ܘܒܥܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -1406,10 +1406,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>ܝܪܚܐ</displayName>
+				<relative type="-1">ܝܪܚܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܢܐ ܝܪܚܐ</relative>
+				<relative type="1">ܝܪܚܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ܒ{0} ܝܪܚܐ</relativeTimePattern>
 					<relativeTimePattern count="other">ܒ{0} ܝܪ̈ܚܐ</relativeTimePattern>
@@ -1420,17 +1420,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>ܝܪܚܐ</displayName>
+				<relative type="-1">ܝܪܚܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܢܐ ܝܪܚܐ</relative>
+				<relative type="1">ܝܪܚܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܝܪܚܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܝܪ̈ܚܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܝܪܚܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܝܖ̈ܚܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -1450,42 +1450,42 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>ܫܒ܊</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܫܒܘܥܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܫܒܘܥܐ</relative>
+				<relative type="1">ܫܒܘܥܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܫܒܘܥܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܫܒ̈ܘܥܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܫܒܘܥܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܫܒ̈ܘܥܐ</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>ܫܒܘܥܐ ܕ{0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>ܫܒ܊</displayName>
+				<relative type="-1">ܫܒܘܥܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܫܒܘܥܐ</relative>
+				<relative type="1">ܫܒܘܥܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܫܒܘܥܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܫܒ̈ܘܥܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܫܒܘܥܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܫܒ̈ܘܥܐ</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>ܫܒܘܥܐ ܕ{0}</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName>ܫܒܘܥܐ ܕܝܪܚܐ</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܫܒܘܥܐ ܕܝܪܚܐ</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܫܒܘܥܐ ܕܝܪܚܐ</displayName>
 			</field>
 			<field type="day">
 				<displayName>ܝܘܡܐ</displayName>
@@ -1502,59 +1502,59 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>ܝܘܡܐ</displayName>
+				<relative type="-1">ܐܬܡܠܝ</relative>
+				<relative type="0">ܐܕܝܘܡ</relative>
+				<relative type="1">ܝܘܡܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܝܘܡܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܝܘܡܢ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܝܘܡܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܝܘܡܢ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>ܝܘܡܐ</displayName>
+				<relative type="-1">ܐܬܡܠܝ</relative>
+				<relative type="0">ܐܕܝܘܡ</relative>
+				<relative type="1">ܝܘܡܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܝܘܡܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܝܘܡܢ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܝܘܡܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܝܘܡܢ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
 				<displayName>ܝܘܡܐ ܕܫܢܬܐ</displayName>
 			</field>
 			<field type="dayOfYear-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܝܘܡܐ ܕܫܢܬܐ</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܝܘܡܐ ܕܫܢܬܐ</displayName>
 			</field>
 			<field type="weekday">
 				<displayName>ܝܘܡܐ ܕܫܒܘܥܐ</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܝܘܡܐ ܕܫܒܘܥܐ</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܝܘܡܐ ܕܫܒܘܥܐ</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>ܝܘܡܐ ܦܘܠܚܢܐ ܕܫܒܘܥܐ</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܝܘܡܐ ܦܘܠܚܢܐ ܕܫܒܘܥܐ</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܝܘܡܐ ܦܘܠܚܢܐ ܕܫܒܘܥܐ</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1">ܚܕܒܫܒܐ ܕܕܥܒܪ</relative>
@@ -1570,29 +1570,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܚܕܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܚܕܒܫܒܐ</relative>
+				<relative type="1">ܚܕܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܚܕܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܚܕܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܚܕܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܚܕܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܚܕܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܚܕܒܫܒܐ</relative>
+				<relative type="1">ܚܕܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܚܕܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܚܕܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܚܕܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܚܕܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -1609,29 +1609,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="mon-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܬܪܝܢܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܬܪܝܢܒܫܒܐ</relative>
+				<relative type="1">ܬܪܝܢܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܬܪܝܢܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܬܪܝܢܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܬܪܝܢܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܬܪܝܢܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܬܪܝܢܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܬܪܝܢܒܫܒܐ</relative>
+				<relative type="1">ܬܪܝܢܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܬܪܝܢܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܬܪܝܢܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܬܪܝܢܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܬܪܝܢܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -1648,29 +1648,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="tue-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܬܠܬܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܬܠܬܒܫܒܐ</relative>
+				<relative type="1">ܬܠܬܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܬܠܬܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܬܠܬܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܬܠܬܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܬܠܬܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܬܠܬܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܬܠܬܒܫܒܐ</relative>
+				<relative type="1">ܬܠܬܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܬܠܬܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܬܠܬܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܬܠܬܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܬܠܬܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed">
@@ -1687,29 +1687,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="wed-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܐܪܒܥܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܐܪܒܥܒܫܒܐ</relative>
+				<relative type="1">ܐܪܒܥܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܐܪܒܥܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܐܪܒܥܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܐܪܒܥܒܫܒ̈ܐ</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܐܪܒܥܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܐܪܒܥܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܐܪܒܥܒܫܒܐ</relative>
+				<relative type="1">ܐܪܒܥܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܐܪܒܥܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܐܪܒܥܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܐܪܒܥܒܫܒ̈ܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܐܪܒܥܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu">
@@ -1726,29 +1726,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="thu-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܚܡܫܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܚܡܫܒܫܒܐ</relative>
+				<relative type="1">ܚܡܫܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܚܡܫܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܚܡܫܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܚܡܫܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܚܡܫܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܚܡܫܒܫܒܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܚܡܫܒܫܒܐ</relative>
+				<relative type="1">ܚܡܫܒܫܒܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܚܡܫܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܚܡܫܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܚܡܫܒܫܒܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܚܡܫܒܫܒ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -1765,29 +1765,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="fri-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܥܪܘܒܬܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܥܪܘܒܬܐ</relative>
+				<relative type="1">ܥܪܘܒܬܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܥܪܘܒܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܥܪ̈ܘܒܬܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܥܪܘܒܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܥܪ̈ܘܒܬܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܥܪܘܒܬܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܥܪܘܒܬܐ</relative>
+				<relative type="1">ܥܪܘܒܬܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܥܪܘܒܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܥܪ̈ܘܒܬܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܥܪܘܒܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܥܪ̈ܘܒܬܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
@@ -1804,39 +1804,39 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sat-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܫܒܬܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܫܒܬܐ</relative>
+				<relative type="1">ܫܒܬܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܫܒܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܫܒ̈ܬܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܫܒܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܫܒ̈ܬܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ܫܒܬܐ ܕܕܥܒܪ</relative>
+				<relative type="0">ܗܕܐ ܫܒܬܐ</relative>
+				<relative type="1">ܫܒܬܐ ܕܐܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܫܒܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܫܒ̈ܬܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܫܒܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܫܒ̈ܬܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܩܛ/ܒܛ</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>ܩܛ/ܒܛ</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܩܛ/ܒܛ</displayName>
 			</field>
 			<field type="hour">
 				<displayName>ܫܥܬܐ</displayName>
@@ -1852,26 +1852,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-short">
 				<displayName>ܫܥ܊</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ܗܕܐ ܫܥܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܫܥܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܫܥ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܫܥܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܫܥ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>ܫܥ܊</displayName>
+				<relative type="0">ܗܕܐ ܫܥܬܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܫܥܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܫܥ̈ܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܫܥܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܫܥ̈ܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
@@ -1887,27 +1887,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="minute-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>ܩܛܝܢܬܐ</displayName>
+				<relative type="0">ܗܢܐ ܩܛܝܢܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܩܛܝܢܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܩܛܝ̈ܢܬܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܩܛܝܢܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܩܛܝ̈ܢܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>ܩܛܝܢܬܐ</displayName>
+				<relative type="0">ܗܢܐ ܩܛܝܢܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܩܛܝܢܬܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܩܛܝ̈ܢܬܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܩܛܝܢܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܩܛܝ̈ܢܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -1923,27 +1923,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="second-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>ܪܦܦܐ</displayName>
+				<relative type="0">ܗܫܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܪܦܦܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܪ̈ܦܦܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܪܦܦܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܖ̈ܦܦܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>ܪܦܦܐ</displayName>
+				<relative type="0">ܗܫܐ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܒ{0} ܪܦܦܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܒ{0} ܪ̈ܦܦܐ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ܡ̣ܢ ܩܕܡ {0} ܪܦܦܐ</relativeTimePattern>
+					<relativeTimePattern count="other">ܡ̣ܢ ܩܕܡ {0} ܖ̈ܦܦܐ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
@@ -4226,7 +4226,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</otherNumberingSystems>
 		<minimumGroupingDigits draft="contributed">↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
@@ -4235,65 +4235,65 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<nan draft="unconfirmed">ܠܝܬ ܡܢܝܢܐ</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hmnp">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lana">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lanatham">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
@@ -4310,73 +4310,73 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mong">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mtei">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymr">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mymrshan">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="nkoo">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="osma">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="shrd">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sora">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="takr">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="thai">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tibt">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="vaii">
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<decimalFormats>
 			<decimalFormatLength>
@@ -4419,10 +4419,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>
 			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencies>
@@ -4529,7 +4529,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>ܝܘܒܝ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="one">{0} ܡܪܒܥܐ</compoundUnitPattern1>
@@ -4540,12 +4540,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">{0} ܡܩܦܣܐ</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܚܝܠܐ ܢܬܘܦܘܬܐ</displayName>
+				<unitPattern count="one">{0} ܚܝܠܐ ܢܬܘܦܘܬܐ</unitPattern>
+				<unitPattern count="other">{0} ܚܝܠܐ ܢܬܘܦܘܬܐ</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>ܡܝܬܪ̈ܐ ܒܪܦܦܐ ܡܪܒܥܐ</displayName>
@@ -4558,24 +4558,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܚܘܕܖ̈ܐ</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܪܐܕܝܐܢ</displayName>
+				<unitPattern count="one">{0} ܪܐܕܝܐܢ</unitPattern>
+				<unitPattern count="other">{0} ܪܐܕܝܐܢ</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܕܪ̈ܓ݂ܐ</displayName>
 				<unitPattern count="one">ܕܪܓ݂ܐ</unitPattern>
 				<unitPattern count="other">{0} ܕܪ̈ܓ݂ܐ</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>ܩܛܝ̈ܢܬܐ ܩܫܬܢܝܬܐ</displayName>
+				<unitPattern count="one">ܩܛܝܢܐ ܩܫܬܢܝܐ</unitPattern>
 				<unitPattern count="other">{0} ܩܛܝ̈ܢܬܐ ܩܫܬܢܝܬܐ</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܪ̈ܦܦܐ ܩܫܬܢܝܐ</displayName>
 				<unitPattern count="one">{0} ܪ̈ܦܦܐ ܩܫܬܢܝܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ܪ̈ܦܦܐ ܩܫܬܢ̈ܝܐ</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>ܟܝܠܘܡܝܬܪ̈ܐ ܡܪܒܥܐ</displayName>
@@ -4607,9 +4607,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} ܒܡܝܠ̈ܐ ܡܪܒܥܐ</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܦ̈ܕܢܐ</displayName>
+				<unitPattern count="one">{0} ܦܕܢܐ</unitPattern>
+				<unitPattern count="other">{0} ܦ̈ܕܢܐ</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>ܝܪ̈ܕܐ ܡܪܒܥܐ</displayName>
@@ -4628,8 +4628,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} ܒܐܢܟ ܡܪܒܥܐ</perUnitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>ܩܪ̈ܛܐ</displayName>
+				<unitPattern count="one">ܩܪܛܐ</unitPattern>
 				<unitPattern count="other">{0} ܩܪ̈ܛܐ</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
@@ -4653,24 +4653,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܡܢܘ̈ܬܐ ܒܡܠܝܘܢ</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܒܡܐܐ</displayName>
 				<unitPattern count="one">{0} ܒܡܐܐ</unitPattern>
 				<unitPattern count="other">{0} ܒܡܐܐ</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܒܐܠܦܐ</displayName>
 				<unitPattern count="one">{0} ܒܐܠܦܐ</unitPattern>
 				<unitPattern count="other">{0} ܒܐܠܦܐ</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">‱</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}‱</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܘܠ</displayName>
+				<unitPattern count="one">{0} ܡܘܠ</unitPattern>
+				<unitPattern count="other">{0} ܡܘܠ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>ܠܝܬܪ̈ܐ ܒܟܝܠܘܡܝܬܪܐ</displayName>
@@ -4693,59 +4693,59 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܡܝܠ̈ܐ ܒܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܦܝܬܐܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܦܝܬܐܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܦܝܬܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܬܝܪܐܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܬܝܪܐܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܬܝܪܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܬܝܪܐܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܬܝܪܐܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܬܝܪܐܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܓܝܓܐܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܓܝܓܐܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܓܐܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܓܐܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܟܝܠܘܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܟܝܠܘܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܒܬ</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>ܕܪ̈ܐ</displayName>
@@ -4754,8 +4754,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-decade">
 				<displayName>ܥܣܝܪ̈ܘܬܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ܥܣܝܪܘܬܐ</unitPattern>
+				<unitPattern count="other">{0} ܥܣܝܪ̈ܘܬܐ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ܫ̈ܢܐ</displayName>
@@ -4765,14 +4765,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>ܪ̈ܘܒܥܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ܪܘܒܥܐ</unitPattern>
+				<unitPattern count="other">{0} ܪ̈ܘܒܥܐ</unitPattern>
 				<perUnitPattern>{0}/ܪܘܒܥܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܝܪ̈ܚܐ</displayName>
+				<unitPattern count="one">ܝܪܚܐ</unitPattern>
+				<unitPattern count="other">{0} ܝܪ̈ܚܐ</unitPattern>
 				<perUnitPattern>{0} ܒܝܪܚܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
@@ -4782,13 +4782,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} ܒܫܒ݂ܘܥܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܝܘ̈ܡܬܐ</displayName>
+				<unitPattern count="one">ܝܘܡܐ</unitPattern>
+				<unitPattern count="other">{0} ܝܘ̈ܡܬܐ</unitPattern>
 				<perUnitPattern>{0} ܒܝܘܡܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܫ̈ܥܐ</displayName>
 				<unitPattern count="one">ܫܥܬܐ</unitPattern>
 				<unitPattern count="other">{0} ܫ̈ܥܐ</unitPattern>
 				<perUnitPattern>{0} ܒܫܥܬܐ</perUnitPattern>
@@ -4800,13 +4800,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} ܒܩܛܝܢܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܪ̈ܦܦܐ</displayName>
 				<unitPattern count="one">ܪܦܦܐ</unitPattern>
 				<unitPattern count="other">{0} ܪ̈ܦܦܐ</unitPattern>
 				<perUnitPattern>{0} ܒܪܦܦܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܡܝܠܝܪ̈ܦܦܐ</displayName>
 				<unitPattern count="one">{0} ܡܝܠܝܪܦܦܐ</unitPattern>
 				<unitPattern count="other">{0} ܡܝܠܝܪ̈ܦܦܐ</unitPattern>
 			</unit>
@@ -4821,34 +4821,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܢܐܢܘܪ̈ܦܦܐ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܐܡܦܝܪ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܐܡܦܝܪ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܐܡܦܝܪ</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܠܝܐܡܦܝܪ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡ ܐܡܦܝܪ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡ ܐܡܦܝܪ</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܘܗܡ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܘܗܡ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܘܗܡ</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܒܘܠܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܒܘܠܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܒܘܠܬ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܟ ܟܐܠܘܪܝ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟ ܟܐܠܘܪܝ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܟܐܠܘܪܝ</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܟܐܠ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܐܠ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟܐܠ</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName draft="unconfirmed">ܟܝܠܘܓܝܐܘܠ</displayName>
@@ -4856,9 +4856,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܓܝܐܘܠ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܓܝܐܘܠ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܐܘܠ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܐܘܠ</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName draft="unconfirmed">ܟܝܠܘܘܐܬ-ܫܥ̈ܐ</displayName>
@@ -4866,19 +4866,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܘܐܬ-ܫܥ̈ܐ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܐܠܝܟܬܪܘܢ ܒܘܠܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܐܠܝܟܬܪܘܢ ܒܘܠܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܐܠܝܟܬܪܘܢ ܒܘܠܬ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܒܪܝܛܢܝܐ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܒܪܝܛܢܝܐ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܒܪܝܛܢܝܐ</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܐܡܪܝܟܐ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܐܡܪܝܟܐ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܐܡܪܝܟܐ</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>ܢܝܘܬܢ</displayName>
@@ -4891,24 +4891,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܟܝܠܘܘܐܬ-ܫܥ̈ܐ ܒ 100 ܟܝܠܘܡܝܬܪ̈ܐ</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܓܝܓܐܗܪܬܙ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܗܪܬܙ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܓܐܗܪܬܙ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܗܪܬܙ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܟܝܠܘܗܪܬܙ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܗܪܬܙ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܗܪܬܙ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܗܪܬܙ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>ܦܝ̈ܟܣܠܐ</displayName>
@@ -4979,20 +4979,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܦܝܟܘܡܝܬܪ̈ܐ</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܡܝܠ̈ܐ</displayName>
 				<unitPattern count="one">{0} ܡܝܠܐ</unitPattern>
 				<unitPattern count="other">{0} ܡܝܠ̈ܐ</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܝܪܕ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܝܪܕ̈ܐ</unitPattern>
+				<unitPattern count="other">{0} ܝܪܕ̈ܐ</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܐܩܠ̈ܐ</displayName>
 				<unitPattern count="one">{0} ܐܩܠܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} ܐܩܠ̈ܐ</unitPattern>
+				<perUnitPattern>{0}/ܐܩܠܐ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>ܐܢܟ̈ܐ</displayName>
@@ -5031,9 +5031,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܡܝ̈ܠܐ-ܐܣܟܢܕܝܢܒܝܝܢ</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܢܘܩܙ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܢܘܩܙܐ</unitPattern>
+				<unitPattern count="other">{0} ܢܘܩܙ̈ܐ</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>ܥܘܒܐ ܦܫܝܬܐ ܫܡܫܝܐ</displayName>
@@ -5130,54 +5130,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܦܪ̈ܕܐ</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ܓ ܘܐܬ</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܘܐܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ܡ ܘܐܬ</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܘܐܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ܟ ܘܐܬ</displayName>
 				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܘܐܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܘܐܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܘܐܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܠܝܘܐܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܠܝܘܐܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܠܝܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܚܝܠܐ ܕܣܘܣܝܐ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܣܘܣܝܐ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܣܘܣܝܐ</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>ܦܣܟ̈ܠܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܦܣܟ̈ܠܐ</unitPattern>
 				<unitPattern count="other">{0} ܦܣܟ̈ܠܐ</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>ܗܟܬܘܦܣܟ̈ܠܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܗܟܬܘܦܣܟ̈ܠܐ</unitPattern>
 				<unitPattern count="other">{0} ܗܟܬܘܦܣܟ̈ܠܐ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܟܝܠܘܦܣܟܠ</displayName>
+				<unitPattern count="one">{0} ܟܝܠܘܦܣܟܠ</unitPattern>
+				<unitPattern count="other">{0} ܟܝܠܘܦܣܟܠ</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܝܓܐܦܣܟܠ</displayName>
+				<unitPattern count="one">{0} ܡܝܓܐܦܣܟܠ</unitPattern>
+				<unitPattern count="other">{0} ܡܝܓܐܦܣܟܠ</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ܟܝܠܘܡܝܬܪ̈ܐ ܒܫܥܬܐ</displayName>
@@ -5196,13 +5196,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="speed-knot">
 				<displayName>ܩܛܪ̈ܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܩܛܪܐ</unitPattern>
+				<unitPattern count="other">{0} ܩܛܪ̈ܐ</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>ܕܪ̈ܓܐ ܡܐܢܝܐ</displayName>
@@ -5273,8 +5273,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ܠܝܬܪ̈ܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܠܝܬܪܐ</unitPattern>
+				<unitPattern count="other">{0} ܠܝܬܪ̈ܐ</unitPattern>
 				<perUnitPattern>{0}/ܠܝܬܪܐ</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
@@ -5293,9 +5293,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܡܝܠܝܠܝܬܪ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>ܐܩܠ̈ܐ-ܦܕܢܐ</displayName>
@@ -5303,73 +5303,73 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܐܩܠ̈ܐ-ܦܕܢܐ</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܓܠܘܢ̈ܐ</displayName>
 				<unitPattern count="one">{0} ܓܠܘܢܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ܓܠܘܢ̈ܐ</unitPattern>
 				<perUnitPattern>{0}/ܓܠܘܢܐ</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ܓܠܘܢ̈ܐ ܐܡܦܪܬܘܪܝܐ</displayName>
+				<unitPattern count="one">{0} ܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܓܠܘܢ̈ܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<perUnitPattern>{0}/ܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܪ̈ܘܒܥܐ ܓܠܘܢ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܪܘܒܥܐ ܓܠܘܢܐ</unitPattern>
+				<unitPattern count="other">{0} ܪ̈ܘܒܥܐ ܓܠܘܢ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܐܘܢܩ̈ܝܐ ܪ̈ܕܘܝܐ</displayName>
 				<unitPattern count="one">{0} ܐܘܢܩܝܐ ܪܕܘܝܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ܐܘܢܩ̈ܝܐ ܪ̈ܕܘܝܐ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܐܘܢܩ̈ܝܐ ܪ̈ܕܘܝܐ ܐܡܦܪܬܘܪܝܐ</displayName>
 				<unitPattern count="one">{0} ܐܘܢܩܝܐ ܪܕܘܝܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ܐܘܢܩ̈ܝܐ ܪ̈ܕܘܝܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܬܪ̈ܘܕܐ ܪ̈ܒܐ</displayName>
+				<unitPattern count="one">{0} ܬܪܘܕܐ ܪܒܐ</unitPattern>
+				<unitPattern count="other">{0} ܬܪ̈ܘܕܐ ܪ̈ܒܐ</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܬܪ̈ܘܕܐ ܙܥܘܪ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܬܪܘܕܐ ܙܥܘܪܐ</unitPattern>
+				<unitPattern count="other">{0} ܬܪ̈ܘܕܐ ܙܥܘܪ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܬܪ̈ܘܕܐ ܚܠܝ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܬܪܘܕܐ ܚܠܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܬܪ̈ܘܕܐ ܚܠܝ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܬܪ̈ܘܕܐ ܚܠܝ̈ܐ ܐܡܦܪܬܘܪܝܐ</displayName>
+				<unitPattern count="one">{0} ܬܪܘܕܐ ܚܠܝܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܬܪ̈ܘܕܐ ܚܠܝ̈ܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>ܛܘܦ̈ܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܛܘܦܬܐ</unitPattern>
+				<unitPattern count="other">{0} ܛܘܦ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>ܕܪ̈ܟܡܐ ܪ̈ܕܘܝܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܕܪܟܡܐ ܪܕܘܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܕܪ̈ܟܡܐ ܪ̈ܕܘܝܐ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܪ̈ܘܒܥܐ ܓܠܘܢ̈ܐ ܐܡܦܪܬܘܪܝܐ</displayName>
+				<unitPattern count="one">{0} ܪܘܒܥܐ ܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܪ̈ܘܒܥܐ ܓܠܘܢ̈ܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>ܦܢܝܬܐ ܫܪܫܢܝܬܐ</displayName>
+				<coordinateUnitPattern type="east">{0} ܡܕܢܚܐ</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} ܓܪܒܝܐ</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0} ܬܝܡܢܐ</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0} ܡܥܪܒ݂ܐ</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<unitLength type="short">
@@ -5461,11 +5461,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -5473,12 +5473,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>ܚܝܠܐ ܢܬܘܦܘܬܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܚܝܠܐ ܢܬܘܦܘܬܐ</unitPattern>
 				<unitPattern count="other">{0} ܚܝܠܐ ܢܬܘܦܘܬܐ</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>ܡ/ܪ²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡ/ܪ²</unitPattern>
 				<unitPattern count="other">{0} ܡ/ܪ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
@@ -5488,7 +5488,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="angle-radian">
 				<displayName>ܪܐܕܝܐܢ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܪܐܕܝܐܢ</unitPattern>
 				<unitPattern count="other">{0} ܪܐܕܝܐܢ</unitPattern>
 			</unit>
 			<unit type="angle-degree">
@@ -5583,22 +5583,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>ܒܡܐܐ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}%</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>ܒܐܠܦܐ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}‰</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0}‱</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>ܡܘܠ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡܘܠ</unitPattern>
 				<unitPattern count="other">{0} ܡܘܠ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -5623,57 +5623,57 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName draft="unconfirmed">ܦܝܬܐܒܐܝܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܦܝܬܐܒܐܝܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܦܝܬܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName draft="unconfirmed">ܬܝܪܐܒܐܝܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܬܝܪܐܒܐܝܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܬܝܪܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName draft="unconfirmed">ܬܝܪܐܒܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܬܝܪܐܒܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܬܝܪܐܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName draft="unconfirmed">ܓܝܓܐܒܐܝܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܒܐܝܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName draft="unconfirmed">ܓܝܓܐܒܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܒܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName draft="unconfirmed">ܡܝܓܐܒܐܝܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܒܐܝܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName draft="unconfirmed">ܡܝܓܐܒܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܒܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName draft="unconfirmed">ܟܝܠܘܒܐܝܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܒܐܝܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName draft="unconfirmed">ܟܝܠܘܒܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܒܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName draft="unconfirmed">ܒܐܝܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܒܐܝܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName draft="unconfirmed">ܒܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܒܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܒܬ</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -5718,95 +5718,95 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ܫ̈ܥܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܫܥ</unitPattern>
 				<unitPattern count="other">{0} ܫܥ</unitPattern>
 				<perUnitPattern>{0}/ܫܥ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>ܩ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܩ</unitPattern>
 				<unitPattern count="other">{0} ܩ</unitPattern>
 				<perUnitPattern>{0}/ܩ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ܪ̈ܦܦܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܪ</unitPattern>
 				<unitPattern count="other">{0} ܪ</unitPattern>
 				<perUnitPattern>{0}/ܪ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ܡܝܠܝܪ̈ܦܦܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡܝܠܝ ܪ</unitPattern>
 				<unitPattern count="other">{0} ܡܝܠܝ ܪ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>ܡܝܟܪܘ ܪ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡܝܟܪܘ ܪ</unitPattern>
 				<unitPattern count="other">{0} ܡܝܟܪܘ ܪ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>ܢܐܢܘ ܪ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܢܐܢܘ ܪ</unitPattern>
 				<unitPattern count="other">{0} ܢܐܢܘ ܪ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName draft="unconfirmed">ܐܡܦܝܪ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܐܡܦܝܪ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܐܡܦܝܪ</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName draft="unconfirmed">ܡܝܠܝܐܡܦܝܪ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡ ܐܡܦܝܪ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܡ ܐܡܦܝܪ</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName draft="unconfirmed">ܘܗܡ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܘܗܡ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܘܗܡ</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName draft="unconfirmed">ܒܘܠܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܒܘܠܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܒܘܠܬ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName draft="unconfirmed">ܟ ܟܐܠܘܪܝ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟ ܟܐܠܘܪܝ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟ ܟܐܠܘܪܝ</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName draft="unconfirmed">ܟܐܠ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܐܠ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟܐܠ</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName draft="unconfirmed">ܟ ܓܝܐܘܠ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟ ܓܝܐܘܠ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟ ܓܝܐܘܠ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName draft="unconfirmed">ܓܝܐܘܠ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܐܘܠ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܐܘܠ</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName draft="unconfirmed">ܟܝܠܘܘܐܬ-ܫ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܘܫ܏-ܫ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟܘܫ܏-ܫ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName draft="unconfirmed">ܐܠܝܟܬܪܘܢ ܒܘܠܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܐܠܝܟܬܪܘܢ ܒܘܠܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܐܠܝܟܬܪܘܢ ܒܘܠܬ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName draft="unconfirmed">ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܒܪܝܛܢܝܐ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܒܪܝܛܢܝܐ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܒܪܝܛܢܝܐ</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName draft="unconfirmed">ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܐܡܪܝܟܐ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܐܡܪܝܟܐ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܐܡܪܝܟܐ</unitPattern>
 			</unit>
 			<unit type="force-newton">
@@ -5821,22 +5821,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName draft="unconfirmed">ܓܝܓܐܗܪܬܙ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܗܪܬܙ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName draft="unconfirmed">ܡܝܓܐܗܪܬܙ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܗܪܬܙ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName draft="unconfirmed">ܟܝܠܘܗܪܬܙ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܗܪܬܙ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName draft="unconfirmed">ܗܪܬܙ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܗܪܬܙ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -5866,7 +5866,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>ܟܡ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܟܡ</unitPattern>
 				<unitPattern count="other">{0} ܟܡ</unitPattern>
 				<perUnitPattern>{0}/ܟܡ</perUnitPattern>
 			</unit>
@@ -5878,18 +5878,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>ܕܣܡ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܕܣܡ</unitPattern>
 				<unitPattern count="other">{0} ܕܣܡ</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>ܣܡ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܣܡ</unitPattern>
 				<unitPattern count="other">{0} ܣܡ</unitPattern>
 				<perUnitPattern>{0}/ܣܡ</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>ܡܡ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡܡ</unitPattern>
 				<unitPattern count="other">{0} ܡܡ</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
@@ -5914,12 +5914,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-yard">
 				<displayName>ܝܪܕ̈ܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܝܪܕ̈ܐ</unitPattern>
 				<unitPattern count="other">{0} ܝܪܕ̈ܐ</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>ܐܩܠ̈ܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܐܩܠ̈ܐ</unitPattern>
 				<unitPattern count="other">{0} ܐܩܠ̈ܐ</unitPattern>
 				<perUnitPattern>{0}/ܐܩܠܐ</perUnitPattern>
 			</unit>
@@ -6045,7 +6045,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>ܥܘܫܢܐ ܐܪܥܝܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܥܘܫܢܐ ܐܪܥܝܐ</unitPattern>
 				<unitPattern count="other">{0} ܥܘܫܢܐ ܐܪܥܝܐ</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
@@ -6060,62 +6060,62 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName draft="unconfirmed">ܓ ܘܐܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓ ܘܐܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܓ ܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName draft="unconfirmed">ܡ ܘܐܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡ ܘܐܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܡ ܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName draft="unconfirmed">ܟ ܘܐܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟ ܘܐܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܟ ܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName draft="unconfirmed">ܘܐܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܘܐܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName draft="unconfirmed">ܡܝܠܝܘܐܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܠܝܘܐܬ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܠܝܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName draft="unconfirmed">ܚܝܠܐ ܕܣܘܣܝܐ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܣܘܣܝܐ</unitPattern>
 				<unitPattern count="other" draft="unconfirmed">{0} ܣܘܣܝܐ</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>ܦܣܟܠ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܦܣܟ̈ܠܐ</unitPattern>
 				<unitPattern count="other">{0} ܦܣܟ̈ܠܐ</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>ܗܟܬܘܦܣܟܠ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܗܟܬܘܦܣܟ̈ܠܐ</unitPattern>
 				<unitPattern count="other">{0} ܗܟܬܘܦܣܟ̈ܠܐ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>ܟܝܠܘܦܣܟܠ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܟܝܠܘܦܣܟܠ</unitPattern>
 				<unitPattern count="other">{0} ܟܝܠܘܦܣܟܠ</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>ܡܝܓܐܦܣܟܠ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡܝܓܐܦܣܟܠ</unitPattern>
 				<unitPattern count="other">{0} ܡܝܓܐܦܣܟܠ</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>ܟܡ/ܫ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܟܡ/ܫ</unitPattern>
 				<unitPattern count="other">{0} ܟܡ/ܫ</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>ܡ/ܪ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡ/ܪ</unitPattern>
 				<unitPattern count="other">{0} ܡ/ܪ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
@@ -6130,22 +6130,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>ܕܪܓܐ ܡܐܢܝܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°ܡ</unitPattern>
 				<unitPattern count="other">{0}°ܡ</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>ܕܪܓܐ ܦܐܗܪܢܗܥܝܬ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°ܦ</unitPattern>
 				<unitPattern count="other">{0}°ܦ</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>ܕ ܟܠܒܝܢ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܕ ܟܠܒܝܢ</unitPattern>
 				<unitPattern count="other">{0} ܕ ܟܠܒܝܢ</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
@@ -6155,18 +6155,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>ܟܡ³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܟܡ³</unitPattern>
 				<unitPattern count="other">{0} ܟܡ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>ܡܝܬܪ̈ܐ ܡܩܦܣܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡ³</unitPattern>
 				<unitPattern count="other">{0} ܡ³</unitPattern>
 				<perUnitPattern>{0}/ܡ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>ܣܡ³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܣܡ³</unitPattern>
 				<unitPattern count="other">{0} ܣܡ³</unitPattern>
 				<perUnitPattern>{0}/ܣܡ³</perUnitPattern>
 			</unit>
@@ -6223,7 +6223,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
@@ -6303,10 +6303,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>ܕܝܣܝ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>ܣܢܬܝ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
 				<unitPrefixPattern>ܡ{0}</unitPrefixPattern>
@@ -6387,53 +6387,53 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>ܝܘܒܝ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܚܝܠܐ ܢܬܘܦܘܬܐ</displayName>
+				<unitPattern count="one">{0} ܚܝܠܐ ܢܬܘܦܘܬܐ</unitPattern>
+				<unitPattern count="other">{0} ܚܝܠܐ ܢܬܘܦܘܬܐ</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡ/ܪ²</displayName>
+				<unitPattern count="one">{0} ܡ/ܪ²</unitPattern>
+				<unitPattern count="other">{0} ܡ/ܪ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܚܘܕ</displayName>
+				<unitPattern count="one">{0} ܚܘܕ</unitPattern>
+				<unitPattern count="other">{0} ܚܘܕ</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܪܐܕܝܐܢ</displayName>
+				<unitPattern count="one">{0} ܪܐܕܝܐܢ</unitPattern>
+				<unitPattern count="other">{0} ܪܐܕܝܐܢ</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܕܪ̈ܓ݂ܐ</displayName>
+				<unitPattern count="one">ܕܪܓ݂ܐ</unitPattern>
+				<unitPattern count="other">{0} ܕܪ̈ܓ݂ܐ</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܩܛܝ̈ܢܬܐ ܩܫܬܢܝܬܐ</displayName>
+				<unitPattern count="one">ܩܛܝܢܐ ܩܫܬܢܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܩܛܝ̈ܢܬܐ ܩܫܬܢܝܬܐ</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܪ̈ܦܦܐ ܩܫܬܢܝܐ</displayName>
+				<unitPattern count="one">ܪܦܦܐ ܩܫܬܢܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܪ̈ܦܦܐ ܩܫܬܢ̈ܝܐ</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>ܟܡ²</displayName>
@@ -6466,18 +6466,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-acre">
 				<displayName>ܦܕܢܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܦܕܢܐ</unitPattern>
+				<unitPattern count="other">{0} ܦ̈ܕܢܐ</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>ܝܪ̈ܕܐ²</displayName>
+				<unitPattern count="one">{0} ܝܪܕܐ²</unitPattern>
 				<unitPattern count="other">{0} ܝܪ̈ܕܐ²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ܐܩܠ̈ܐ²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܐܩܠܐ²</unitPattern>
+				<unitPattern count="other">{0} ܐܩܠ̈ܐ²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>ܐܢ²</displayName>
@@ -6487,8 +6487,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>ܩܪܛܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ܩܪܛܐ</unitPattern>
+				<unitPattern count="other">{0} ܩܪ̈ܛܐ</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>ܡܓ/ܕܝܣܝܠܝܬܪܐ</displayName>
@@ -6501,34 +6501,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܡܡܘܠ܊/ܠ</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܠܘܐܐ</displayName>
+				<unitPattern count="one">ܡܠܘܐܐ</unitPattern>
+				<unitPattern count="other">{0} ܡܠܘܐ̈ܐ</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܡܢܘ̈ܬܐ/ܡܠܝܘܢ</displayName>
 				<unitPattern count="one">{0} ܡܢܘܬܐ/ܡܠ܊</unitPattern>
 				<unitPattern count="other">{0} ܡܢܘ̈ܬܐ/ܡܠ܊</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName>ܒܡܐܐ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}%</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName>ܒܐܠܦܐ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}‰</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">‱</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0}‱</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܘܠ</displayName>
+				<unitPattern count="one">{0} ܡܘܠ</unitPattern>
+				<unitPattern count="other">{0} ܡܘܠ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>ܠ/ܟܡ</displayName>
@@ -6541,97 +6541,97 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܠ/100ܟܡ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܝܠ̈ܐ/ܓܠܘܢܐ</displayName>
+				<unitPattern count="one">{0} ܡܝܠܐ ܒܓܠܘܢܐ</unitPattern>
+				<unitPattern count="other">{0} ܡܝܠ̈ܐ ܒܓܠܘܢܐ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܝܠ̈ܐ/ܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</displayName>
+				<unitPattern count="one">{0} ܡܝܠܐ/ܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܡܝܠܐ/ܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܦܝܬܐܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܦܝܬܐܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܦܝܬܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܬܝܪܐܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܬܝܪܐܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܬܝܪܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܬܝܪܐܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܬܝܪܐܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܬܝܪܐܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܓܝܓܐܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܓܝܓܐܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܓܐܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܓܐܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܟܝܠܘܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܟܝܠܘܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܒܬ</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܒܐܝܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܒܐܝܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܒܐܝܬ</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܒܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܒܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܒܬ</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>ܕܪܐ</displayName>
 				<unitPattern count="one">{0} ܕܪܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ܕܪ̈ܐ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܥܣܝܪܘܬܐ</displayName>
 				<unitPattern count="one">{0} ܥܣܝܪܘܬܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ܥܣܝܪ̈ܘܬܐ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ܫܢܬܐ</displayName>
 				<unitPattern count="one">{0} ܫܢܬܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} ܫ̈ܢܐ</unitPattern>
+				<perUnitPattern>{0}/ܫܢܬܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܪܘܒܥܐ</displayName>
 				<unitPattern count="one">{0} ܪܘܒܥܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ܪ̈ܘܒܥܐ</unitPattern>
 				<perUnitPattern>{0}/ܪܘܒܥܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>ܝܪܚܐ</displayName>
 				<unitPattern count="one">{0} ܝܪܚܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} ܝܪ̈ܚܐ</unitPattern>
+				<perUnitPattern>{0}/ܝܪܚܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ܫܒܘܥܐ</displayName>
@@ -6643,181 +6643,181 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ܝܘܡܐ</displayName>
 				<unitPattern count="one">{0} ܝ</unitPattern>
 				<unitPattern count="other">{0} ܝ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ܝܘܡܐ</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ܫܥܬܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} ܫܥ</unitPattern>
+				<unitPattern count="other">{0} ܫܥ</unitPattern>
+				<perUnitPattern>{0}/ܫܥ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ܩ</displayName>
+				<unitPattern count="one">{0} ܩ</unitPattern>
+				<unitPattern count="other">{0} ܩ</unitPattern>
+				<perUnitPattern>{0}/ܩ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ܪ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܪ</unitPattern>
+				<unitPattern count="other">{0} ܪ</unitPattern>
 				<perUnitPattern>{0}/ܪ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ܡܝܠܝ ܪ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡܝܠܝ ܪ</unitPattern>
+				<unitPattern count="other">{0} ܡܝܠܝ ܪ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>ܡܝܟܪܘ ܪ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡܝܟܪܘ ܪ</unitPattern>
+				<unitPattern count="other">{0} ܡܝܟܪܘ ܪ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܢܐܢܘ ܪ</displayName>
+				<unitPattern count="one">{0} ܢܐܢܘ ܪ</unitPattern>
+				<unitPattern count="other">{0} ܢܐܢܘ ܪ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܐܡܦܝܪ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܐܡܦܝܪ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܐܡܦܝܪ</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܠܝܐܡܦܝܪ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡ ܐܡܦܝܪ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡ ܐܡܦܝܪ</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܘܗܡ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܘܗܡ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܘܗܡ</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܒܘܠܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܒܘܠܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܒܘܠܬ</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName draft="unconfirmed">ܟ ܟܐܠܘܪܝ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟ ܟܐܠܘܪܝ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟ ܟܐܠܘܪܝ</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName draft="unconfirmed">ܟܐܠ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܐܠ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟܐܠ</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName draft="unconfirmed">ܟ ܓܝܐܘܠ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟ ܓܝܐܘܠ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟ ܓܝܐܘܠ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܓܝܐܘܠ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܐܘܠ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܐܘܠ</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName draft="unconfirmed">ܟܘܫ܏-ܫ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܘܫ܏-ܫ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟܘܫ܏-ܫ</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܐܠܝܟܬܪܘܢ ܒܘܠܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܐܠܝܟܬܪܘܢ ܒܘܠܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܐܠܝܟܬܪܘܢ ܒܘܠܬ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܒܪܝܛܢܝܐ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܒܪܝܛܢܝܐ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܒܪܝܛܢܝܐ</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܐܡܪܝܟܐ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܐܡܪܝܟܐ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܫܘܚܬܐ ܕܫܚܝܢܘܬܐ ܕܐܡܪܝܟܐ</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܢܝܘܬܢ</displayName>
+				<unitPattern count="one">{0} ܢܝܘܬܢ</unitPattern>
+				<unitPattern count="other">{0} ܢܝܘܬܢ</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>ܟܘܫ܊/100 ܟܡ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܟܘܫ܊ ܒ 100 ܟܡ</unitPattern>
+				<unitPattern count="other">{0} ܟܘܫ܊ ܒ 100 ܟܡ</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܓܝܓܐܗܪܬܙ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓܝܓܐܗܪܬܙ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܓܝܓܐܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܓܐܗܪܬܙ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܓܐܗܪܬܙ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܓܐܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܟܝܠܘܗܪܬܙ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟܝܠܘܗܪܬܙ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟܝܠܘܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܗܪܬܙ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܗܪܬܙ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܗܪܬܙ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>ܦܝ̈ܟܣܠܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܦܝܟܣܠܐ</unitPattern>
+				<unitPattern count="other">{0} ܦܝܟܣܠܐ</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>ܡܝܓܐܦܝ̈ܟܣܠܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡ.ܦܝܟܣܠܐ</unitPattern>
+				<unitPattern count="other">{0} ܡ.ܦܝܟܣܠܐ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ܦܝ̈ܟܣܠܐ/ܣܡ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܦܝ̈ܟܣܠܐ/ܣܡ</unitPattern>
+				<unitPattern count="other">{0} ܦܝ̈ܟܣܠܐ/ܣܡ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ܦܝ̈ܟܣܠܐ ܒܐܢܟ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܦܝ̈ܟܣܠܐ/ܐܢ</unitPattern>
+				<unitPattern count="other">{0} ܦܝ̈ܟܣܠܐ/ܐܢ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܥܘܒܐ ܐܪܥܝܐ</displayName>
+				<unitPattern count="one">{0} ܥܘܒܐ ܐܪܥܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܥܘܒܐ ܐܪܥܝܐ</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܟܡ</displayName>
 				<unitPattern count="one">{0}ܟܡ</unitPattern>
 				<unitPattern count="other">{0}ܟܡ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ܟܡ</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>ܡ</displayName>
 				<unitPattern count="one">{0}ܡ</unitPattern>
 				<unitPattern count="other">{0}ܡ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ܡ</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܕܣܡ</displayName>
 				<unitPattern count="one">{0}ܕܣܡ</unitPattern>
 				<unitPattern count="other">{0}ܕܣܡ</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܣܡ</displayName>
 				<unitPattern count="one">{0}ܣܡ</unitPattern>
 				<unitPattern count="other">{0}ܣܡ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ܣܡ</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ܡܡ</displayName>
 				<unitPattern count="one">{0}ܡܡ</unitPattern>
 				<unitPattern count="other">{0}ܡܡ</unitPattern>
 			</unit>
@@ -6842,81 +6842,81 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܡܝܠ̈ܐ</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܝܪܕ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܝܪܕ̈ܐ</unitPattern>
+				<unitPattern count="other">{0} ܝܪܕ̈ܐ</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܐܩܠ̈ܐ</displayName>
 				<unitPattern count="one">{0} ܐܩܠܐ</unitPattern>
 				<unitPattern count="other">{0} ܐܩܠ̈ܐ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ܐܩܠܐ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>ܐܢ܊</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ܚܕܐ ܐܢ܊</unitPattern>
+				<unitPattern count="other">{0} ܐܢ܊</unitPattern>
 				<perUnitPattern>{0}/ܐܢܟ</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>ܦܪܣܚܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܦܪܣܚܐ</unitPattern>
+				<unitPattern count="other">{0} ܦܪ̈ܣܚܐ</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܫ̈ܢܐ ܕܢܘܗܪܐ</displayName>
 				<unitPattern count="one">{0} ܫ ܢ</unitPattern>
 				<unitPattern count="other">{0} ܫ ܢ</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>ܡ.ܪ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡ.ܪ.</unitPattern>
+				<unitPattern count="other">{0} ܡ.ܪ.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>ܦܘܪܠܢܓ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܦܘܪܠܢܓ</unitPattern>
+				<unitPattern count="other">{0} ܦܘܪ̈ܠܢܓ</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܝ̈ܠܐ ܝܡܝ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܡܝܠܐ ܝܡܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܡܝ̈ܠܐ ܝܡܝ̈ܐ</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܝ̈ܠܐ-ܐܣܟܢܕܝܢܒܝܝܢ</displayName>
+				<unitPattern count="one">{0} ܡܝ̈ܠܐ-ܐܣܟܢܕܝܢܒܝܝܢ</unitPattern>
+				<unitPattern count="other">{0} ܡܝ̈ܠܐ-ܐܣܟܢܕܝܢܒܝܝܢ</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܢܘܩܙ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܢܘܩܙܐ</unitPattern>
+				<unitPattern count="other">{0} ܢܘܩܙ̈ܐ</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>ܥܘܒܐ ܫܡܫܝܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܥܘܒܐ ܫܡܫܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܥܘܒܐ ܫܡܫܝܐ</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܠܘܩܣ</displayName>
+				<unitPattern count="one">{0} ܠܘܩܣ</unitPattern>
+				<unitPattern count="other">{0} ܠܘܩܣ</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܢܗܝܪܐ</displayName>
+				<unitPattern count="one">{0} ܢܗܝܪܐ</unitPattern>
+				<unitPattern count="other">{0} ܢܗܝܪܐ</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܠܘܡܝܢ</displayName>
 				<unitPattern count="one">{0} ܠܘܡܝܢ</unitPattern>
 				<unitPattern count="other">{0} ܠܘܡܝܢ</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܬ.ܡ</displayName>
+				<unitPattern count="one">{0} ܬ.ܡ</unitPattern>
+				<unitPattern count="other">{0} ܬ.ܡ</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>ܟܓ</displayName>
@@ -6946,9 +6946,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܬܘܢ̈ܐ</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܣܬܘܢ</displayName>
+				<unitPattern count="one">{0} ܣܛܘܢ</unitPattern>
+				<unitPattern count="other">{0} ܣܛܘܢ</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>ܡܢܝܐ</displayName>
@@ -6968,151 +6968,151 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܩܪ̈ܛܐ</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܕܐܠܬܘܢ</displayName>
+				<unitPattern count="one">{0} ܕܐܠܬܘܢ</unitPattern>
+				<unitPattern count="other">{0} ܕܐܠܬܘܢ</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܥܘܫܢܐ ܐܪܥܝܐ</displayName>
 				<unitPattern count="one">{0} ܥܘܫܢܐ ܐܪܥܝܐ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ܥܘܫܢܐ ܐܪܥܝܐ</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܥܘܫܢܐ ܫܡܫܝܐ</displayName>
+				<unitPattern count="one">{0} ܥܘܫܢܐ ܫܡܫܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܥܘܫܢܐ ܫܡܫܝܐ</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܦܪܕܐ</displayName>
+				<unitPattern count="one">{0} ܦܪܕܐ</unitPattern>
+				<unitPattern count="other">{0} ܦܪ̈ܕܐ</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName draft="unconfirmed">ܓ ܘܐܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܓ ܘܐܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܓ ܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName draft="unconfirmed">ܡ ܘܐܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡ ܘܐܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡ ܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName draft="unconfirmed">ܟ ܘܐܬ</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="unconfirmed">{0} ܟ ܘܐܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܟ ܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܘܐܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܘܐܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܡܝܠܝܘܐܬ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܡܝܠܝܘܐܬ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܡܝܠܝܘܐܬ</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ܚܝܠܐ ܕܣܘܣܝܐ</displayName>
+				<unitPattern count="one" draft="unconfirmed">{0} ܣܘܣܝܐ</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} ܣܘܣܝܐ</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>ܦܣܟܠ</displayName>
+				<unitPattern count="one">{0} ܦܣܟ̈ܠܐ</unitPattern>
 				<unitPattern count="other">{0} ܦܣܟ̈ܠܐ</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>ܗܟܬܘܦܣܟܠ</displayName>
+				<unitPattern count="one">{0} ܗܟܬܘܦܣܟ̈ܠܐ</unitPattern>
 				<unitPattern count="other">{0} ܗܟܬܘܦܣܟ̈ܠܐ</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܟܝܠܘܦܣܟܠ</displayName>
+				<unitPattern count="one">{0} ܟܝܠܘܦܣܟܠ</unitPattern>
+				<unitPattern count="other">{0} ܟܝܠܘܦܣܟܠ</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܝܓܐܦܣܟܠ</displayName>
+				<unitPattern count="one">{0} ܡܝܓܐܦܣܟܠ</unitPattern>
+				<unitPattern count="other">{0} ܡܝܓܐܦܣܟܠ</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܟܡ/ܫ</displayName>
+				<unitPattern count="one">{0} ܟܡ/ܫ</unitPattern>
+				<unitPattern count="other">{0} ܟܡ/ܫ</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡ/ܪ</displayName>
+				<unitPattern count="one">{0} ܡ/ܪ</unitPattern>
+				<unitPattern count="other">{0} ܡ/ܪ</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܡܝܠ̈ܐ/ܫ</displayName>
+				<unitPattern count="one">{0} ܡܝܠܐ/ܫ</unitPattern>
+				<unitPattern count="other">{0} ܡܝܠ̈ܐ/ܫ</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܩܛܪ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܩܛܪܐ</unitPattern>
+				<unitPattern count="other">{0} ܩܛܪ̈ܐ</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°ܡ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°ܡ</unitPattern>
+				<unitPattern count="other">{0}°ܡ</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>°ܦ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°ܦ</unitPattern>
+				<unitPattern count="other">{0}°ܦ</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܕ ܟܠܒܝܢ</displayName>
+				<unitPattern count="one">{0} ܕ ܟܠܒܝܢ</unitPattern>
+				<unitPattern count="other">{0} ܕ ܟܠܒܝܢ</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ܢܝܘܬܢ-ܡܝܬܪ̈ܐ</displayName>
 				<unitPattern count="one">{0} ܢܝܘܬܢ-ܡܝܬܪ̈ܐ</unitPattern>
 				<unitPattern count="other">{0} ܢܝܘܬܢ-ܡܝܬܪ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܟܡ³</displayName>
+				<unitPattern count="one">{0} ܟܡ³</unitPattern>
+				<unitPattern count="other">{0} ܟܡ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>ܡ³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} ܡ³</unitPattern>
+				<unitPattern count="other">{0} ܡ³</unitPattern>
+				<perUnitPattern>{0}/ܡ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>ܣܡ³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} ܣܡ³</unitPattern>
+				<unitPattern count="other">{0} ܣܡ³</unitPattern>
+				<perUnitPattern>{0}/ܣܡ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>ܡܝܠ̈ܐ³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܡܝܠܐ³</unitPattern>
+				<unitPattern count="other">{0} ܡܝܠ̈ܐ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>ܝܪ̈ܕܐ³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܝܪܕܐ³</unitPattern>
+				<unitPattern count="other">{0} ܝܪ̈ܕܐ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>ܐܩܠ̈ܐ³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܐܩܠܐ³</unitPattern>
+				<unitPattern count="other">{0} ܐܩܠ̈ܐ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>ܐܢ³</displayName>
@@ -7131,9 +7131,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ܠܝܬܪܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} ܠܝܬܪܐ</unitPattern>
+				<unitPattern count="other">{0} ܠܝܬܪ̈ܐ</unitPattern>
+				<perUnitPattern>{0}/ܠ</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>ܕܝܣܝܠܝܬܪ̈ܐ</displayName>
@@ -7151,9 +7151,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܡܠܬܪ̈܊</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>ܐܩܠ̈ܐ-ܦܕܢܐ</displayName>
@@ -7161,73 +7161,73 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ܐܩܠ̈ܐ-ܦܕܢܐ</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܓܠܘܢ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܓܠܘܢܐ</unitPattern>
+				<unitPattern count="other">{0} ܓܠܘܢ̈ܐ</unitPattern>
 				<perUnitPattern>{0}/ܓܠܘܢ̈ܐ</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ܓܠܘܢ̈ܐ ܐܡܦܪܬܘܪܝܐ</displayName>
+				<unitPattern count="one">{0} ܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܓܠܘܢ̈ܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<perUnitPattern>{0}/ܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܪ̈ܘܒܥܐ ܓܠܘܢ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܪܘܒܥܐ ܓܠܘܢܐ</unitPattern>
+				<unitPattern count="other">{0} ܪ̈ܘܒܥܐ ܓܠܘܢ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܐܘܢܩ̈ܝܐ ܪ̈ܕܘܝܐ</displayName>
+				<unitPattern count="one">{0} ܐܘܢܩܝܐ ܪܕܘܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܐܘܢܩ̈ܝܐ ܪ̈ܕܘܝܐ</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܐܘܢܩ̈ܝܐ ܪ̈ܕܘܝܐ ܐܡܦܪܬܘܪܝܐ</displayName>
+				<unitPattern count="one">{0} ܐܘܢܩܝܐ ܪܕܘܝܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܐܘܢܩ̈ܝܐ ܪ̈ܕܘܝܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܬܪ̈ܘܕܐ ܪ̈ܒܐ</displayName>
+				<unitPattern count="one">{0} ܬܪܘܕܐ ܪܒܐ</unitPattern>
+				<unitPattern count="other">{0} ܬܪ̈ܘܕܐ ܪ̈ܒܐ</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܬܪ̈ܘܕܐ ܙܥܘܪ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܬܪܘܕܐ ܙܥܘܪܐ</unitPattern>
+				<unitPattern count="other">{0} ܬܪ̈ܘܕܐ ܙܥܘܪ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܬܪ̈ܘܕܐ ܚܠܝ̈ܐ</displayName>
+				<unitPattern count="one">{0} ܬܪܘܕܐ ܚܠܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܬܪ̈ܘܕܐ ܚܠܝ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܬܪ̈ܘܕܐ ܚܠܝ̈ܐ ܐܡܦܪܬܘܪܝܐ</displayName>
+				<unitPattern count="one">{0} ܬܪܘܕܐ ܚܠܝܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܬܪ̈ܘܕܐ ܚܠܝ̈ܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܛܘܦܬܐ</displayName>
+				<unitPattern count="one">{0} ܛܘܦܬܐ</unitPattern>
+				<unitPattern count="other">{0} ܛܘܦ̈ܐ</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>ܕܪܟܡܐ ܪܕܘܝܐ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ܕܪܟܡܐ ܪܕܘܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܕܪ̈ܟܡܐ ܪ̈ܕܘܝܐ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ܪ̈ܘܒܥܐ ܓܠܘܢ̈ܐ ܐܡܦܪܬܘܪܝܐ</displayName>
+				<unitPattern count="one">{0} ܪܘܒܥܐ ܓܠܘܢܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
+				<unitPattern count="other">{0} ܪ̈ܘܒܥܐ ܓܠܘܢ̈ܐ ܐܡܦܪܬܘܪܝܐ</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>ܦܢܝܬܐ ܫܪܫܢܝܬܐ</displayName>
+				<coordinateUnitPattern type="east">{0} ܡܕܢܚܐ</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} ܓܪܒܝܐ</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0} ܬܝܡܢܐ</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0} ܡܥܪܒ݂ܐ</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -7254,46 +7254,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} ܝܐ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}، ܝܐ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ܝܐ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}، ܝܐ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ܝܐ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}، ܘ{1}</listPatternPart>
+			<listPatternPart type="2">{0} ܘ{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}، ܘ{1}</listPatternPart>
+			<listPatternPart type="2">{0} ܘ{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}، ܘ{1}</listPatternPart>
+			<listPatternPart type="2">{0} ܘ{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}، ܘ{1}</listPatternPart>
+			<listPatternPart type="2">{0} ܘ{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}، ܘ{1}</listPatternPart>
+			<listPatternPart type="2">{0} ܘ{1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>
@@ -7314,10 +7314,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern draft="provisional">{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>

--- a/common/main/szl.xml
+++ b/common/main/szl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -621,7 +621,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR" draft="unconfirmed">Nauru</territory>
 			<territory type="NU" draft="unconfirmed">Niue</territory>
 			<territory type="NZ" draft="unconfirmed">Nowo Zelandyjo</territory>
-			<territory type="NZ" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="NZ" alt="variant" draft="unconfirmed">Nowo Zelandyjo</territory>
 			<territory type="OM" draft="unconfirmed">Ōman</territory>
 			<territory type="PA" draft="unconfirmed">Panama</territory>
 			<territory type="PE" draft="unconfirmed">Peru</territory>
@@ -681,7 +681,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN" draft="unconfirmed">Tunezyjo</territory>
 			<territory type="TO" draft="unconfirmed">Tōnga</territory>
 			<territory type="TR" draft="unconfirmed">Turcyjo</territory>
-			<territory type="TR" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="TR" alt="variant" draft="unconfirmed">Turcyjo</territory>
 			<territory type="TT" draft="unconfirmed">Trynidad i Tobago</territory>
 			<territory type="TV" draft="unconfirmed">Tuvalu</territory>
 			<territory type="TW" draft="unconfirmed">Tajwan</territory>
@@ -809,7 +809,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} 'ô' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} 'ô' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -817,7 +817,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} 'ô' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} 'ô' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -825,7 +825,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -833,7 +833,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1178,13 +1178,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat" draft="unconfirmed">sb</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">niydziela</day>
+							<day type="mon" draft="unconfirmed">pyńdziałek</day>
+							<day type="tue" draft="unconfirmed">wtorek</day>
+							<day type="wed" draft="unconfirmed">strzoda</day>
+							<day type="thu" draft="unconfirmed">sztwortek</day>
+							<day type="fri" draft="unconfirmed">piōntek</day>
+							<day type="sat" draft="unconfirmed">sobota</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -1237,8 +1237,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">po połedniu</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">do połedniŏ</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">po połedniu</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">do połedniŏ</dayPeriod>
@@ -1251,8 +1251,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">po połedniu</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">do połedniŏ</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">po połedniu</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">do połedniŏ</dayPeriod>
@@ -1332,7 +1332,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} 'ô' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} 'ô' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1340,7 +1340,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1} 'ô' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1} 'ô' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1348,7 +1348,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1356,7 +1356,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4250,8 +4250,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
@@ -4282,7 +4282,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern draft="unconfirmed">{0} na {1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName draft="unconfirmed">stało grawitacyje</displayName>
@@ -5673,10 +5673,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<unitPattern count="other" draft="unconfirmed">{0} G</unitPattern>
@@ -5688,8 +5688,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0}″</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">procynt</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}%</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName draft="unconfirmed">l/100 km</displayName>
@@ -5718,31 +5718,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-minute">
 				<displayName draft="unconfirmed">minuty</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} min</unitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName draft="unconfirmed">sekundy</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} sek.</unitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">milisekundy</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ms</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">km</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} km</unitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName draft="unconfirmed">metry</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} m</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">cyntymetry</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} cm</unitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">mm</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName draft="unconfirmed">mile</displayName>
@@ -5756,12 +5756,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern draft="unconfirmed">{0}/cal</perUnitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">kg</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} kg</unitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">g</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} g</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName draft="unconfirmed">funty</displayName>
@@ -5770,23 +5770,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} KM</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">km/h</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} km/h</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">°C</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0}°C</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName draft="unconfirmed">liter</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} l</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<coordinateUnitPattern type="east" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
+				<displayName draft="unconfirmed">rychtōnek</displayName>
+				<coordinateUnitPattern type="east" draft="unconfirmed">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north" draft="unconfirmed">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south" draft="unconfirmed">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west" draft="unconfirmed">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -5813,14 +5813,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0} abo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0}, abo {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0} abo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0}, abo {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0} abo {1}</listPatternPart>
 		</listPattern>
@@ -5837,20 +5837,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} i {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} i {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0} i {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}, {1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} i {1}</listPatternPart>
 			<listPatternPart type="2" draft="unconfirmed">{0} i {1}</listPatternPart>
 		</listPattern>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -103,8 +103,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">செரோகீ</language>
 			<language type="chy">செயேனி</language>
 			<language type="ckb">மத்திய குர்திஷ்</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">மத்திய குர்திஷ்</language>
+			<language type="ckb" alt="variant">மத்திய குர்திஷ்</language>
 			<language type="clc">சில்கோடின்</language>
 			<language type="co">கார்சிகன்</language>
 			<language type="cop">காப்டிக்</language>
@@ -1012,7 +1012,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">டுனிசியா</territory>
 			<territory type="TO">டோங்கா</territory>
 			<territory type="TR">துருக்கியே</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">துருக்கியே</territory>
 			<territory type="TT">டிரினிடாட் &amp; டொபாகோ</territory>
 			<territory type="TV">துவாலு</territory>
 			<territory type="TW">தைவான்</territory>
@@ -1589,7 +1589,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1597,7 +1597,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2173,7 +2173,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2181,7 +2181,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2485,18 +2485,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">பங்.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">சித்திரை</month>
@@ -2588,18 +2588,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">துல் ஹிஜ்.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">முஹர்ரம்</month>
@@ -2675,53 +2675,53 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, d MMMM, y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM, y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM, y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d/M/y GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
 						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d MMM, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E, d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d MMM, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -5782,7 +5782,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -5914,13 +5914,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000000" count="one">¤ 000மி</pattern>
 					<pattern type="100000000" count="other">¤ 000மி</pattern>
 					<pattern type="1000000000" count="one">¤ 0பி</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber" draft="contributed">¤ 0பி</pattern>
 					<pattern type="1000000000" count="other">¤0பி</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber" draft="contributed">¤ 0பி</pattern>
 					<pattern type="10000000000" count="one">¤ 00பி</pattern>
 					<pattern type="10000000000" count="other">¤ 00பி</pattern>
 					<pattern type="100000000000" count="one">¤ 000பி</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber" draft="contributed">¤ 000பி</pattern>
 					<pattern type="100000000000" count="other">¤000பி</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber" draft="contributed">¤ 000பி</pattern>
 					<pattern type="1000000000000" count="one">¤ 0டி</pattern>
@@ -7557,7 +7557,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-decade">
 				<displayName>தசாப்தங்கள்</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} தசாப்தம்</unitPattern>
 				<unitPattern count="one" case="ablative">{0} தசாப்தத்தில்</unitPattern>
 				<unitPattern count="one" case="accusative">{0} தசாப்தத்தை</unitPattern>
 				<unitPattern count="one" case="dative">{0} தசாப்தத்திற்கு</unitPattern>
@@ -8852,12 +8852,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8990,7 +8990,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>பெர்மிரியட்</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -9198,7 +9198,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>எலக்ட்ரான்வோல்ட்</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -9288,7 +9288,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9398,7 +9398,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>சூரிய ஆரம்</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -9418,7 +9418,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>சூரிய ஒளிர்வுத்தன்மை</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -9487,12 +9487,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>புவித் திணிவுகள்</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>சூரியத் திணிவுகள்</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -9802,7 +9802,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>குவாட். இம்பீ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} குவாட். இம்பீ.</unitPattern>
 				<unitPattern count="other">{0} குவாட். இம்பீ.</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -9815,64 +9815,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>டெ.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>செ.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>மி.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
 				<unitPrefixPattern>மை.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>நா.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>பி.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>பெ.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>அட்.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>ஜெப்.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>யொ.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>டெக்.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>ஹெ.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>கி.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>மெ.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>ஜி.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
 				<unitPrefixPattern>டெரா{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>பெட்.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>எ.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>ஜெ.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>யா.{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>கிபி{0}</unitPrefixPattern>
@@ -9902,35 +9902,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஜி-ஃபோர்ஸ்</displayName>
 				<unitPattern count="one">{0} ஜி.ஃபோ.</unitPattern>
 				<unitPattern count="other">{0} ஜி.ஃபோ.</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>மீ/வி²</displayName>
 				<unitPattern count="one" draft="contributed">{0}மீ/வி²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மீ/வி²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
+				<displayName>சுழற்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}சுழற்.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}சுழற்.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>ரேடி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}ரேடி.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ரேடி.</unitPattern>
 			</unit>
@@ -9940,46 +9940,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஆர்க்நிமி.</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஆர்க்விநா.</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>கி.மீ.²</displayName>
 				<unitPattern count="one">{0} ச.கிமீ.</unitPattern>
 				<unitPattern count="other">{0} ச.கிமீ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/கி.மீ.²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஹெக்டேர்</displayName>
 				<unitPattern count="one">{0} ஹெக்.</unitPattern>
 				<unitPattern count="other">{0} ஹெக்.</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>மீட்டர்கள்²</displayName>
 				<unitPattern count="one">{0} ச.மீ.</unitPattern>
 				<unitPattern count="other">{0} ச.மீ.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/மீ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>செ.மீ.²</displayName>
 				<unitPattern count="one" draft="contributed">{0}செ.மீ.²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}செ.மீ.²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/செ.மீ.²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>சதுர மைல்கள்</displayName>
 				<unitPattern count="one">{0} ச. மை.</unitPattern>
 				<unitPattern count="other">{0} ச. மை.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/மை.²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஏக்கர்</displayName>
 				<unitPattern count="one">{0} ஏக்.</unitPattern>
 				<unitPattern count="other">{0} ஏக்.</unitPattern>
 			</unit>
@@ -9997,7 +9997,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName draft="contributed">அங்.²</displayName>
 				<unitPattern count="one" draft="contributed">{0}அங்.²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}அங்.²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/அங்.²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName draft="contributed">ட்யூனம்</displayName>
@@ -10010,12 +10010,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}கார.</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>மி.கி./டெ.லி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மிகி/டெ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மிகி/டெ</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>மி.மோ./லி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மிமோ/லி</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மிமோ/லி</unitPattern>
 			</unit>
@@ -10025,7 +10025,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}உருப்படி</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>ப./மி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}ப./மி.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ப./மி.</unitPattern>
 			</unit>
@@ -10036,21 +10036,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName draft="contributed">‰</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName draft="contributed">‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>மோல்</displayName>
 				<unitPattern count="one" draft="contributed">{0}மோல்</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மோல்</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>லி./கி.மீ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}லி./கி.மீ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}லி./கி.மீ.</unitPattern>
 			</unit>
@@ -10060,7 +10060,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}லி./100கி.மீ</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>மை./கே.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மை./கே.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மை./கே.</unitPattern>
 			</unit>
@@ -10070,12 +10070,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>PB</displayName>
 				<unitPattern count="one" draft="contributed">{0}PB</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>TB</displayName>
 				<unitPattern count="one" draft="contributed">{0}TB</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}TB</unitPattern>
 			</unit>
@@ -10120,12 +10120,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}பை.</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>பிட்</displayName>
 				<unitPattern count="one" draft="contributed">{0}பிட்</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பிட்</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>நூ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}நூ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}நூ.</unitPattern>
 			</unit>
@@ -10138,7 +10138,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>ஆண்டு</displayName>
 				<unitPattern count="one">{0} ஆ</unitPattern>
 				<unitPattern count="other">{0} ஆ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ஆ.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName draft="contributed">கா.</displayName>
@@ -10150,13 +10150,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>மா</displayName>
 				<unitPattern count="one">{0} மா</unitPattern>
 				<unitPattern count="other">{0} மா</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/மா</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>வா</displayName>
 				<unitPattern count="one">{0} வா</unitPattern>
 				<unitPattern count="other">{0} வா</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/வா.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>நா</displayName>
@@ -10198,7 +10198,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}நா.செ.</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஆம்ப்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}ஆம்.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ஆம்.</unitPattern>
 			</unit>
@@ -10218,32 +10218,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}வோ.</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>கி.கலோ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கி.கலோ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கி.கலோ.</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>கலோ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கலோ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கலோ.</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>கலோ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கலோ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கலோ.</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>கி.ஜூ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கி.ஜூ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கி.ஜூ.</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஜூல்</displayName>
 				<unitPattern count="one" draft="contributed">{0}ஜூ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ஜூ.</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>கி.வா-ம.நே.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கி.வா.ம.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கி.வா.ம.</unitPattern>
 			</unit>
@@ -10253,12 +10253,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>பி.டி.யூ</displayName>
 				<unitPattern count="one" draft="contributed">{0}பி.டி.யூ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பி.டி.யூ</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>யூஎஸ் தெர்ம்</displayName>
 				<unitPattern count="one" draft="contributed">{0}யூஎஸ் தெ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}யூஎஸ் தெ.</unitPattern>
 			</unit>
@@ -10278,32 +10278,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}கி.வா.ம./100கி.மி.</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஜி.ஹெஸ்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}ஜி.ஹெ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ஜி.ஹெ.</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>மெ.ஹெஸ்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மெ.ஹெ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மெ.ஹெ.</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>கி.ஹெஸ்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கி.ஹெ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கி.ஹெ.</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஹெஸ்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}ஹெ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ஹெ.</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>எம்</displayName>
 				<unitPattern count="one" draft="contributed">{0}எம்</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}எம்</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>பிக்</displayName>
 				<unitPattern count="one" draft="contributed">{0}பிக்</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பிக்</unitPattern>
 			</unit>
@@ -10313,32 +10313,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}எம்.பி</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>பிக். / செ.மீ</displayName>
 				<unitPattern count="one" draft="contributed">{0}பி/செ.மீ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பி/செ.மீ</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>பிக். / அங்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}பி/அங்.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பி/அங்.</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>பு / செ.மீ</displayName>
 				<unitPattern count="one" draft="contributed">{0}பு/செ.மீ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பு/செ.மீ</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>பு / அங்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}பு/அங்.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பு/அங்.</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>புள்ளி</displayName>
 				<unitPattern count="one" draft="contributed">{0}புள்ளி</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}புள்ளி</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="one" draft="contributed">{0}R⊕</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}R⊕</unitPattern>
 			</unit>
@@ -10376,12 +10376,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}μமீ.</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>நா.மீ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}நா.மீ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}நா.மீ.</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>பை.மீ</displayName>
 				<unitPattern count="one">{0} பை.மீ.</unitPattern>
 				<unitPattern count="other">{0} பை.மீ.</unitPattern>
 			</unit>
@@ -10392,8 +10392,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-yard">
 				<displayName draft="contributed">கெஜ.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} கெஜ.</unitPattern>
+				<unitPattern count="other">{0} கெஜ.</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName draft="contributed">அடி</displayName>
@@ -10408,7 +10408,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/அங்.</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>பு.நொ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}பு.நொ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பு.நொ.</unitPattern>
 			</unit>
@@ -10418,22 +10418,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ஒ.ஆ.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>வா.அ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}வா.அ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}வா.அ.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>பர்</displayName>
 				<unitPattern count="one" draft="contributed">{0}பர்</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பர்</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஃபே.</displayName>
 				<unitPattern count="one" draft="contributed">{0}ஃபே.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ஃபே.</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>க.மை.</displayName>
 				<unitPattern count="one" draft="contributed">{0}க.மை.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}க.மை.</unitPattern>
 			</unit>
@@ -10443,7 +10443,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} ஸ்.மை.</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>அ.பு.</displayName>
 				<unitPattern count="one" draft="contributed">{0}அ.பு.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}அ.பு.</unitPattern>
 			</unit>
@@ -10463,7 +10463,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} கே.</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>லூம.</displayName>
 				<unitPattern count="one" draft="contributed">{0}லூம.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}லூம.</unitPattern>
 			</unit>
@@ -10473,7 +10473,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>ட.</displayName>
 				<unitPattern count="one" draft="contributed">{0}ட.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ட.</unitPattern>
 			</unit>
@@ -10490,17 +10490,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/கி.</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>மி.கி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மி.கி.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மி.கி.</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">μகி</displayName>
 				<unitPattern count="one" draft="contributed">{0}μகி</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}μகி</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>டன்</displayName>
 				<unitPattern count="one" draft="contributed">{0}டன்</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}டன்</unitPattern>
 			</unit>
@@ -10522,12 +10522,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/அவு.</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>அவு. டி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}அவு. டி.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}அவு. டி.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>கேர.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கேர.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கேர.</unitPattern>
 			</unit>
@@ -10547,37 +10547,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>கிரைன்</displayName>
 				<unitPattern count="one" draft="contributed">{0}கிரைன்</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கிரைன்</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>கி.வாட்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கி.வாட்.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கி.வாட்.</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>மெ.வா.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மெ.வா.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மெ.வா.</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>கி.வா.</displayName>
 				<unitPattern count="one">{0} கி.வா.</unitPattern>
 				<unitPattern count="other">{0} கி.வா.</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>வா.</displayName>
 				<unitPattern count="one">{0} வா.</unitPattern>
 				<unitPattern count="other">{0} வா.</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>மி.வா.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மி.வா.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மி.வா.</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>கு.தி.</displayName>
 				<unitPattern count="one">{0} கு.வே.</unitPattern>
 				<unitPattern count="other">{0} கு.வே.</unitPattern>
 			</unit>
@@ -10597,7 +10597,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} பா.அங்.</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>பார்</displayName>
 				<unitPattern count="one" draft="contributed">{0}பார்</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பார்</unitPattern>
 			</unit>
@@ -10607,12 +10607,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} மி.பா.</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm</displayName>
 				<unitPattern count="one" draft="contributed">{0}atm</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>பா.</displayName>
 				<unitPattern count="one" draft="contributed">{0}பா.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}பா.</unitPattern>
 			</unit>
@@ -10622,12 +10622,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ஹெ.பா.</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>கிபா</displayName>
 				<unitPattern count="one" draft="contributed">{0}கிபா</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கிபா</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>மெபா</displayName>
 				<unitPattern count="one" draft="contributed">{0}மெபா</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மெபா</unitPattern>
 			</unit>
@@ -10647,7 +10647,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} மை/ம.நே.</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>நா.</displayName>
 				<unitPattern count="one" draft="contributed">{0}நா.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}நா.</unitPattern>
 			</unit>
@@ -10672,59 +10672,59 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} கெல்.</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ப.அடி</displayName>
 				<unitPattern count="one" draft="contributed">{0}ப.அடி</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ப.அடி</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>நியூ.மீ</displayName>
 				<unitPattern count="one" draft="contributed">{0}நியூ.மீ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}நியூ.மீ</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>கிமீ³</displayName>
 				<unitPattern count="one">{0} க.கி.மீ.</unitPattern>
 				<unitPattern count="other">{0} க.கி.மீ.</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>மீ³</displayName>
 				<unitPattern count="one" draft="contributed">{0}மீ³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மீ³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/மீ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>செ.மீ.³</displayName>
 				<unitPattern count="one" draft="contributed">{0}செ.மீ.³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}செ.மீ.³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/செ.மீ.³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>மை³</displayName>
 				<unitPattern count="one">{0} க.மை.</unitPattern>
 				<unitPattern count="other">{0} க.மை.</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>யா.³</displayName>
 				<unitPattern count="one" draft="contributed">{0}யா.³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}யா.³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>அடி³</displayName>
 				<unitPattern count="one" draft="contributed">{0}அடி³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}அடி³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>அங்.³</displayName>
 				<unitPattern count="one" draft="contributed">{0}அங்.³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}அங்.³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>மெ.லி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மெ.லி.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மெ.லி.</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஹெ.லி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}ஹெ.லி.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ஹெ.லி.</unitPattern>
 			</unit>
@@ -10732,35 +10732,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>லி.</displayName>
 				<unitPattern count="one">{0}லி.</unitPattern>
 				<unitPattern count="other">{0}லி.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/லி.</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>டெ.லி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}டெ.லி.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}டெ.லி.</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>செ.லி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}செ.லி.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}செ.லி.</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>மிலி</displayName>
 				<unitPattern count="one" draft="contributed">{0}மிலி</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மிலி</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>மெ.பி.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மெ.பி.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மெ.பி.</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>மெ.கோப்பை</displayName>
 				<unitPattern count="one" draft="contributed">{0}மெ.கோ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மெ.கோ.</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஏக். அடி</displayName>
 				<unitPattern count="one" draft="contributed">{0}ஏக். அடி</unitPattern>
 				<unitPattern count="other">{0}ஏக். அடி</unitPattern>
 			</unit>
@@ -10770,19 +10770,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}புச.</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>கேல.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கேல.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கேல.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/கேல.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>இம். கேல.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கே.இம்.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கே.இம்.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/கேல. இம்.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>குவாட்.</displayName>
 				<unitPattern count="one" draft="contributed">{0}குவா.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}குவா.</unitPattern>
 			</unit>
@@ -10792,27 +10792,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}பின்.</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>கோ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கோ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கோ.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>தி. அவு.</displayName>
 				<unitPattern count="one" draft="contributed">{0}தி.அவு.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}தி.அவு.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>இம்பீ. தி. அவு.</displayName>
 				<unitPattern count="one" draft="contributed">{0}தி. அ. இ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}தி. அ. இ.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>மே.க.</displayName>
 				<unitPattern count="one" draft="contributed">{0}மே.க.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}மே.க.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>தே.க.</displayName>
 				<unitPattern count="one" draft="contributed">{0}தே.க.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}தே.க.</unitPattern>
 			</unit>
@@ -10822,17 +10822,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}பீப்.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>இ.க.</displayName>
 				<unitPattern count="one" draft="contributed">{0}இ.க.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}இ.க.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>இ.க. இம்பீ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}இ.க. இ.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}இ.க. இ.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>துளி</displayName>
 				<unitPattern count="one" draft="contributed">{0}துளி</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}துளி</unitPattern>
 			</unit>
@@ -10842,17 +10842,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}தி.டிரா.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>ஜிக.</displayName>
 				<unitPattern count="one" draft="contributed">{0}ஜிக.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ஜிக.</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>சிட்டி</displayName>
 				<unitPattern count="one" draft="contributed">{0}சிட்டி</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}சிட்டி</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>குவாட். இம்பீ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}கு. இம்.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}கு. இம்.</unitPattern>
 			</unit>
@@ -10888,16 +10888,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} அல்லது {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} அல்லது {1}</listPatternPart>
+			<listPatternPart type="2">{0} அல்லது {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} அல்லது {1}</listPatternPart>
+			<listPatternPart type="2">{0} அல்லது {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -10915,7 +10915,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
 			<listPatternPart type="start">{0} {1}</listPatternPart>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -1009,7 +1009,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">ట్యునీషియా</territory>
 			<territory type="TO">టోంగా</territory>
 			<territory type="TR">తుర్కియె</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">తుర్కియె</territory>
 			<territory type="TT">ట్రినిడాడ్ మరియు టొబాగో</territory>
 			<territory type="TV">టువాలు</territory>
 			<territory type="TW">తైవాన్</territory>
@@ -1519,7 +1519,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1527,7 +1527,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1535,7 +1535,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1543,7 +1543,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2095,7 +2095,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2103,7 +2103,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2905,7 +2905,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="one">{0} వారం క్రితం</relativeTimePattern>
 					<relativeTimePattern count="other">{0} వారాల క్రితం</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>{0} వారం</relativePeriod>
 			</field>
 			<field type="week-narrow">
 				<displayName>వా</displayName>
@@ -3346,7 +3346,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>నిమి.</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} నిమి.లో</relativeTimePattern>
 					<relativeTimePattern count="other">{0} నిమి.లో</relativeTimePattern>
@@ -5685,13 +5685,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -5714,7 +5714,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -6100,7 +6100,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="CNH">
 				<displayName>చైనీస్ యువాన్ (ఆఫ్‌షోర్)</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">చైనీస్ యువాన్ (ఆఫ్‌షోర్)</displayName>
 				<displayName count="other">చైనీస్ యువాన్ (ఆఫ్‌షోర్)</displayName>
 				<symbol>CNH</symbol>
 			</currency>
@@ -7198,7 +7198,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>చదరపు అంగుళానికి {0}</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>డునామ్‌లు</displayName>
 				<unitPattern count="one">{0} డునామ్</unitPattern>
 				<unitPattern count="other">{0} డునామ్‌లు</unitPattern>
 			</unit>
@@ -7363,8 +7363,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>రోజుకు {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-day-person">
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} రోజు</unitPattern>
+				<unitPattern count="other">{0} రోజులు</unitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>గంటలు</displayName>
@@ -7500,8 +7500,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} హెర్ట్‌జ్</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} emలు</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -8161,7 +8161,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8294,7 +8294,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>పెర్మేరియాడ్</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -8502,12 +8502,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>ఎలక్ట్రాన్‌వోల్ట్</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -8517,12 +8517,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>పౌండ్-ఫోర్స్</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>న్యూటన్</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -8547,17 +8547,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>పిక్సెల్స్</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
@@ -8592,7 +8592,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -8702,7 +8702,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>సౌర అర్ధవ్యాసం</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -8722,7 +8722,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>సోలార్ ల్యూమినోసైటైస్</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8791,12 +8791,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>భూమి ద్రవ్యరాశులు</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>సౌర ద్రవ్యరాశులు</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -8821,7 +8821,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="power-watt">
 				<displayName>వాట్‌లు</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
@@ -8866,7 +8866,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>పా</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} పాస్క.</unitPattern>
 				<unitPattern count="other">{0} పాస్క.</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8876,12 +8876,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>MPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -9056,7 +9056,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -9206,58 +9206,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>గు-శక్తి</displayName>
 				<unitPattern count="one">{0} గు</unitPattern>
 				<unitPattern count="other">{0} గు</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మీటర్లు/సెక²</displayName>
+				<unitPattern count="one">{0} మీ/సె²</unitPattern>
+				<unitPattern count="other">{0} మీ/సె²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>భ్రమ.</displayName>
+				<unitPattern count="one">{0} భ్రమ</unitPattern>
+				<unitPattern count="other">{0} భ్రమ.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>రేడియన్లు</displayName>
+				<unitPattern count="one">{0} రే.</unitPattern>
+				<unitPattern count="other">{0} రే.</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>డిగ్రీలు</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>ఆర్క్ నిమి.</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>ఆర్క్ సెక.</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>కి.మీ²</displayName>
 				<unitPattern count="one">{0} కి.మీ²</unitPattern>
 				<unitPattern count="other">{0} కి.మీ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ కి.మీ²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>హెక్టారు</displayName>
@@ -9265,61 +9265,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} హె.</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>మీటర్లు²</displayName>
 				<unitPattern count="one">{0} మీ²</unitPattern>
 				<unitPattern count="other">{0} మీ²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/మీ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>సెం.మీ²</displayName>
+				<unitPattern count="one">{0} సెం.మీ²</unitPattern>
+				<unitPattern count="other">{0} సెం.మీ²</unitPattern>
+				<perUnitPattern>{0}/సెం.మీ²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>చద. మైళ్లు</displayName>
 				<unitPattern count="one">{0} మై²</unitPattern>
 				<unitPattern count="other">{0} మై²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ చద. మై²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ఎకరాలు</displayName>
 				<unitPattern count="one">{0} ఎక.</unitPattern>
 				<unitPattern count="other">{0} ఎక.</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>గజాలు²</displayName>
+				<unitPattern count="one">{0} గ²</unitPattern>
+				<unitPattern count="other">{0} గ²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>చద. అడుగులు</displayName>
 				<unitPattern count="one">{0} అ²</unitPattern>
 				<unitPattern count="other">{0} అ²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>అంగుళాలు²</displayName>
+				<unitPattern count="one">{0} అం²</unitPattern>
+				<unitPattern count="other">{0} అం²</unitPattern>
+				<perUnitPattern>{0}/అం²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>డునామ్‌లు</displayName>
+				<unitPattern count="one">{0} డునామ్</unitPattern>
+				<unitPattern count="other">{0} డునామ్</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>కేరట్లు</displayName>
+				<unitPattern count="one" draft="contributed">{0} కేర.</unitPattern>
+				<unitPattern count="other">{0} కేర.</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>మి.గ్రా./డె.లీ.</displayName>
 				<unitPattern count="one" draft="contributed">{0}మిగ/డెలీ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}మిగ/డెలీ</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>మిల్లీమోల్‌/లీటర్</displayName>
 				<unitPattern count="one" draft="contributed">{0}మిమో/లీ</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}మిమో/లీ</unitPattern>
 			</unit>
@@ -9329,9 +9329,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}ఐటమ్</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>భాగాలు/మిలియన్</displayName>
+				<unitPattern count="one">{0} భా./మి.</unitPattern>
+				<unitPattern count="other">{0} భా./మి.</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9339,24 +9339,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మైలుకు</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName draft="contributed">‱</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>మోల్</displayName>
 				<unitPattern count="one">{0} మోల్</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} మోల్</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>లీటర్లు/కి.మీ</displayName>
+				<unitPattern count="one">{0} లీ./కి.మీ</unitPattern>
+				<unitPattern count="other">{0} లీ./కి.మీ</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>లీ/100కి.మీ.</displayName>
@@ -9364,88 +9364,88 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}లీ/100కి.మీ.</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>మైళ్లు/గ్యా.</displayName>
 				<unitPattern count="one">{0}మై./గ్యా.</unitPattern>
 				<unitPattern count="other">{0}మై./గ్యా.</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>మైళ్లు/గ్యా. ఇంపీరియల్</displayName>
 				<unitPattern count="one">{0}మై/గ.ఇం</unitPattern>
 				<unitPattern count="other">{0}మై/గ.ఇం</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>పె.బైట్</displayName>
+				<unitPattern count="one">{0} పీబీ</unitPattern>
+				<unitPattern count="other">{0} పీబీ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>టె.బైట్</displayName>
+				<unitPattern count="one">{0} టీబీ</unitPattern>
+				<unitPattern count="other">{0} టీబీ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName draft="contributed">టె.బిట్</displayName>
+				<unitPattern count="one">{0} టె.బిట్</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}టె.బిట్లు</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>గి.బైట్</displayName>
+				<unitPattern count="one">{0} జీబీ</unitPattern>
+				<unitPattern count="other">{0} జీబీ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>గి.బిట్</displayName>
+				<unitPattern count="one">{0} గి.బిట్</unitPattern>
+				<unitPattern count="other">{0} గి.బిట్లు</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మె.బైట్</displayName>
+				<unitPattern count="one">{0} ఎమ్‌బి</unitPattern>
+				<unitPattern count="other">{0} ఎమ్‌బి</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>మె.బిట్</displayName>
+				<unitPattern count="one">{0} మె.బిట్</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}మె.బి.</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>కి.బైట్</displayName>
+				<unitPattern count="one">{0} కేబీ</unitPattern>
+				<unitPattern count="other">{0} కేబీ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>కి.బిట్</displayName>
+				<unitPattern count="one">{0} కి.బిట్</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} కి.బిట్లు</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>బైట్</displayName>
+				<unitPattern count="one">{0} బై</unitPattern>
+				<unitPattern count="other">{0} బై</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>బిట్</displayName>
+				<unitPattern count="one">{0} బి</unitPattern>
+				<unitPattern count="other">{0} బి</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>శ</displayName>
+				<unitPattern count="one">{0} శ</unitPattern>
+				<unitPattern count="other">{0} శ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>దశా.</displayName>
+				<unitPattern count="one">{0} దశా.</unitPattern>
+				<unitPattern count="other">{0} ద.</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>సం</displayName>
 				<unitPattern count="one">{0}సం</unitPattern>
 				<unitPattern count="other">{0}సం</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/సం.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
+				<displayName>క్వా</displayName>
 				<unitPattern count="one">{0}క్వా</unitPattern>
 				<unitPattern count="other">{0}క్వా</unitPattern>
 				<perUnitPattern>{0}/క్వా</perUnitPattern>
@@ -9454,13 +9454,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>నెల</displayName>
 				<unitPattern count="one">{0}నె</unitPattern>
 				<unitPattern count="other">{0}నె</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/నె.</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>వా</displayName>
 				<unitPattern count="one">{0}వా</unitPattern>
 				<unitPattern count="other">{0}వా</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/వా.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>రోజు</displayName>
@@ -9492,89 +9492,89 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}మి.సె</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మై.సె.</displayName>
+				<unitPattern count="one">{0} మై.సె</unitPattern>
+				<unitPattern count="other">{0} మై.సె</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>నా.సె.</displayName>
+				<unitPattern count="one">{0} నా.సె</unitPattern>
+				<unitPattern count="other">{0} నా.సె</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ఆంప్స్</displayName>
+				<unitPattern count="one" draft="contributed">{0} ఆం</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ఆం</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">మిల్లీ ఆంప్స్</displayName>
+				<unitPattern count="one" draft="contributed">{0} మి. ఆం</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} మి. ఆం</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ఓమ్స్</displayName>
+				<unitPattern count="one" draft="contributed">{0} Ω</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">వోల్ట్స్</displayName>
+				<unitPattern count="one" draft="contributed">{0} వో</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} వో</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">కి.కే</displayName>
+				<unitPattern count="one" draft="contributed">{0} కి.కే</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} కి.కే</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>కే</displayName>
+				<unitPattern count="one">{0} కే.</unitPattern>
+				<unitPattern count="other">{0} కే.</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>కే.</displayName>
+				<unitPattern count="one">{0} కే.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} కే.</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">కిలోజౌల్</displayName>
+				<unitPattern count="one" draft="contributed">{0} కి.జౌ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} కి.జౌ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">జౌల్స్</displayName>
+				<unitPattern count="one" draft="contributed">{0} జౌ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} జౌ.</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">కి.వా. గంట</displayName>
+				<unitPattern count="one" draft="contributed">{0} కి.వా.గం</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} కి.వా.గం</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ఎలక్ట్రాన్‌వోల్ట్</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">US థెర్మ్‌</displayName>
+				<unitPattern count="one" draft="contributed">{0} US థెర్మ్‌</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}US థెర్మ్‌.</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>పౌండ్-ఫోర్స్</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>న్యూటన్</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName draft="contributed">కి.వా./100కి.మీ.</displayName>
@@ -9582,19 +9582,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}కి.వా/100కి.మీ</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">గిగా హెడ్జ్</displayName>
 				<unitPattern count="one" draft="contributed">{0} గి. హె.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} గి. హె.</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">మె.హె</displayName>
+				<unitPattern count="one" draft="contributed">{0} మె.హె</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} మె.హె</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">కి.హె</displayName>
+				<unitPattern count="one" draft="contributed">{0} కి.హె</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} కి.హె</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>Hz</displayName>
@@ -9602,49 +9602,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
 				<unitPattern count="one">{0}MP</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>పి/సె.మీ.</displayName>
+				<unitPattern count="one">{0} పి/సె.మీ.</unitPattern>
+				<unitPattern count="other">{0} పి/సె.మీ.</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>పి/అం.</displayName>
+				<unitPattern count="one">{0} పి/అం.</unitPattern>
+				<unitPattern count="other">{0} పి/అం.</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>బి/సె.మీ.</displayName>
+				<unitPattern count="one">{0} బి/సె.మీ.</unitPattern>
+				<unitPattern count="other">{0} బి/సె.మీ.</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>బి/అం.</displayName>
+				<unitPattern count="one">{0} బి/అం.</unitPattern>
+				<unitPattern count="other">{0} బి/అం.</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>బిందువు</displayName>
+				<unitPattern count="one">{0} బిందువు</unitPattern>
+				<unitPattern count="other">{0} బిందువు</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>కి.మీ</displayName>
@@ -9675,17 +9675,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}మి.మీ</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మై.మీటర్లు</displayName>
+				<unitPattern count="one">{0} మై.మీ.</unitPattern>
+				<unitPattern count="other">{0} మై.మీ.</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>నా.మీ.</displayName>
+				<unitPattern count="one">{0} నా.మీ.</unitPattern>
+				<unitPattern count="other">{0} నా.మీ.</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>పి.మీ.</displayName>
 				<unitPattern count="one">{0} పి.మీ</unitPattern>
 				<unitPattern count="other">{0} పి.మీ</unitPattern>
 			</unit>
@@ -9712,34 +9712,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/అం.</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>పార్సెక్‌లు</displayName>
+				<unitPattern count="one">{0} పా.లు</unitPattern>
+				<unitPattern count="other">{0} పా.</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>కాంతి సం.</displayName>
 				<unitPattern count="one">{0} కాం. సం</unitPattern>
 				<unitPattern count="other">{0} కాం. సం</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="one">au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ఫర్లాంగులు</displayName>
+				<unitPattern count="one">{0} ఫర్</unitPattern>
+				<unitPattern count="other">{0} ఫర్</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>వ్యామములు</displayName>
+				<unitPattern count="one">{0} వ్యా.</unitPattern>
+				<unitPattern count="other">{0} వ్యా.</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>నా.మై.</displayName>
+				<unitPattern count="one">{0} నా.మై.</unitPattern>
+				<unitPattern count="other">{0} నా.మై.</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>స్కాం.మై.</displayName>
@@ -9747,39 +9747,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} స్కాం.మై.</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>పాయింట్‌లు</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>సౌర అర్ధవ్యాసం</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>లక్స్</displayName>
+				<unitPattern count="one">{0} ల.</unitPattern>
+				<unitPattern count="other">{0} ల.</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>క్యా.</displayName>
+				<unitPattern count="one">{0} క్యా.</unitPattern>
+				<unitPattern count="other">{0} క్యా.</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>లు.</displayName>
+				<unitPattern count="one">{0} లు.</unitPattern>
+				<unitPattern count="other">{0} లు.</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>సోలార్ ల్యూమినోసైటైస్</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ట</displayName>
+				<unitPattern count="one">{0} ట</unitPattern>
+				<unitPattern count="other">{0} ట</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>కి.గ్రా</displayName>
@@ -9794,17 +9794,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/గ్రా.</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మి.గ్రా.</displayName>
+				<unitPattern count="one">{0} మి.గ్రా.</unitPattern>
+				<unitPattern count="other">{0} మి.గ్రా.</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మై.గ్రా.</displayName>
+				<unitPattern count="one">{0} మై.గ్రా.</unitPattern>
+				<unitPattern count="other">{0} మై.గ్రా.</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>టన్నులు</displayName>
 				<unitPattern count="one" draft="contributed">{0} ట</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ట</unitPattern>
 			</unit>
@@ -9826,47 +9826,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/ ఔ.</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ట్రా.ఔ.</displayName>
+				<unitPattern count="one">{0} ట్రా.ఔ.</unitPattern>
+				<unitPattern count="other">{0} ట్రా.ఔ.</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>క్యారెట్లు</displayName>
+				<unitPattern count="one">{0} క్యారె.</unitPattern>
+				<unitPattern count="other">{0} క్యారె.</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>డాల్టన్‌లు</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>భూమి ద్రవ్యరాశులు</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>సౌర ద్రవ్యరాశులు</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>ధాన్యము</displayName>
 				<unitPattern count="one" draft="contributed">{0} ధాన్య.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} ధాన్య.</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">గి.వా</displayName>
+				<unitPattern count="one" draft="contributed">{0} గి.వా</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} గి.వా</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">మె.వా</displayName>
+				<unitPattern count="one" draft="contributed">{0} మె.వా</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} మె.వా</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">కి.వా</displayName>
 				<unitPattern count="one">{0} కి.వా</unitPattern>
 				<unitPattern count="other">{0} కి.వా</unitPattern>
 			</unit>
@@ -9876,12 +9876,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">మి.వా</displayName>
+				<unitPattern count="one" draft="contributed">{0} మి.వా</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} మి.వా</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">హా.ప</displayName>
 				<unitPattern count="one">{0} హా.ప</unitPattern>
 				<unitPattern count="other">{0} హా.ప</unitPattern>
 			</unit>
@@ -9901,9 +9901,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} అం.పాద</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">బార్</displayName>
+				<unitPattern count="one" draft="contributed">{0} బార్</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} బార్‌లు</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName draft="contributed">మి.బార్</displayName>
@@ -9911,14 +9911,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} మి.బార్</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">వాతావ</displayName>
+				<unitPattern count="one" draft="contributed">{0} వాతావ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} వాతావ</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>పా</displayName>
+				<unitPattern count="one">{0} పాస్క.</unitPattern>
+				<unitPattern count="other">{0} పాస్క.</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName draft="contributed">హె.పా</displayName>
@@ -9926,14 +9926,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} హె.పా</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>కి.మీ/గం</displayName>
@@ -9951,9 +9951,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} మై/గం.</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>నా.</displayName>
+				<unitPattern count="one">{0} నా.</unitPattern>
+				<unitPattern count="other">{0} నా.</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName draft="contributed">°</displayName>
@@ -9976,187 +9976,187 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} కె</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>పౌం.ఫీ.</displayName>
+				<unitPattern count="one">{0} పౌం.ఫీ.</unitPattern>
+				<unitPattern count="other">{0} పౌం.ఫీ.</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>కి.మీ³</displayName>
 				<unitPattern count="one">{0} కిమీ³</unitPattern>
 				<unitPattern count="other">{0} కిమీ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>మీ³</displayName>
+				<unitPattern count="one">{0} మీ³</unitPattern>
+				<unitPattern count="other">{0} మీ³</unitPattern>
+				<perUnitPattern>{0}/మీ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>సెం.మీ³</displayName>
+				<unitPattern count="one">{0} సెం.మీ³</unitPattern>
+				<unitPattern count="other">{0} సెం.మీ³</unitPattern>
+				<perUnitPattern>{0}/సెం.మీ³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>మై³</displayName>
 				<unitPattern count="one">{0} మై³</unitPattern>
 				<unitPattern count="other">{0} మై³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>గజాలు³</displayName>
+				<unitPattern count="one">{0} గ³</unitPattern>
+				<unitPattern count="other">{0} గ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>అ³</displayName>
+				<unitPattern count="one">{0} అ³</unitPattern>
+				<unitPattern count="other">{0} అ³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>అం³</displayName>
+				<unitPattern count="one">{0} అం³</unitPattern>
+				<unitPattern count="other">{0} అం³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మె.లీ.</displayName>
+				<unitPattern count="one">{0} మె.లీ.</unitPattern>
+				<unitPattern count="other">{0} మె.లీ.</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>హె.లీ.</displayName>
+				<unitPattern count="one">{0} హె.లీ.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} హె.లీ.</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>లీటరు</displayName>
 				<unitPattern count="one">{0}లీ</unitPattern>
 				<unitPattern count="other">{0}లీ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/లీ.</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>డె.లీ.</displayName>
+				<unitPattern count="one">{0} డె.లీ.</unitPattern>
+				<unitPattern count="other">{0} డె.లీ.</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>సె.లీ.</displayName>
+				<unitPattern count="one">{0} సె.లీ.</unitPattern>
+				<unitPattern count="other">{0} సె.లీ.</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మి.లీ.</displayName>
+				<unitPattern count="one">{0} మి.లీ.</unitPattern>
+				<unitPattern count="other">{0} మి.లీ.</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మె.పిం.</displayName>
+				<unitPattern count="one">{0} మె.పిం.</unitPattern>
+				<unitPattern count="other">{0} మె.పిం.</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>మె.కప్పు</displayName>
+				<unitPattern count="one">{0}/మె.క.</unitPattern>
+				<unitPattern count="other">{0}/మె.క.</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ఎ.అ.</displayName>
+				<unitPattern count="one">{0} ఎ.అ.</unitPattern>
+				<unitPattern count="other">{0} ఎ.అ.</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>బుషెల్‌లు</displayName>
+				<unitPattern count="one">{0} బు.</unitPattern>
+				<unitPattern count="other">{0} బు.</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>గ్యా.</displayName>
+				<unitPattern count="one">{0} గ్యా.</unitPattern>
+				<unitPattern count="other">{0} గ్యా.</unitPattern>
+				<perUnitPattern>{0}/గ్యా.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>ఇంపీరియల్ గ్యా.</displayName>
 				<unitPattern count="one">{0}గ్యా. ఇం.</unitPattern>
 				<unitPattern count="other">{0}గ్యా. ఇం.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ గ్యా. ఇంపీరియల్</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>పావు వం.</displayName>
 				<unitPattern count="one">{0}పావు వం.</unitPattern>
 				<unitPattern count="other">{0}పావు వం.</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>పింట్లు</displayName>
+				<unitPattern count="one">{0} పిం.</unitPattern>
+				<unitPattern count="other">{0} పిం.</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>కప్పులు</displayName>
+				<unitPattern count="one">{0} క.</unitPattern>
+				<unitPattern count="other">{0} క.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ద్ర.ఔ.</displayName>
+				<unitPattern count="one">{0} ద్ర.ఔ.</unitPattern>
+				<unitPattern count="other">{0} ద్ర.ఔ.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="one" draft="contributed">{0}ద.ఔ.ఇం.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}ద.ఔ.ఇం.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>టే.స్పూ.</displayName>
+				<unitPattern count="one">{0} టే.స్పూ</unitPattern>
+				<unitPattern count="other">{0} టే.స్పూ</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>టీ.స్పూ.</displayName>
 				<unitPattern count="one">{0}టీ.స్పూ.</unitPattern>
 				<unitPattern count="other">{0}టీ.స్పూ.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>బారెల్</displayName>
+				<unitPattern count="one">{0} బారెల్</unitPattern>
+				<unitPattern count="other">{0} బారెల్</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>డె.స్పూ.</displayName>
+				<unitPattern count="one">{0} డె.స్పూ.</unitPattern>
+				<unitPattern count="other">{0} డె.స్పూ.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>డె.స్పూ. ఇంపీరియల్</displayName>
 				<unitPattern count="one">{0}డె.ఇం.</unitPattern>
 				<unitPattern count="other">{0}డె.ఇం.</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>తగ్గించు</displayName>
+				<unitPattern count="one">{0} తగ్గించు</unitPattern>
+				<unitPattern count="other">{0} తగ్గించు</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
+				<displayName>డ్రామ్ ఫ్లూయిడ్</displayName>
 				<unitPattern count="one">{0}డ్రా.ఫ.</unitPattern>
 				<unitPattern count="other">{0}డ్రా.ఫ.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>జిగ్గర్</displayName>
+				<unitPattern count="one">{0} జిగ్గర్</unitPattern>
+				<unitPattern count="other">{0} జిగ్గర్</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>చిటిక</displayName>
+				<unitPattern count="one">{0} చిటిక</unitPattern>
+				<unitPattern count="other">{0} చిటిక</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>చతు. ఇంపీరియల్</displayName>
 				<unitPattern count="one" draft="contributed">{0}చతు.ఇం.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}చతు.ఇం.</unitPattern>
 			</unit>
@@ -10192,20 +10192,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} లేదా {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} లేదా {1}</listPatternPart>
+			<listPatternPart type="2">{0} లేదా {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} లేదా {1}</listPatternPart>
+			<listPatternPart type="2">{0} లేదా {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -10430,11 +10430,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
-			<namePattern alt="1">{given-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 			<namePattern>{given-monogram-allCaps}.{given2-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
+			<namePattern alt="1">{given-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}.{given2-monogram-allCaps}.{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{given} {given2-initial} {surname} {credentials}</namePattern>
@@ -10488,10 +10488,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {given-informal}</namePattern>

--- a/common/main/tg.xml
+++ b/common/main/tg.xml
@@ -909,8 +909,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">AM</dayPeriod>
@@ -919,16 +919,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
@@ -1233,18 +1233,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Дхул-Ҳ.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">муҳаррам</month>
@@ -1423,7 +1423,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>мабдаи таърих</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>мабдаи таърих</displayName>
 			</field>
 			<field type="era-narrow">
 				<displayName>мабдаи таърих</displayName>
@@ -1488,10 +1488,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="quarter-narrow">
 				<displayName>чр.</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">пас аз {0} чр.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} чр. пеш</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -1557,7 +1557,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativePeriod>ҳ. {0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ҳ.</displayName>
 				<relative type="-1">ҳафтаи г.</relative>
 				<relative type="0">ҳафтаи ҷ.</relative>
 				<relative type="1">ҳафтаи о.</relative>
@@ -1591,10 +1591,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>рӯз</displayName>
+				<relative type="-1">дирӯз</relative>
+				<relative type="0">имрӯз</relative>
+				<relative type="1">фардо</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">пас аз {0} рӯз</relativeTimePattern>
 				</relativeTime>
@@ -1604,9 +1604,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>рӯз</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">дирӯз</relative>
+				<relative type="0">имрӯз</relative>
+				<relative type="1">фардо</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">пас аз {0} рӯз</relativeTimePattern>
 				</relativeTime>
@@ -1873,13 +1873,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>AM/PM</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>AM/PM</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>AM/PM</displayName>
 			</field>
 			<field type="hour">
 				<displayName>соат</displayName>
@@ -1969,10 +1969,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>минтақаи вақт</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>минтақаи вақт</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>минтақаи вақт</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -124,7 +124,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">เชอโรกี</language>
 			<language type="chy">เชเยนเน</language>
 			<language type="ckb">เคิร์ดตอนกลาง</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">เคิร์ดตอนกลาง</language>
 			<language type="ckb" alt="variant">เคิร์ดโซรานี</language>
 			<language type="clc">ชิลโคติน</language>
 			<language type="co">คอร์ซิกา</language>
@@ -2325,7 +2325,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2333,7 +2333,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2919,7 +2919,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2927,7 +2927,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3186,7 +3186,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="5" draft="contributed">5</month>
 							<month type="6" draft="contributed">6</month>
 							<month type="7" draft="contributed">7</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
+							<month type="7" yeartype="leap" draft="contributed">7</month>
 							<month type="8" draft="contributed">8</month>
 							<month type="9" draft="contributed">9</month>
 							<month type="10" draft="contributed">10</month>
@@ -4543,7 +4543,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="minute-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>นาที</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">ใน {0} นาที</relativeTimePattern>
 				</relativeTime>
@@ -7716,7 +7716,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>โลตีเลโซโท</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">โลตีเลโซโท</displayName>
 				<symbol>LSL</symbol>
 			</currency>
 			<currency type="LTL">
@@ -8559,7 +8559,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">ลูกบาศก์{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>แรง G</displayName>
@@ -8871,8 +8871,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} เฮิรตซ์</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>พิกเซล</displayName>
@@ -8900,7 +8900,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ดอท</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ดอท</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>รัศมีของโลก</displayName>
@@ -10283,18 +10283,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>แรง G</displayName>
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
@@ -10302,76 +10302,76 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ม./วิ²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
+				<displayName>รอบ</displayName>
 				<unitPattern count="other">{0}รอบ</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>เรเดียน</displayName>
 				<unitPattern count="other">{0}เรเดียน</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>องศา</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>ลิปดา</displayName>
 				<unitPattern count="other">{0}ลิปดา</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>พิลิปดา</displayName>
 				<unitPattern count="other">{0}พิลิปดา</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ตร.กม.</displayName>
 				<unitPattern count="other">{0}ตร.กม.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ตร.กม.</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>เฮกตาร์</displayName>
 				<unitPattern count="other">{0}เฮกตาร์</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ตร.ม.</displayName>
 				<unitPattern count="other">{0}ตร.ม.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ตร.ม.</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ตร.ซม.</displayName>
 				<unitPattern count="other">{0}ตร.ซม.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ตร.ซม.</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ตร.ไมล์</displayName>
 				<unitPattern count="other">{0}ตร.ไมล์</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ตร.ไมล์</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>เอเคอร์</displayName>
 				<unitPattern count="other">{0}เอเคอร์</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>ตร.หลา</displayName>
 				<unitPattern count="other">{0}ตร.หลา</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ตร.ฟุต</displayName>
 				<unitPattern count="other">{0}ตร.ฟุต</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ตร.นิ้ว</displayName>
 				<unitPattern count="other">{0}ตร.นิ้ว</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ตร.นิ้ว</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>ดูนัม</displayName>
 				<unitPattern count="other">{0}ดูนัม</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>กะรัต</displayName>
 				<unitPattern count="other">{0}กะรัต</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>มก./ดล.</displayName>
 				<unitPattern count="other">{0}มก./ดล.</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
@@ -10387,19 +10387,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}สตล.</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>เปอร์เซ็นต์</displayName>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>‰</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>โมล</displayName>
 				<unitPattern count="other">{0}โมล</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -10419,61 +10419,61 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>PB</displayName>
 				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>TB</displayName>
 				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Tb</displayName>
 				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>GB</displayName>
 				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gb</displayName>
 				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MB</displayName>
 				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mb</displayName>
 				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>kB</displayName>
 				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>kb</displayName>
 				<unitPattern count="other">{0}kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>ไบต์</displayName>
 				<unitPattern count="other">{0}ไบต์</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>บิต</displayName>
 				<unitPattern count="other">{0}บิต</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>ศตวรรษ</displayName>
 				<unitPattern count="other">{0}ศตวรรษ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>ทศวรรษ</displayName>
 				<unitPattern count="other">{0}ทศวรรษ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ปี</displayName>
 				<unitPattern count="other">{0}ปี</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ปี</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>ไตรมาส</displayName>
@@ -10483,32 +10483,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-month">
 				<displayName>เดือน</displayName>
 				<unitPattern count="other">{0}เดือน</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/เดือน</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>สัปดาห์</displayName>
 				<unitPattern count="other">{0}สัปดาห์</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/สัปดาห์</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>วัน</displayName>
 				<unitPattern count="other">{0}วัน</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/วัน</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>ชั่วโมง</displayName>
 				<unitPattern count="other">{0}ชม.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ชม.</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>นาที</displayName>
 				<unitPattern count="other">{0}นาที</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/นาที</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>วิ</displayName>
 				<unitPattern count="other">{0}วิ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/วิ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>มิลลิวินาที</displayName>
@@ -10523,19 +10523,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}นาโนวิ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>แอมป์</displayName>
 				<unitPattern count="other">{0}แอมป์</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>มิลลิแอมป์</displayName>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>โอห์ม</displayName>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>โวลต์</displayName>
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
@@ -10551,15 +10551,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}แคลอรี</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>กิโลจูล</displayName>
 				<unitPattern count="other">{0}กิโลจูล</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>จูล</displayName>
 				<unitPattern count="other">{0}จูล</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>กว.-ชม.</displayName>
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
@@ -10567,11 +10567,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>บีทียู</displayName>
 				<unitPattern count="other">{0}BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>เธิร์ม</displayName>
 				<unitPattern count="other">{0}เธิร์ม</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
@@ -10583,43 +10583,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>กิโลวัตต์-ชม./100กม.</displayName>
 				<unitPattern count="other">{0}กิโลวัตต์-ชม./100กม.</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>MP</displayName>
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -10631,31 +10631,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ดอท</displayName>
 				<unitPattern count="other">{0}ดอท</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>กม.</displayName>
 				<unitPattern count="other">{0}กม.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/กม.</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>เมตร</displayName>
 				<unitPattern count="other">{0}ม.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ม.</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ดม.</displayName>
 				<unitPattern count="other">{0}ดม.</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>ซม.</displayName>
 				<unitPattern count="other">{0}ซม.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ซม.</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>มม.</displayName>
@@ -10666,53 +10666,53 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>น.ม.</displayName>
 				<unitPattern count="other">{0}น.ม.</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>พิโกเมตร</displayName>
 				<unitPattern count="other">{0}พิโกเมตร</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ไมล์</displayName>
 				<unitPattern count="other">{0}ไมล์</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>หลา</displayName>
 				<unitPattern count="other">{0}หลา</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ฟุต</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ฟุต</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>นิ้ว</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/นิ้ว</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>พาร์เซก</displayName>
 				<unitPattern count="other">{0}พาร์เซก</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>ปีแสง</displayName>
 				<unitPattern count="other">{0}ปีแสง</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>หน่วยดาราศาสตร์</displayName>
 				<unitPattern count="other">{0}au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>เฟอร์ลอง</displayName>
 				<unitPattern count="other">{0}fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>ฟาทอม</displayName>
 				<unitPattern count="other">{0}fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ไมล์ทะเล</displayName>
 				<unitPattern count="other">{0}ไมล์ทะเล</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
@@ -10720,7 +10720,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>จุด</displayName>
 				<unitPattern count="other">{0}จุด</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
@@ -10728,15 +10728,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>ลักซ์</displayName>
 				<unitPattern count="other">{0}ลักซ์</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -10744,51 +10744,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>ต.</displayName>
 				<unitPattern count="other">{0}ต.</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>กก.</displayName>
 				<unitPattern count="other">{0}กก.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/กก.</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>กรัม</displayName>
 				<unitPattern count="other">{0}ก.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ก.</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>มก.</displayName>
 				<unitPattern count="other">{0}มก.</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>มคก.</displayName>
 				<unitPattern count="other">{0}มคก.</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>ตัน</displayName>
 				<unitPattern count="other">{0}ตัน</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>สโตน</displayName>
 				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>ปอนด์</displayName>
 				<unitPattern count="other">{0}#</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ปอนด์</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>ออนซ์</displayName>
 				<unitPattern count="other">{0}ออนซ์</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ออนซ์</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz t</displayName>
 				<unitPattern count="other">{0}oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>กะรัต</displayName>
 				<unitPattern count="other">{0}กะรัต</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
@@ -10804,59 +10804,59 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>เกรน</displayName>
 				<unitPattern count="other">{0}เกรน</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>กิกะวัตต์</displayName>
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>เมกะวัตต์</displayName>
 				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>กิโลวัตต์</displayName>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>วัตต์</displayName>
 				<unitPattern count="other">{0}วัตต์</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>มิลลิวัตต์</displayName>
 				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>แรงม้า</displayName>
 				<unitPattern count="other">{0}แรงม้า</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>มม. ปรอท</displayName>
 				<unitPattern count="other">{0}มม. ปรอท</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ปอนด์/ตร.นิ้ว</displayName>
 				<unitPattern count="other">{0}psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>นิ้วปรอท</displayName>
 				<unitPattern count="other">{0}นิ้วปรอท</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>บาร์</displayName>
 				<unitPattern count="other">{0}บาร์</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>มิลลิบาร์</displayName>
 				<unitPattern count="other">{0}มิลลิบาร์</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>บรรยากาศ</displayName>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -10864,11 +10864,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -10884,12 +10884,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ไมล์/ชม.</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>นอต</displayName>
 				<unitPattern count="other">{0}นอต</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -10900,108 +10900,108 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>N⋅m</displayName>
 				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>ลบ.กม.</displayName>
 				<unitPattern count="other">{0}ลบ.กม.</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ลบ.ม.</displayName>
 				<unitPattern count="other">{0}ลบ.ม.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ลบ.ม.</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ลบ.ซม.</displayName>
 				<unitPattern count="other">{0}ลบ.ซม.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ลบ.ซม.</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>ลบ.ไมล์</displayName>
 				<unitPattern count="other">{0}ลบ.ไมล์</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>ลบ.หลา</displayName>
 				<unitPattern count="other">{0}ลบ.หลา</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ลบ.ฟุต</displayName>
 				<unitPattern count="other">{0}ลบ.ฟุต</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ลบ.นิ้ว</displayName>
 				<unitPattern count="other">{0}ลบ.นิ้ว</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>เมกะลิตร</displayName>
 				<unitPattern count="other">{0}เมกะลิตร</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ฮล.</displayName>
 				<unitPattern count="other">{0}ฮล.</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ลิตร</displayName>
 				<unitPattern count="other">{0}ล.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ล.</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ดล.</displayName>
 				<unitPattern count="other">{0}ดล.</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ซล.</displayName>
 				<unitPattern count="other">{0}ซล.</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>มล.</displayName>
 				<unitPattern count="other">{0}มล.</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>ไพนต์เมตริก</displayName>
 				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>ถ. เมตริก</displayName>
 				<unitPattern count="other">{0}mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>เอเคอร์-ฟุต</displayName>
 				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>บุชเชล</displayName>
 				<unitPattern count="other">{0}bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>แกลลอน</displayName>
 				<unitPattern count="other">{0}แกลลอน</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/แกลลอน</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>แกลลอนอังกฤษ</displayName>
 				<unitPattern count="other">{0}galIm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/แกลลอนอังกฤษ</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>คว.</displayName>
 				<unitPattern count="other">{0}คว.</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>ไพนต์</displayName>
 				<unitPattern count="other">{0}ไพนต์</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>ถ้วย</displayName>
 				<unitPattern count="other">{0}ถ.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
@@ -11013,11 +11013,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ชต.</displayName>
 				<unitPattern count="other">{0}ชต.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ชช.</displayName>
 				<unitPattern count="other">{0}ชช.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
@@ -11025,7 +11025,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ช้อนขนม</displayName>
 				<unitPattern count="other">{0}ช้อนขนม</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
@@ -11033,7 +11033,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>หยด</displayName>
 				<unitPattern count="other">{0}หยด</unitPattern>
 			</unit>
 			<unit type="volume-dram">
@@ -11041,15 +11041,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>จิกเกอร์</displayName>
 				<unitPattern count="other">{0}จิกเกอร์</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
+				<displayName>หยิบมือ</displayName>
 				<unitPattern count="other">{0}หยิบมือ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt Imp</displayName>
 				<unitPattern count="other">{0}qt-Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -11084,28 +11084,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} หรือ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} หรือ {1}</listPatternPart>
 			<listPatternPart type="2">{0}หรือ{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} หรือ {1}</listPatternPart>
 			<listPatternPart type="2">{0}หรือ{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0} {1}</listPatternPart>
+			<listPatternPart type="middle">{0} {1}</listPatternPart>
+			<listPatternPart type="end">{0} และ{1}</listPatternPart>
 			<listPatternPart type="2">{0}และ{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0} {1}</listPatternPart>
 			<listPatternPart type="middle">{0} {1}</listPatternPart>
 			<listPatternPart type="end">{0} และ{1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0}และ{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0} {1}</listPatternPart>
@@ -11317,7 +11317,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -11329,13 +11329,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -11353,25 +11353,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -11383,31 +11383,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
 			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
 			<namePattern>{given-informal}</namePattern>
@@ -11425,16 +11425,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">ธนา</nameField>

--- a/common/main/ti.xml
+++ b/common/main/ti.xml
@@ -79,7 +79,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">ቸሮኪ</language>
 			<language type="chy">ሻያን</language>
 			<language type="ckb">ሶራኒ ኩርዲሽ</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">ሶራኒ ኩርዲሽ</language>
 			<language type="ckb" alt="variant">ማእከላይ ኩርዲሽ</language>
 			<language type="clc">ቺልኮቲን</language>
 			<language type="co">ኮርስኛ</language>
@@ -690,7 +690,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">ናውሩ</territory>
 			<territory type="NU">ኒዩ</territory>
 			<territory type="NZ">ኒው ዚላንድ</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">ኒው ዚላንድ</territory>
 			<territory type="OM">ዖማን</territory>
 			<territory type="PA">ፓናማ</territory>
 			<territory type="PE">ፔሩ</territory>
@@ -750,7 +750,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">ቱኒዝያ</territory>
 			<territory type="TO">ቶንጋ</territory>
 			<territory type="TR">ቱርኪ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ቱርኪ</territory>
 			<territory type="TT">ትሪኒዳድን ቶባጎን</territory>
 			<territory type="TV">ቱቫሉ</territory>
 			<territory type="TW">ታይዋን</territory>
@@ -855,29 +855,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE፣ d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM y G</pattern>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>dd/MM/yy GGGGG</pattern>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 				</dateTimeFormats>
@@ -885,14 +885,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<calendar type="dangi">
 				<dateTimeFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
 			<calendar type="ethiopic">
 				<dateTimeFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -1458,7 +1458,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1466,7 +1466,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1688,18 +1688,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -1718,18 +1718,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Muh.</month>
+							<month type="2">Saf.</month>
+							<month type="3">Rab. I</month>
+							<month type="4">Rab. II</month>
+							<month type="5">Jum. I</month>
+							<month type="6">Jum. II</month>
+							<month type="7">Raj.</month>
+							<month type="8">Sha.</month>
+							<month type="9">Ram.</month>
+							<month type="10">Shaw.</month>
+							<month type="11">Dhuʻl-Q.</month>
+							<month type="12">Dhuʻl-H.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -1746,18 +1746,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Muharram</month>
+							<month type="2">Safar</month>
+							<month type="3">Rabiʻ I</month>
+							<month type="4">Rabiʻ II</month>
+							<month type="5">Jumada I</month>
+							<month type="6">Jumada II</month>
+							<month type="7">Rajab</month>
+							<month type="8">Shaʻban</month>
+							<month type="9">Ramadan</month>
+							<month type="10">Shawwal</month>
+							<month type="11">Dhuʻl-Qiʻdah</month>
+							<month type="12">Dhuʻl-Hijjah</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1769,79 +1769,79 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE፣ d MMMM y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MMMM y G</pattern>
+							<datetimeSkeleton>GyMMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MMM y G</pattern>
+							<datetimeSkeleton>GyMMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/yy GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E d</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E፣ d MMM y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E፣ d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E፣ d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E፣ d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E፣ d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
 			<calendar type="japanese">
 				<dateTimeFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
 			<calendar type="persian">
 				<dateTimeFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
 			<calendar type="roc">
 				<dateTimeFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -1866,15 +1866,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">ኣብ {0} ዓ</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ቅድሚ {0} ዓ</relativeTimePattern>
 					<relativeTimePattern count="other">ቅድሚ {0} ዓ</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-short">
 				<displayName>ዓመት</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ዓሚ</relative>
+				<relative type="0">ሎሚ ዓመት</relative>
+				<relative type="1">ንዓመታ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ዓ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ዓ</relativeTimePattern>
@@ -1886,9 +1886,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>ዓመት</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ዓሚ</relative>
+				<relative type="0">ሎሚ ዓመት</relative>
+				<relative type="1">ንዓመታ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ዓ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ዓ</relativeTimePattern>
@@ -1914,9 +1914,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="quarter-short">
 				<displayName>ርብዒ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ዝሓለፈ ርብዒ</relative>
+				<relative type="0">ህሉው ርብዒ</relative>
+				<relative type="1">ዝመጽእ ርብዒ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ርብዒ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ርብዒ</relativeTimePattern>
@@ -1928,9 +1928,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="quarter-narrow">
 				<displayName>ርብዒ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ዝሓለፈ ርብዒ</relative>
+				<relative type="0">ህሉው ርብዒ</relative>
+				<relative type="1">ዝመጽእ ርብዒ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ርብዒ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ርብዒ</relativeTimePattern>
@@ -1957,8 +1957,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="month-short">
 				<displayName>ወርሒ</displayName>
 				<relative type="-1">ዝሓለፈ ወርሒ</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="0">ህሉው ወርሒ</relative>
+				<relative type="1">ዝመጽእ ወርሒ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ወርሒ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ወርሒ</relativeTimePattern>
@@ -1971,8 +1971,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="month-narrow">
 				<displayName>ወርሒ</displayName>
 				<relative type="-1">ዝሓለፈ ወርሒ</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="0">ህሉው ወርሒ</relative>
+				<relative type="1">ዝመጽእ ወርሒ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ወርሒ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ወርሒ</relativeTimePattern>
@@ -1999,9 +1999,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>ሰሙን</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ዝሓለፈ ሰሙን</relative>
+				<relative type="0">ህሉው ሰሙን</relative>
+				<relative type="1">ዝመጽእ ሰሙን</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ሰሙን</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ሰሙን</relativeTimePattern>
@@ -2014,9 +2014,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>ሰሙን</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ዝሓለፈ ሰሙን</relative>
+				<relative type="0">ህሉው ሰሙን</relative>
+				<relative type="1">ዝመጽእ ሰሙን</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ሰሙን</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ሰሙን</relativeTimePattern>
@@ -2034,7 +2034,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>ሰሙ. ናይ ወር.</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>ሰሙ. ናይ ወር.</displayName>
 			</field>
 			<field type="day">
 				<displayName>መዓልቲ</displayName>
@@ -2052,9 +2052,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>መዓልቲ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ትማሊ</relative>
+				<relative type="0">ሎሚ</relative>
+				<relative type="1">ጽባሕ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} መዓልቲ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} መዓልቲ</relativeTimePattern>
@@ -2066,9 +2066,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>መዓልቲ</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">ትማሊ</relative>
+				<relative type="0">ሎሚ</relative>
+				<relative type="1">ጽባሕ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} መዓልቲ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} መዓልቲ</relativeTimePattern>
@@ -2401,7 +2401,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-short">
 				<displayName>ሰዓት</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ኣብዚ ሰዓት</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ሰዓት</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ሰዓት</relativeTimePattern>
@@ -2413,7 +2413,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-narrow">
 				<displayName>ሰዓት</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ኣብዚ ሰዓት</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ሰዓት</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ሰዓት</relativeTimePattern>
@@ -2437,7 +2437,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-short">
 				<displayName>ደቒቕ</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ኣብዚ ደቒቕ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ደቒቕ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ደቒቕ</relativeTimePattern>
@@ -2449,7 +2449,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-narrow">
 				<displayName>ደቒ.</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ኣብዚ ደቒቕ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ደቒቕ</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ደቒቕ</relativeTimePattern>
@@ -2473,7 +2473,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="second-short">
 				<displayName>ካልኢት</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ሕጂ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ካልኢት</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ካልኢት</relativeTimePattern>
@@ -2485,7 +2485,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="second-narrow">
 				<displayName>ካልኢት</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">ሕጂ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ኣብ {0} ካልኢት</relativeTimePattern>
 					<relativeTimePattern count="other">ኣብ {0} ካልኢት</relativeTimePattern>
@@ -4300,69 +4300,69 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>g-force</displayName>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hectare</displayName>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre</displayName>
+				<unitPattern count="one">{0} ac</unitPattern>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>ዘመናት</displayName>
@@ -4376,496 +4376,496 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-year">
 				<displayName>ዓመታት</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} y</unitPattern>
+				<unitPattern count="other">{0} y</unitPattern>
+				<perUnitPattern>{0}/y</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mon</displayName>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>wk</displayName>
+				<unitPattern count="one">{0} w</unitPattern>
+				<unitPattern count="other">{0} w</unitPattern>
+				<perUnitPattern>{0}/w</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>day</displayName>
+				<unitPattern count="one">{0} d</unitPattern>
+				<unitPattern count="other">{0} d</unitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>hr</displayName>
+				<unitPattern count="one">{0} h</unitPattern>
+				<unitPattern count="other">{0} h</unitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>min</displayName>
+				<unitPattern count="one">{0} min</unitPattern>
+				<unitPattern count="other">{0} min</unitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sec</displayName>
+				<unitPattern count="one">{0} s</unitPattern>
+				<unitPattern count="other">{0} s</unitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ms</displayName>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>meter</displayName>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi</displayName>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd</displayName>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in</displayName>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ly</displayName>
+				<unitPattern count="one">{0} ly</unitPattern>
+				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="one">{0} kg</unitPattern>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gram</displayName>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="one">{0} km/h</unitPattern>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/h</displayName>
+				<unitPattern count="one">{0} mi/h</unitPattern>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>liter</displayName>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="other">{0} l</unitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>US gal</displayName>
+				<unitPattern count="one">{0} gal US</unitPattern>
+				<unitPattern count="other">{0} gal US</unitPattern>
+				<perUnitPattern>{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="one">{0} gal Imp.</unitPattern>
+				<unitPattern count="other">{0} gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cup</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US fl oz</displayName>
+				<unitPattern count="one">{0} fl oz US</unitPattern>
+				<unitPattern count="other">{0} fl oz US</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn Imp</displayName>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>drop</displayName>
+				<unitPattern count="one">{0} drop</unitPattern>
+				<unitPattern count="other">{0} drop</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram fluid</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="one">{0} pinch</unitPattern>
+				<unitPattern count="other">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 		</unitLength>
 		<unitLength type="short">
 			<unit type="acceleration-g-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-century">
@@ -4880,421 +4880,421 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-year">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} y</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} w</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} d</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ly</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} au</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nmi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ML</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mL</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} gal US</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} gal Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} c</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz US</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} tbsp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} drop</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pinch</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 		</unitLength>
@@ -5310,84 +5310,84 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ዓ.ዓ.</unitPattern>
 			</unit>
 			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yr</displayName>
+				<unitPattern count="one">{0} y</unitPattern>
+				<unitPattern count="other">{0} y</unitPattern>
 			</unit>
 			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mon</displayName>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
 			</unit>
 			<unit type="duration-week">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>wk</displayName>
+				<unitPattern count="one">{0} w</unitPattern>
+				<unitPattern count="other">{0} w</unitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>day</displayName>
+				<unitPattern count="one">{0} d</unitPattern>
+				<unitPattern count="other">{0} d</unitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hr</displayName>
+				<unitPattern count="one">{0} h</unitPattern>
+				<unitPattern count="other">{0} h</unitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>min</displayName>
+				<unitPattern count="one">{0} min</unitPattern>
+				<unitPattern count="other">{0} min</unitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sec</displayName>
+				<unitPattern count="one">{0} s</unitPattern>
+				<unitPattern count="other">{0} s</unitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ms</displayName>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>meter</displayName>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="one">{0} kg</unitPattern>
+				<unitPattern count="other">{0} kg</unitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gram</displayName>
+				<unitPattern count="one">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="one">{0} km/h</unitPattern>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>liter</displayName>
+				<unitPattern count="one">{0} l</unitPattern>
+				<unitPattern count="other">{0} l</unitPattern>
 			</unit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -5414,22 +5414,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} ወይ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="middle">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="end">{0} ወይ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ወይ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="middle">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="end">{0} ወይ {1}</listPatternPart>
+			<listPatternPart type="2">{0} ወይ {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="middle">{0}፣ {1}</listPatternPart>
+			<listPatternPart type="end">{0}ን {1}ን</listPatternPart>
+			<listPatternPart type="2">{0}ን {1}ን</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}፣ {1}</listPatternPart>
@@ -5526,127 +5526,127 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 	</personNames>
 </ldml>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -120,7 +120,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="en_AU">↑↑↑</language>
 			<language type="en_CA">↑↑↑</language>
 			<language type="en_GB">iňlis dili (Beýik Britaniýa)</language>
-			<language type="en_GB" alt="short">↑↑↑</language>
+			<language type="en_GB" alt="short">iňlis dili (Beýik Britaniýa)</language>
 			<language type="en_US">iňlis dili (Amerika)</language>
 			<language type="en_US" alt="short">iňlis dili (ABŞ)</language>
 			<language type="eo">esperanto dili</language>
@@ -805,7 +805,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunis</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Türkiýe</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Türkiýe</territory>
 			<territory type="TT">Trinidad we Tobago</territory>
 			<territory type="TV">Tuwalu</territory>
 			<territory type="TW">Taýwan</territory>
@@ -1968,9 +1968,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>ý.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">geçen ýyl</relative>
+				<relative type="0">şu ýyl</relative>
+				<relative type="1">indiki ýyl</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ý-dan</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ý-dan</relativeTimePattern>
@@ -1982,9 +1982,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>ý.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">geçen ýyl</relative>
+				<relative type="0">şu ýyl</relative>
+				<relative type="1">indiki ýyl</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ý-dan</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ý-dan</relativeTimePattern>
@@ -2046,9 +2046,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName>aý</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">geçen aý</relative>
+				<relative type="0">şu aý</relative>
+				<relative type="1">indiki aý</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} aýdan</relativeTimePattern>
 					<relativeTimePattern count="other">{0} aýdan</relativeTimePattern>
@@ -2060,9 +2060,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>aý</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">geçen aý</relative>
+				<relative type="0">şu aý</relative>
+				<relative type="1">indiki aý</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} aýdan</relativeTimePattern>
 					<relativeTimePattern count="other">{0} aýdan</relativeTimePattern>
@@ -2089,9 +2089,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>hep.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">geçen hepde</relative>
+				<relative type="0">şu hepde</relative>
+				<relative type="1">indiki hepde</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} hep-den</relativeTimePattern>
 					<relativeTimePattern count="other">{0} hep-den</relativeTimePattern>
@@ -2104,9 +2104,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>hep.</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">geçen hepde</relative>
+				<relative type="0">şu hepde</relative>
+				<relative type="1">indiki hepde</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} h-den</relativeTimePattern>
 					<relativeTimePattern count="other">{0} h-den</relativeTimePattern>
@@ -2142,9 +2142,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>gün</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">düýn</relative>
+				<relative type="0">şu gün</relative>
+				<relative type="1">ertir</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} g-den</relativeTimePattern>
 					<relativeTimePattern count="other">{0} g-den</relativeTimePattern>
@@ -2156,9 +2156,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>gün</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">düýn</relative>
+				<relative type="0">şu gün</relative>
+				<relative type="1">ertir</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} g-den</relativeTimePattern>
 					<relativeTimePattern count="other">{0} g-den</relativeTimePattern>
@@ -6208,7 +6208,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/inedördül dýuým</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>dunamlar</displayName>
 				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
@@ -6228,9 +6228,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} millimol/litr</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>bölejik/million</displayName>
@@ -6807,7 +6807,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="pressure-bar">
 				<displayName>barlar</displayName>
 				<unitPattern count="one">{0} bar</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>millibar</displayName>
@@ -7162,12 +7162,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -7280,7 +7280,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -7558,7 +7558,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -7568,7 +7568,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapiksel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
@@ -7857,7 +7857,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -7872,7 +7872,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8125,64 +8125,64 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -8212,42 +8212,42 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}.{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>G</displayName>
+				<unitPattern count="one">{0} G</unitPattern>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>aýl.</displayName>
+				<unitPattern count="one">{0} aýl.</unitPattern>
+				<unitPattern count="other">{0} aýl.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dereje</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>burç min.</displayName>
@@ -8260,84 +8260,84 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ga</displayName>
+				<unitPattern count="one">{0} ga</unitPattern>
+				<unitPattern count="other">{0} ga</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>akr</displayName>
+				<unitPattern count="one">{0} akr</unitPattern>
+				<unitPattern count="other">{0} akr</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ýd²</displayName>
+				<unitPattern count="one">{0} ýd²</unitPattern>
+				<unitPattern count="other">{0} ýd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>dý²</displayName>
+				<unitPattern count="one">{0} dý²</unitPattern>
+				<unitPattern count="other">{0} dý²</unitPattern>
+				<perUnitPattern>{0}/dý²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunamlar</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millimol/litr</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bölejik/million</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -8345,24 +8345,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>promille</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>permiriad</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>litr/km</displayName>
+				<unitPattern count="one">{0} l/km</unitPattern>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100 km</displayName>
@@ -8370,85 +8370,85 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} l/100 km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil/gal.</displayName>
+				<unitPattern count="one">{0} mil/gal.</unitPattern>
+				<unitPattern count="other">{0} mil/gal.</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil/imp. gal.</displayName>
 				<unitPattern count="one">{0}m/gUK</unitPattern>
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tbit</displayName>
+				<unitPattern count="one">{0} Tbit</unitPattern>
+				<unitPattern count="other">{0} Tbit</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gbit</displayName>
+				<unitPattern count="one">{0} Gbit</unitPattern>
+				<unitPattern count="other">{0} Gbit</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mbit</displayName>
+				<unitPattern count="one">{0} Mbit</unitPattern>
+				<unitPattern count="other">{0} Mbit</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kbit</displayName>
+				<unitPattern count="one">{0} kbit</unitPattern>
+				<unitPattern count="other">{0} kbit</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>as</displayName>
+				<unitPattern count="one">{0} as</unitPattern>
+				<unitPattern count="other">{0} as</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oný</displayName>
+				<unitPattern count="one">{0} oný</unitPattern>
+				<unitPattern count="other">{0} oný</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ý</displayName>
 				<unitPattern count="one">{0}ý</unitPattern>
 				<unitPattern count="other">{0}ý</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ý.</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName draft="contributed">çär</displayName>
@@ -8460,37 +8460,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>a</displayName>
 				<unitPattern count="one">{0}a</unitPattern>
 				<unitPattern count="other">{0}a</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/a</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>h</displayName>
 				<unitPattern count="one">{0}h</unitPattern>
 				<unitPattern count="other">{0}h</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/hep</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gün</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>sg</displayName>
 				<unitPattern count="one">{0}sg</unitPattern>
 				<unitPattern count="other">{0}sg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sag</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>se</displayName>
 				<unitPattern count="one">{0}se</unitPattern>
 				<unitPattern count="other">{0}se</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sek</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -8498,59 +8498,59 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mks</displayName>
+				<unitPattern count="one">{0} mks</unitPattern>
+				<unitPattern count="other">{0} mks</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milliamp</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Om</displayName>
+				<unitPattern count="one">{0} Om</unitPattern>
+				<unitPattern count="other">{0} Om</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>W</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kkal</displayName>
+				<unitPattern count="one">{0} kkal</unitPattern>
+				<unitPattern count="other">{0} kkal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kal</displayName>
+				<unitPattern count="one">{0} kal</unitPattern>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kal</displayName>
+				<unitPattern count="one">{0} kal</unitPattern>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilojoul</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kWs</displayName>
@@ -8558,29 +8558,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kWs</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>electronwolt</displayName>
+				<unitPattern count="one">{0} eW</unitPattern>
+				<unitPattern count="other">{0} eW</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ABŞ termi</displayName>
+				<unitPattern count="one">{0} ABŞ termi</unitPattern>
+				<unitPattern count="other">{0} ABŞ termi</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nýuton</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kWs/100km</displayName>
@@ -8588,92 +8588,92 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GGs</displayName>
+				<unitPattern count="one">{0} GGs</unitPattern>
+				<unitPattern count="other">{0} GGs</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MGs</displayName>
+				<unitPattern count="one">{0} MGs</unitPattern>
+				<unitPattern count="other">{0} MGs</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kGs</displayName>
+				<unitPattern count="one">{0} kGs</unitPattern>
+				<unitPattern count="other">{0} kGs</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gs</displayName>
+				<unitPattern count="one">{0} Gs</unitPattern>
+				<unitPattern count="other">{0} Gs</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pikseller</displayName>
+				<unitPattern count="one">{0} pks</unitPattern>
+				<unitPattern count="other">{0} pks</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapiksel</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sbp</displayName>
+				<unitPattern count="one">{0} sbp</unitPattern>
+				<unitPattern count="other">{0} sbp</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dbp</displayName>
+				<unitPattern count="one">{0} dbp</unitPattern>
+				<unitPattern count="other">{0} dbp</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smbn</displayName>
+				<unitPattern count="one">{0} smbn</unitPattern>
+				<unitPattern count="other">{0} smbn</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dbn</displayName>
+				<unitPattern count="one">{0} dbn</unitPattern>
+				<unitPattern count="other">{0} dbn</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nokat</displayName>
+				<unitPattern count="one">{0} nokat</unitPattern>
+				<unitPattern count="other">{0} nokat</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0}km</unitPattern>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0}m</unitPattern>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>sm</displayName>
 				<unitPattern count="one">{0}sm</unitPattern>
 				<unitPattern count="other">{0}sm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -8681,215 +8681,215 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi</displayName>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ýd</displayName>
+				<unitPattern count="one">{0} ýd</unitPattern>
+				<unitPattern count="other">{0} ýd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>dý</displayName>
+				<unitPattern count="one">{0} dý</unitPattern>
+				<unitPattern count="other">{0} dý</unitPattern>
+				<perUnitPattern>{0}/dý</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pk</displayName>
+				<unitPattern count="one">{0} pk</unitPattern>
+				<unitPattern count="other">{0} pk</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ýý</displayName>
+				<unitPattern count="one">{0} ýý</unitPattern>
+				<unitPattern count="other">{0} ýý</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ab</displayName>
+				<unitPattern count="one">{0} ab</unitPattern>
+				<unitPattern count="other">{0} ab</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>furlong</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fatom</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dmi</displayName>
+				<unitPattern count="one">{0} dmi</unitPattern>
+				<unitPattern count="other">{0} dmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>punkt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gün radiuslary</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lk</displayName>
+				<unitPattern count="one">{0} lk</unitPattern>
+				<unitPattern count="other">{0} lk</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kd</displayName>
+				<unitPattern count="one">{0} kd</unitPattern>
+				<unitPattern count="other">{0} kd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gün ýagtylyklary</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gram</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tonna</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>stoun</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>funt</displayName>
+				<unitPattern count="one">{0} funt</unitPattern>
+				<unitPattern count="other">{0} funt</unitPattern>
+				<perUnitPattern>{0}/funt</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>uns.</displayName>
+				<unitPattern count="one">{0} uns.</unitPattern>
+				<unitPattern count="other">{0} uns.</unitPattern>
+				<perUnitPattern>{0}/uns.</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kar</displayName>
+				<unitPattern count="one">{0} kar</unitPattern>
+				<unitPattern count="other">{0} kar</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>daltonlar</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ýer massalary</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gün massalary</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gran</displayName>
+				<unitPattern count="one">{0} gran</unitPattern>
+				<unitPattern count="other">{0} gran</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GWt</displayName>
+				<unitPattern count="one">{0} GWt</unitPattern>
+				<unitPattern count="other">{0} GWt</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MWt</displayName>
+				<unitPattern count="one">{0} MWt</unitPattern>
+				<unitPattern count="other">{0} MWt</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWt</displayName>
+				<unitPattern count="one">{0} kWt</unitPattern>
+				<unitPattern count="other">{0} kWt</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Wt</displayName>
+				<unitPattern count="one">{0} Wt</unitPattern>
+				<unitPattern count="other">{0} Wt</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mWt</displayName>
+				<unitPattern count="one">{0} mWt</unitPattern>
+				<unitPattern count="other">{0} mWt</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>a.g.</displayName>
+				<unitPattern count="one">{0} a.g.</unitPattern>
+				<unitPattern count="other">{0} a.g.</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>mmHg</displayName>
@@ -8897,9 +8897,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>″ Hg</displayName>
@@ -8907,39 +8907,39 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gPa</displayName>
+				<unitPattern count="one">{0} gPa</unitPattern>
+				<unitPattern count="other">{0} gPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/sag</displayName>
@@ -8947,24 +8947,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}km/sag</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil/sag</displayName>
+				<unitPattern count="one">{0} mil/sag</unitPattern>
+				<unitPattern count="other">{0} mil/sag</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dü.</displayName>
+				<unitPattern count="one">{0} dü.</unitPattern>
+				<unitPattern count="other">{0} dü.</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -8972,139 +8972,139 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="one">{0}°F</unitPattern>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sm³</displayName>
+				<unitPattern count="one">{0} sm³</unitPattern>
+				<unitPattern count="other">{0} sm³</unitPattern>
+				<perUnitPattern>{0}/sm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ýd³</displayName>
+				<unitPattern count="one">{0} ýd³</unitPattern>
+				<unitPattern count="other">{0} ýd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dý³</displayName>
+				<unitPattern count="one">{0} dý³</unitPattern>
+				<unitPattern count="other">{0} dý³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ml</displayName>
+				<unitPattern count="one">{0} Ml</unitPattern>
+				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gl</displayName>
+				<unitPattern count="one">{0} gl</unitPattern>
+				<unitPattern count="other">{0} gl</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litr</displayName>
 				<unitPattern count="one">{0}l</unitPattern>
 				<unitPattern count="other">{0}l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dl</displayName>
+				<unitPattern count="one">{0} dl</unitPattern>
+				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sl</displayName>
+				<unitPattern count="one">{0} sl</unitPattern>
+				<unitPattern count="other">{0} sl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ml</displayName>
+				<unitPattern count="one">{0} ml</unitPattern>
+				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mkä</displayName>
+				<unitPattern count="one">{0} mkä</unitPattern>
+				<unitPattern count="other">{0} mkä</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>akr-ft</displayName>
+				<unitPattern count="one">{0} ak-ft</unitPattern>
+				<unitPattern count="other">{0} ak-ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>buşel</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal.</displayName>
+				<unitPattern count="one">{0} gal.</unitPattern>
+				<unitPattern count="other">{0} gal.</unitPattern>
+				<perUnitPattern>{0}/gal.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. gal</displayName>
 				<unitPattern count="one">{0}galIm</unitPattern>
 				<unitPattern count="other">{0}galIm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/imp.gal.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kwt</displayName>
+				<unitPattern count="one">{0} kwt</unitPattern>
+				<unitPattern count="other">{0} kwt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>käse</displayName>
+				<unitPattern count="one">{0} kä</unitPattern>
+				<unitPattern count="other">{0} kä</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<displayName>s.uns.</displayName>
@@ -9117,24 +9117,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>n. ç.</displayName>
+				<unitPattern count="one">{0} n. ç.</unitPattern>
+				<unitPattern count="other">{0} n. ç.</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ç. ç.</displayName>
+				<unitPattern count="one">{0} ç. ç.</unitPattern>
+				<unitPattern count="other">{0} ç. ç.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>barrel</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>dsp Imp</displayName>
@@ -9142,9 +9142,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>damja</displayName>
+				<unitPattern count="one">{0} damja</unitPattern>
+				<unitPattern count="other">{0} damja</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl.dr.</displayName>
@@ -9152,9 +9152,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>pn</displayName>
@@ -9162,7 +9162,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}pn</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>kt Imp</displayName>
 				<unitPattern count="one">{0} kt-Imp.</unitPattern>
 				<unitPattern count="other">{0} kt-Imp.</unitPattern>
 			</unit>
@@ -9198,20 +9198,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} ýa-da {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ýa-da {1}</listPatternPart>
+			<listPatternPart type="2">{0} ýa-da {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} ýa-da {1}</listPatternPart>
+			<listPatternPart type="2">{0} ýa-da {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -9219,13 +9219,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} we {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0} we {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
 			<listPatternPart type="start">{0} {1}</listPatternPart>
@@ -9427,37 +9427,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
@@ -9496,7 +9496,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2}, {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {given}</namePattern>

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -122,7 +122,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">lea fakaselokī</language>
 			<language type="chy">lea fakaseiene</language>
 			<language type="ckb">lea fakakūtisi-loloto</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">lea fakakūtisi-loloto</language>
 			<language type="ckb" alt="variant">lea fakakūtisi-solani</language>
 			<language type="clc">lea fakatisilikōtini</language>
 			<language type="co">lea fakakōsika</language>
@@ -1162,7 +1162,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tunīsia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Toake</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Toake</territory>
 			<territory type="TT">Tilinitati mo Topako</territory>
 			<territory type="TV">Tūvalu</territory>
 			<territory type="TW">Taiuani</territory>
@@ -1519,241 +1519,241 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern draft="unconfirmed">↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern draft="unconfirmed">EEEE d MMMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern draft="unconfirmed">↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern draft="unconfirmed">d MMMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern draft="unconfirmed">↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern draft="unconfirmed">d MMM y G</pattern>
+							<datetimeSkeleton draft="unconfirmed">GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern draft="unconfirmed">↑↑↑</pattern>
-							<datetimeSkeleton draft="unconfirmed">↑↑↑</datetimeSkeleton>
+							<pattern draft="unconfirmed">d/M/yy GGGGG</pattern>
+							<datetimeSkeleton draft="unconfirmed">GGGGGyyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="unconfirmed">↑↑↑</pattern>
+							<pattern draft="unconfirmed">{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ" draft="unconfirmed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ" draft="unconfirmed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d" draft="unconfirmed">d</dateFormatItem>
+						<dateFormatItem id="E" draft="unconfirmed">ccc</dateFormatItem>
+						<dateFormatItem id="Ed" draft="unconfirmed">E d</dateFormatItem>
+						<dateFormatItem id="Gy" draft="unconfirmed">y G</dateFormatItem>
+						<dateFormatItem id="GyMd" draft="unconfirmed">dd MM y GGGGG</dateFormatItem>
+						<dateFormatItem id="GyMMM" draft="unconfirmed">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd" draft="unconfirmed">d MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd" draft="unconfirmed">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="M" draft="unconfirmed">L</dateFormatItem>
+						<dateFormatItem id="Md" draft="unconfirmed">d/M</dateFormatItem>
+						<dateFormatItem id="MEd" draft="unconfirmed">E d/M</dateFormatItem>
+						<dateFormatItem id="MMM" draft="unconfirmed">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd" draft="unconfirmed">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd" draft="unconfirmed">E d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd" draft="unconfirmed">d MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd" draft="unconfirmed">E d MMMM</dateFormatItem>
+						<dateFormatItem id="y" draft="unconfirmed">y G</dateFormatItem>
+						<dateFormatItem id="yM" draft="unconfirmed">M-y</dateFormatItem>
+						<dateFormatItem id="yMd" draft="unconfirmed">d-M-y</dateFormatItem>
+						<dateFormatItem id="yMEd" draft="unconfirmed">E d/M/y</dateFormatItem>
+						<dateFormatItem id="yMM" draft="unconfirmed">MM-y</dateFormatItem>
+						<dateFormatItem id="yMMM" draft="unconfirmed">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMd" draft="unconfirmed">d MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd" draft="unconfirmed">E d MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMM" draft="unconfirmed">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ" draft="unconfirmed">y QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ" draft="unconfirmed">y QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy" draft="unconfirmed">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM" draft="unconfirmed">y/MM GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd" draft="unconfirmed">dd/MM/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd" draft="unconfirmed">E dd-MM-y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM" draft="unconfirmed">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd" draft="unconfirmed">d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd" draft="unconfirmed">E d MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM" draft="unconfirmed">G y MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ" draft="unconfirmed">y QQQ G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ" draft="unconfirmed">y QQQQ G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="unconfirmed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="unconfirmed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="unconfirmed">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="unconfirmed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">d – d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="unconfirmed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="unconfirmed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="unconfirmed">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="unconfirmed">E d/M/y GGGGG – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="unconfirmed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="unconfirmed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="unconfirmed">E d MMM y G – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="unconfirmed">h a – h a</greatestDifference>
+							<greatestDifference id="h" draft="unconfirmed">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="unconfirmed">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="unconfirmed">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="unconfirmed">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="unconfirmed">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="unconfirmed">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h" draft="unconfirmed">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m" draft="unconfirmed">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="unconfirmed">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m" draft="unconfirmed">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="unconfirmed">h a – h a v</greatestDifference>
+							<greatestDifference id="h" draft="unconfirmed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="unconfirmed">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">M – M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">d/M – d/M</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">d/M – d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E d/M – E d/M</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E d/M – E d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">LLL – LLL</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">d – d MMM</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E d MMM – E d MMM</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E d MMM – E d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">d/M/y – d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E d/M/y – E d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">E d/M/y – E d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="unconfirmed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E d MMM – E d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">E d MMM y – E d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="unconfirmed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1882,7 +1882,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1890,7 +1890,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1898,7 +1898,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1906,7 +1906,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2427,7 +2427,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2435,7 +2435,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2443,7 +2443,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2451,7 +2451,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5673,19 +5673,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</otherNumberingSystems>
 		<minimumGroupingDigits draft="contributed">↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">.</decimal>
+			<group draft="unconfirmed">,</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">TF</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="unconfirmed">٫</decimal>
@@ -5724,7 +5724,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5739,7 +5739,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5754,7 +5754,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5769,7 +5769,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5784,7 +5784,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5799,7 +5799,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5814,7 +5814,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5823,19 +5823,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">.</decimal>
+			<group draft="unconfirmed">,</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">TF</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gonm">
 			<decimal draft="unconfirmed">.</decimal>
@@ -5844,7 +5844,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5859,7 +5859,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5874,7 +5874,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5889,7 +5889,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5899,12 +5899,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</symbols>
 		<symbols numberSystem="java">
 			<decimal draft="unconfirmed">.</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
+			<group draft="unconfirmed">,</group>
 			<list draft="unconfirmed">;</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
+			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5919,7 +5919,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5934,7 +5934,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5949,7 +5949,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5964,7 +5964,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5979,7 +5979,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -5994,13 +5994,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
 			<infinity draft="unconfirmed">∞</infinity>
 			<nan draft="unconfirmed">TF</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -6024,7 +6024,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6039,7 +6039,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6054,7 +6054,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6069,7 +6069,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6084,7 +6084,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6099,7 +6099,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6114,7 +6114,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6129,8 +6129,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
 			<infinity draft="unconfirmed">∞</infinity>
@@ -6138,18 +6138,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
+			<decimal draft="unconfirmed">.</decimal>
+			<group draft="unconfirmed">,</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">TF</nan>
 			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="orya">
@@ -6159,7 +6159,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6174,7 +6174,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6183,19 +6183,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="rohg">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<decimal draft="unconfirmed">.</decimal>
+			<group draft="unconfirmed">,</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">TF</nan>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="saur">
 			<decimal draft="unconfirmed">.</decimal>
@@ -6204,7 +6204,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6219,7 +6219,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6234,13 +6234,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
 			<infinity draft="unconfirmed">∞</infinity>
 			<nan draft="unconfirmed">TF</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="sund">
 			<decimal draft="unconfirmed">.</decimal>
@@ -6249,7 +6249,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6264,7 +6264,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6273,18 +6273,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal draft="unconfirmed">↑↑↑</decimal>
-			<group draft="unconfirmed">↑↑↑</group>
-			<list draft="unconfirmed">↑↑↑</list>
-			<percentSign draft="unconfirmed">↑↑↑</percentSign>
-			<plusSign draft="unconfirmed">↑↑↑</plusSign>
-			<minusSign draft="unconfirmed">↑↑↑</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
-			<exponential draft="unconfirmed">↑↑↑</exponential>
-			<superscriptingExponent draft="unconfirmed">↑↑↑</superscriptingExponent>
-			<perMille draft="unconfirmed">↑↑↑</perMille>
-			<infinity draft="unconfirmed">↑↑↑</infinity>
-			<nan draft="unconfirmed">↑↑↑</nan>
+			<decimal draft="unconfirmed">.</decimal>
+			<group draft="unconfirmed">,</group>
+			<list draft="unconfirmed">;</list>
+			<percentSign draft="unconfirmed">%</percentSign>
+			<plusSign draft="unconfirmed">+</plusSign>
+			<minusSign draft="unconfirmed">-</minusSign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
+			<exponential draft="unconfirmed">E</exponential>
+			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
+			<perMille draft="unconfirmed">‰</perMille>
+			<infinity draft="unconfirmed">∞</infinity>
+			<nan draft="unconfirmed">TF</nan>
 			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="tamldec">
@@ -6294,13 +6294,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
 			<infinity draft="unconfirmed">∞</infinity>
 			<nan draft="unconfirmed">TF</nan>
-			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
+			<timeSeparator draft="unconfirmed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="telu">
 			<decimal draft="unconfirmed">.</decimal>
@@ -6309,7 +6309,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6324,7 +6324,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6339,7 +6339,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -6354,7 +6354,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign draft="unconfirmed">%</percentSign>
 			<plusSign draft="unconfirmed">+</plusSign>
 			<minusSign draft="unconfirmed">-</minusSign>
-			<approximatelySign draft="unconfirmed">↑↑↑</approximatelySign>
+			<approximatelySign draft="unconfirmed">~</approximatelySign>
 			<exponential draft="unconfirmed">E</exponential>
 			<superscriptingExponent draft="unconfirmed">×</superscriptingExponent>
 			<perMille draft="unconfirmed">‰</perMille>
@@ -7298,7 +7298,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
-			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+			<unitPattern count="other" draft="unconfirmed">{1} {0}</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="arab">
 			<currencyFormatLength>
@@ -8126,7 +8126,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">{0} kiupite</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>k-mālohi</displayName>
@@ -8419,7 +8419,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>kilouate-houa he kilomita ʻe 100</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>kikahēti</displayName>
@@ -9767,94 +9767,94 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>s{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
 				<unitPrefixPattern>ta{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>k-mā</displayName>
@@ -9958,7 +9958,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -10126,7 +10126,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>eV</displayName>
 				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -10142,11 +10142,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} pāmā</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>N</displayName>
 				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>GHz</displayName>
@@ -10197,7 +10197,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>L⊕</displayName>
 				<unitPattern count="other">{0} L⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -10298,8 +10298,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ktl</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">lm ʻe {0}</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>H☉</displayName>
@@ -10366,7 +10366,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>tenga</displayName>
 				<unitPattern count="other">{0} tenga</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -10418,7 +10418,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ʻati</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -10426,11 +10426,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -10470,7 +10470,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} pā⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>N⋅m</displayName>
 				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -10646,22 +10646,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} pē {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, pē {1}</listPatternPart>
+			<listPatternPart type="2">{0} pē {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, pē {1}</listPatternPart>
+			<listPatternPart type="2">{0} pē {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0} mo {1}</listPatternPart>
+			<listPatternPart type="middle">{0} mo {1}</listPatternPart>
+			<listPatternPart type="end">{0} mo {1}</listPatternPart>
+			<listPatternPart type="2">{0} mo {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0} mo {1}</listPatternPart>
@@ -10889,7 +10889,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{given-informal} {surname}</namePattern>
@@ -10943,7 +10943,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname}, {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>
@@ -10985,7 +10985,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{surname}, {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}, {given-informal}</namePattern>

--- a/common/main/tok.xml
+++ b/common/main/tok.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -58,7 +58,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Arab" draft="unconfirmed">sitelen Alapi</script>
 			<script type="Cyrl" draft="unconfirmed">sitelen Kililita</script>
 			<script type="Hans" draft="unconfirmed">sitelen Sonko</script>
-			<script type="Hans" alt="stand-alone" draft="unconfirmed">↑↑↑</script>
+			<script type="Hans" alt="stand-alone" draft="unconfirmed">sitelen Sonko</script>
 			<script type="Jpan" draft="unconfirmed">sitelen Nijon</script>
 			<script type="Kore" draft="unconfirmed">sitelen Anku</script>
 			<script type="Latn" draft="unconfirmed">sitelen Lasina</script>
@@ -92,20 +92,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="BW" draft="unconfirmed">ma Posuwana</territory>
 			<territory type="BY" draft="unconfirmed">ma Pelalusi</territory>
 			<territory type="CD" draft="unconfirmed">ma Konko pi ma tomo Kinsasa</territory>
-			<territory type="CD" alt="variant">↑↑↑</territory>
+			<territory type="CD" alt="variant">ma Konko pi ma tomo Kinsasa</territory>
 			<territory type="CF" draft="unconfirmed">ma Santapiken</territory>
 			<territory type="CG" draft="unconfirmed">ma Konko pi ma tomo Pasapi</territory>
-			<territory type="CG" alt="variant">↑↑↑</territory>
+			<territory type="CG" alt="variant">ma Konko pi ma tomo Pasapi</territory>
 			<territory type="CH" draft="unconfirmed">ma Suwasi</territory>
 			<territory type="CI" draft="unconfirmed">ma Kosiwa</territory>
-			<territory type="CI" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="CI" alt="variant" draft="unconfirmed">ma Kosiwa</territory>
 			<territory type="CL" draft="unconfirmed">ma Sile</territory>
 			<territory type="CM" draft="unconfirmed">ma Kamelun</territory>
 			<territory type="CN" draft="unconfirmed">ma Sonko</territory>
 			<territory type="CO" draft="unconfirmed">ma Kolonpija</territory>
 			<territory type="CY" draft="unconfirmed">ma Kiposi</territory>
 			<territory type="CZ" draft="unconfirmed">ma Seki</territory>
-			<territory type="CZ" alt="variant" draft="unconfirmed">↑↑↑</territory>
+			<territory type="CZ" alt="variant" draft="unconfirmed">ma Seki</territory>
 			<territory type="DE" draft="unconfirmed">ma Tosi</territory>
 			<territory type="DJ" draft="unconfirmed">ma Sipusi</territory>
 			<territory type="DK" draft="unconfirmed">ma Tansi</territory>
@@ -129,7 +129,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="GR" draft="unconfirmed">ma Elena</territory>
 			<territory type="GW" draft="unconfirmed">ma Kinepisa</territory>
 			<territory type="HK" draft="unconfirmed">ma Onkon</territory>
-			<territory type="HK" alt="short" draft="unconfirmed">↑↑↑</territory>
+			<territory type="HK" alt="short" draft="unconfirmed">ma Onkon</territory>
 			<territory type="HR" draft="unconfirmed">ma Lowasi</territory>
 			<territory type="HU" draft="unconfirmed">ma Mosijo</territory>
 			<territory type="ID" draft="unconfirmed">ma Intonesija</territory>
@@ -214,7 +214,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UG" draft="unconfirmed">ma Ukanta</territory>
 			<territory type="UN" draft="unconfirmed">kulupu pi ma ale</territory>
 			<territory type="US" draft="unconfirmed">ma Mewika</territory>
-			<territory type="US" alt="short" draft="unconfirmed">↑↑↑</territory>
+			<territory type="US" alt="short" draft="unconfirmed">ma Mewika</territory>
 			<territory type="VA" draft="unconfirmed">ma Wasikano</territory>
 			<territory type="VE" draft="unconfirmed">ma Penesuwela</territory>
 			<territory type="VN" draft="unconfirmed">ma Wije</territory>

--- a/common/main/tpi.xml
+++ b/common/main/tpi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -24,9 +24,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="en_AU">Australian Inglis</language>
 			<language type="en_CA">Kenedien Inglis</language>
 			<language type="en_GB">Britis Inglis</language>
-			<language type="en_GB" alt="short">↑↑↑</language>
+			<language type="en_GB" alt="short">Britis Inglis</language>
 			<language type="en_US">Amerikan Inglis</language>
-			<language type="en_US" alt="short">↑↑↑</language>
+			<language type="en_US" alt="short">Amerikan Inglis</language>
 			<language type="es">Spenis</language>
 			<language type="es_419">Saut Amerikan Spenis</language>
 			<language type="es_ES">Spenis (Spein)</language>
@@ -43,19 +43,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="tpi">Tok Pisin</language>
 			<language type="und">Tok ples i no stap</language>
 			<language type="zh">Sainis</language>
-			<language type="zh" alt="menu">↑↑↑</language>
+			<language type="zh" alt="menu">Sainis</language>
 			<language type="zh_Hans">Isipela Sainis</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">Isipela Sainis</language>
 			<language type="zh_Hant">Tredisinol Sainis</language>
-			<language type="zh_Hant" alt="long">↑↑↑</language>
+			<language type="zh_Hant" alt="long">Tredisinol Sainis</language>
 		</languages>
 		<scripts>
 			<script type="Arab">Arabik</script>
 			<script type="Cyrl">Syrilik</script>
 			<script type="Hans">Han (isipela)</script>
-			<script type="Hans" alt="stand-alone">↑↑↑</script>
+			<script type="Hans" alt="stand-alone">Han (isipela)</script>
 			<script type="Hant">Han (tredisinol)</script>
-			<script type="Hant" alt="stand-alone">↑↑↑</script>
+			<script type="Hant" alt="stand-alone">Han (tredisinol)</script>
 			<script type="Latn">Latin</script>
 			<script type="Zxxx">Tok i no raitim yet</script>
 			<script type="Zzzz">Tok i no gat kod yet</script>
@@ -150,8 +150,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dayPeriods>
 					<dayPeriodContext type="format">
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -64,7 +64,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="awa">Awadhi</language>
 			<language type="ay">Aymara</language>
 			<language type="az">Azerbaycan dili</language>
-			<language type="az" alt="short">↑↑↑</language>
+			<language type="az" alt="short">Azerbaycan dili</language>
 			<language type="az_Arab">Güney Azerice</language>
 			<language type="ba">Başkırtça</language>
 			<language type="bal">Beluçça</language>
@@ -1135,7 +1135,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunus</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Türkiye</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Türkiye</territory>
 			<territory type="TT">Trinidad ve Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tayvan</territory>
@@ -1655,7 +1655,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1663,7 +1663,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1671,7 +1671,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1679,7 +1679,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2176,10 +2176,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<era type="1" alt="variant">İS</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
-						<era type="0" alt="variant" draft="contributed">↑↑↑</era>
-						<era type="1" draft="contributed">↑↑↑</era>
-						<era type="1" alt="variant" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">MÖ</era>
+						<era type="0" alt="variant" draft="contributed">İÖ</era>
+						<era type="1" draft="contributed">MS</era>
+						<era type="1" alt="variant" draft="contributed">İS</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -2240,7 +2240,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2248,7 +2248,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2256,7 +2256,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2264,7 +2264,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2474,18 +2474,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<monthWidth type="abbreviated">
 							<month type="1" draft="contributed">Tişri</month>
 							<month type="2" draft="contributed">Heşvan</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
+							<month type="3" draft="contributed">Kislev</month>
+							<month type="4" draft="contributed">Tevet</month>
 							<month type="5" draft="contributed">Şevat</month>
 							<month type="6" draft="contributed">Adar Rişon</month>
-							<month type="7" draft="contributed">↑↑↑</month>
+							<month type="7" draft="contributed">Adar</month>
 							<month type="7" yeartype="leap" draft="contributed">Veadar</month>
-							<month type="8" draft="contributed">↑↑↑</month>
+							<month type="8" draft="contributed">Nisan</month>
 							<month type="9" draft="contributed">İyar</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="10" draft="contributed">Sivan</month>
+							<month type="11" draft="contributed">Tamuz</month>
+							<month type="12" draft="contributed">Av</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Tişri</month>
@@ -2508,34 +2508,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<monthWidth type="abbreviated">
 							<month type="1" draft="contributed">Tişri</month>
 							<month type="2" draft="contributed">Heşvan</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
+							<month type="3" draft="contributed">Kislev</month>
+							<month type="4" draft="contributed">Tevet</month>
 							<month type="5" draft="contributed">Şevat</month>
 							<month type="6" draft="contributed">Adar Rişon</month>
-							<month type="7" draft="contributed">↑↑↑</month>
+							<month type="7" draft="contributed">Adar</month>
 							<month type="7" yeartype="leap" draft="contributed">Veadar</month>
-							<month type="8" draft="contributed">↑↑↑</month>
+							<month type="8" draft="contributed">Nisan</month>
 							<month type="9" draft="contributed">İyar</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="10" draft="contributed">Sivan</month>
+							<month type="11" draft="contributed">Tamuz</month>
+							<month type="12" draft="contributed">Av</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1" draft="contributed">Tişri</month>
 							<month type="2" draft="contributed">Heşvan</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
+							<month type="3" draft="contributed">Kislev</month>
+							<month type="4" draft="contributed">Tevet</month>
 							<month type="5" draft="contributed">Şevat</month>
 							<month type="6" draft="contributed">Adar Rişon</month>
-							<month type="7" draft="contributed">↑↑↑</month>
+							<month type="7" draft="contributed">Adar</month>
 							<month type="7" yeartype="leap" draft="contributed">Veadar</month>
-							<month type="8" draft="contributed">↑↑↑</month>
+							<month type="8" draft="contributed">Nisan</month>
 							<month type="9" draft="contributed">İyar</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="10" draft="contributed">Sivan</month>
+							<month type="11" draft="contributed">Tamuz</month>
+							<month type="12" draft="contributed">Av</month>
+							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -2638,7 +2638,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="6">C.ahir</month>
 							<month type="7">Recep</month>
 							<month type="8">Şaban</month>
-							<month type="9">↑↑↑</month>
+							<month type="9">Ram.</month>
 							<month type="10">Şevval</month>
 							<month type="11">Zilkade</month>
 							<month type="12">Zilhicce</month>
@@ -2687,58 +2687,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>G d MMMM y EEEE</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>G d MMMM y</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>G d MMM y</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>GGGGG d.MM.y</pattern>
+							<datetimeSkeleton>GGGGGyMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d E</dateFormatItem>
+						<dateFormatItem id="Gy">G y</dateFormatItem>
 						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMMM">G MMM y</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G d MMM y</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G d MMM y E</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">dd/MM</dateFormatItem>
+						<dateFormatItem id="MEd">dd/MM E</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">d MMM E</dateFormatItem>
+						<dateFormatItem id="MMMMd">dd MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">dd MMMM E</dateFormatItem>
+						<dateFormatItem id="y">G y</dateFormatItem>
+						<dateFormatItem id="yyyy">G y</dateFormatItem>
+						<dateFormatItem id="yyyyM">GGGGG M/y</dateFormatItem>
+						<dateFormatItem id="yyyyMd">GGGGG dd.MM.y</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">GGGGG dd.MM.y E</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">G MMM y</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">G dd MMM y</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">G d MMM y E</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">G MMMM y</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">G y/QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">G y/QQQQ</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -3409,7 +3409,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>dk.</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">bu dakika</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} dk. sonra</relativeTimePattern>
 					<relativeTimePattern count="other">{0} dk. sonra</relativeTimePattern>
@@ -3421,7 +3421,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-narrow">
 				<displayName>dk.</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">bu dakika</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} dk. sonra</relativeTimePattern>
 					<relativeTimePattern count="other">{0} dk. sonra</relativeTimePattern>
@@ -3445,7 +3445,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>sn.</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">şimdi</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} sn. sonra</relativeTimePattern>
 					<relativeTimePattern count="other">{0} sn. sonra</relativeTimePattern>
@@ -3457,7 +3457,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-narrow">
 				<displayName>sn.</displayName>
-				<relative type="0" draft="contributed">↑↑↑</relative>
+				<relative type="0" draft="contributed">şimdi</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} sn. sonra</relativeTimePattern>
 					<relativeTimePattern count="other">{0} sn. sonra</relativeTimePattern>
@@ -5764,17 +5764,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
 		<symbols numberSystem="adlm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
@@ -5789,102 +5789,102 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
 		</symbols>
 		<symbols numberSystem="bali">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="beng">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="brah">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cakm">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="cham">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<percentSign draft="contributed">↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<approximatelySign draft="contributed">↑↑↑</approximatelySign>
-			<exponential draft="contributed">↑↑↑</exponential>
-			<superscriptingExponent draft="contributed">↑↑↑</superscriptingExponent>
-			<perMille draft="contributed">↑↑↑</perMille>
-			<infinity draft="contributed">↑↑↑</infinity>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<decimal draft="contributed">,</decimal>
+			<group draft="contributed">.</group>
+			<percentSign draft="contributed">%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<approximatelySign draft="contributed">~</approximatelySign>
+			<exponential draft="contributed">E</exponential>
+			<superscriptingExponent draft="contributed">×</superscriptingExponent>
+			<perMille draft="contributed">‰</perMille>
+			<infinity draft="contributed">∞</infinity>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="deva">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="fullwide">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gong">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="gujr">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="guru">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="hanidec">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="java">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="kali">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="khmr">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="knda">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="laoo">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
@@ -5902,13 +5902,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator>:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="lepc">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="limb">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="mlym">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="latn">
 			<decimalFormatLength>
@@ -7959,7 +7959,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}küp</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g kuvveti</displayName>
@@ -8092,9 +8092,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">onbinde {0}</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litre/kilometre</displayName>
@@ -8346,8 +8346,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipografik em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piksel</displayName>
@@ -8644,9 +8644,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inç cıva</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>milibar</displayName>
@@ -8889,9 +8889,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>tutam</displayName>
@@ -9001,12 +9001,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -9144,7 +9144,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -9362,12 +9362,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>pound kuvvet</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -9397,38 +9397,38 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piksel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapiksel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>nokta</displayName>
@@ -9437,7 +9437,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -9557,12 +9557,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
@@ -9696,7 +9696,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -9711,7 +9711,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -9941,7 +9941,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
@@ -9964,64 +9964,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -10051,17 +10051,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g kuvveti</displayName>
@@ -10079,24 +10079,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>radyan</displayName>
 				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>derece</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>açısal dk.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} açısal dk.</unitPattern>
+				<unitPattern count="other">{0} açısal dk.</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>açısal sn.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} açısal sn.</unitPattern>
+				<unitPattern count="other">{0} açısal sn.</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>km²</displayName>
@@ -10149,9 +10149,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>ayar</displayName>
@@ -10189,14 +10189,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>onbinde</displayName>
+				<unitPattern count="one">‱{0}</unitPattern>
+				<unitPattern count="other">‱{0}</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>l/km</displayName>
@@ -10209,19 +10209,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil/gal</displayName>
 				<unitPattern count="one">{0} mpg</unitPattern>
 				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil/İng. gal</displayName>
+				<unitPattern count="one">{0} mil/İng. gal</unitPattern>
+				<unitPattern count="other">{0} mil/İng. gal</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>TB</displayName>
@@ -10265,8 +10265,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="digital-byte">
 				<displayName>bayt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bayt</unitPattern>
+				<unitPattern count="other">{0} bayt</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>bit</displayName>
@@ -10279,9 +10279,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} yy</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>on yıl</displayName>
+				<unitPattern count="one">{0} on yıl</unitPattern>
+				<unitPattern count="other">{0} on yıl</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>yıl</displayName>
@@ -10367,54 +10367,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="one">{0} cal</unitPattern>
 				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kJ</displayName>
 				<unitPattern count="one">{0} kJ</unitPattern>
 				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>jul</displayName>
 				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh</displayName>
 				<unitPattern count="one">{0} kWh</unitPattern>
 				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ABD ısı birimi</displayName>
+				<unitPattern count="one">{0} ABD ısı birimi</unitPattern>
+				<unitPattern count="other">{0} ABD ısı birimi</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pound kuvvet</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
@@ -10447,49 +10447,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nokta</displayName>
+				<unitPattern count="one">{0} nokta</unitPattern>
+				<unitPattern count="other">{0} nokta</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -10598,8 +10598,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lüks</displayName>
@@ -10607,19 +10607,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} lüks</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Güneş parlaklığı</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -10682,58 +10682,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Da</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tane</displayName>
+				<unitPattern count="one">{0} tane</unitPattern>
+				<unitPattern count="other">{0} tane</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="one">{0} GW</unitPattern>
 				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>vat</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>bg</displayName>
 				<unitPattern count="one">{0} bg</unitPattern>
 				<unitPattern count="other">{0} bg</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>lb/in²</displayName>
@@ -10742,13 +10742,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>inHg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -10756,14 +10756,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -10771,14 +10771,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/sa</displayName>
@@ -10816,59 +10816,59 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} °F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="one">{0} K</unitPattern>
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="other">{0} m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="other">{0} cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil³</displayName>
 				<unitPattern count="one">{0} mil³</unitPattern>
 				<unitPattern count="other">{0} mil³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yarda³</displayName>
 				<unitPattern count="one">{0} yarda³</unitPattern>
 				<unitPattern count="other">{0} yarda³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>fit³</displayName>
 				<unitPattern count="one">{0} fit³</unitPattern>
 				<unitPattern count="other">{0} fit³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>inç³</displayName>
 				<unitPattern count="one">{0} inç³</unitPattern>
 				<unitPattern count="other">{0} inç³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ml</displayName>
 				<unitPattern count="one">{0} Ml</unitPattern>
 				<unitPattern count="other">{0} Ml</unitPattern>
 			</unit>
@@ -10881,35 +10881,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>litre</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dl</displayName>
 				<unitPattern count="one">{0} dl</unitPattern>
 				<unitPattern count="other">{0} dl</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cl</displayName>
 				<unitPattern count="one">{0} cl</unitPattern>
 				<unitPattern count="other">{0} cl</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ml</displayName>
 				<unitPattern count="one">{0} ml</unitPattern>
 				<unitPattern count="other">{0} ml</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>msub</displayName>
+				<unitPattern count="one">{0} msb</unitPattern>
+				<unitPattern count="other">{0} msb</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>akre fit</displayName>
 				<unitPattern count="one">{0} akre fit</unitPattern>
 				<unitPattern count="other">{0} akre fit</unitPattern>
 			</unit>
@@ -10919,56 +10919,56 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">{0} galon</unitPattern>
 				<unitPattern count="other">{0} galon</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>İng. gal</displayName>
+				<unitPattern count="one">{0} İng. gal</unitPattern>
+				<unitPattern count="other">{0} İng. gal</unitPattern>
+				<perUnitPattern>{0}/İng. gal</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt</displayName>
 				<unitPattern count="one">{0} quart</unitPattern>
 				<unitPattern count="other">{0} quart</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>pint</displayName>
 				<unitPattern count="one">{0} pint</unitPattern>
 				<unitPattern count="other">{0} pint</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>su b.</displayName>
 				<unitPattern count="one">{0} sb</unitPattern>
 				<unitPattern count="other">{0} sb</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>sıvı ons</displayName>
 				<unitPattern count="one">{0} sıvı ons</unitPattern>
 				<unitPattern count="other">{0} sıvı ons</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>İng. sıvı ons</displayName>
 				<unitPattern count="one">{0} İng. sıvı ons</unitPattern>
 				<unitPattern count="other">{0} İng. sıvı ons</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>yk</displayName>
 				<unitPattern count="one">{0} yk</unitPattern>
 				<unitPattern count="other">{0} yk</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>çk</displayName>
 				<unitPattern count="one">{0} çk</unitPattern>
 				<unitPattern count="other">{0} çk</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>bbl</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>tk</displayName>
@@ -10981,24 +10981,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} İng. tk</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>damla</displayName>
+				<unitPattern count="one">{0} damla</unitPattern>
+				<unitPattern count="other">{0} damla</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sıvı dram</displayName>
+				<unitPattern count="one">{0} sıvı dram</unitPattern>
+				<unitPattern count="other">{0} sıvı dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tutam</displayName>
+				<unitPattern count="one">{0} tutam</unitPattern>
+				<unitPattern count="other">{0} tutam</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>İng. qt</displayName>
@@ -11037,20 +11037,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} veya {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} veya {1}</listPatternPart>
+			<listPatternPart type="2">{0} veya {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} veya {1}</listPatternPart>
+			<listPatternPart type="2">{0} veya {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -11295,7 +11295,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
 			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
@@ -11313,7 +11313,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
 			<namePattern>{given-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
@@ -11334,7 +11334,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{title} {surname} {given-initial} {given2}, {credentials}</namePattern>

--- a/common/main/trw.xml
+++ b/common/main/trw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -666,18 +666,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="unconfirmed">↑↑↑</month>
-							<month type="2" draft="unconfirmed">↑↑↑</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="1" draft="unconfirmed">جنوری</month>
+							<month type="2" draft="unconfirmed">فروری</month>
+							<month type="3" draft="unconfirmed">مارچ</month>
+							<month type="4" draft="unconfirmed">اپریل</month>
+							<month type="5" draft="unconfirmed">مئ</month>
+							<month type="6" draft="unconfirmed">جون</month>
+							<month type="7" draft="unconfirmed">جولائی</month>
+							<month type="8" draft="unconfirmed">اگست</month>
+							<month type="9" draft="unconfirmed">ستمبر</month>
+							<month type="10" draft="unconfirmed">اکتوبر</month>
+							<month type="11" draft="unconfirmed">نومبر</month>
+							<month type="12" draft="unconfirmed">دسمبر</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="unconfirmed">ج</month>
@@ -740,29 +740,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<monthWidth type="wide">
 							<month type="1" draft="unconfirmed">جنوری</month>
 							<month type="2" draft="unconfirmed">فروری</month>
-							<month type="3" draft="unconfirmed">↑↑↑</month>
-							<month type="4" draft="unconfirmed">↑↑↑</month>
-							<month type="5" draft="unconfirmed">↑↑↑</month>
-							<month type="6" draft="unconfirmed">↑↑↑</month>
-							<month type="7" draft="unconfirmed">↑↑↑</month>
-							<month type="8" draft="unconfirmed">↑↑↑</month>
-							<month type="9" draft="unconfirmed">↑↑↑</month>
-							<month type="10" draft="unconfirmed">↑↑↑</month>
-							<month type="11" draft="unconfirmed">↑↑↑</month>
-							<month type="12" draft="unconfirmed">↑↑↑</month>
+							<month type="3" draft="unconfirmed">مارچ</month>
+							<month type="4" draft="unconfirmed">اپریل</month>
+							<month type="5" draft="unconfirmed">مئ</month>
+							<month type="6" draft="unconfirmed">جون</month>
+							<month type="7" draft="unconfirmed">جولائی</month>
+							<month type="8" draft="unconfirmed">اگست</month>
+							<month type="9" draft="unconfirmed">ستمبر</month>
+							<month type="10" draft="unconfirmed">اکتوبر</month>
+							<month type="11" draft="unconfirmed">نومبر</month>
+							<month type="12" draft="unconfirmed">دسمبر</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">ایکشیمے</day>
+							<day type="mon" draft="unconfirmed">دُوشیمے</day>
+							<day type="tue" draft="unconfirmed">گھن آنگا</day>
+							<day type="wed" draft="unconfirmed">چارشیمے</day>
+							<day type="thu" draft="unconfirmed">پَئ شیمے</day>
+							<day type="fri" draft="unconfirmed">شُوگار</day>
+							<day type="sat" draft="unconfirmed">لَو آنگا</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun" draft="unconfirmed">ا</day>
@@ -821,13 +821,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat" draft="unconfirmed">لَو آنگا</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun" draft="unconfirmed">↑↑↑</day>
-							<day type="mon" draft="unconfirmed">↑↑↑</day>
-							<day type="tue" draft="unconfirmed">↑↑↑</day>
-							<day type="wed" draft="unconfirmed">↑↑↑</day>
-							<day type="thu" draft="unconfirmed">↑↑↑</day>
-							<day type="fri" draft="unconfirmed">↑↑↑</day>
-							<day type="sat" draft="unconfirmed">↑↑↑</day>
+							<day type="sun" draft="unconfirmed">ایکشیمے</day>
+							<day type="mon" draft="unconfirmed">دُوشیمے</day>
+							<day type="tue" draft="unconfirmed">گھن آنگا</day>
+							<day type="wed" draft="unconfirmed">چارشیمے</day>
+							<day type="thu" draft="unconfirmed">پَئ شیمے</day>
+							<day type="fri" draft="unconfirmed">شُوگار</day>
+							<day type="sat" draft="unconfirmed">لَو آنگا</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -840,10 +840,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4" draft="unconfirmed">چوٹھوم ڇامای</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="2" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="3" draft="unconfirmed">↑↑↑</quarter>
-							<quarter type="4" draft="unconfirmed">↑↑↑</quarter>
+							<quarter type="1" draft="unconfirmed">1</quarter>
+							<quarter type="2" draft="unconfirmed">2</quarter>
+							<quarter type="3" draft="unconfirmed">3</quarter>
+							<quarter type="4" draft="unconfirmed">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1" draft="unconfirmed">اول ڇامای</quarter>
@@ -884,35 +884,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm" draft="unconfirmed">p</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am" draft="unconfirmed">↑↑↑</dayPeriod>
-							<dayPeriod type="pm" draft="unconfirmed">↑↑↑</dayPeriod>
+							<dayPeriod type="am" draft="unconfirmed">AM</dayPeriod>
+							<dayPeriod type="pm" draft="unconfirmed">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
 				<eras>
 					<eraNames>
 						<era type="0" draft="unconfirmed">عیسٰیؑ ما مُش</era>
-						<era type="0" alt="variant" draft="unconfirmed">↑↑↑</era>
+						<era type="0" alt="variant" draft="unconfirmed">ع-م</era>
 						<era type="1" draft="unconfirmed">عیسوی</era>
 						<era type="1" alt="variant" draft="unconfirmed">عام دور</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="unconfirmed">ع-م</era>
-						<era type="0" alt="variant" draft="unconfirmed">↑↑↑</era>
+						<era type="0" alt="variant" draft="unconfirmed">ع-م</era>
 						<era type="1" draft="unconfirmed">ع</era>
 						<era type="1" alt="variant" draft="unconfirmed">ع-د</era>
 					</eraAbbr>
@@ -1183,10 +1183,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">دور</displayName>
 			</field>
 			<field type="era-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">دور</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">دور</displayName>
 			</field>
 			<field type="year">
 				<displayName draft="unconfirmed">کال</displayName>
@@ -1293,7 +1293,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativeTime type="past">
 					<relativeTimePattern count="other" draft="unconfirmed">{0} ہفتائے موش</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod draft="unconfirmed">↑↑↑</relativePeriod>
+				<relativePeriod draft="unconfirmed">{0} سی ہفتہ</relativePeriod>
 			</field>
 			<field type="week-narrow">
 				<displayName draft="unconfirmed">ہفتہ</displayName>
@@ -1306,7 +1306,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativeTime type="past">
 					<relativeTimePattern count="other" draft="unconfirmed">{0} ہفتائے موش</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod draft="unconfirmed">↑↑↑</relativePeriod>
+				<relativePeriod draft="unconfirmed">{0} سی ہفتہ</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName draft="unconfirmed">ما سی ہفتہ</displayName>
@@ -1366,10 +1366,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">ہفتہ سی دی</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ہفتہ سی دی</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">ہفتہ سی دی</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1" draft="unconfirmed">موشوم ایکشیمے</relative>
@@ -1383,22 +1383,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">موشوم ایکشیمے</relative>
+				<relative type="0" draft="unconfirmed">مے ایکشیمے</relative>
+				<relative type="1" draft="unconfirmed">دوی ایکشیمے</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} ایکشیمے</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} ایکشیمے</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">موشوم ایکشیمے</relative>
+				<relative type="0" draft="unconfirmed">مے ایکشیمے</relative>
+				<relative type="1" draft="unconfirmed">دوی ایکشیمے</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} ایکشیمے</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other" draft="unconfirmed">-{0} ایکشیمے</relativeTimePattern>
@@ -1416,7 +1416,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="mon-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">موشوم دوشیمے</relative>
 				<relative type="0" draft="unconfirmed">مے دوشیمے</relative>
 				<relative type="1" draft="unconfirmed">دوی دوشیمے</relative>
 				<relativeTime type="future">
@@ -1431,10 +1431,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0" draft="unconfirmed">مے دوشیمے</relative>
 				<relative type="1" draft="unconfirmed">دوی دوشیمے</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} دوشیمے</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} دوشیمے</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -1581,35 +1581,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sat-short">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">موشوم لَو آنگا</relative>
+				<relative type="0" draft="unconfirmed">مے لَو آنگا</relative>
+				<relative type="1" draft="unconfirmed">دوی لَو آنگا</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} لَو آنگا</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} لَو آنگا</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
-				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
-				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="-1" draft="unconfirmed">موشوم لَو آنگا</relative>
+				<relative type="0" draft="unconfirmed">مے لَو آنگا</relative>
+				<relative type="1" draft="unconfirmed">دوی لَو آنگا</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">+{0} لَو آنگا</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other" draft="unconfirmed">-{0} لَو آنگا</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">پیشیا موش/پیشیا پأش</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName draft="unconfirmed">پیشیا موش/پیشیا پأش</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">پیشیا موش/پیشیا پأش</displayName>
 			</field>
 			<field type="hour">
 				<displayName draft="unconfirmed">گینٹہ</displayName>
@@ -1623,7 +1623,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-short">
 				<displayName draft="unconfirmed">گینٹہ</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">میں گینٹہ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other" draft="unconfirmed">{0} گینٹہ میں</relativeTimePattern>
 				</relativeTime>
@@ -1633,7 +1633,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="hour-narrow">
 				<displayName draft="unconfirmed">گینٹہ</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">میں گینٹہ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other" draft="unconfirmed">{0} گینٹہ میں</relativeTimePattern>
 				</relativeTime>
@@ -1653,7 +1653,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-short">
 				<displayName draft="unconfirmed">میلٹ</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">میں میلٹ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other" draft="unconfirmed">+{0} میلڑا میں</relativeTimePattern>
 				</relativeTime>
@@ -1663,7 +1663,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="minute-narrow">
 				<displayName draft="unconfirmed">میلٹ</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">میں میلٹ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other" draft="unconfirmed">+{0} میلٹ میں</relativeTimePattern>
 				</relativeTime>
@@ -1683,7 +1683,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="second-short">
 				<displayName draft="unconfirmed">سیکنڈ</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">مھیرے</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other" draft="unconfirmed">+{0} سیکنڈ میں</relativeTimePattern>
 				</relativeTime>
@@ -1693,7 +1693,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="second-narrow">
 				<displayName draft="unconfirmed">سیکنڈ</displayName>
-				<relative type="0" draft="unconfirmed">↑↑↑</relative>
+				<relative type="0" draft="unconfirmed">مھیرے</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other" draft="unconfirmed">+{0} سیکنڈ میں</relativeTimePattern>
 				</relativeTime>
@@ -1705,10 +1705,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">منطقۂ وَخ</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">منطقۂ وَخ</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">منطقۂ وَخ</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -3942,7 +3942,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern draft="unconfirmed">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
@@ -4082,7 +4082,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">بیلاروسی روبل</displayName>
 				<displayName count="other" draft="unconfirmed">بیلاروسی روبل</displayName>
 				<symbol draft="unconfirmed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="unconfirmed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="unconfirmed">BYN</symbol>
 			</currency>
 			<currency type="BZD">
 				<displayName draft="unconfirmed">بیلیز ڈالر</displayName>
@@ -5238,7 +5238,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="graphics-em">
 				<displayName draft="unconfirmed">ٹائپوگرافک em</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName draft="unconfirmed">پکسلز</displayName>
@@ -5522,8 +5522,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} ناٹ</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">°</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName draft="unconfirmed">ڈگری سیلسیس</displayName>
@@ -5659,32 +5659,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} بیرل</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">dstspn</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">dstspn Imp</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName draft="unconfirmed">ٹیگیل</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} ٹیگیل</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">dram fluid</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">jigger</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName draft="unconfirmed">پینچ</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} پینچ</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">qt Imp</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName draft="unconfirmed">کارڈینل ڈائریکشن</displayName>
@@ -6036,8 +6036,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">kcal</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
@@ -6108,12 +6108,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ppcm</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ppi</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName draft="unconfirmed">ڈاٹ</displayName>
@@ -6556,7 +6556,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern draft="unconfirmed">ملی {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
 				<unitPrefixPattern draft="unconfirmed">نینو {0}</unitPrefixPattern>
@@ -6610,91 +6610,91 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern draft="unconfirmed">کیبی{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern draft="unconfirmed">↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern draft="unconfirmed">Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern draft="unconfirmed">↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern draft="unconfirmed">{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="other" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" draft="unconfirmed">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="other" draft="unconfirmed">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" draft="unconfirmed">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern draft="unconfirmed">{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="area-hectare">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ہیکٹر</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ہیکٹر</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">مربع میٹر</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} m²</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">cm²</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} cm²</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">مربع میل</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} sq mi</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ایکڑ</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ایکڑ</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">مربع گز</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">مربع فٹ</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} مربع فٹ</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">مربع انچا</displayName>
 			</unit>
 			<unit type="area-dunam">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">دُنامز</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} دُنام</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">فیصد</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0}%</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName draft="unconfirmed">لیٹر/100 کلو میٹر</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="unconfirmed">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">قرن</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} قرن</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">دہائی</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} دہائی</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName draft="unconfirmed">کال</displayName>
@@ -6703,12 +6703,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-month">
 				<displayName draft="unconfirmed">ما</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} ما</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">فی ما {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName draft="unconfirmed">ہفتہ</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} ہفتہ</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0} فی ہفتہ</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName draft="unconfirmed">دی</displayName>
@@ -6717,47 +6717,47 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-hour">
 				<displayName draft="unconfirmed">گینٹہ</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} گینٹہ</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0} فی گینٹہ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName draft="unconfirmed">میلٹ</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} میلٹ</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0} فی میلٹ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName draft="unconfirmed">سیکنڈ</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} سیکنڈ</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="unconfirmed">{0} فی سیکنڈ</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName draft="unconfirmed">ملی سیکنڈ</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} ملی س</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">مائیکرو سیکنڈ</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} م س</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">نینو سیکنڈز</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} ن س</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">پکسلز</displayName>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">میگا پکسلز</displayName>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ڈاٹ</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} ڈاٹ</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
-				<perUnitPattern draft="unconfirmed">↑↑↑</perUnitPattern>
+				<displayName draft="unconfirmed">کلو میٹر</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} کلو میٹر</unitPattern>
+				<perUnitPattern draft="unconfirmed">{0} فی کلو میٹر</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">میٹر</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} میٹر</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
@@ -6770,41 +6770,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} ملی میٹر</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">پیکو میٹر</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} پیکو میٹر</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">میل</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} میل</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">گز</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} گز</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">فٹ</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} فٹ</unitPattern>
 				<perUnitPattern draft="unconfirmed">{0}/فٹ</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">انچا</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} انچا</unitPattern>
 				<perUnitPattern draft="unconfirmed">{0}/انچا</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">پارسیک</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} پارسیک</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">نوری کال</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} نوری کال</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">فرلانگ</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} فرلانگ</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">فیتھامز</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} فیتھامز</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -6812,19 +6812,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0} بحری میل</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">پوائنٹس</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} پوائنٹس</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">شمسی رداس</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} شمسی ر</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">kg</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0} kg</unitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<displayName draft="unconfirmed">گرام</displayName>
 				<unitPattern count="other" draft="unconfirmed">{0} گرام</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -6832,8 +6832,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other" draft="unconfirmed">{0}kph</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName draft="unconfirmed">↑↑↑</displayName>
-				<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
+				<displayName draft="unconfirmed">ڈگری سیلسیس</displayName>
+				<unitPattern count="other" draft="unconfirmed">{0}‎°C</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName draft="unconfirmed">لیٹر</displayName>
@@ -6841,10 +6841,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<coordinateUnit>
 				<displayName draft="unconfirmed">ڈائریکشن</displayName>
-				<coordinateUnitPattern type="east" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="east" draft="unconfirmed">{0}E</coordinateUnitPattern>
 				<coordinateUnitPattern type="north" draft="unconfirmed">{0}N</coordinateUnitPattern>
-				<coordinateUnitPattern type="south" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west" draft="unconfirmed">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="south" draft="unconfirmed">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west" draft="unconfirmed">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -6871,16 +6871,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0} یا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}، یا {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} یا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0}، یا {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} یا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start" draft="unconfirmed">{0}،{1}</listPatternPart>
@@ -6889,28 +6889,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2" draft="unconfirmed">{0}،{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}،{1}</listPatternPart>
 			<listPatternPart type="end" draft="unconfirmed">{0} ،آں {1}</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} آں {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} ،آں {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} آں {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} ،آں {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} آں {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="middle" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="end" draft="unconfirmed">↑↑↑</listPatternPart>
-			<listPatternPart type="2" draft="unconfirmed">↑↑↑</listPatternPart>
+			<listPatternPart type="start" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="middle" draft="unconfirmed">{0}،{1}</listPatternPart>
+			<listPatternPart type="end" draft="unconfirmed">{0} ،آں {1}</listPatternPart>
+			<listPatternPart type="2" draft="unconfirmed">{0} آں {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/tt.xml
+++ b/common/main/tt.xml
@@ -922,7 +922,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<eraNames>
 						<era type="0">безнең эрага кадәр</era>
 						<era type="0" alt="variant">безнең эрага кадәр</era>
-						<era type="1">↑↑↑</era>
+						<era type="1">милади</era>
 						<era type="1" alt="variant">безнең эра</era>
 					</eraNames>
 					<eraAbbr>
@@ -1207,10 +1207,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>эра</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>эра</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>эра</displayName>
 			</field>
 			<field type="year">
 				<displayName>ел</displayName>
@@ -1238,7 +1238,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>ел</displayName>
-				<relative type="-1">↑↑↑</relative>
+				<relative type="-1">узган ел</relative>
 				<relative type="0">быел</relative>
 				<relative type="1">киләсе елда</relative>
 				<relativeTime type="future">
@@ -1376,9 +1376,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>көн</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">кичә</relative>
+				<relative type="0">бүген</relative>
+				<relative type="1">иртәгә</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} көннән</relativeTimePattern>
 				</relativeTime>
@@ -1388,9 +1388,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>көн</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">кичә</relative>
+				<relative type="0">бүген</relative>
+				<relative type="1">иртәгә</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} көннән</relativeTimePattern>
 				</relativeTime>
@@ -1411,10 +1411,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>атна көне</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>атна көне</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>атна көне</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>айның эш көне</displayName>
@@ -1614,7 +1614,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="fri-narrow">
 				<relative type="-1">узган җом.</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">бу җом.</relative>
 				<relative type="1">киләсе җом.</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} җом. узгач</relativeTimePattern>
@@ -1650,20 +1650,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">бу шим.</relative>
 				<relative type="1">киләсе шим.</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} шим. узгач</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0} шим. элек</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>AM/PM</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>AM/PM</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>AM/PM</displayName>
 			</field>
 			<field type="hour">
 				<displayName>сәгать</displayName>
@@ -1753,10 +1753,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>вакыт өлкәсе</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>вакыт өлкәсе</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>вакыт өлкәсе</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -2011,22 +2011,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
 			<namePattern>{title} {surname}</namePattern>
@@ -2035,7 +2035,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname} {title} {given} {given2} {generation}, {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {title} {given} {given2} {generation}, {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">Зөхрә</nameField>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -1046,7 +1046,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Туніс</territory>
 			<territory type="TO">Тонга</territory>
 			<territory type="TR">Туреччина</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Туреччина</territory>
 			<territory type="TT">Тринідад і Тобаго</territory>
 			<territory type="TV">Тувалу</territory>
 			<territory type="TW">Тайвань</territory>
@@ -2064,7 +2064,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="night1">ніч</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="midnight">↑↑↑</dayPeriod>
+							<dayPeriod type="midnight">північ</dayPeriod>
 							<dayPeriod type="am">дп</dayPeriod>
 							<dayPeriod type="noon">полудень</dayPeriod>
 							<dayPeriod type="pm">пп</dayPeriod>
@@ -2167,7 +2167,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2175,7 +2175,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3272,10 +3272,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<relativeTimePattern count="other">за {0} д.</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="many">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} дн. тому</relativeTimePattern>
+					<relativeTimePattern count="few">{0} дн. тому</relativeTimePattern>
+					<relativeTimePattern count="many">{0} дн. тому</relativeTimePattern>
+					<relativeTimePattern count="other">{0} дн. тому</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
@@ -8245,7 +8245,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>квадратні {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">квадратний {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">квадратний {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="dative">квадратному {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="instrumental">квадратним {0}</compoundUnitPattern1>
@@ -8257,70 +8257,70 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">квадратною {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="locative">квадратній {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine">квадратний {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">квадратний {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="dative">квадратному {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="instrumental">квадратним {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="locative">квадратному {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">квадратні {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">квадратні {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="dative">квадратним {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="genitive">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="instrumental">квадратними {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="locative">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine">квадратні {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">квадратні {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="dative">квадратним {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">квадратними {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="locative">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine">квадратні {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine" case="accusative">квадратні {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="dative">квадратним {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="genitive">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="instrumental">квадратними {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="locative">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">квадратних {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="accusative">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="dative">квадратним {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="genitive">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="instrumental">квадратними {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="locative">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="dative">квадратним {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">квадратними {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="locative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="locative">квадратних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="masculine" case="accusative">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="masculine" case="dative">квадратним {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="genitive">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="masculine" case="instrumental">квадратними {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="locative">квадратних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">квадратного {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">квадратного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine">квадратної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">квадратної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="dative">квадратної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">квадратної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">квадратної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="locative">квадратної {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="dative">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">квадратного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="locative">квадратного {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>кубічні {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">кубічний {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" case="accusative">кубічний {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="dative">кубічному {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="genitive">кубічного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" case="instrumental">кубічним {0}</compoundUnitPattern1>
@@ -8331,209 +8331,209 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="one" gender="feminine" case="genitive">кубічної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="instrumental">кубічною {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="feminine" case="locative">кубічній {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine">кубічний {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="masculine" case="accusative">кубічний {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="dative">кубічному {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="genitive">кубічного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="instrumental">кубічним {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one" gender="masculine" case="locative">кубічному {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few">кубічні {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" case="accusative">кубічні {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="dative">кубічним {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="genitive">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="instrumental">кубічними {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" case="locative">кубічних {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine">кубічні {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="feminine" case="accusative">кубічні {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="dative">кубічним {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="genitive">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="instrumental">кубічними {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="feminine" case="locative">кубічних {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine">кубічні {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few" gender="masculine" case="accusative">кубічні {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="dative">кубічним {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="genitive">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="instrumental">кубічними {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="few" gender="masculine" case="locative">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many">кубічних {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="accusative">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="dative">кубічним {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" case="genitive">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="instrumental">кубічними {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" case="locative">кубічних {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine">кубічних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="accusative">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="dative">кубічним {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="feminine" case="genitive">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="instrumental">кубічними {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="feminine" case="locative">кубічних {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine">кубічних {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="accusative">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="masculine" case="dative">кубічним {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many" gender="masculine" case="genitive">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="masculine" case="instrumental">кубічними {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="many" gender="masculine" case="locative">кубічних {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">кубічного {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="accusative">кубічного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="dative">кубічного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="genitive">кубічного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="instrumental">кубічного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" case="locative">кубічного {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine">кубічної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="accusative">кубічної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="dative">кубічної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="genitive">кубічної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="instrumental">кубічної {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other" gender="feminine" case="locative">кубічної {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="dative">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="masculine" case="locative">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine">кубічного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="accusative">кубічного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="dative">кубічного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="genitive">кубічного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="instrumental">кубічного {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="masculine" case="locative">кубічного {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>neuter</gender>
 				<displayName>прискорення вільного падіння</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="one" case="accusative">{0} g</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="dative">{0} g</unitPattern>
 				<unitPattern count="one" case="genitive">{0} g</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} g</unitPattern>
+				<unitPattern count="one" case="locative">{0} g</unitPattern>
+				<unitPattern count="few">{0} g</unitPattern>
 				<unitPattern count="few" case="accusative">{0} g</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="dative">{0} g</unitPattern>
 				<unitPattern count="few" case="genitive">{0} g</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} g</unitPattern>
+				<unitPattern count="few" case="locative">{0} g</unitPattern>
+				<unitPattern count="many">{0} g</unitPattern>
 				<unitPattern count="many" case="accusative">{0} g</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="dative">{0} g</unitPattern>
 				<unitPattern count="many" case="genitive">{0} g</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} g</unitPattern>
+				<unitPattern count="many" case="locative">{0} g</unitPattern>
+				<unitPattern count="other">{0} g</unitPattern>
 				<unitPattern count="other" case="accusative">{0} g</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="dative">{0} g</unitPattern>
 				<unitPattern count="other" case="genitive">{0} g</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} g</unitPattern>
+				<unitPattern count="other" case="locative">{0} g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<gender>masculine</gender>
 				<displayName>метри на секунду у квадраті</displayName>
 				<unitPattern count="one">{0} метр на секунду у квадраті</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} метр на секунду у квадраті</unitPattern>
 				<unitPattern count="one" case="dative">{0} метру на секунду у квадраті</unitPattern>
 				<unitPattern count="one" case="genitive">{0} метра на секунду у квадраті</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} метром на секунду у квадраті</unitPattern>
 				<unitPattern count="one" case="locative">{0} метрі на секунду у квадраті</unitPattern>
 				<unitPattern count="few">{0} метри на секунду у квадраті</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метри на секунду у квадраті</unitPattern>
 				<unitPattern count="few" case="dative" draft="contributed">{0} метру на секунду у квадраті</unitPattern>
 				<unitPattern count="few" case="genitive">{0} метрів на секунду у квадраті</unitPattern>
 				<unitPattern count="few" case="instrumental" draft="contributed">{0} метром на секунду у квадраті</unitPattern>
 				<unitPattern count="few" case="locative">{0} метрах на секунду у квадраті</unitPattern>
 				<unitPattern count="many">{0} метрів на секунду у квадраті</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} метрів на секунду у квадраті</unitPattern>
 				<unitPattern count="many" case="dative">{0} метрам на секунду у квадраті</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} метрів на секунду у квадраті</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} метрами на секунду у квадраті</unitPattern>
 				<unitPattern count="many" case="locative">{0} метрах на секунду у квадраті</unitPattern>
 				<unitPattern count="other">{0} метра на секунду у квадраті</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метра на секунду у квадраті</unitPattern>
+				<unitPattern count="other" case="dative">{0} метра на секунду у квадраті</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метра на секунду у квадраті</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метра на секунду у квадраті</unitPattern>
+				<unitPattern count="other" case="locative">{0} метра на секунду у квадраті</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<gender>masculine</gender>
 				<displayName>оберти</displayName>
 				<unitPattern count="one">{0} оберт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} оберт</unitPattern>
 				<unitPattern count="one" case="dative">{0} оберту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} оберта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} обертом</unitPattern>
 				<unitPattern count="one" case="locative">{0} оберті</unitPattern>
 				<unitPattern count="few">{0} оберти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} оберти</unitPattern>
 				<unitPattern count="few" case="dative">{0} обертам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} обертів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} обертами</unitPattern>
 				<unitPattern count="few" case="locative">{0} обертах</unitPattern>
 				<unitPattern count="many">{0} обертів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} обертів</unitPattern>
 				<unitPattern count="many" case="dative">{0} обертам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} обертів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} обертами</unitPattern>
 				<unitPattern count="many" case="locative">{0} обертах</unitPattern>
 				<unitPattern count="other">{0} оберта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} оберта</unitPattern>
+				<unitPattern count="other" case="dative">{0} оберта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} оберта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} оберта</unitPattern>
+				<unitPattern count="other" case="locative">{0} оберта</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<gender>masculine</gender>
 				<displayName>радіани</displayName>
 				<unitPattern count="one">{0} радіан</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} радіан</unitPattern>
 				<unitPattern count="one" case="dative">{0} радіану</unitPattern>
 				<unitPattern count="one" case="genitive">{0} радіана</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} радіаном</unitPattern>
 				<unitPattern count="one" case="locative">{0} радіані</unitPattern>
 				<unitPattern count="few">{0} радіани</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} радіани</unitPattern>
 				<unitPattern count="few" case="dative">{0} радіанам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} радіанів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} радіанами</unitPattern>
 				<unitPattern count="few" case="locative">{0} радіанах</unitPattern>
 				<unitPattern count="many">{0} радіанів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} радіанів</unitPattern>
 				<unitPattern count="many" case="dative">{0} радіанам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} радіанів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} радіанами</unitPattern>
 				<unitPattern count="many" case="locative">{0} радіанах</unitPattern>
 				<unitPattern count="other">{0} радіана</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} радіана</unitPattern>
+				<unitPattern count="other" case="dative">{0} радіана</unitPattern>
+				<unitPattern count="other" case="genitive">{0} радіана</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} радіана</unitPattern>
+				<unitPattern count="other" case="locative">{0} радіана</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<gender>masculine</gender>
 				<displayName>градуси</displayName>
 				<unitPattern count="one">{0} градус</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} градус</unitPattern>
 				<unitPattern count="one" case="dative">{0} градусу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} градуса</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} градусом</unitPattern>
 				<unitPattern count="one" case="locative">{0} градусі</unitPattern>
 				<unitPattern count="few">{0} градуси</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} градуси</unitPattern>
 				<unitPattern count="few" case="dative">{0} градусам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} градусів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} градусами</unitPattern>
 				<unitPattern count="few" case="locative">{0} градусах</unitPattern>
 				<unitPattern count="many">{0} градусів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} градусів</unitPattern>
 				<unitPattern count="many" case="dative">{0} градусам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} градусів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} градусами</unitPattern>
 				<unitPattern count="many" case="locative">{0} градусах</unitPattern>
 				<unitPattern count="other">{0} градуса</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} градуса</unitPattern>
+				<unitPattern count="other" case="dative">{0} градуса</unitPattern>
+				<unitPattern count="other" case="genitive">{0} градуса</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} градуса</unitPattern>
+				<unitPattern count="other" case="locative">{0} градуса</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
 				<gender>feminine</gender>
@@ -8558,10 +8558,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="locative">{0} кутових мінутах</unitPattern>
 				<unitPattern count="other">{0} кутової мінути</unitPattern>
 				<unitPattern count="other" case="accusative">{0} кутової мінути</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="dative">{0} кутової мінути</unitPattern>
 				<unitPattern count="other" case="genitive">{0} кутової мінути</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кутової мінути</unitPattern>
+				<unitPattern count="other" case="locative">{0} кутової мінути</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<gender>feminine</gender>
@@ -8573,137 +8573,137 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} кутовою секундою</unitPattern>
 				<unitPattern count="one" case="locative">{0} кутовій секунді</unitPattern>
 				<unitPattern count="few">{0} кутові секунди</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кутові секунди</unitPattern>
 				<unitPattern count="few" case="dative">{0} кутовим секундам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кутових секунд</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кутовими секундами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кутових секундах</unitPattern>
 				<unitPattern count="many">{0} кутових секунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кутових секунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} кутовим секундам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кутових секунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кутовими секундами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кутових секундах</unitPattern>
 				<unitPattern count="other">{0} кутової секунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кутової секунди</unitPattern>
+				<unitPattern count="other" case="dative">{0} кутової секунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кутової секунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кутової секунди</unitPattern>
+				<unitPattern count="other" case="locative">{0} кутової секунди</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<gender>masculine</gender>
 				<displayName>квадратні кілометри</displayName>
 				<unitPattern count="one">{0} квадратний кілометр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} квадратний кілометр</unitPattern>
 				<unitPattern count="one" case="dative">{0} квадратному кілометру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} квадратного кілометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} квадратним кілометром</unitPattern>
 				<unitPattern count="one" case="locative">{0} квадратному кілометрі</unitPattern>
 				<unitPattern count="few">{0} квадратні кілометри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратні кілометри</unitPattern>
 				<unitPattern count="few" case="dative">{0} квадратним кілометрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} квадратних кілометрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} квадратними кілометрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} квадратних кілометрах</unitPattern>
 				<unitPattern count="many">{0} квадратних кілометрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} квадратних кілометрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} квадратним кілометрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} квадратних кілометрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} квадратними кілометрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} квадратних кілометрах</unitPattern>
 				<unitPattern count="other">{0} квадратного кілометра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратного кілометра</unitPattern>
+				<unitPattern count="other" case="dative">{0} квадратного кілометра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратного кілометра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратного кілометра</unitPattern>
+				<unitPattern count="other" case="locative">{0} квадратного кілометра</unitPattern>
 				<perUnitPattern>{0} на квадратний кілометр</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<gender>masculine</gender>
 				<displayName>гектари</displayName>
 				<unitPattern count="one">{0} гектар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гектар</unitPattern>
 				<unitPattern count="one" case="dative">{0} гектару</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гектара</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гектаром</unitPattern>
 				<unitPattern count="one" case="locative">{0} гектарі</unitPattern>
 				<unitPattern count="few">{0} гектари</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гектари</unitPattern>
 				<unitPattern count="few" case="dative">{0} гектарам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гектарів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гектарами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гектарах</unitPattern>
 				<unitPattern count="many">{0} гектарів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гектарів</unitPattern>
 				<unitPattern count="many" case="dative">{0} гектарам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гектарів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гектарами</unitPattern>
 				<unitPattern count="many" case="locative">{0} гектарах</unitPattern>
 				<unitPattern count="other">{0} гектара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гектара</unitPattern>
+				<unitPattern count="other" case="dative">{0} гектара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гектара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гектара</unitPattern>
+				<unitPattern count="other" case="locative">{0} гектара</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<gender>masculine</gender>
 				<displayName>квадратні метри</displayName>
 				<unitPattern count="one">{0} квадратний метр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} квадратний метр</unitPattern>
 				<unitPattern count="one" case="dative">{0} квадратному метру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} квадратного метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} квадратним метром</unitPattern>
 				<unitPattern count="one" case="locative">{0} квадратному метрі</unitPattern>
 				<unitPattern count="few">{0} квадратні метри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратні метри</unitPattern>
 				<unitPattern count="few" case="dative">{0} квадратним метрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} квадратних метрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} квадратними метрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} квадратних метрах</unitPattern>
 				<unitPattern count="many">{0} квадратних метрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} квадратних метрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} квадратним метрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} квадратних метрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} квадратними метрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} квадратних метрах</unitPattern>
 				<unitPattern count="other">{0} квадратного метра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратного метра</unitPattern>
+				<unitPattern count="other" case="dative">{0} квадратного метра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратного метра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратного метра</unitPattern>
+				<unitPattern count="other" case="locative">{0} квадратного метра</unitPattern>
 				<perUnitPattern>{0} на квадратний метр</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<gender>masculine</gender>
 				<displayName>квадратні сантиметри</displayName>
 				<unitPattern count="one">{0} квадратний сантиметр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} квадратний сантиметр</unitPattern>
 				<unitPattern count="one" case="dative">{0} квадратному сантиметру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} квадратного сантиметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} квадратним сантиметром</unitPattern>
 				<unitPattern count="one" case="locative">{0} квадратному сантиметрі</unitPattern>
 				<unitPattern count="few">{0} квадратні сантиметри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квадратні сантиметри</unitPattern>
 				<unitPattern count="few" case="dative">{0} квадратним сантиметрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} квадратних сантиметрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} квадратними сантиметрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} квадратних сантиметрах</unitPattern>
 				<unitPattern count="many">{0} квадратних сантиметрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} квадратних сантиметрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} квадратним сантиметрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} квадратних сантиметрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} квадратними сантиметрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} квадратних сантиметрах</unitPattern>
 				<unitPattern count="other">{0} квадратного сантиметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} квадратного сантиметра</unitPattern>
+				<unitPattern count="other" case="locative">{0} квадратного сантиметра</unitPattern>
 				<perUnitPattern>{0} на квадратний сантиметр</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
@@ -8754,29 +8754,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>карати</displayName>
 				<unitPattern count="one">{0} карат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} карат</unitPattern>
 				<unitPattern count="one" case="dative">{0} карату</unitPattern>
 				<unitPattern count="one" case="genitive">{0} карата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} каратом</unitPattern>
 				<unitPattern count="one" case="locative">{0} караті</unitPattern>
 				<unitPattern count="few">{0} карати</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} карати</unitPattern>
 				<unitPattern count="few" case="dative">{0} каратам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} каратів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} каратами</unitPattern>
 				<unitPattern count="few" case="locative">{0} каратах</unitPattern>
 				<unitPattern count="many">{0} каратів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} каратів</unitPattern>
 				<unitPattern count="many" case="dative">{0} каратам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} каратів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} каратами</unitPattern>
 				<unitPattern count="many" case="locative">{0} каратах</unitPattern>
 				<unitPattern count="other">{0} карата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} карата</unitPattern>
+				<unitPattern count="other" case="dative">{0} карата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} карата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} карата</unitPattern>
+				<unitPattern count="other" case="locative">{0} карата</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>міліграми на децилітр</displayName>
@@ -8789,57 +8789,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>мілімолі на літр</displayName>
 				<unitPattern count="one">{0} мілімоль на літр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мілімоль на літр</unitPattern>
 				<unitPattern count="one" case="dative">{0} мілімолю на літр</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мілімоля на літр</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мілімолем на літр</unitPattern>
 				<unitPattern count="one" case="locative">{0} мілімолі на літр</unitPattern>
 				<unitPattern count="few">{0} мілімолі на літр</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мілімолі на літр</unitPattern>
 				<unitPattern count="few" case="dative">{0} мілімолям на літр</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мілімолів на літр</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мілімолями на літр</unitPattern>
 				<unitPattern count="few" case="locative">{0} мілімолях на літр</unitPattern>
 				<unitPattern count="many">{0} мілімолів на літр</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мілімолів на літр</unitPattern>
 				<unitPattern count="many" case="dative">{0} мілімолям на літр</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мілімолів на літр</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мілімолями на літр</unitPattern>
 				<unitPattern count="many" case="locative">{0} мілімолях на літр</unitPattern>
 				<unitPattern count="other">{0} мілімоля на літр</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мілімоля на літр</unitPattern>
+				<unitPattern count="other" case="dative">{0} мілімоля на літр</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мілімоля на літр</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мілімоля на літр</unitPattern>
+				<unitPattern count="other" case="locative">{0} мілімоля на літр</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<gender>masculine</gender>
 				<displayName>елементи</displayName>
 				<unitPattern count="one">{0} елемент</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} елемент</unitPattern>
 				<unitPattern count="one" case="dative">{0} елементу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} елемента</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} елементом</unitPattern>
 				<unitPattern count="one" case="locative">{0} елементі</unitPattern>
 				<unitPattern count="few">{0} елементи</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} елементи</unitPattern>
 				<unitPattern count="few" case="dative">{0} елементам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} елементів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} елементами</unitPattern>
 				<unitPattern count="few" case="locative">{0} елементах</unitPattern>
 				<unitPattern count="many">{0} елементів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} елементів</unitPattern>
 				<unitPattern count="many" case="dative">{0} елементам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} елементів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} елементами</unitPattern>
 				<unitPattern count="many" case="locative">{0} елементах</unitPattern>
 				<unitPattern count="other">{0} елемента</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} елемента</unitPattern>
+				<unitPattern count="other" case="dative">{0} елемента</unitPattern>
+				<unitPattern count="other" case="genitive">{0} елемента</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} елемента</unitPattern>
+				<unitPattern count="other" case="locative">{0} елемента</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<gender>feminine</gender>
@@ -8851,79 +8851,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} мільйонною долею</unitPattern>
 				<unitPattern count="one" case="locative">{0} мільйонній долі</unitPattern>
 				<unitPattern count="few">{0} мільйонні долі</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мільйонні долі</unitPattern>
 				<unitPattern count="few" case="dative">{0} мільйонним долям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мільйонних доль</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мільйонними долями</unitPattern>
 				<unitPattern count="few" case="locative">{0} мільйонних долях</unitPattern>
 				<unitPattern count="many">{0} мільйонних доль</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мільйонних доль</unitPattern>
 				<unitPattern count="many" case="dative">{0} мільйонним долям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мільйонних доль</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мільйонними долями</unitPattern>
 				<unitPattern count="many" case="locative">{0} мільйонних долях</unitPattern>
 				<unitPattern count="other">{0} мільйонної долі</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мільйонної долі</unitPattern>
+				<unitPattern count="other" case="dative">{0} мільйонної долі</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мільйонної долі</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мільйонної долі</unitPattern>
+				<unitPattern count="other" case="locative">{0} мільйонної долі</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<gender>masculine</gender>
 				<displayName>відсоток</displayName>
 				<unitPattern count="one">{0} відсоток</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} відсоток</unitPattern>
 				<unitPattern count="one" case="dative">{0} відсотку</unitPattern>
 				<unitPattern count="one" case="genitive">{0} відсотка</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} відсотком</unitPattern>
 				<unitPattern count="one" case="locative">{0} відсотку</unitPattern>
 				<unitPattern count="few">{0} відсотки</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} відсотки</unitPattern>
 				<unitPattern count="few" case="dative">{0} відсоткам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} відсотків</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} відсотками</unitPattern>
 				<unitPattern count="few" case="locative">{0} відсотках</unitPattern>
 				<unitPattern count="many">{0} відсотків</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} відсотків</unitPattern>
 				<unitPattern count="many" case="dative">{0} відсоткам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} відсотків</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} відсотками</unitPattern>
 				<unitPattern count="many" case="locative">{0} відсотках</unitPattern>
 				<unitPattern count="other">{0} відсотка</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} відсотка</unitPattern>
+				<unitPattern count="other" case="dative">{0} відсотка</unitPattern>
+				<unitPattern count="other" case="genitive">{0} відсотка</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} відсотка</unitPattern>
+				<unitPattern count="other" case="locative">{0} відсотка</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<gender>masculine</gender>
 				<displayName>проміле</displayName>
 				<unitPattern count="one">{0} проміле</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} проміле</unitPattern>
+				<unitPattern count="one" case="dative">{0} проміле</unitPattern>
+				<unitPattern count="one" case="genitive">{0} проміле</unitPattern>
+				<unitPattern count="one" case="instrumental">{0} проміле</unitPattern>
+				<unitPattern count="one" case="locative">{0} проміле</unitPattern>
 				<unitPattern count="few">{0} проміле</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} проміле</unitPattern>
+				<unitPattern count="few" case="dative">{0} проміле</unitPattern>
+				<unitPattern count="few" case="genitive">{0} проміле</unitPattern>
+				<unitPattern count="few" case="instrumental">{0} проміле</unitPattern>
+				<unitPattern count="few" case="locative">{0} проміле</unitPattern>
 				<unitPattern count="many">{0} проміле</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} проміле</unitPattern>
+				<unitPattern count="many" case="dative">{0} проміле</unitPattern>
+				<unitPattern count="many" case="genitive">{0} проміле</unitPattern>
+				<unitPattern count="many" case="instrumental">{0} проміле</unitPattern>
+				<unitPattern count="many" case="locative">{0} проміле</unitPattern>
 				<unitPattern count="other">{0} проміле</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} проміле</unitPattern>
+				<unitPattern count="other" case="dative">{0} проміле</unitPattern>
+				<unitPattern count="other" case="genitive">{0} проміле</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} проміле</unitPattern>
+				<unitPattern count="other" case="locative">{0} проміле</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<gender>masculine</gender>
@@ -8935,21 +8935,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} проміріадом</unitPattern>
 				<unitPattern count="one" case="locative">{0} проміріаді</unitPattern>
 				<unitPattern count="few">{0} проміріади</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} проміріади</unitPattern>
 				<unitPattern count="few" case="dative">{0} проміріадам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} проміріадів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} проміріадами</unitPattern>
 				<unitPattern count="few" case="locative">{0} проміріадах</unitPattern>
 				<unitPattern count="many">{0} проміріадів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} проміріадів</unitPattern>
 				<unitPattern count="many" case="dative">{0} проміріадам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} проміріадів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} проміріадами</unitPattern>
 				<unitPattern count="many" case="locative">{0} проміріадах</unitPattern>
 				<unitPattern count="other">{0} проміріада</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} проміріада</unitPattern>
 				<unitPattern count="other" case="dative">{0} проміріада</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="other" case="genitive">{0} проміріада</unitPattern>
 				<unitPattern count="other" case="instrumental">{0} проміріада</unitPattern>
 				<unitPattern count="other" case="locative">{0} проміріада</unitPattern>
 			</unit>
@@ -8957,85 +8957,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>молі</displayName>
 				<unitPattern count="one">{0} моль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} моль</unitPattern>
 				<unitPattern count="one" case="dative">{0} молю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} моля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} молем</unitPattern>
 				<unitPattern count="one" case="locative">{0} молі</unitPattern>
 				<unitPattern count="few">{0} молі</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} молі</unitPattern>
 				<unitPattern count="few" case="dative">{0} молям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} молів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} молями</unitPattern>
 				<unitPattern count="few" case="locative">{0} молях</unitPattern>
 				<unitPattern count="many">{0} молів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} молів</unitPattern>
 				<unitPattern count="many" case="dative">{0} молям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} молів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} молями</unitPattern>
 				<unitPattern count="many" case="locative">{0} молях</unitPattern>
 				<unitPattern count="other">{0} моля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} моля</unitPattern>
+				<unitPattern count="other" case="dative">{0} моля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} моля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} моля</unitPattern>
+				<unitPattern count="other" case="locative">{0} моля</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<gender>masculine</gender>
 				<displayName>літри на кілометр</displayName>
 				<unitPattern count="one">{0} літр на кілометр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} літр на кілометр</unitPattern>
 				<unitPattern count="one" case="dative">{0} літру на кілометр</unitPattern>
 				<unitPattern count="one" case="genitive">{0} літра на кілометр</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} літром на кілометр</unitPattern>
 				<unitPattern count="one" case="locative">{0} літрі на кілометр</unitPattern>
 				<unitPattern count="few">{0} літри на кілометр</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} літри на кілометр</unitPattern>
 				<unitPattern count="few" case="dative">{0} літрам на кілометр</unitPattern>
 				<unitPattern count="few" case="genitive">{0} літрів на кілометр</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} літрами на кілометр</unitPattern>
 				<unitPattern count="few" case="locative">{0} літрах на кілометр</unitPattern>
 				<unitPattern count="many">{0} літрів на кілометр</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} літрів на кілометр</unitPattern>
 				<unitPattern count="many" case="dative">{0} літрам на кілометр</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} літрів на кілометр</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} літрами на кілометр</unitPattern>
 				<unitPattern count="many" case="locative">{0} літрах на кілометр</unitPattern>
 				<unitPattern count="other">{0} літра на кілометр</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} літра на кілометр</unitPattern>
+				<unitPattern count="other" case="dative">{0} літра на кілометр</unitPattern>
+				<unitPattern count="other" case="genitive">{0} літра на кілометр</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} літра на кілометр</unitPattern>
+				<unitPattern count="other" case="locative">{0} літра на кілометр</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<gender>masculine</gender>
 				<displayName>літри на 100 кілометрів</displayName>
 				<unitPattern count="one">{0} літр на 100 кілометрів</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} літр на 100 кілометрів</unitPattern>
 				<unitPattern count="one" case="dative">{0} літру на 100 кілометрів</unitPattern>
 				<unitPattern count="one" case="genitive">{0} літра на 100 кілометрів</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} літром на 100 кілометрів</unitPattern>
 				<unitPattern count="one" case="locative">{0} літрі на 100 кілометрів</unitPattern>
 				<unitPattern count="few">{0} літри на 100 кілометрів</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} літри на 100 кілометрів</unitPattern>
 				<unitPattern count="few" case="dative">{0} літрам на 100 кілометрів</unitPattern>
 				<unitPattern count="few" case="genitive">{0} літрів на 100 кілометрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} літрами на 100 кілометрів</unitPattern>
 				<unitPattern count="few" case="locative">{0} літрах на 100 кілометрів</unitPattern>
 				<unitPattern count="many">{0} літрів на 100 кілометрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} літрів на 100 кілометрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} літрам на 100 кілометрів</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} літрів на 100 кілометрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} літрами на 100 кілометрів</unitPattern>
 				<unitPattern count="many" case="locative">{0} літрах на 100 кілометрів</unitPattern>
 				<unitPattern count="other">{0} літра на 100 кілометрів</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} літра на 100 кілометрів</unitPattern>
+				<unitPattern count="other" case="dative">{0} літра на 100 кілометрів</unitPattern>
+				<unitPattern count="other" case="genitive">{0} літра на 100 кілометрів</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} літра на 100 кілометрів</unitPattern>
+				<unitPattern count="other" case="locative">{0} літра на 100 кілометрів</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>милі на галон</displayName>
@@ -9055,393 +9055,393 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>петабайти</displayName>
 				<unitPattern count="one">{0} петабайт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} петабайт</unitPattern>
 				<unitPattern count="one" case="dative">{0} петабайту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} петабайта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} петабайтом</unitPattern>
 				<unitPattern count="one" case="locative">{0} петабайті</unitPattern>
 				<unitPattern count="few">{0} петабайти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} петабайти</unitPattern>
 				<unitPattern count="few" case="dative">{0} петабайтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} петабайтів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} петабайтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} петабайтах</unitPattern>
 				<unitPattern count="many">{0} петабайтів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} петабайтів</unitPattern>
 				<unitPattern count="many" case="dative">{0} петабайтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} петабайтів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} петабайтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} петабайтах</unitPattern>
 				<unitPattern count="other">{0} петабайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} петабайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} петабайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} петабайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} петабайта</unitPattern>
+				<unitPattern count="other" case="locative">{0} петабайта</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<gender>masculine</gender>
 				<displayName>терабайти</displayName>
 				<unitPattern count="one">{0} терабайт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} терабайт</unitPattern>
 				<unitPattern count="one" case="dative">{0} терабайту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} терабайта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} терабайтом</unitPattern>
 				<unitPattern count="one" case="locative">{0} терабайті</unitPattern>
 				<unitPattern count="few">{0} терабайти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} терабайти</unitPattern>
 				<unitPattern count="few" case="dative">{0} терабайтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} терабайтів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} терабайтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} терабайтах</unitPattern>
 				<unitPattern count="many">{0} терабайтів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} терабайтів</unitPattern>
 				<unitPattern count="many" case="dative">{0} терабайтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} терабайтів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} терабайтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} терабайтах</unitPattern>
 				<unitPattern count="other">{0} терабайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} терабайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} терабайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} терабайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} терабайта</unitPattern>
+				<unitPattern count="other" case="locative">{0} терабайта</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>masculine</gender>
 				<displayName>терабіти</displayName>
 				<unitPattern count="one">{0} терабіт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} терабіт</unitPattern>
 				<unitPattern count="one" case="dative">{0} терабіту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} терабіта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} терабітом</unitPattern>
 				<unitPattern count="one" case="locative">{0} терабіті</unitPattern>
 				<unitPattern count="few">{0} терабіти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} терабіти</unitPattern>
 				<unitPattern count="few" case="dative">{0} терабітам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} терабітів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} терабітами</unitPattern>
 				<unitPattern count="few" case="locative">{0} терабітах</unitPattern>
 				<unitPattern count="many">{0} терабітів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} терабітів</unitPattern>
 				<unitPattern count="many" case="dative">{0} терабітам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} терабітів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} терабітами</unitPattern>
 				<unitPattern count="many" case="locative">{0} терабітах</unitPattern>
 				<unitPattern count="other">{0} терабіта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} терабіта</unitPattern>
+				<unitPattern count="other" case="dative">{0} терабіта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} терабіта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} терабіта</unitPattern>
+				<unitPattern count="other" case="locative">{0} терабіта</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<gender>masculine</gender>
 				<displayName>гігабайти</displayName>
 				<unitPattern count="one">{0} гігабайт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гігабайт</unitPattern>
 				<unitPattern count="one" case="dative">{0} гігабайту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гігабайта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гігабайтом</unitPattern>
 				<unitPattern count="one" case="locative">{0} гігабайті</unitPattern>
 				<unitPattern count="few">{0} гігабайти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гігабайти</unitPattern>
 				<unitPattern count="few" case="dative">{0} гігабайтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гігабайтів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гігабайтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гігабайтах</unitPattern>
 				<unitPattern count="many">{0} гігабайтів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гігабайтів</unitPattern>
 				<unitPattern count="many" case="dative">{0} гігабайтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гігабайтів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гігабайтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} гігабайтах</unitPattern>
 				<unitPattern count="other">{0} гігабайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гігабайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} гігабайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гігабайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гігабайта</unitPattern>
+				<unitPattern count="other" case="locative">{0} гігабайта</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<gender>masculine</gender>
 				<displayName>гігабіти</displayName>
 				<unitPattern count="one">{0} гігабіт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гігабіт</unitPattern>
 				<unitPattern count="one" case="dative">{0} гігабіту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гігабіта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гігабітом</unitPattern>
 				<unitPattern count="one" case="locative">{0} гігабіті</unitPattern>
 				<unitPattern count="few">{0} гігабіти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гігабіти</unitPattern>
 				<unitPattern count="few" case="dative">{0} гігабітам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гігабітів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гігабітами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гігабітах</unitPattern>
 				<unitPattern count="many">{0} гігабітів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гігабітів</unitPattern>
 				<unitPattern count="many" case="dative">{0} гігабітам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гігабітів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гігабітами</unitPattern>
 				<unitPattern count="many" case="locative">{0} гігабітах</unitPattern>
 				<unitPattern count="other">{0} гігабіта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гігабіта</unitPattern>
+				<unitPattern count="other" case="dative">{0} гігабіта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гігабіта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гігабіта</unitPattern>
+				<unitPattern count="other" case="locative">{0} гігабіта</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<gender>masculine</gender>
 				<displayName>мегабайти</displayName>
 				<unitPattern count="one">{0} мегабайт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегабайт</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегабайту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегабайта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегабайтом</unitPattern>
 				<unitPattern count="one" case="locative">{0} мегабайті</unitPattern>
 				<unitPattern count="few">{0} мегабайти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегабайти</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегабайтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегабайтів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегабайтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мегабайтах</unitPattern>
 				<unitPattern count="many">{0} мегабайтів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегабайтів</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегабайтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегабайтів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегабайтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мегабайтах</unitPattern>
 				<unitPattern count="other">{0} мегабайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегабайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегабайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегабайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегабайта</unitPattern>
+				<unitPattern count="other" case="locative">{0} мегабайта</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<gender>masculine</gender>
 				<displayName>мегабіти</displayName>
 				<unitPattern count="one">{0} мегабіт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегабіт</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегабіту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегабіта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегабітом</unitPattern>
 				<unitPattern count="one" case="locative">{0} мегабіті</unitPattern>
 				<unitPattern count="few">{0} мегабіти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегабіти</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегабітам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегабітів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегабітами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мегабітах</unitPattern>
 				<unitPattern count="many">{0} мегабітів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегабітів</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегабітам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегабітів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегабітами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мегабітах</unitPattern>
 				<unitPattern count="other">{0} мегабіта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегабіта</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегабіта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегабіта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегабіта</unitPattern>
+				<unitPattern count="other" case="locative">{0} мегабіта</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<gender>masculine</gender>
 				<displayName>кілобайти</displayName>
 				<unitPattern count="one">{0} кілобайт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кілобайт</unitPattern>
 				<unitPattern count="one" case="dative">{0} кілобайту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кілобайта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кілобайтом</unitPattern>
 				<unitPattern count="one" case="locative">{0} кілобайті</unitPattern>
 				<unitPattern count="few">{0} кілобайти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кілобайти</unitPattern>
 				<unitPattern count="few" case="dative">{0} кілобайтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кілобайтів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кілобайтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кілобайтах</unitPattern>
 				<unitPattern count="many">{0} кілобайтів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кілобайтів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кілобайтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кілобайтів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кілобайтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кілобайтах</unitPattern>
 				<unitPattern count="other">{0} кілобайта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кілобайта</unitPattern>
+				<unitPattern count="other" case="dative">{0} кілобайта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кілобайта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кілобайта</unitPattern>
+				<unitPattern count="other" case="locative">{0} кілобайта</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<gender>masculine</gender>
 				<displayName>кілобіти</displayName>
 				<unitPattern count="one">{0} кілобіт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кілобіт</unitPattern>
 				<unitPattern count="one" case="dative">{0} кілобіту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кілобіта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кілобітом</unitPattern>
 				<unitPattern count="one" case="locative">{0} кілобіті</unitPattern>
 				<unitPattern count="few">{0} кілобіти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кілобіти</unitPattern>
 				<unitPattern count="few" case="dative">{0} кілобітам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кілобітів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кілобітами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кілобітах</unitPattern>
 				<unitPattern count="many">{0} кілобітів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кілобітів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кілобітам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кілобітів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кілобітами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кілобітах</unitPattern>
 				<unitPattern count="other">{0} кілобіта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кілобіта</unitPattern>
+				<unitPattern count="other" case="dative">{0} кілобіта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кілобіта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кілобіта</unitPattern>
+				<unitPattern count="other" case="locative">{0} кілобіта</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<gender>masculine</gender>
 				<displayName>байти</displayName>
 				<unitPattern count="one">{0} байт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} байт</unitPattern>
 				<unitPattern count="one" case="dative">{0} байту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} байта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} байтом</unitPattern>
 				<unitPattern count="one" case="locative">{0} байті</unitPattern>
 				<unitPattern count="few">{0} байти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} байти</unitPattern>
 				<unitPattern count="few" case="dative">{0} байтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} байтів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} байтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} байтах</unitPattern>
 				<unitPattern count="many">{0} байтів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} байтів</unitPattern>
 				<unitPattern count="many" case="dative">{0} байтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} байтів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} байтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} байтах</unitPattern>
 				<unitPattern count="other">{0} байта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} байта</unitPattern>
+				<unitPattern count="other" case="dative">{0} байта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} байта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} байта</unitPattern>
+				<unitPattern count="other" case="locative">{0} байта</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<gender>masculine</gender>
 				<displayName>біти</displayName>
 				<unitPattern count="one">{0} біт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} біт</unitPattern>
 				<unitPattern count="one" case="dative">{0} біту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} біта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} бітом</unitPattern>
 				<unitPattern count="one" case="locative">{0} біті</unitPattern>
 				<unitPattern count="few">{0} біти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} біти</unitPattern>
 				<unitPattern count="few" case="dative">{0} бітам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} бітів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} бітами</unitPattern>
 				<unitPattern count="few" case="locative">{0} бітах</unitPattern>
 				<unitPattern count="many">{0} бітів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} бітів</unitPattern>
 				<unitPattern count="many" case="dative">{0} бітам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} бітів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} бітами</unitPattern>
 				<unitPattern count="many" case="locative">{0} бітах</unitPattern>
 				<unitPattern count="other">{0} біта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} біта</unitPattern>
+				<unitPattern count="other" case="dative">{0} біта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} біта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} біта</unitPattern>
+				<unitPattern count="other" case="locative">{0} біта</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<gender>neuter</gender>
 				<displayName>століття</displayName>
 				<unitPattern count="one">{0} століття</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} століття</unitPattern>
 				<unitPattern count="one" case="dative">{0} століттю</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} століття</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} століттям</unitPattern>
 				<unitPattern count="one" case="locative">{0} столітті</unitPattern>
 				<unitPattern count="few">{0} століття</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} століття</unitPattern>
 				<unitPattern count="few" case="dative">{0} століттям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} століть</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} століттями</unitPattern>
 				<unitPattern count="few" case="locative">{0} століттях</unitPattern>
 				<unitPattern count="many">{0} століть</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} століть</unitPattern>
 				<unitPattern count="many" case="dative">{0} століттям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} століть</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} століттями</unitPattern>
 				<unitPattern count="many" case="locative">{0} століттях</unitPattern>
 				<unitPattern count="other">{0} століття</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} століття</unitPattern>
+				<unitPattern count="other" case="dative">{0} століття</unitPattern>
+				<unitPattern count="other" case="genitive">{0} століття</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} століття</unitPattern>
+				<unitPattern count="other" case="locative">{0} століття</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<gender>neuter</gender>
 				<displayName>десятиріччя</displayName>
 				<unitPattern count="one">{0} десятиріччя</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} десятиріччя</unitPattern>
 				<unitPattern count="one" case="dative">{0} десятиріччю</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive">{0} десятиріччя</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} десятиріччям</unitPattern>
 				<unitPattern count="one" case="locative">{0} десятиріччі</unitPattern>
 				<unitPattern count="few">{0} десятиріччя</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} десятиріччя</unitPattern>
 				<unitPattern count="few" case="dative">{0} десятиріччям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} десятиріч</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} десятиріччями</unitPattern>
 				<unitPattern count="few" case="locative">{0} десятиріччях</unitPattern>
 				<unitPattern count="many">{0} десятиріч</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} десятиріч</unitPattern>
 				<unitPattern count="many" case="dative">{0} десятиріччям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} десятиріч</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} десятиріччями</unitPattern>
 				<unitPattern count="many" case="locative">{0} десятиріччях</unitPattern>
 				<unitPattern count="other">{0} десятиріччя</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} десятиріччя</unitPattern>
+				<unitPattern count="other" case="dative">{0} десятиріччя</unitPattern>
+				<unitPattern count="other" case="genitive">{0} десятиріччя</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} десятиріччя</unitPattern>
+				<unitPattern count="other" case="locative">{0} десятиріччя</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<gender>masculine</gender>
 				<displayName>роки</displayName>
 				<unitPattern count="one">{0} рік</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} рік</unitPattern>
 				<unitPattern count="one" case="dative">{0} року</unitPattern>
 				<unitPattern count="one" case="genitive">{0} року</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} роком</unitPattern>
 				<unitPattern count="one" case="locative">{0} році</unitPattern>
 				<unitPattern count="few">{0} роки</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} роки</unitPattern>
 				<unitPattern count="few" case="dative">{0} рокам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} років</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} роками</unitPattern>
 				<unitPattern count="few" case="locative">{0} роках</unitPattern>
 				<unitPattern count="many">{0} років</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} років</unitPattern>
 				<unitPattern count="many" case="dative">{0} рокам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} років</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} роками</unitPattern>
 				<unitPattern count="many" case="locative">{0} роках</unitPattern>
 				<unitPattern count="other">{0} року</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} року</unitPattern>
+				<unitPattern count="other" case="dative">{0} року</unitPattern>
+				<unitPattern count="other" case="genitive">{0} року</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} року</unitPattern>
+				<unitPattern count="other" case="locative">{0} року</unitPattern>
 				<perUnitPattern>{0} на рік</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
@@ -9454,15 +9454,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} кварталом</unitPattern>
 				<unitPattern count="one" case="locative">{0} кварталі</unitPattern>
 				<unitPattern count="few">{0} квартали</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} квартали</unitPattern>
 				<unitPattern count="few" case="dative">{0} кварталам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кварталів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кварталами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кварталах</unitPattern>
 				<unitPattern count="many">{0} кварталів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кварталів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кварталам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кварталів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кварталами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кварталах</unitPattern>
 				<unitPattern count="other">{0} кварталу</unitPattern>
@@ -9477,87 +9477,87 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>місяці</displayName>
 				<unitPattern count="one">{0} місяць</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} місяць</unitPattern>
 				<unitPattern count="one" case="dative">{0} місяцю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} місяця</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} місяцем</unitPattern>
 				<unitPattern count="one" case="locative">{0} місяці</unitPattern>
 				<unitPattern count="few">{0} місяці</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} місяці</unitPattern>
 				<unitPattern count="few" case="dative">{0} місяцям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} місяців</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} місяцями</unitPattern>
 				<unitPattern count="few" case="locative">{0} місяцях</unitPattern>
 				<unitPattern count="many">{0} місяців</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} місяців</unitPattern>
 				<unitPattern count="many" case="dative">{0} місяцям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} місяців</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} місяцями</unitPattern>
 				<unitPattern count="many" case="locative">{0} місяцях</unitPattern>
 				<unitPattern count="other">{0} місяця</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} місяця</unitPattern>
+				<unitPattern count="other" case="dative">{0} місяця</unitPattern>
+				<unitPattern count="other" case="genitive">{0} місяця</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} місяця</unitPattern>
+				<unitPattern count="other" case="locative">{0} місяця</unitPattern>
 				<perUnitPattern>{0} на місяць</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<gender>masculine</gender>
 				<displayName>тижні</displayName>
 				<unitPattern count="one">{0} тиждень</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} тиждень</unitPattern>
 				<unitPattern count="one" case="dative">{0} тижню</unitPattern>
 				<unitPattern count="one" case="genitive">{0} тижня</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} тижнем</unitPattern>
 				<unitPattern count="one" case="locative">{0} тижні</unitPattern>
 				<unitPattern count="few">{0} тижні</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} тижні</unitPattern>
 				<unitPattern count="few" case="dative">{0} тижням</unitPattern>
 				<unitPattern count="few" case="genitive">{0} тижнів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} тижнями</unitPattern>
 				<unitPattern count="few" case="locative">{0} тижнях</unitPattern>
 				<unitPattern count="many">{0} тижнів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} тижнів</unitPattern>
 				<unitPattern count="many" case="dative">{0} тижням</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} тижнів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} тижнями</unitPattern>
 				<unitPattern count="many" case="locative">{0} тижнях</unitPattern>
 				<unitPattern count="other">{0} тижня</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} тижня</unitPattern>
+				<unitPattern count="other" case="dative">{0} тижня</unitPattern>
+				<unitPattern count="other" case="genitive">{0} тижня</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} тижня</unitPattern>
+				<unitPattern count="other" case="locative">{0} тижня</unitPattern>
 				<perUnitPattern>{0} на тиждень</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<gender>masculine</gender>
 				<displayName>дні</displayName>
 				<unitPattern count="one">{0} день</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} день</unitPattern>
 				<unitPattern count="one" case="dative">{0} дню</unitPattern>
 				<unitPattern count="one" case="genitive">{0} дня</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} днем</unitPattern>
 				<unitPattern count="one" case="locative">{0} дні</unitPattern>
 				<unitPattern count="few">{0} дні</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} дні</unitPattern>
 				<unitPattern count="few" case="dative">{0} дням</unitPattern>
 				<unitPattern count="few" case="genitive">{0} днів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} днями</unitPattern>
 				<unitPattern count="few" case="locative">{0} днях</unitPattern>
 				<unitPattern count="many">{0} днів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} днів</unitPattern>
 				<unitPattern count="many" case="dative">{0} дням</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} днів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} днями</unitPattern>
 				<unitPattern count="many" case="locative">{0} днях</unitPattern>
 				<unitPattern count="other">{0} дня</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} дня</unitPattern>
+				<unitPattern count="other" case="dative">{0} дня</unitPattern>
+				<unitPattern count="other" case="genitive">{0} дня</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} дня</unitPattern>
+				<unitPattern count="other" case="locative">{0} дня</unitPattern>
 				<perUnitPattern>{0} на день</perUnitPattern>
 			</unit>
 			<unit type="duration-day-person">
@@ -9585,23 +9585,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} годиною</unitPattern>
 				<unitPattern count="one" case="locative">{0} годині</unitPattern>
 				<unitPattern count="few">{0} години</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} години</unitPattern>
 				<unitPattern count="few" case="dative">{0} годинам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} годин</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} годинами</unitPattern>
 				<unitPattern count="few" case="locative">{0} годинах</unitPattern>
 				<unitPattern count="many">{0} годин</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} годин</unitPattern>
 				<unitPattern count="many" case="dative">{0} годинам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} годин</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} годинами</unitPattern>
 				<unitPattern count="many" case="locative">{0} годинах</unitPattern>
 				<unitPattern count="other">{0} години</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} години</unitPattern>
+				<unitPattern count="other" case="dative">{0} години</unitPattern>
+				<unitPattern count="other" case="genitive">{0} години</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} години</unitPattern>
+				<unitPattern count="other" case="locative">{0} години</unitPattern>
 				<perUnitPattern>{0} на годину</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -9614,23 +9614,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} хвилиною</unitPattern>
 				<unitPattern count="one" case="locative">{0} хвилині</unitPattern>
 				<unitPattern count="few">{0} хвилини</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} хвилини</unitPattern>
 				<unitPattern count="few" case="dative">{0} хвилинам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} хвилин</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} хвилинами</unitPattern>
 				<unitPattern count="few" case="locative">{0} хвилинах</unitPattern>
 				<unitPattern count="many">{0} хвилин</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} хвилин</unitPattern>
 				<unitPattern count="many" case="dative">{0} хвилинам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} хвилин</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} хвилинами</unitPattern>
 				<unitPattern count="many" case="locative">{0} хвилинах</unitPattern>
 				<unitPattern count="other">{0} хвилини</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} хвилини</unitPattern>
+				<unitPattern count="other" case="dative">{0} хвилини</unitPattern>
+				<unitPattern count="other" case="genitive">{0} хвилини</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} хвилини</unitPattern>
+				<unitPattern count="other" case="locative">{0} хвилини</unitPattern>
 				<perUnitPattern>{0} на хвилину</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -9643,23 +9643,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} секундою</unitPattern>
 				<unitPattern count="one" case="locative">{0} секунді</unitPattern>
 				<unitPattern count="few">{0} секунди</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} секунди</unitPattern>
 				<unitPattern count="few" case="dative">{0} секундам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} секунд</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} секундами</unitPattern>
 				<unitPattern count="few" case="locative">{0} секундах</unitPattern>
 				<unitPattern count="many">{0} секунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} секунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} секундам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} секунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} секундами</unitPattern>
 				<unitPattern count="many" case="locative">{0} секундах</unitPattern>
 				<unitPattern count="other">{0} секунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} секунди</unitPattern>
+				<unitPattern count="other" case="dative">{0} секунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} секунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} секунди</unitPattern>
+				<unitPattern count="other" case="locative">{0} секунди</unitPattern>
 				<perUnitPattern>{0} на секунду</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
@@ -9672,23 +9672,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} мілісекундою</unitPattern>
 				<unitPattern count="one" case="locative">{0} мілісекунді</unitPattern>
 				<unitPattern count="few">{0} мілісекунди</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мілісекунди</unitPattern>
 				<unitPattern count="few" case="dative">{0} мілісекундам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мілісекунд</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мілісекундами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мілісекундах</unitPattern>
 				<unitPattern count="many">{0} мілісекунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мілісекунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} мілісекундам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мілісекунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мілісекундами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мілісекундах</unitPattern>
 				<unitPattern count="other">{0} мілісекунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мілісекунди</unitPattern>
+				<unitPattern count="other" case="dative">{0} мілісекунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мілісекунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мілісекунди</unitPattern>
+				<unitPattern count="other" case="locative">{0} мілісекунди</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>feminine</gender>
@@ -9700,23 +9700,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} мікросекундою</unitPattern>
 				<unitPattern count="one" case="locative">{0} мікросекунді</unitPattern>
 				<unitPattern count="few">{0} мікросекунди</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мікросекунди</unitPattern>
 				<unitPattern count="few" case="dative">{0} мікросекундам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мікросекунд</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мікросекундами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мікросекундах</unitPattern>
 				<unitPattern count="many">{0} мікросекунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мікросекунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} мікросекундам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мікросекунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мікросекундами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мікросекундах</unitPattern>
 				<unitPattern count="other">{0} мікросекунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мікросекунди</unitPattern>
+				<unitPattern count="other" case="dative">{0} мікросекунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мікросекунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мікросекунди</unitPattern>
+				<unitPattern count="other" case="locative">{0} мікросекунди</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<gender>feminine</gender>
@@ -9728,135 +9728,135 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} наносекундою</unitPattern>
 				<unitPattern count="one" case="locative">{0} наносекунді</unitPattern>
 				<unitPattern count="few">{0} наносекунди</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} наносекунди</unitPattern>
 				<unitPattern count="few" case="dative">{0} наносекундам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} наносекунд</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} наносекундами</unitPattern>
 				<unitPattern count="few" case="locative">{0} наносекундах</unitPattern>
 				<unitPattern count="many">{0} наносекунд</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} наносекунд</unitPattern>
 				<unitPattern count="many" case="dative">{0} наносекундам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} наносекунд</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} наносекундами</unitPattern>
 				<unitPattern count="many" case="locative">{0} наносекундах</unitPattern>
 				<unitPattern count="other">{0} наносекунди</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} наносекунди</unitPattern>
+				<unitPattern count="other" case="dative">{0} наносекунди</unitPattern>
+				<unitPattern count="other" case="genitive">{0} наносекунди</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} наносекунди</unitPattern>
+				<unitPattern count="other" case="locative">{0} наносекунди</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<gender>masculine</gender>
 				<displayName>ампери</displayName>
 				<unitPattern count="one">{0} ампер</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ампер</unitPattern>
 				<unitPattern count="one" case="dative">{0} амперу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ампера</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ампером</unitPattern>
 				<unitPattern count="one" case="locative">{0} ампері</unitPattern>
 				<unitPattern count="few">{0} ампери</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ампери</unitPattern>
 				<unitPattern count="few" case="dative">{0} амперам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} амперів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} амперами</unitPattern>
 				<unitPattern count="few" case="locative">{0} амперах</unitPattern>
 				<unitPattern count="many">{0} амперів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} амперів</unitPattern>
 				<unitPattern count="many" case="dative">{0} амперам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} амперів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} амперами</unitPattern>
 				<unitPattern count="many" case="locative">{0} амперах</unitPattern>
 				<unitPattern count="other">{0} ампера</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ампера</unitPattern>
+				<unitPattern count="other" case="dative">{0} ампера</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ампера</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ампера</unitPattern>
+				<unitPattern count="other" case="locative">{0} ампера</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<gender>masculine</gender>
 				<displayName>міліампери</displayName>
 				<unitPattern count="one">{0} міліампер</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} міліампер</unitPattern>
 				<unitPattern count="one" case="dative">{0} міліамперу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} міліампера</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} міліампером</unitPattern>
 				<unitPattern count="one" case="locative">{0} міліампері</unitPattern>
 				<unitPattern count="few">{0} міліампери</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} міліампери</unitPattern>
 				<unitPattern count="few" case="dative">{0} міліамперам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} міліамперів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} міліамперами</unitPattern>
 				<unitPattern count="few" case="locative">{0} міліамперах</unitPattern>
 				<unitPattern count="many">{0} міліамперів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} міліамперів</unitPattern>
 				<unitPattern count="many" case="dative">{0} міліамперам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} міліамперів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} міліамперами</unitPattern>
 				<unitPattern count="many" case="locative">{0} міліамперах</unitPattern>
 				<unitPattern count="other">{0} міліампера</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} міліампера</unitPattern>
+				<unitPattern count="other" case="dative">{0} міліампера</unitPattern>
+				<unitPattern count="other" case="genitive">{0} міліампера</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} міліампера</unitPattern>
+				<unitPattern count="other" case="locative">{0} міліампера</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<gender>masculine</gender>
 				<displayName>оми</displayName>
 				<unitPattern count="one">{0} ом</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ом</unitPattern>
 				<unitPattern count="one" case="dative">{0} ому</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ома</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} омом</unitPattern>
 				<unitPattern count="one" case="locative">{0} омі</unitPattern>
 				<unitPattern count="few">{0} оми</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} оми</unitPattern>
 				<unitPattern count="few" case="dative">{0} омам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} омів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} омами</unitPattern>
 				<unitPattern count="few" case="locative">{0} омах</unitPattern>
 				<unitPattern count="many">{0} омів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} омів</unitPattern>
 				<unitPattern count="many" case="dative">{0} омам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} омів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} омами</unitPattern>
 				<unitPattern count="many" case="locative">{0} омах</unitPattern>
 				<unitPattern count="other">{0} ома</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ома</unitPattern>
+				<unitPattern count="other" case="dative">{0} ома</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ома</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ома</unitPattern>
+				<unitPattern count="other" case="locative">{0} ома</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<gender>masculine</gender>
 				<displayName>вольти</displayName>
 				<unitPattern count="one">{0} вольт</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} вольт</unitPattern>
 				<unitPattern count="one" case="dative">{0} вольту</unitPattern>
 				<unitPattern count="one" case="genitive">{0} вольта</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} вольтом</unitPattern>
 				<unitPattern count="one" case="locative">{0} вольті</unitPattern>
 				<unitPattern count="few">{0} вольти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} вольти</unitPattern>
 				<unitPattern count="few" case="dative">{0} вольтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} вольтів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} вольтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} вольтах</unitPattern>
 				<unitPattern count="many">{0} вольтів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} вольтів</unitPattern>
 				<unitPattern count="many" case="dative">{0} вольтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} вольтів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} вольтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} вольтах</unitPattern>
 				<unitPattern count="other">{0} вольта</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} вольта</unitPattern>
+				<unitPattern count="other" case="dative">{0} вольта</unitPattern>
+				<unitPattern count="other" case="genitive">{0} вольта</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} вольта</unitPattern>
+				<unitPattern count="other" case="locative">{0} вольта</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>кілокалорії</displayName>
@@ -9875,23 +9875,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} калорією</unitPattern>
 				<unitPattern count="one" case="locative">{0} калорії</unitPattern>
 				<unitPattern count="few">{0} калорії</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} калорії</unitPattern>
 				<unitPattern count="few" case="dative">{0} калоріям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} калорій</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} калоріями</unitPattern>
 				<unitPattern count="few" case="locative">{0} калоріях</unitPattern>
 				<unitPattern count="many">{0} калорій</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} калорій</unitPattern>
 				<unitPattern count="many" case="dative">{0} калоріям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} калорій</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} калоріями</unitPattern>
 				<unitPattern count="many" case="locative">{0} калоріях</unitPattern>
 				<unitPattern count="other">{0} калорії</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} калорії</unitPattern>
+				<unitPattern count="other" case="dative">{0} калорії</unitPattern>
+				<unitPattern count="other" case="genitive">{0} калорії</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} калорії</unitPattern>
+				<unitPattern count="other" case="locative">{0} калорії</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>кілокалорії</displayName>
@@ -9904,57 +9904,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>кілоджоулі</displayName>
 				<unitPattern count="one">{0} кілоджоуль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кілоджоуль</unitPattern>
 				<unitPattern count="one" case="dative">{0} кілоджоулю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кілоджоуля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кілоджоулем</unitPattern>
 				<unitPattern count="one" case="locative">{0} кілоджоулі</unitPattern>
 				<unitPattern count="few">{0} кілоджоулі</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кілоджоулі</unitPattern>
 				<unitPattern count="few" case="dative">{0} кілоджоулям</unitPattern>
-				<unitPattern count="few" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="few" case="genitive" draft="contributed">{0} кілоджоулі</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кілоджоулями</unitPattern>
 				<unitPattern count="few" case="locative" draft="contributed">{0} кілоджоулів</unitPattern>
 				<unitPattern count="many">{0} кілоджоулів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кілоджоулів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кілоджоулям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кілоджоулів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кілоджоулями</unitPattern>
 				<unitPattern count="many" case="locative">{0} кілоджоулях</unitPattern>
 				<unitPattern count="other">{0} кілоджоуля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кілоджоуля</unitPattern>
+				<unitPattern count="other" case="dative">{0} кілоджоуля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кілоджоуля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кілоджоуля</unitPattern>
+				<unitPattern count="other" case="locative">{0} кілоджоуля</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<gender>masculine</gender>
 				<displayName>джоулі</displayName>
 				<unitPattern count="one">{0} джоуль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} джоуль</unitPattern>
 				<unitPattern count="one" case="dative">{0} джоулю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} джоуля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} джоулем</unitPattern>
 				<unitPattern count="one" case="locative">{0} джоулі</unitPattern>
 				<unitPattern count="few">{0} джоулі</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} джоулі</unitPattern>
 				<unitPattern count="few" case="dative">{0} джоулям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} джоулів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} джоулями</unitPattern>
 				<unitPattern count="few" case="locative">{0} джоулях</unitPattern>
 				<unitPattern count="many">{0} джоулів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} джоулів</unitPattern>
 				<unitPattern count="many" case="dative">{0} джоулям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} джоулів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} джоулями</unitPattern>
 				<unitPattern count="many" case="locative">{0} джоулях</unitPattern>
 				<unitPattern count="other">{0} джоуля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} джоуля</unitPattern>
+				<unitPattern count="other" case="dative">{0} джоуля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} джоуля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} джоуля</unitPattern>
+				<unitPattern count="other" case="locative">{0} джоуля</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<gender>feminine</gender>
@@ -9966,23 +9966,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} кіловат-годиною</unitPattern>
 				<unitPattern count="one" case="locative">{0} кіловат-годині</unitPattern>
 				<unitPattern count="few">{0} кіловат-години</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кіловат-години</unitPattern>
 				<unitPattern count="few" case="dative">{0} кіловат-годинам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кіловат-годин</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кіловат-годинами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кіловат-годинах</unitPattern>
 				<unitPattern count="many">{0} кіловат-годин</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кіловат-годин</unitPattern>
 				<unitPattern count="many" case="dative">{0} кіловат-годинам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кіловат-годин</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кіловат-годинами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кіловат-годинах</unitPattern>
 				<unitPattern count="other">{0} кіловат-години</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кіловат-години</unitPattern>
+				<unitPattern count="other" case="dative">{0} кіловат-години</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кіловат-години</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кіловат-години</unitPattern>
+				<unitPattern count="other" case="locative">{0} кіловат-години</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>електрон-вольти</displayName>
@@ -10016,29 +10016,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ньютони</displayName>
 				<unitPattern count="one">{0} ньютон</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ньютон</unitPattern>
 				<unitPattern count="one" case="dative">{0} ньютону</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ньютона</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ньютоном</unitPattern>
 				<unitPattern count="one" case="locative">{0} ньютоні</unitPattern>
 				<unitPattern count="few">{0} ньютони</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ньютони</unitPattern>
 				<unitPattern count="few" case="dative">{0} ньютонам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ньютонів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} ньютонами</unitPattern>
 				<unitPattern count="few" case="locative">{0} ньютонах</unitPattern>
 				<unitPattern count="many">{0} ньютонів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ньютонів</unitPattern>
 				<unitPattern count="many" case="dative">{0} ньютонам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ньютонів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} ньютонами</unitPattern>
 				<unitPattern count="many" case="locative">{0} ньютонах</unitPattern>
 				<unitPattern count="other">{0} ньютона</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ньютона</unitPattern>
+				<unitPattern count="other" case="dative">{0} ньютона</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ньютона</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ньютона</unitPattern>
+				<unitPattern count="other" case="locative">{0} ньютона</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<gender>feminine</gender>
@@ -10050,135 +10050,135 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} кіловат-годиною на 100 кілометрів</unitPattern>
 				<unitPattern count="one" case="locative">{0} кіловат-годині на 100 кілометрів</unitPattern>
 				<unitPattern count="few">{0} кіловат-години на 100 кілометрів</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кіловат-години на 100 кілометрів</unitPattern>
 				<unitPattern count="few" case="dative">{0} кіловат-годинам на 100 кілометрів</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кіловат-годин на 100 кілометрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кіловат-годинами на 100 кілометрів</unitPattern>
 				<unitPattern count="few" case="locative">{0} кіловат-годинах на 100 кілометрів</unitPattern>
 				<unitPattern count="many">{0} кіловат-годин на 100 кілометрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кіловат-годин на 100 кілометрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кіловат-годинам на 100 кілометрів</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кіловат-годин на 100 кілометрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кіловат-годинами на 100 кілометрів</unitPattern>
 				<unitPattern count="many" case="locative">{0} кіловат-годинах на 100 кілометрів</unitPattern>
 				<unitPattern count="other">{0} кіловат-години на 100 кілометрів</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кіловат-години на 100 кілометрів</unitPattern>
+				<unitPattern count="other" case="dative">{0} кіловат-години на 100 кілометрів</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кіловат-години на 100 кілометрів</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кіловат-години на 100 кілометрів</unitPattern>
+				<unitPattern count="other" case="locative">{0} кіловат-години на 100 кілометрів</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<gender>masculine</gender>
 				<displayName>гігагерци</displayName>
 				<unitPattern count="one">{0} гігагерц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гігагерц</unitPattern>
 				<unitPattern count="one" case="dative">{0} гігагерцу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гігагерца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гігагерцом</unitPattern>
 				<unitPattern count="one" case="locative">{0} гігагерці</unitPattern>
 				<unitPattern count="few">{0} гігагерци</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гігагерци</unitPattern>
 				<unitPattern count="few" case="dative">{0} гігагерцам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гігагерців</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гігагерцами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гігагерцах</unitPattern>
 				<unitPattern count="many">{0} гігагерців</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гігагерців</unitPattern>
 				<unitPattern count="many" case="dative">{0} гігагерцам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гігагерців</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гігагерцами</unitPattern>
 				<unitPattern count="many" case="locative">{0} гігагерцах</unitPattern>
 				<unitPattern count="other">{0} гігагерца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гігагерца</unitPattern>
+				<unitPattern count="other" case="dative">{0} гігагерца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гігагерца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гігагерца</unitPattern>
+				<unitPattern count="other" case="locative">{0} гігагерца</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<gender>masculine</gender>
 				<displayName>мегагерци</displayName>
 				<unitPattern count="one">{0} мегагерц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегагерц</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегагерцу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегагерца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегагерцом</unitPattern>
 				<unitPattern count="one" case="locative">{0} мегагерці</unitPattern>
 				<unitPattern count="few">{0} мегагерци</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегагерци</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегагерцам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегагерців</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегагерцами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мегагерцах</unitPattern>
 				<unitPattern count="many">{0} мегагерців</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегагерців</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегагерцам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегагерців</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегагерцами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мегагерцах</unitPattern>
 				<unitPattern count="other">{0} мегагерца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегагерца</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегагерца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегагерца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегагерца</unitPattern>
+				<unitPattern count="other" case="locative">{0} мегагерца</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<gender>masculine</gender>
 				<displayName>кілогерци</displayName>
 				<unitPattern count="one">{0} кілогерц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кілогерц</unitPattern>
 				<unitPattern count="one" case="dative">{0} кілогерцу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кілогерца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кілогерцом</unitPattern>
 				<unitPattern count="one" case="locative">{0} кілогерці</unitPattern>
 				<unitPattern count="few">{0} кілогерци</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кілогерци</unitPattern>
 				<unitPattern count="few" case="dative">{0} кілогерцам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кілогерців</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кілогерцами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кілогерцах</unitPattern>
 				<unitPattern count="many">{0} кілогерців</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кілогерців</unitPattern>
 				<unitPattern count="many" case="dative">{0} кілогерцам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кілогерців</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кілогерцами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кілогерцах</unitPattern>
 				<unitPattern count="other">{0} кілогерца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кілогерца</unitPattern>
+				<unitPattern count="other" case="dative">{0} кілогерца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кілогерца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кілогерца</unitPattern>
+				<unitPattern count="other" case="locative">{0} кілогерца</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<gender>masculine</gender>
 				<displayName>герци</displayName>
 				<unitPattern count="one">{0} герц</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} герц</unitPattern>
 				<unitPattern count="one" case="dative">{0} герцу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} герца</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} герцом</unitPattern>
 				<unitPattern count="one" case="locative">{0} герці</unitPattern>
 				<unitPattern count="few">{0} герци</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} герци</unitPattern>
 				<unitPattern count="few" case="dative">{0} герцам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} герців</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} герцами</unitPattern>
 				<unitPattern count="few" case="locative">{0} герцах</unitPattern>
 				<unitPattern count="many">{0} герців</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} герців</unitPattern>
 				<unitPattern count="many" case="dative">{0} герцам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} герців</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} герцами</unitPattern>
 				<unitPattern count="many" case="locative">{0} герцах</unitPattern>
 				<unitPattern count="other">{0} герца</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} герца</unitPattern>
+				<unitPattern count="other" case="dative">{0} герца</unitPattern>
+				<unitPattern count="other" case="genitive">{0} герца</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} герца</unitPattern>
+				<unitPattern count="other" case="locative">{0} герца</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<gender>masculine</gender>
@@ -10231,10 +10231,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="locative">{0} пікселях</unitPattern>
 				<unitPattern count="other">{0} пікселя</unitPattern>
 				<unitPattern count="other" case="accusative">{0} пікселя</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="dative">{0} пікселя</unitPattern>
 				<unitPattern count="other" case="genitive">{0} пікселя</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} пікселя</unitPattern>
+				<unitPattern count="other" case="locative">{0} пікселя</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<gender>masculine</gender>
@@ -10258,11 +10258,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} мегапікселями</unitPattern>
 				<unitPattern count="many" case="locative">{0} мегапікселях</unitPattern>
 				<unitPattern count="other">{0} мегапікселя</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегапікселя</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегапікселя</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегапікселя</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегапікселя</unitPattern>
+				<unitPattern count="other" case="locative">{0} мегапікселя</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<gender>masculine</gender>
@@ -10331,7 +10331,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>кілометри</displayName>
 				<unitPattern count="one">{0} кілометр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кілометр</unitPattern>
 				<unitPattern count="one" case="dative">{0} кілометру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кілометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кілометром</unitPattern>
@@ -10349,40 +10349,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} кілометрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кілометрах</unitPattern>
 				<unitPattern count="other">{0} кілометра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кілометра</unitPattern>
+				<unitPattern count="other" case="dative">{0} кілометра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кілометра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кілометра</unitPattern>
+				<unitPattern count="other" case="locative">{0} кілометра</unitPattern>
 				<perUnitPattern>{0} на кілометр</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<gender>masculine</gender>
 				<displayName>метри</displayName>
 				<unitPattern count="one">{0} метр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} метр</unitPattern>
 				<unitPattern count="one" case="dative">{0} метру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} метром</unitPattern>
 				<unitPattern count="one" case="locative">{0} метрі</unitPattern>
 				<unitPattern count="few">{0} метри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метри</unitPattern>
 				<unitPattern count="few" case="dative">{0} метрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} метрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} метрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} метрах</unitPattern>
 				<unitPattern count="many">{0} метрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} метрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} метрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} метрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} метрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} метрах</unitPattern>
 				<unitPattern count="other">{0} метра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метра</unitPattern>
+				<unitPattern count="other" case="dative">{0} метра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метра</unitPattern>
+				<unitPattern count="other" case="locative">{0} метра</unitPattern>
 				<perUnitPattern>{0} на метр</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
@@ -10401,158 +10401,158 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few" case="instrumental">{0} дециметрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} дециметрах</unitPattern>
 				<unitPattern count="many">{0} дециметрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} дециметрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} дециметрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} дециметрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} дециметрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} дециметрах</unitPattern>
 				<unitPattern count="other">{0} дециметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} дециметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} дециметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} дециметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} дециметра</unitPattern>
+				<unitPattern count="other" case="locative">{0} дециметра</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<gender>masculine</gender>
 				<displayName>сантиметри</displayName>
 				<unitPattern count="one">{0} сантиметр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} сантиметр</unitPattern>
 				<unitPattern count="one" case="dative">{0} сантиметру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} сантиметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} сантиметром</unitPattern>
 				<unitPattern count="one" case="locative">{0} сантиметрі</unitPattern>
 				<unitPattern count="few">{0} сантиметри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} сантиметри</unitPattern>
 				<unitPattern count="few" case="dative">{0} сантиметрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} сантиметрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} сантиметрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} сантиметрах</unitPattern>
 				<unitPattern count="many">{0} сантиметрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} сантиметрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} сантиметрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} сантиметрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} сантиметрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} сантиметрах</unitPattern>
 				<unitPattern count="other">{0} сантиметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} сантиметра</unitPattern>
+				<unitPattern count="other" case="locative">{0} сантиметра</unitPattern>
 				<perUnitPattern>{0} на сантиметр</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<gender>masculine</gender>
 				<displayName>міліметри</displayName>
 				<unitPattern count="one">{0} міліметр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} міліметр</unitPattern>
 				<unitPattern count="one" case="dative">{0} міліметру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} міліметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} міліметром</unitPattern>
 				<unitPattern count="one" case="locative">{0} міліметрі</unitPattern>
 				<unitPattern count="few">{0} міліметри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} міліметри</unitPattern>
 				<unitPattern count="few" case="dative">{0} міліметрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} міліметрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} міліметрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} міліметрах</unitPattern>
 				<unitPattern count="many">{0} міліметрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} міліметрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} міліметрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} міліметрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} міліметрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} міліметрах</unitPattern>
 				<unitPattern count="other">{0} міліметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} міліметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} міліметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} міліметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} міліметра</unitPattern>
+				<unitPattern count="other" case="locative">{0} міліметра</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<gender>masculine</gender>
 				<displayName>мікрометри</displayName>
 				<unitPattern count="one">{0} мікрометр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мікрометр</unitPattern>
 				<unitPattern count="one" case="dative">{0} мікрометру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мікрометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мікрометром</unitPattern>
 				<unitPattern count="one" case="locative">{0} мікрометрі</unitPattern>
 				<unitPattern count="few">{0} мікрометри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мікрометри</unitPattern>
 				<unitPattern count="few" case="dative">{0} мікрометрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мікрометрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мікрометрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мікрометрах</unitPattern>
 				<unitPattern count="many">{0} мікрометрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мікрометрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} мікрометрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мікрометрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мікрометрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мікрометрах</unitPattern>
 				<unitPattern count="other">{0} мікрометра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мікрометра</unitPattern>
+				<unitPattern count="other" case="dative">{0} мікрометра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мікрометра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мікрометра</unitPattern>
+				<unitPattern count="other" case="locative">{0} мікрометра</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<gender>masculine</gender>
 				<displayName>нанометри</displayName>
 				<unitPattern count="one">{0} нанометр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} нанометр</unitPattern>
 				<unitPattern count="one" case="dative">{0} нанометру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} нанометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} нанометром</unitPattern>
 				<unitPattern count="one" case="locative">{0} нанометрі</unitPattern>
 				<unitPattern count="few">{0} нанометри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} нанометри</unitPattern>
 				<unitPattern count="few" case="dative">{0} нанометрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} нанометрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} нанометрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} нанометрах</unitPattern>
 				<unitPattern count="many">{0} нанометрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} нанометрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} нанометрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} нанометрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} нанометрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} нанометрах</unitPattern>
 				<unitPattern count="other">{0} нанометра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} нанометра</unitPattern>
+				<unitPattern count="other" case="dative">{0} нанометра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} нанометра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} нанометра</unitPattern>
+				<unitPattern count="other" case="locative">{0} нанометра</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<gender>masculine</gender>
 				<displayName>пікометри</displayName>
 				<unitPattern count="one">{0} пікометр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} пікометр</unitPattern>
 				<unitPattern count="one" case="dative">{0} пікометру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} пікометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} пікометром</unitPattern>
 				<unitPattern count="one" case="locative">{0} пікометрі</unitPattern>
 				<unitPattern count="few">{0} пікометри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} пікометри</unitPattern>
 				<unitPattern count="few" case="dative">{0} пікометрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} пікометрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} пікометрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} пікометрах</unitPattern>
 				<unitPattern count="many">{0} пікометрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} пікометрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} пікометрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} пікометрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} пікометрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} пікометрах</unitPattern>
 				<unitPattern count="other">{0} пікометра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} пікометра</unitPattern>
+				<unitPattern count="other" case="dative">{0} пікометра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} пікометра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} пікометра</unitPattern>
+				<unitPattern count="other" case="locative">{0} пікометра</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>милі</displayName>
@@ -10636,23 +10636,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} скандинавською милею</unitPattern>
 				<unitPattern count="one" case="locative">{0} скандинавській милі</unitPattern>
 				<unitPattern count="few">{0} скандинавські милі</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} скандинавські милі</unitPattern>
 				<unitPattern count="few" case="dative">{0} скандинавським милям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} скандинавських миль</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} скандинавськими милями</unitPattern>
 				<unitPattern count="few" case="locative">{0} скандинавських милях</unitPattern>
 				<unitPattern count="many">{0} скандинавських миль</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} скандинавських миль</unitPattern>
 				<unitPattern count="many" case="dative">{0} скандинавським милям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} скандинавських миль</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} скандинавськими милями</unitPattern>
 				<unitPattern count="many" case="locative">{0} скандинавських милях</unitPattern>
 				<unitPattern count="other">{0} скандинавської милі</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} скандинавської милі</unitPattern>
+				<unitPattern count="other" case="dative">{0} скандинавської милі</unitPattern>
+				<unitPattern count="other" case="genitive">{0} скандинавської милі</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} скандинавської милі</unitPattern>
+				<unitPattern count="other" case="locative">{0} скандинавської милі</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>пункти</displayName>
@@ -10672,29 +10672,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>люкси</displayName>
 				<unitPattern count="one">{0} люкс</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} люкс</unitPattern>
 				<unitPattern count="one" case="dative">{0} люксу</unitPattern>
 				<unitPattern count="one" case="genitive">{0} люкса</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} люксом</unitPattern>
 				<unitPattern count="one" case="locative">{0} люксі</unitPattern>
 				<unitPattern count="few">{0} люкси</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} люкси</unitPattern>
 				<unitPattern count="few" case="dative">{0} люксам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} люксів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} люксами</unitPattern>
 				<unitPattern count="few" case="locative">{0} люксах</unitPattern>
 				<unitPattern count="many">{0} люксів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} люксів</unitPattern>
 				<unitPattern count="many" case="dative">{0} люксам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} люксів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} люксами</unitPattern>
 				<unitPattern count="many" case="locative">{0} люксах</unitPattern>
 				<unitPattern count="other">{0} люкса</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} люкса</unitPattern>
+				<unitPattern count="other" case="dative">{0} люкса</unitPattern>
+				<unitPattern count="other" case="genitive">{0} люкса</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} люкса</unitPattern>
+				<unitPattern count="other" case="locative">{0} люкса</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<gender>feminine</gender>
@@ -10706,51 +10706,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} канделою</unitPattern>
 				<unitPattern count="one" case="locative">{0} канделі</unitPattern>
 				<unitPattern count="few">{0} кандели</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кандели</unitPattern>
 				<unitPattern count="few" case="dative">{0} канделам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кандел</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} канделами</unitPattern>
 				<unitPattern count="few" case="locative">{0} канделах</unitPattern>
 				<unitPattern count="many">{0} кандел</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кандел</unitPattern>
 				<unitPattern count="many" case="dative">{0} канделам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кандел</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} канделами</unitPattern>
 				<unitPattern count="many" case="locative">{0} канделах</unitPattern>
 				<unitPattern count="other">{0} кандели</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кандели</unitPattern>
+				<unitPattern count="other" case="dative">{0} кандели</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кандели</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кандели</unitPattern>
+				<unitPattern count="other" case="locative">{0} кандели</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<gender>masculine</gender>
 				<displayName>люмени</displayName>
 				<unitPattern count="one">{0} люмен</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} люмен</unitPattern>
 				<unitPattern count="one" case="dative">{0} люмену</unitPattern>
 				<unitPattern count="one" case="genitive">{0} люмена</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} люменом</unitPattern>
 				<unitPattern count="one" case="locative">{0} люмені</unitPattern>
 				<unitPattern count="few">{0} люмени</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} люмени</unitPattern>
 				<unitPattern count="few" case="dative">{0} люменам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} люменів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} люменами</unitPattern>
 				<unitPattern count="few" case="locative">{0} люменах</unitPattern>
 				<unitPattern count="many">{0} люменів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} люменів</unitPattern>
 				<unitPattern count="many" case="dative">{0} люменам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} люменів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} люменами</unitPattern>
 				<unitPattern count="many" case="locative">{0} люменах</unitPattern>
 				<unitPattern count="other">{0} люмена</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} люмена</unitPattern>
+				<unitPattern count="other" case="dative">{0} люмена</unitPattern>
+				<unitPattern count="other" case="genitive">{0} люмена</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} люмена</unitPattern>
+				<unitPattern count="other" case="locative">{0} люмена</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>світності Сонця</displayName>
@@ -10769,93 +10769,93 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} метричною тонною</unitPattern>
 				<unitPattern count="one" case="locative">{0} метричній тонні</unitPattern>
 				<unitPattern count="few">{0} метричні тонни</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метричні тонни</unitPattern>
 				<unitPattern count="few" case="dative">{0} метричним тоннам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} метричних тонн</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} метричними тоннами</unitPattern>
 				<unitPattern count="few" case="locative">{0} метричних тоннах</unitPattern>
 				<unitPattern count="many">{0} метричних тонн</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} метричних тонн</unitPattern>
 				<unitPattern count="many" case="dative">{0} метричним тоннам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} метричних тонн</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} метричними тоннами</unitPattern>
 				<unitPattern count="many" case="locative">{0} метричних тоннах</unitPattern>
 				<unitPattern count="other">{0} метричної тонни</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метричної тонни</unitPattern>
+				<unitPattern count="other" case="dative">{0} метричної тонни</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метричної тонни</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метричної тонни</unitPattern>
+				<unitPattern count="other" case="locative">{0} метричної тонни</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<gender>masculine</gender>
 				<displayName>кілограми</displayName>
 				<unitPattern count="one">{0} кілограм</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кілограм</unitPattern>
 				<unitPattern count="one" case="dative">{0} кілограму</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кілограма</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кілограмом</unitPattern>
 				<unitPattern count="one" case="locative">{0} кілограмі</unitPattern>
 				<unitPattern count="few">{0} кілограми</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кілограми</unitPattern>
 				<unitPattern count="few" case="dative">{0} кілограмам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кілограмів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кілограмами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кілограмах</unitPattern>
 				<unitPattern count="many">{0} кілограмів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кілограмів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кілограмам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кілограмів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кілограмами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кілограмах</unitPattern>
 				<unitPattern count="other">{0} кілограма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кілограма</unitPattern>
+				<unitPattern count="other" case="dative">{0} кілограма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кілограма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кілограма</unitPattern>
+				<unitPattern count="other" case="locative">{0} кілограма</unitPattern>
 				<perUnitPattern>{0} на кілограм</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<gender>masculine</gender>
 				<displayName>грами</displayName>
 				<unitPattern count="one">{0} грам</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} грам</unitPattern>
 				<unitPattern count="one" case="dative">{0} граму</unitPattern>
 				<unitPattern count="one" case="genitive">{0} грама</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} грамом</unitPattern>
 				<unitPattern count="one" case="locative">{0} грамі</unitPattern>
 				<unitPattern count="few">{0} грами</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} грами</unitPattern>
 				<unitPattern count="few" case="dative">{0} грамам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} грамів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} грамами</unitPattern>
 				<unitPattern count="few" case="locative">{0} грамах</unitPattern>
 				<unitPattern count="many">{0} грамів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} грамів</unitPattern>
 				<unitPattern count="many" case="dative">{0} грамам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} грамів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} грамами</unitPattern>
 				<unitPattern count="many" case="locative">{0} грамах</unitPattern>
 				<unitPattern count="other">{0} грама</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} грама</unitPattern>
+				<unitPattern count="other" case="dative">{0} грама</unitPattern>
+				<unitPattern count="other" case="genitive">{0} грама</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} грама</unitPattern>
+				<unitPattern count="other" case="locative">{0} грама</unitPattern>
 				<perUnitPattern>{0} на грам</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<gender>masculine</gender>
 				<displayName>міліграми</displayName>
 				<unitPattern count="one">{0} міліграм</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} міліграм</unitPattern>
 				<unitPattern count="one" case="dative">{0} міліграму</unitPattern>
 				<unitPattern count="one" case="genitive">{0} міліграма</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} міліграмом</unitPattern>
 				<unitPattern count="one" case="locative">{0} міліграмі</unitPattern>
 				<unitPattern count="few">{0} міліграми</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} міліграми</unitPattern>
 				<unitPattern count="few" case="dative">{0} міліграмам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} міліграмів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} міліграмами</unitPattern>
@@ -10867,23 +10867,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} міліграмами</unitPattern>
 				<unitPattern count="many" case="locative">{0} міліграмах</unitPattern>
 				<unitPattern count="other">{0} міліграма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} міліграма</unitPattern>
+				<unitPattern count="other" case="dative">{0} міліграма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} міліграма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} міліграма</unitPattern>
+				<unitPattern count="other" case="locative">{0} міліграма</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<gender>masculine</gender>
 				<displayName>мікрограми</displayName>
 				<unitPattern count="one">{0} мікрограм</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мікрограм</unitPattern>
 				<unitPattern count="one" case="dative">{0} мікрограму</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мікрограма</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мікрограмом</unitPattern>
 				<unitPattern count="one" case="locative">{0} мікрограмі</unitPattern>
 				<unitPattern count="few">{0} мікрограми</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мікрограми</unitPattern>
 				<unitPattern count="few" case="dative">{0} мікрограмам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мікрограмів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мікрограмами</unitPattern>
@@ -10895,11 +10895,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} мікрограмами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мікрограмах</unitPattern>
 				<unitPattern count="other">{0} мікрограма</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мікрограма</unitPattern>
+				<unitPattern count="other" case="dative">{0} мікрограма</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мікрограма</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мікрограма</unitPattern>
+				<unitPattern count="other" case="locative">{0} мікрограма</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>тонни</displayName>
@@ -10942,29 +10942,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>карати</displayName>
 				<unitPattern count="one">{0} карат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} карат</unitPattern>
 				<unitPattern count="one" case="dative">{0} карату</unitPattern>
 				<unitPattern count="one" case="genitive">{0} карата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} каратом</unitPattern>
 				<unitPattern count="one" case="locative">{0} караті</unitPattern>
 				<unitPattern count="few">{0} карати</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} карати</unitPattern>
 				<unitPattern count="few" case="dative">{0} каратам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} каратів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} каратами</unitPattern>
 				<unitPattern count="few" case="locative">{0} каратах</unitPattern>
 				<unitPattern count="many">{0} каратів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} каратів</unitPattern>
 				<unitPattern count="many" case="dative">{0} каратам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} каратів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} каратами</unitPattern>
 				<unitPattern count="many" case="locative">{0} каратах</unitPattern>
 				<unitPattern count="other">{0} карата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} карата</unitPattern>
+				<unitPattern count="other" case="dative">{0} карата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} карата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} карата</unitPattern>
+				<unitPattern count="other" case="locative">{0} карата</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>дальтони</displayName>
@@ -10998,41 +10998,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>гігавати</displayName>
 				<unitPattern count="one">{0} гігават</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гігават</unitPattern>
 				<unitPattern count="one" case="dative">{0} гігавату</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гігавата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гігаватом</unitPattern>
 				<unitPattern count="one" case="locative">{0} гігаваті</unitPattern>
 				<unitPattern count="few">{0} гігавати</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гігавати</unitPattern>
 				<unitPattern count="few" case="dative">{0} гігаватам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гігаватів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гігаватами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гігаватах</unitPattern>
 				<unitPattern count="many">{0} гігаватів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гігаватів</unitPattern>
 				<unitPattern count="many" case="dative">{0} гігаватам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гігаватів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гігаватами</unitPattern>
 				<unitPattern count="many" case="locative">{0} гігаватах</unitPattern>
 				<unitPattern count="other">{0} гігавата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гігавата</unitPattern>
+				<unitPattern count="other" case="dative">{0} гігавата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гігавата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гігавата</unitPattern>
+				<unitPattern count="other" case="locative">{0} гігавата</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<gender>masculine</gender>
 				<displayName>мегавати</displayName>
 				<unitPattern count="one">{0} мегават</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегават</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегавату</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегавата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегаватом</unitPattern>
 				<unitPattern count="one" case="locative">{0} мегаваті</unitPattern>
 				<unitPattern count="few">{0} мегавати</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегавати</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегаватам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегаватів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегаватами</unitPattern>
@@ -11044,79 +11044,79 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} мегаватами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мегаватах</unitPattern>
 				<unitPattern count="other">{0} мегавата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегавата</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегавата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегавата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегавата</unitPattern>
+				<unitPattern count="other" case="locative">{0} мегавата</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<gender>masculine</gender>
 				<displayName>кіловати</displayName>
 				<unitPattern count="one">{0} кіловат</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кіловат</unitPattern>
 				<unitPattern count="one" case="dative">{0} кіловату</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кіловата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кіловатом</unitPattern>
 				<unitPattern count="one" case="locative">{0} кіловаті</unitPattern>
 				<unitPattern count="few">{0} кіловати</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кіловати</unitPattern>
 				<unitPattern count="few" case="dative">{0} кіловатам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кіловат</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кіловатами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кіловатах</unitPattern>
 				<unitPattern count="many">{0} кіловатів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кіловатів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кіловатам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кіловатів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кіловатами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кіловатах</unitPattern>
 				<unitPattern count="other">{0} кіловата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кіловата</unitPattern>
+				<unitPattern count="other" case="dative">{0} кіловата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кіловата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кіловата</unitPattern>
+				<unitPattern count="other" case="locative">{0} кіловата</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<gender>masculine</gender>
 				<displayName>вати</displayName>
 				<unitPattern count="one">{0} ват</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ват</unitPattern>
 				<unitPattern count="one" case="dative">{0} вату</unitPattern>
 				<unitPattern count="one" case="genitive">{0} вата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ватом</unitPattern>
 				<unitPattern count="one" case="locative">{0} ваті</unitPattern>
 				<unitPattern count="few">{0} вати</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} вати</unitPattern>
 				<unitPattern count="few" case="dative">{0} ватам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ватів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} ватами</unitPattern>
 				<unitPattern count="few" case="locative">{0} ватах</unitPattern>
 				<unitPattern count="many">{0} ватів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ватів</unitPattern>
 				<unitPattern count="many" case="dative">{0} ватам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ватів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} ватами</unitPattern>
 				<unitPattern count="many" case="locative">{0} ватах</unitPattern>
 				<unitPattern count="other">{0} вата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} вата</unitPattern>
+				<unitPattern count="other" case="dative">{0} вата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} вата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} вата</unitPattern>
+				<unitPattern count="other" case="locative">{0} вата</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<gender>masculine</gender>
 				<displayName>мілівати</displayName>
 				<unitPattern count="one">{0} міліват</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} міліват</unitPattern>
 				<unitPattern count="one" case="dative">{0} мілівату</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мілівата</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} міліватом</unitPattern>
 				<unitPattern count="one" case="locative">{0} міліваті</unitPattern>
 				<unitPattern count="few">{0} мілівати</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мілівати</unitPattern>
 				<unitPattern count="few" case="dative">{0} міліватам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} міліватів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} міліватами</unitPattern>
@@ -11128,11 +11128,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="instrumental">{0} міліватами</unitPattern>
 				<unitPattern count="many" case="locative">{0} міліватах</unitPattern>
 				<unitPattern count="other">{0} мілівата</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мілівата</unitPattern>
+				<unitPattern count="other" case="dative">{0} мілівата</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мілівата</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мілівата</unitPattern>
+				<unitPattern count="other" case="locative">{0} мілівата</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>кінські сили</displayName>
@@ -11166,57 +11166,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>бари</displayName>
 				<unitPattern count="one">{0} бар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} бар</unitPattern>
 				<unitPattern count="one" case="dative">{0} бару</unitPattern>
 				<unitPattern count="one" case="genitive">{0} бара</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} баром</unitPattern>
 				<unitPattern count="one" case="locative">{0} барі</unitPattern>
 				<unitPattern count="few">{0} бари</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} бари</unitPattern>
 				<unitPattern count="few" case="dative">{0} барам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} барів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} барами</unitPattern>
 				<unitPattern count="few" case="locative">{0} барах</unitPattern>
 				<unitPattern count="many">{0} барів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} барів</unitPattern>
 				<unitPattern count="many" case="dative">{0} барам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} барів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} барами</unitPattern>
 				<unitPattern count="many" case="locative">{0} барах</unitPattern>
 				<unitPattern count="other">{0} бара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} бара</unitPattern>
+				<unitPattern count="other" case="dative">{0} бара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} бара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} бара</unitPattern>
+				<unitPattern count="other" case="locative">{0} бара</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<gender>masculine</gender>
 				<displayName>мілібари</displayName>
 				<unitPattern count="one">{0} мілібар</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мілібар</unitPattern>
 				<unitPattern count="one" case="dative">{0} мілібару</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мілібара</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мілібаром</unitPattern>
 				<unitPattern count="one" case="locative">{0} мілібарі</unitPattern>
 				<unitPattern count="few">{0} мілібари</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мілібари</unitPattern>
 				<unitPattern count="few" case="dative">{0} мілібарам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мілібарів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мілібарами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мілібарах</unitPattern>
 				<unitPattern count="many">{0} мілібарів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мілібарів</unitPattern>
 				<unitPattern count="many" case="dative">{0} мілібарам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мілібарів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мілібарами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мілібарах</unitPattern>
 				<unitPattern count="other">{0} мілібара</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мілібара</unitPattern>
+				<unitPattern count="other" case="dative">{0} мілібара</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мілібара</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мілібара</unitPattern>
+				<unitPattern count="other" case="locative">{0} мілібара</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<gender>feminine</gender>
@@ -11228,191 +11228,191 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} атмосферою</unitPattern>
 				<unitPattern count="one" case="locative">{0} атмосфері</unitPattern>
 				<unitPattern count="few">{0} атмосфери</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} атмосфери</unitPattern>
 				<unitPattern count="few" case="dative">{0} атмосферам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} атмосфер</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} атмосферами</unitPattern>
 				<unitPattern count="few" case="locative">{0} атмосферах</unitPattern>
 				<unitPattern count="many">{0} атмосфер</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} атмосфер</unitPattern>
 				<unitPattern count="many" case="dative">{0} атмосферам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} атмосфер</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} атмосферами</unitPattern>
 				<unitPattern count="many" case="locative">{0} атмосферах</unitPattern>
 				<unitPattern count="other">{0} атмосфери</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} атмосфери</unitPattern>
+				<unitPattern count="other" case="dative">{0} атмосфери</unitPattern>
+				<unitPattern count="other" case="genitive">{0} атмосфери</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} атмосфери</unitPattern>
+				<unitPattern count="other" case="locative">{0} атмосфери</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<gender>masculine</gender>
 				<displayName>паскалі</displayName>
 				<unitPattern count="one">{0} паскаль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} паскаль</unitPattern>
 				<unitPattern count="one" case="dative">{0} паскалю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} паскаля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} паскалем</unitPattern>
 				<unitPattern count="one" case="locative">{0} паскалі</unitPattern>
 				<unitPattern count="few">{0} паскалі</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} паскалі</unitPattern>
 				<unitPattern count="few" case="dative">{0} паскалям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} паскалів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} паскалями</unitPattern>
 				<unitPattern count="few" case="locative">{0} паскалях</unitPattern>
 				<unitPattern count="many">{0} паскалів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} паскалів</unitPattern>
 				<unitPattern count="many" case="dative">{0} паскалям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} паскалів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} паскалями</unitPattern>
 				<unitPattern count="many" case="locative">{0} паскалях</unitPattern>
 				<unitPattern count="other">{0} паскаля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} паскаля</unitPattern>
+				<unitPattern count="other" case="dative">{0} паскаля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} паскаля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} паскаля</unitPattern>
+				<unitPattern count="other" case="locative">{0} паскаля</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<gender>masculine</gender>
 				<displayName>гектопаскалі</displayName>
 				<unitPattern count="one">{0} гектопаскаль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гектопаскаль</unitPattern>
 				<unitPattern count="one" case="dative">{0} гектопаскалю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гектопаскаля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гектопаскалем</unitPattern>
 				<unitPattern count="one" case="locative">{0} гектопаскалі</unitPattern>
 				<unitPattern count="few">{0} гектопаскалі</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гектопаскалі</unitPattern>
 				<unitPattern count="few" case="dative">{0} гектопаскалям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гектопаскалів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гектопаскалями</unitPattern>
 				<unitPattern count="few" case="locative">{0} гектопаскалях</unitPattern>
 				<unitPattern count="many">{0} гектопаскалів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гектопаскалів</unitPattern>
 				<unitPattern count="many" case="dative">{0} гектопаскалям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гектопаскалів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гектопаскалями</unitPattern>
 				<unitPattern count="many" case="locative">{0} гектопаскалях</unitPattern>
 				<unitPattern count="other">{0} гектопаскаля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гектопаскаля</unitPattern>
+				<unitPattern count="other" case="dative">{0} гектопаскаля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гектопаскаля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гектопаскаля</unitPattern>
+				<unitPattern count="other" case="locative">{0} гектопаскаля</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<gender>masculine</gender>
 				<displayName>кілопаскалі</displayName>
 				<unitPattern count="one">{0} кілопаскаль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кілопаскаль</unitPattern>
 				<unitPattern count="one" case="dative">{0} кілопаскалю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кілопаскаля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кілопаскалем</unitPattern>
 				<unitPattern count="one" case="locative">{0} кілопаскалі</unitPattern>
 				<unitPattern count="few">{0} кілопаскалі</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кілопаскалі</unitPattern>
 				<unitPattern count="few" case="dative">{0} кілопаскалям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кілопаскалів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кілопаскалями</unitPattern>
 				<unitPattern count="few" case="locative">{0} кілопаскалях</unitPattern>
 				<unitPattern count="many">{0} кілопаскалів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кілопаскалів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кілопаскалям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кілопаскалів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кілопаскалями</unitPattern>
 				<unitPattern count="many" case="locative">{0} кілопаскалях</unitPattern>
 				<unitPattern count="other">{0} кілопаскаля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кілопаскаля</unitPattern>
+				<unitPattern count="other" case="dative">{0} кілопаскаля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кілопаскаля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кілопаскаля</unitPattern>
+				<unitPattern count="other" case="locative">{0} кілопаскаля</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<gender>masculine</gender>
 				<displayName>мегапаскалі</displayName>
 				<unitPattern count="one">{0} мегапаскаль</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегапаскаль</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегапаскалю</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегапаскаля</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегапаскалем</unitPattern>
 				<unitPattern count="one" case="locative">{0} мегапаскалі</unitPattern>
 				<unitPattern count="few">{0} мегапаскалі</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегапаскалі</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегапаскалям</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегапаскалів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегапаскалями</unitPattern>
 				<unitPattern count="few" case="locative">{0} мегапаскалях</unitPattern>
 				<unitPattern count="many">{0} мегапаскалів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегапаскалів</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегапаскалям</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегапаскалів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегапаскалями</unitPattern>
 				<unitPattern count="many" case="locative">{0} мегапаскалях</unitPattern>
 				<unitPattern count="other">{0} мегапаскаля</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегапаскаля</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегапаскаля</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегапаскаля</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегапаскаля</unitPattern>
+				<unitPattern count="other" case="locative">{0} мегапаскаля</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<gender>masculine</gender>
 				<displayName>кілометри на годину</displayName>
 				<unitPattern count="one">{0} кілометр на годину</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кілометр на годину</unitPattern>
 				<unitPattern count="one" case="dative">{0} кілометру на годину</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кілометра на годину</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кілометром на годину</unitPattern>
 				<unitPattern count="one" case="locative">{0} кілометрі на годину</unitPattern>
 				<unitPattern count="few">{0} кілометри на годину</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кілометри на годину</unitPattern>
 				<unitPattern count="few" case="dative">{0} кілометрам на годину</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кілометрів на годину</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кілометрами на годину</unitPattern>
 				<unitPattern count="few" case="locative">{0} кілометрах на годину</unitPattern>
 				<unitPattern count="many">{0} кілометрів на годину</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кілометрів на годину</unitPattern>
 				<unitPattern count="many" case="dative">{0} кілометрам на годину</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кілометрів на годину</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кілометрами на годину</unitPattern>
 				<unitPattern count="many" case="locative">{0} кілометрах на годину</unitPattern>
 				<unitPattern count="other">{0} кілометра на годину</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кілометра на годину</unitPattern>
+				<unitPattern count="other" case="dative">{0} кілометра на годину</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кілометра на годину</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кілометра на годину</unitPattern>
+				<unitPattern count="other" case="locative">{0} кілометра на годину</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<gender>masculine</gender>
 				<displayName>метри на секунду</displayName>
 				<unitPattern count="one">{0} метр на секунду</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} метр на секунду</unitPattern>
 				<unitPattern count="one" case="dative">{0} метру на секунду</unitPattern>
 				<unitPattern count="one" case="genitive">{0} метра на секунду</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} метром на секунду</unitPattern>
 				<unitPattern count="one" case="locative">{0} метрі на секунду</unitPattern>
 				<unitPattern count="few">{0} метри на секунду</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метри на секунду</unitPattern>
 				<unitPattern count="few" case="dative">{0} метрам на секунду</unitPattern>
 				<unitPattern count="few" case="genitive">{0} метрів на секунду</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} метрами на секунду</unitPattern>
 				<unitPattern count="few" case="locative">{0} метрах на секунду</unitPattern>
 				<unitPattern count="many">{0} метрів на секунду</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} метрів на секунду</unitPattern>
 				<unitPattern count="many" case="dative">{0} метрам на секунду</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} метрів на секунду</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} метрами на секунду</unitPattern>
 				<unitPattern count="many" case="locative">{0} метрах на секунду</unitPattern>
 				<unitPattern count="other">{0} метра на секунду</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метра на секунду</unitPattern>
+				<unitPattern count="other" case="dative">{0} метра на секунду</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метра на секунду</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метра на секунду</unitPattern>
+				<unitPattern count="other" case="locative">{0} метра на секунду</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>милі на годину</displayName>
@@ -11432,57 +11432,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="one" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="one" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="one" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0}°</unitPattern>
+				<unitPattern count="one" case="dative">{0}°</unitPattern>
+				<unitPattern count="one" case="genitive">{0}°</unitPattern>
+				<unitPattern count="one" case="instrumental">{0}°</unitPattern>
+				<unitPattern count="one" case="locative">{0}°</unitPattern>
 				<unitPattern count="few">{0}°</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="few" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="few" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0}°</unitPattern>
+				<unitPattern count="few" case="dative">{0}°</unitPattern>
+				<unitPattern count="few" case="genitive">{0}°</unitPattern>
+				<unitPattern count="few" case="instrumental">{0}°</unitPattern>
+				<unitPattern count="few" case="locative">{0}°</unitPattern>
 				<unitPattern count="many">{0}°</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="many" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0}°</unitPattern>
+				<unitPattern count="many" case="dative">{0}°</unitPattern>
+				<unitPattern count="many" case="genitive">{0}°</unitPattern>
+				<unitPattern count="many" case="instrumental">{0}°</unitPattern>
+				<unitPattern count="many" case="locative">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0}°</unitPattern>
+				<unitPattern count="other" case="dative">{0}°</unitPattern>
+				<unitPattern count="other" case="genitive">{0}°</unitPattern>
+				<unitPattern count="other" case="instrumental">{0}°</unitPattern>
+				<unitPattern count="other" case="locative">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<gender>masculine</gender>
 				<displayName>градуси Цельсія</displayName>
 				<unitPattern count="one">{0} градус Цельсія</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} градус Цельсія</unitPattern>
 				<unitPattern count="one" case="dative">{0} градусу Цельсія</unitPattern>
 				<unitPattern count="one" case="genitive">{0} градуса Цельсія</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} градусом Цельсія</unitPattern>
 				<unitPattern count="one" case="locative">{0} градусі Цельсія</unitPattern>
 				<unitPattern count="few">{0} градуси Цельсія</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} градуси Цельсія</unitPattern>
 				<unitPattern count="few" case="dative">{0} градусам Цельсія</unitPattern>
 				<unitPattern count="few" case="genitive">{0} градусів Цельсія</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} градусами Цельсія</unitPattern>
 				<unitPattern count="few" case="locative">{0} градусах Цельсія</unitPattern>
 				<unitPattern count="many">{0} градусів Цельсія</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} градусів Цельсія</unitPattern>
 				<unitPattern count="many" case="dative">{0} градусам Цельсія</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} градусів Цельсія</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} градусами Цельсія</unitPattern>
 				<unitPattern count="many" case="locative">{0} градусах Цельсія</unitPattern>
 				<unitPattern count="other">{0} градуса Цельсія</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} градуса Цельсія</unitPattern>
+				<unitPattern count="other" case="dative">{0} градуса Цельсія</unitPattern>
+				<unitPattern count="other" case="genitive">{0} градуса Цельсія</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} градуса Цельсія</unitPattern>
+				<unitPattern count="other" case="locative">{0} градуса Цельсія</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>градуси Фаренгейта</displayName>
@@ -11495,29 +11495,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>кельвіни</displayName>
 				<unitPattern count="one">{0} кельвін</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кельвін</unitPattern>
 				<unitPattern count="one" case="dative">{0} кельвіну</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кельвіна</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кельвіном</unitPattern>
 				<unitPattern count="one" case="locative">{0} кельвіні</unitPattern>
 				<unitPattern count="few">{0} кельвіни</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кельвіни</unitPattern>
 				<unitPattern count="few" case="dative">{0} кельвінам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кельвінів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кельвінами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кельвінах</unitPattern>
 				<unitPattern count="many">{0} кельвінів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кельвінів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кельвінам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кельвінів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кельвінами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кельвінах</unitPattern>
 				<unitPattern count="other">{0} кельвіна</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кельвіна</unitPattern>
+				<unitPattern count="other" case="dative">{0} кельвіна</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кельвіна</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кельвіна</unitPattern>
+				<unitPattern count="other" case="locative">{0} кельвіна</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>фунт-фути</displayName>
@@ -11530,114 +11530,114 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ньютон-метри</displayName>
 				<unitPattern count="one">{0} ньютон-метр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} ньютон-метр</unitPattern>
 				<unitPattern count="one" case="dative">{0} ньютон-метру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} ньютон-метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} ньютон-метром</unitPattern>
 				<unitPattern count="one" case="locative">{0} ньютон-метрі</unitPattern>
 				<unitPattern count="few">{0} ньютон-метри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} ньютон-метри</unitPattern>
 				<unitPattern count="few" case="dative">{0} ньютон-метрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} ньютон-метрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} ньютон-метрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} ньютон-метрах</unitPattern>
 				<unitPattern count="many">{0} ньютон-метрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} ньютон-метрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} ньютон-метрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} ньютон-метрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} ньютон-метрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} ньютон-метрах</unitPattern>
 				<unitPattern count="other">{0} ньютон-метра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} ньютон-метра</unitPattern>
+				<unitPattern count="other" case="dative">{0} ньютон-метра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} ньютон-метра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} ньютон-метра</unitPattern>
+				<unitPattern count="other" case="locative">{0} ньютон-метра</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<gender>masculine</gender>
 				<displayName>кубічні кілометри</displayName>
 				<unitPattern count="one">{0} кубічний кілометр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кубічний кілометр</unitPattern>
 				<unitPattern count="one" case="dative">{0} кубічному кілометру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кубічного кілометра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кубічним кілометром</unitPattern>
 				<unitPattern count="one" case="locative">{0} кубічному кілометрі</unitPattern>
 				<unitPattern count="few">{0} кубічні кілометри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубічні кілометри</unitPattern>
 				<unitPattern count="few" case="dative">{0} кубічним кілометрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кубічних кілометрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кубічними кілометрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кубічних кілометрах</unitPattern>
 				<unitPattern count="many">{0} кубічних кілометрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кубічних кілометрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кубічним кілометрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кубічних кілометрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кубічними кілометрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кубічних кілометрах</unitPattern>
 				<unitPattern count="other">{0} кубічного кілометра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубічного кілометра</unitPattern>
+				<unitPattern count="other" case="dative">{0} кубічного кілометра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубічного кілометра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубічного кілометра</unitPattern>
+				<unitPattern count="other" case="locative">{0} кубічного кілометра</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<gender>masculine</gender>
 				<displayName>кубічні метри</displayName>
 				<unitPattern count="one">{0} кубічний метр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кубічний метр</unitPattern>
 				<unitPattern count="one" case="dative">{0} кубічному метру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кубічного метра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кубічним метром</unitPattern>
 				<unitPattern count="one" case="locative">{0} кубічному метрі</unitPattern>
 				<unitPattern count="few">{0} кубічні метри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубічні метри</unitPattern>
 				<unitPattern count="few" case="dative">{0} кубічним метрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кубічних метрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кубічними метрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кубічних метрах</unitPattern>
 				<unitPattern count="many">{0} кубічних метрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кубічних метрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кубічним метрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кубічних метрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кубічними метрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кубічних метрах</unitPattern>
 				<unitPattern count="other">{0} кубічного метра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубічного метра</unitPattern>
+				<unitPattern count="other" case="dative">{0} кубічного метра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубічного метра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубічного метра</unitPattern>
+				<unitPattern count="other" case="locative">{0} кубічного метра</unitPattern>
 				<perUnitPattern>{0} на кубічний метр</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<gender>masculine</gender>
 				<displayName>кубічні сантиметри</displayName>
 				<unitPattern count="one">{0} кубічний сантиметр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} кубічний сантиметр</unitPattern>
 				<unitPattern count="one" case="dative">{0} кубічному сантиметру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} кубічного сантиметра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} кубічним сантиметром</unitPattern>
 				<unitPattern count="one" case="locative">{0} кубічному сантиметрі</unitPattern>
 				<unitPattern count="few">{0} кубічні сантиметри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} кубічні сантиметри</unitPattern>
 				<unitPattern count="few" case="dative">{0} кубічним сантиметрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} кубічних сантиметрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} кубічними сантиметрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} кубічних сантиметрах</unitPattern>
 				<unitPattern count="many">{0} кубічних сантиметрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} кубічних сантиметрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} кубічним сантиметрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} кубічних сантиметрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} кубічними сантиметрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} кубічних сантиметрах</unitPattern>
 				<unitPattern count="other">{0} кубічного сантиметра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} кубічного сантиметра</unitPattern>
+				<unitPattern count="other" case="dative">{0} кубічного сантиметра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} кубічного сантиметра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} кубічного сантиметра</unitPattern>
+				<unitPattern count="other" case="locative">{0} кубічного сантиметра</unitPattern>
 				<perUnitPattern>{0} на кубічний сантиметр</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
@@ -11672,170 +11672,170 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>мегалітри</displayName>
 				<unitPattern count="one">{0} мегалітр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мегалітр</unitPattern>
 				<unitPattern count="one" case="dative">{0} мегалітру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мегалітра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мегалітром</unitPattern>
 				<unitPattern count="one" case="locative">{0} мегалітрі</unitPattern>
 				<unitPattern count="few">{0} мегалітри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мегалітри</unitPattern>
 				<unitPattern count="few" case="dative">{0} мегалітрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мегалітрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мегалітрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мегалітрах</unitPattern>
 				<unitPattern count="many">{0} мегалітрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мегалітрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} мегалітрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мегалітрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мегалітрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мегалітрах</unitPattern>
 				<unitPattern count="other">{0} мегалітра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мегалітра</unitPattern>
+				<unitPattern count="other" case="dative">{0} мегалітра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мегалітра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мегалітра</unitPattern>
+				<unitPattern count="other" case="locative">{0} мегалітра</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<gender>masculine</gender>
 				<displayName>гектолітри</displayName>
 				<unitPattern count="one">{0} гектолітр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} гектолітр</unitPattern>
 				<unitPattern count="one" case="dative">{0} гектолітру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} гектолітра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} гектолітром</unitPattern>
 				<unitPattern count="one" case="locative">{0} гектолітрі</unitPattern>
 				<unitPattern count="few">{0} гектолітри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} гектолітри</unitPattern>
 				<unitPattern count="few" case="dative">{0} гектолітрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} гектолітрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} гектолітрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} гектолітрах</unitPattern>
 				<unitPattern count="many">{0} гектолітрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} гектолітрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} гектолітрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} гектолітрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} гектолітрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} гектолітрах</unitPattern>
 				<unitPattern count="other">{0} гектолітра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} гектолітра</unitPattern>
+				<unitPattern count="other" case="dative">{0} гектолітра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} гектолітра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} гектолітра</unitPattern>
+				<unitPattern count="other" case="locative">{0} гектолітра</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<gender>masculine</gender>
 				<displayName>літри</displayName>
 				<unitPattern count="one">{0} літр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} літр</unitPattern>
 				<unitPattern count="one" case="dative">{0} літру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} літра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} літром</unitPattern>
 				<unitPattern count="one" case="locative">{0} літрі</unitPattern>
 				<unitPattern count="few">{0} літри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} літри</unitPattern>
 				<unitPattern count="few" case="dative">{0} літрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} літрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} літрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} літрах</unitPattern>
 				<unitPattern count="many">{0} літрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} літрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} літрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} літрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} літрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} літрах</unitPattern>
 				<unitPattern count="other">{0} літра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} літра</unitPattern>
+				<unitPattern count="other" case="dative">{0} літра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} літра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} літра</unitPattern>
+				<unitPattern count="other" case="locative">{0} літра</unitPattern>
 				<perUnitPattern>{0} на літр</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<gender>masculine</gender>
 				<displayName>децилітри</displayName>
 				<unitPattern count="one">{0} децилітр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} децилітр</unitPattern>
 				<unitPattern count="one" case="dative">{0} децилітру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} децилітра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} децилітром</unitPattern>
 				<unitPattern count="one" case="locative">{0} децилітрі</unitPattern>
 				<unitPattern count="few">{0} децилітри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} децилітри</unitPattern>
 				<unitPattern count="few" case="dative">{0} децилітрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} децилітрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} децилітрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} децилітрах</unitPattern>
 				<unitPattern count="many">{0} децилітрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} децилітрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} децилітрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} децилітрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} децилітрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} децилітрах</unitPattern>
 				<unitPattern count="other">{0} децилітра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} децилітра</unitPattern>
+				<unitPattern count="other" case="dative">{0} децилітра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} децилітра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} децилітра</unitPattern>
+				<unitPattern count="other" case="locative">{0} децилітра</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<gender>masculine</gender>
 				<displayName>сантилітри</displayName>
 				<unitPattern count="one">{0} сантилітр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} сантилітр</unitPattern>
 				<unitPattern count="one" case="dative">{0} сантилітру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} сантилітра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} сантилітром</unitPattern>
 				<unitPattern count="one" case="locative">{0} сантилітрі</unitPattern>
 				<unitPattern count="few">{0} сантилітри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} сантилітри</unitPattern>
 				<unitPattern count="few" case="dative">{0} сантилітрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} сантилітрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} сантилітрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} сантилітрах</unitPattern>
 				<unitPattern count="many">{0} сантилітрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} сантилітрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} сантилітрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} сантилітрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} сантилітрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} сантилітрах</unitPattern>
 				<unitPattern count="other">{0} сантилітра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} сантилітра</unitPattern>
+				<unitPattern count="other" case="dative">{0} сантилітра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} сантилітра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} сантилітра</unitPattern>
+				<unitPattern count="other" case="locative">{0} сантилітра</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<gender>masculine</gender>
 				<displayName>мілілітри</displayName>
 				<unitPattern count="one">{0} мілілітр</unitPattern>
-				<unitPattern count="one" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="one" case="accusative">{0} мілілітр</unitPattern>
 				<unitPattern count="one" case="dative">{0} мілілітру</unitPattern>
 				<unitPattern count="one" case="genitive">{0} мілілітра</unitPattern>
 				<unitPattern count="one" case="instrumental">{0} мілілітром</unitPattern>
 				<unitPattern count="one" case="locative">{0} мілілітрі</unitPattern>
 				<unitPattern count="few">{0} мілілітри</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} мілілітри</unitPattern>
 				<unitPattern count="few" case="dative">{0} мілілітрам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} мілілітрів</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} мілілітрами</unitPattern>
 				<unitPattern count="few" case="locative">{0} мілілітрах</unitPattern>
 				<unitPattern count="many">{0} мілілітрів</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} мілілітрів</unitPattern>
 				<unitPattern count="many" case="dative">{0} мілілітрам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} мілілітрів</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} мілілітрами</unitPattern>
 				<unitPattern count="many" case="locative">{0} мілілітрах</unitPattern>
 				<unitPattern count="other">{0} мілілітра</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} мілілітра</unitPattern>
+				<unitPattern count="other" case="dative">{0} мілілітра</unitPattern>
+				<unitPattern count="other" case="genitive">{0} мілілітра</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} мілілітра</unitPattern>
+				<unitPattern count="other" case="locative">{0} мілілітра</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<gender>feminine</gender>
@@ -11847,23 +11847,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one" case="instrumental">{0} метричною пінтою</unitPattern>
 				<unitPattern count="one" case="locative">{0} метричній пінті</unitPattern>
 				<unitPattern count="few">{0} метричні пінти</unitPattern>
-				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="few" case="accusative">{0} метричні пінти</unitPattern>
 				<unitPattern count="few" case="dative">{0} метричним пінтам</unitPattern>
 				<unitPattern count="few" case="genitive">{0} метричних пінт</unitPattern>
 				<unitPattern count="few" case="instrumental">{0} метричними пінтами</unitPattern>
 				<unitPattern count="few" case="locative">{0} метричних пінтах</unitPattern>
 				<unitPattern count="many">{0} метричних пінт</unitPattern>
-				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
+				<unitPattern count="many" case="accusative">{0} метричних пінт</unitPattern>
 				<unitPattern count="many" case="dative">{0} метричним пінтам</unitPattern>
-				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
+				<unitPattern count="many" case="genitive">{0} метричних пінт</unitPattern>
 				<unitPattern count="many" case="instrumental">{0} метричними пінтами</unitPattern>
 				<unitPattern count="many" case="locative">{0} метричних пінтах</unitPattern>
 				<unitPattern count="other">{0} метричної пінти</unitPattern>
-				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
-				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="accusative">{0} метричної пінти</unitPattern>
+				<unitPattern count="other" case="dative">{0} метричної пінти</unitPattern>
+				<unitPattern count="other" case="genitive">{0} метричної пінти</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метричної пінти</unitPattern>
+				<unitPattern count="other" case="locative">{0} метричної пінти</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<gender>feminine</gender>
@@ -11888,10 +11888,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many" case="locative">{0} метричних чашках</unitPattern>
 				<unitPattern count="other">{0} метричної чашки</unitPattern>
 				<unitPattern count="other" case="accusative">{0} метричної чашки</unitPattern>
-				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="dative">{0} метричної чашки</unitPattern>
 				<unitPattern count="other" case="genitive">{0} метричної чашки</unitPattern>
-				<unitPattern count="other" case="instrumental">↑↑↑</unitPattern>
-				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
+				<unitPattern count="other" case="instrumental">{0} метричної чашки</unitPattern>
+				<unitPattern count="other" case="locative">{0} метричної чашки</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>акр-фути</displayName>
@@ -12126,16 +12126,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -12316,9 +12316,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>проміріада</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="few">{0}‱</unitPattern>
+				<unitPattern count="many">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -12481,7 +12481,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-day">
 				<displayName>дні</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} дн.</unitPattern>
 				<unitPattern count="few">{0} дн.</unitPattern>
 				<unitPattern count="many">{0} дн.</unitPattern>
 				<unitPattern count="other">{0} дн.</unitPattern>
@@ -12695,16 +12695,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>ppcm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="few">{0} ppcm</unitPattern>
+				<unitPattern count="many">{0} ppcm</unitPattern>
 				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>ppi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -12716,9 +12716,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="few">{0} ppi</unitPattern>
+				<unitPattern count="many">{0} ppi</unitPattern>
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
@@ -12730,9 +12730,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="few">{0} R⊕</unitPattern>
+				<unitPattern count="many">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -12882,9 +12882,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>радіус Сонця</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="few">{0} R☉</unitPattern>
+				<unitPattern count="many">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -12910,9 +12910,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>світності Сонця</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="few">{0} L☉</unitPattern>
+				<unitPattern count="many">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -13005,16 +13005,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>маси Землі</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="few">{0} M⊕</unitPattern>
+				<unitPattern count="many">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>маси Сонця</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="few">{0} M☉</unitPattern>
+				<unitPattern count="many">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -13546,21 +13546,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="few">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="many">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="few">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="many">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g</displayName>
@@ -13577,18 +13577,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}м/с²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">об</displayName>
+				<unitPattern count="one" draft="contributed">{0} об</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} об</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} об</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} об</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName draft="contributed">рад.</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} рад.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} рад.</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} рад.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} рад.</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName draft="contributed">°</displayName>
@@ -13612,12 +13612,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">км²</displayName>
 				<unitPattern count="one" draft="contributed">{0} км²</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} км²</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} км²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} км²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/км²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>га</displayName>
@@ -13627,23 +13627,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}га</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">м²</displayName>
 				<unitPattern count="one" draft="contributed">{0} м²</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} м²</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} м²</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} м²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/м²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">см²</displayName>
+				<unitPattern count="one" draft="contributed">{0} см²</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} см²</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} см²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} см²</unitPattern>
+				<perUnitPattern draft="contributed">{0}/см²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">милі²</displayName>
 				<unitPattern count="one">{0} мл²</unitPattern>
 				<unitPattern count="few">{0} мл²</unitPattern>
 				<unitPattern count="many">{0} мл²</unitPattern>
@@ -13651,18 +13651,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/мл²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">акри</displayName>
 				<unitPattern count="one" draft="contributed">{0} акр</unitPattern>
 				<unitPattern count="few">{0} акр</unitPattern>
 				<unitPattern count="many">{0} акр</unitPattern>
 				<unitPattern count="other">{0} акр</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ярди²</displayName>
+				<unitPattern count="one" draft="contributed">{0} ярд²</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ярди²</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ярдів²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ярда²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName draft="contributed">фт²</displayName>
@@ -13672,12 +13672,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} фт²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">дюйми²</displayName>
+				<unitPattern count="one" draft="contributed">{0} дюйм²</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} дюйми²</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} дюймів²</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дюйма²</unitPattern>
+				<perUnitPattern draft="contributed">{0}/дюйм²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName draft="contributed">дунам</displayName>
@@ -13688,24 +13688,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-karat">
 				<displayName draft="contributed">кар.</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} кар.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} кар.</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} кар.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кар.</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мг/дл</displayName>
+				<unitPattern count="one" draft="contributed">{0} мг/дл</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} мг/дл</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} мг/дл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мг/дл</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName draft="contributed">ммоль/л</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ммоль/л</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ммоль/л</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ммоль/л</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ммоль/л</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>ел.</displayName>
@@ -13730,20 +13730,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permille">
 				<displayName draft="contributed">‰</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0}‰</unitPattern>
+				<unitPattern count="few" draft="contributed">{0}‰</unitPattern>
+				<unitPattern count="many" draft="contributed">{0}‰</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName draft="contributed">‱</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0}‱</unitPattern>
+				<unitPattern count="few" draft="contributed">{0}‱</unitPattern>
+				<unitPattern count="many" draft="contributed">{0}‱</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">моль</displayName>
 				<unitPattern count="one" draft="contributed">{0}моль</unitPattern>
 				<unitPattern count="few" draft="contributed">{0}моль</unitPattern>
 				<unitPattern count="many" draft="contributed">{0}моль</unitPattern>
@@ -13751,10 +13751,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName draft="contributed">л/км</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} л/км</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} л/км</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} л/км</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} л/км</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>л/100 км</displayName>
@@ -13778,81 +13778,81 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} мл/англ. гал.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ПБ</displayName>
+				<unitPattern count="one" draft="contributed">{0} ПБ</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ПБ</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ПБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ПБ</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName draft="contributed">ТБ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ТБ</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ТБ</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ТБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ТБ</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName draft="contributed">Тб</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Тб</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} Тб</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} Тб</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Тб</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
 				<displayName draft="contributed">ГБ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} ГБ</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ГБ</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ГБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ГБ</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
 				<displayName draft="contributed">Гб</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Гб</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} Гб</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} Гб</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Гб</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName draft="contributed">МБ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} МБ</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} МБ</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} МБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} МБ</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
 				<displayName draft="contributed">Мб</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Мб</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} Мб</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} Мб</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Мб</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
 				<displayName draft="contributed">кБ</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} кБ</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} кБ</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} кБ</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кБ</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
 				<displayName draft="contributed">кб</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} кб</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} кб</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} кб</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кб</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName draft="contributed">Б</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Б</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} Б</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} Б</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Б</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName draft="contributed">б</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} б</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} б</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} б</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} б</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>ст</displayName>
@@ -13862,11 +13862,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ст</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>10-річчя</displayName>
+				<unitPattern count="one">{0} 10-річчя</unitPattern>
+				<unitPattern count="few">{0} 10-річчя</unitPattern>
+				<unitPattern count="many">{0} 10-річ</unitPattern>
+				<unitPattern count="other">{0} 10-річчя</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>р</displayName>
@@ -13954,67 +13954,67 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}нс</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">А</displayName>
+				<unitPattern count="one" draft="contributed">{0} А</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} А</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} А</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} А</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мА</displayName>
+				<unitPattern count="one" draft="contributed">{0} мА</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} мА</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} мА</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мА</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName draft="contributed">Ом</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Ом</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} Ом</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} Ом</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Ом</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName draft="contributed">В</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} В</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} В</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} В</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} В</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ккал</displayName>
+				<unitPattern count="one" draft="contributed">{0} ккал</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ккал</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ккал</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">кал</displayName>
+				<unitPattern count="one" draft="contributed">{0} кал</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} кал</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} кал</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кал</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ккал</displayName>
+				<unitPattern count="one" draft="contributed">{0} ккал</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ккал</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ккал</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ккал</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName draft="contributed">кДж</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} кДж</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} кДж</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} кДж</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кДж</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>Дж</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} Дж</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} Дж</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} Дж</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Дж</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName draft="contributed">кВт⋅год</displayName>
@@ -14031,7 +14031,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}еВ</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">Отб</displayName>
 				<unitPattern count="one" draft="contributed">{0}Отб</unitPattern>
 				<unitPattern count="few" draft="contributed">{0}Отб</unitPattern>
 				<unitPattern count="many" draft="contributed">{0}Отб</unitPattern>
@@ -14066,32 +14066,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}кВт⋅год/100км</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ГГц</displayName>
+				<unitPattern count="one" draft="contributed">{0} ГГц</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ГГц</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ГГц</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ГГц</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">МГц</displayName>
+				<unitPattern count="one" draft="contributed">{0} МГц</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} МГц</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} МГц</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} МГц</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">кГц</displayName>
+				<unitPattern count="one" draft="contributed">{0} кГц</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} кГц</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} кГц</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кГц</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Гц</displayName>
+				<unitPattern count="one" draft="contributed">{0} Гц</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} Гц</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} Гц</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Гц</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>ем</displayName>
@@ -14108,7 +14108,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}п</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>Мп</displayName>
 				<unitPattern count="one">{0}Мп</unitPattern>
 				<unitPattern count="few">{0}Мп</unitPattern>
 				<unitPattern count="many">{0}Мп</unitPattern>
@@ -14143,18 +14143,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} тчк/“</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">тчк</displayName>
+				<unitPattern count="one" draft="contributed">{0} тчк</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} тчк</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} тчк</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} тчк</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">R⊕</displayName>
+				<unitPattern count="one" draft="contributed">{0} R⊕</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} R⊕</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} R⊕</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>км</displayName>
@@ -14223,7 +14223,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} мл</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">ярди</displayName>
 				<unitPattern count="one" draft="contributed">{0} ярд</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} ярди</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} ярдів</unitPattern>
@@ -14238,7 +14238,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/фт</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">дюйми</displayName>
 				<unitPattern count="one">{0} дм</unitPattern>
 				<unitPattern count="few">{0} дм</unitPattern>
 				<unitPattern count="many">{0} дм</unitPattern>
@@ -14253,18 +14253,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}пк</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">св. р.</displayName>
 				<unitPattern count="one" draft="contributed">{0} св. р.</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} св. р.</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} св. р.</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} св. р.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">а. о.</displayName>
+				<unitPattern count="one" draft="contributed">{0} а. о.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} а. о.</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} а. о.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} а. о.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName draft="contributed">фрл</displayName>
@@ -14281,7 +14281,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} фтм</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">м. милі</displayName>
 				<unitPattern count="one" draft="contributed">{0} м. мл</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} м. мл</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} м. мл</unitPattern>
@@ -14310,24 +14310,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-lux">
 				<displayName draft="contributed">лк</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" draft="contributed">{0} лк</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} лк</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} лк</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} лк</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">кд</displayName>
+				<unitPattern count="one" draft="contributed">{0} кд</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} кд</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} кд</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кд</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">лм</displayName>
+				<unitPattern count="one" draft="contributed">{0} лм</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} лм</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} лм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} лм</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
@@ -14360,14 +14360,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/г</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">мг</displayName>
 				<unitPattern count="one" draft="contributed">{0}мг</unitPattern>
 				<unitPattern count="few" draft="contributed">{0}мг</unitPattern>
 				<unitPattern count="many" draft="contributed">{0}мг</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}мг</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">мкг</displayName>
 				<unitPattern count="one" draft="contributed">{0}мкг</unitPattern>
 				<unitPattern count="few" draft="contributed">{0}мкг</unitPattern>
 				<unitPattern count="many" draft="contributed">{0}мкг</unitPattern>
@@ -14446,21 +14446,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} гр.</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ГВт</displayName>
+				<unitPattern count="one" draft="contributed">{0} ГВт</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ГВт</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ГВт</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ГВт</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">МВт</displayName>
+				<unitPattern count="one" draft="contributed">{0} МВт</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} МВт</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} МВт</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} МВт</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">кВт</displayName>
 				<unitPattern count="one" draft="contributed">{0} кВт</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} кВт</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} кВт</unitPattern>
@@ -14474,14 +14474,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} Вт</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мВт</displayName>
+				<unitPattern count="one" draft="contributed">{0} мВт</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} мВт</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} мВт</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мВт</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">к. с.</displayName>
 				<unitPattern count="one" draft="contributed">{0} к.с.</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} к.с.</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} к.с.</unitPattern>
@@ -14502,18 +14502,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дюйми рт. ст.</displayName>
+				<unitPattern count="one" draft="contributed">{0} дюйм рт. ст.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} дюйми рт. ст.</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} дюймів рт. ст.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дюйма рт. ст.</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">бар</displayName>
+				<unitPattern count="one" draft="contributed">{0} бар</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} бар</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} бар</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} бар</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName draft="contributed">мбар</displayName>
@@ -14523,18 +14523,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} мбара</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">атм</displayName>
+				<unitPattern count="one" draft="contributed">{0} атм</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} атм</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} атм</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} атм</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Па</displayName>
+				<unitPattern count="one" draft="contributed">{0} Па</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} Па</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} Па</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Па</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName draft="contributed">гПа</displayName>
@@ -14544,18 +14544,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} гПа</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">кПа</displayName>
+				<unitPattern count="one" draft="contributed">{0} кПа</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} кПа</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} кПа</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} кПа</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">МПа</displayName>
+				<unitPattern count="one" draft="contributed">{0} МПа</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} МПа</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} МПа</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} МПа</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>км/год</displayName>
@@ -14614,55 +14614,55 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} К</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">фунт-фут</displayName>
 				<unitPattern count="one" draft="contributed">{0}фн-фт</unitPattern>
 				<unitPattern count="few" draft="contributed">{0}фн-фт</unitPattern>
 				<unitPattern count="many" draft="contributed">{0}фн-фт</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}фн-фт</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>Н·м</displayName>
 				<unitPattern count="one">{0}Н·м</unitPattern>
 				<unitPattern count="few">{0}Н·м</unitPattern>
 				<unitPattern count="many">{0}Н·м</unitPattern>
 				<unitPattern count="other">{0}Н·м</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">км³</displayName>
 				<unitPattern count="one" draft="contributed">{0} км³</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} км³</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} км³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} км³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">м³</displayName>
+				<unitPattern count="one" draft="contributed">{0} м³</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} м³</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} м³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} м³</unitPattern>
+				<perUnitPattern draft="contributed">{0}/м³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">см³</displayName>
+				<unitPattern count="one" draft="contributed">{0} см³</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} см³</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} см³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} см³</unitPattern>
+				<perUnitPattern draft="contributed">{0}/см³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">милі³</displayName>
 				<unitPattern count="one" draft="contributed">{0} миля³</unitPattern>
 				<unitPattern count="few" draft="contributed">{0} милі³</unitPattern>
 				<unitPattern count="many" draft="contributed">{0} миль³</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} милі³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ярди³</displayName>
+				<unitPattern count="one" draft="contributed">{0} ярд³</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ярди³</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ярдів³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ярда³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName draft="contributed">фт³</displayName>
@@ -14672,25 +14672,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} фт³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дюйми³</displayName>
+				<unitPattern count="one" draft="contributed">{0} дюйм³</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} дюйми³</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} дюймів³</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дюйма³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">Мл</displayName>
+				<unitPattern count="one" draft="contributed">{0} Мл</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} Мл</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} Мл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} Мл</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">гл</displayName>
+				<unitPattern count="one" draft="contributed">{0} гл</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} гл</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} гл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} гл</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>л</displayName>
@@ -14698,28 +14698,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0}л</unitPattern>
 				<unitPattern count="many">{0}л</unitPattern>
 				<unitPattern count="other">{0}л</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/л</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дл</displayName>
+				<unitPattern count="one" draft="contributed">{0} дл</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} дл</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} дл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дл</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">сл</displayName>
+				<unitPattern count="one" draft="contributed">{0} сл</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} сл</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} сл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} сл</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">мл</displayName>
+				<unitPattern count="one" draft="contributed">{0} мл</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} мл</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} мл</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} мл</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName draft="contributed">м. пінт.</displayName>
@@ -14750,12 +14750,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}буш</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName draft="contributed">гал.</displayName>
+				<unitPattern count="one" draft="contributed">{0} гал.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} гал.</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} гал.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} гал.</unitPattern>
+				<perUnitPattern draft="contributed">{0}/гал.</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName draft="contributed">англ. гал.</displayName>
@@ -14766,11 +14766,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern draft="contributed">{0}/англ. гал.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">квар.</displayName>
+				<unitPattern count="one" draft="contributed">{0} квар.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} квар.</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} квар.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} квар.</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName draft="contributed">пінт.</displayName>
@@ -14787,11 +14787,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} чаш.</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">рід. унція</displayName>
+				<unitPattern count="one" draft="contributed">{0} рід. унція</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} рід. унції</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} рід. унцій</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} рід. унції</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>англ. рід. ун.</displayName>
@@ -14801,18 +14801,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} англ. рід. ун.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ст. ложка</displayName>
+				<unitPattern count="one" draft="contributed">{0} ст. ложка</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ст. ложки</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ст. ложок</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ст. ложки</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">ч. л.</displayName>
+				<unitPattern count="one" draft="contributed">{0} ч. л.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} ч. л.</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} ч. л.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} ч. л.</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>брл</displayName>
@@ -14822,11 +14822,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}брл</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="few" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="many" draft="contributed">↑↑↑</unitPattern>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">дес. л.</displayName>
+				<unitPattern count="one" draft="contributed">{0} дес. л.</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} дес. л.</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} дес. л.</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} дес. л.</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>англ. дес. л.</displayName>
@@ -14902,20 +14902,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} або {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} або {1}</listPatternPart>
+			<listPatternPart type="2">{0} або {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} або {1}</listPatternPart>
+			<listPatternPart type="2">{0} або {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -14934,14 +14934,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<listPattern type="unit-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} і {1}</listPatternPart>
+			<listPatternPart type="2">{0} і {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} і {1}</listPatternPart>
+			<listPatternPart type="2">{0} і {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>
@@ -15137,7 +15137,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2}, {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
 			<namePattern>{given-informal} {surname} {surname2}</namePattern>
@@ -15161,7 +15161,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal} {surname} {surname2}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}{surname2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
 			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}{surname2-monogram-allCaps}</namePattern>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -84,8 +84,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">چیروکی</language>
 			<language type="chy">چینّے</language>
 			<language type="ckb">سینٹرل کردش</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">سینٹرل کردش</language>
+			<language type="ckb" alt="variant">سینٹرل کردش</language>
 			<language type="clc">چلکوٹن</language>
 			<language type="co">کوراسیکن</language>
 			<language type="crg">میچیف</language>
@@ -822,7 +822,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">تونس</territory>
 			<territory type="TO">ٹونگا</territory>
 			<territory type="TR">ترکیہ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">ترکیہ</territory>
 			<territory type="TT">ترینیداد اور ٹوباگو</territory>
 			<territory type="TV">ٹووالو</territory>
 			<territory type="TW">تائیوان</territory>
@@ -1266,7 +1266,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2259,18 +2259,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">ذوالحجۃ</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">محرم</month>
@@ -2346,57 +2346,57 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE، d MMMM، y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MMMM، y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MMM، y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d/M/y GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
 						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d MMM، y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E، d MMM، y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E، d/M</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E، d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E، d/M/y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">d MMM، y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E، d MMM، y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
@@ -6119,7 +6119,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>لیسوتھو لوتی</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName count="one">لیسوتھو لوتی</displayName>
 				<displayName count="other">لیسوتھو لوتی</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
@@ -6758,19 +6758,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>مربع {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">مربع {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">مربع {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">مربع {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">مربع {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>کیوبک {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="one">کیوبک {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one" gender="feminine">کیوبک {0}</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">کیوبک {0}</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other" gender="feminine">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other" gender="feminine">کیوبک {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>feminine</gender>
@@ -7063,8 +7063,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-day-person">
 				<gender>masculine</gender>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} دن</unitPattern>
+				<unitPattern count="other">{0} دن</unitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<gender>masculine</gender>
@@ -7091,7 +7091,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<gender>masculine</gender>
 				<displayName>ملی سیکنڈز</displayName>
 				<unitPattern count="one">{0} ملی سیکنڈ</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ملی سیکنڈ</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<gender>masculine</gender>
@@ -7222,7 +7222,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="graphics-em">
 				<gender>masculine</gender>
 				<displayName>ٹائپوگرافک em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} ems</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
@@ -7260,8 +7260,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>ڈاٹ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ڈاٹ</unitPattern>
+				<unitPattern count="other">{0} ڈاٹ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>زمینی رداس</displayName>
@@ -7927,12 +7927,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
@@ -8065,7 +8065,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>پرمرئیڈ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -8273,12 +8273,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>الیکٹرون وولٹ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>BTU</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
@@ -8288,17 +8288,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>پاؤنڈ قوت</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>نیوٹن</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -8323,27 +8323,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>پکسلز</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>میگا پکسلز</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -8473,7 +8473,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>شمسی رداس</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -8493,7 +8493,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>شمسی چمک</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8637,7 +8637,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8697,12 +8697,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -8827,7 +8827,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -8842,7 +8842,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>بیرل</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
@@ -8899,7 +8899,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
 				<unitPrefixPattern>n{0}</unitPrefixPattern>
@@ -8977,91 +8977,91 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>جی-فورس</displayName>
 				<unitPattern count="one">{0}g</unitPattern>
 				<unitPattern count="other">{0}g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>ریڈین</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>ڈگری</displayName>
 				<unitPattern count="one">{0} ڈگری</unitPattern>
 				<unitPattern count="other">{0} ڈگری</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>آرک منٹ</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>آرک سیکنڈ</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ہیکٹر</displayName>
 				<unitPattern count="one">{0} ہیکٹر</unitPattern>
 				<unitPattern count="other">{0} ہیکٹر</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>مربع میٹر</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>mi²</displayName>
 				<unitPattern count="one">{0}mi²</unitPattern>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ایکڑ</displayName>
 				<unitPattern count="one">{0} ایکڑ</unitPattern>
 				<unitPattern count="other">{0} ایکڑ</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>yd²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>ft²</displayName>
@@ -9070,39 +9070,39 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>in²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>دُنام</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} دُنام</unitPattern>
+				<unitPattern count="other">{0} دُنام</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قیراط</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ملی مول/لیٹر</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>آئٹم</displayName>
+				<unitPattern count="one">{0} آئٹم</unitPattern>
 				<unitPattern count="other">{0} آئٹمز</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>حصے/ملین</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9110,24 +9110,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>فی ہزار</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پرمرئیڈ</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مول</displayName>
+				<unitPattern count="one">{0} مول</unitPattern>
+				<unitPattern count="other">{0} مول</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>لیٹر/100 کلو میٹر</displayName>
@@ -9135,9 +9135,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>mpg UK</displayName>
@@ -9145,69 +9145,69 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پی بائٹ</displayName>
+				<unitPattern count="one">{0} پی بی</unitPattern>
+				<unitPattern count="other">{0} پی بی</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tbit</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gbit</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MByte</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kByte</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kbit</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>بائٹ</displayName>
 				<unitPattern count="one">{0}B</unitPattern>
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>صدی</displayName>
+				<unitPattern count="one">{0} صدی</unitPattern>
+				<unitPattern count="other">{0} صدیاں</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>دہائی</displayName>
+				<unitPattern count="one">{0} دہائی</unitPattern>
+				<unitPattern count="other">{0} دہائی</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>سال</displayName>
@@ -9263,139 +9263,139 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>مائیکرو سیکنڈ</displayName>
+				<unitPattern count="one">{0} مائیکرو سیکنڈ</unitPattern>
+				<unitPattern count="other">{0} مائیکرو سیکنڈ</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نینو سیکنڈز</displayName>
+				<unitPattern count="one">{0} نینو سیکنڈ</unitPattern>
+				<unitPattern count="other">{0} نینو سیکنڈ</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amp</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milliamps</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>اوہم</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>وولٹ</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>جول</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kWh</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>الیکٹرون وولٹ</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>امریکی تھرم</displayName>
+				<unitPattern count="one">{0} امریکی تھرم</unitPattern>
+				<unitPattern count="other">{0} امریکی تھرمز</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>نیوٹن</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>px</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
@@ -9408,14 +9408,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ڈاٹ</displayName>
+				<unitPattern count="one">{0} ڈاٹ</unitPattern>
+				<unitPattern count="other">{0} ڈاٹ</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>کلو میٹر</displayName>
@@ -9446,14 +9446,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ملیمیٹر</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>pm</displayName>
@@ -9483,9 +9483,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} فی انچ</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پارسیک</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>ly</displayName>
@@ -9493,64 +9493,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>فرلانگ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} فرلانگ</unitPattern>
+				<unitPattern count="other">{0} فرلانگ</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>فیدم</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} فیدم</unitPattern>
+				<unitPattern count="other">{0} فیدم</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>پوائنٹس</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>شمسی چمک</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
@@ -9565,19 +9565,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} فی گرام</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ٹن</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>st</displayName>
@@ -9588,7 +9588,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>lb</displayName>
 				<unitPattern count="one">{0} پونڈ</unitPattern>
 				<unitPattern count="other">{0} پونڈ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>oz</displayName>
@@ -9597,62 +9597,62 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قیراط</displayName>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>ڈالٹن</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>زمینی کمیت</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>شمسی کمیت</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>گرین</displayName>
 				<unitPattern count="one">{0}gr</unitPattern>
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="one">{0}kW</unitPattern>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>واٹ</displayName>
 				<unitPattern count="one">{0} واٹ</unitPattern>
 				<unitPattern count="other">{0} واٹ</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="one">{0}hp</unitPattern>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
@@ -9672,9 +9672,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} انچ مرکری</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بار</displayName>
+				<unitPattern count="one">{0} بار</unitPattern>
+				<unitPattern count="other">{0} بارز</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -9682,14 +9682,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -9697,14 +9697,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/hr</displayName>
@@ -9722,9 +9722,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
@@ -9747,14 +9747,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>km³</displayName>
@@ -9762,16 +9762,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>cm³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>mi³</displayName>
@@ -9780,121 +9780,121 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>yd³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>ft³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>in³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>لیٹر</displayName>
 				<unitPattern count="one">{0} لیٹر</unitPattern>
 				<unitPattern count="other">{0} لیٹر</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} فی لیٹر</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>dL</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>cL</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>pt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ایکڑ فٹ</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>بُشل</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} بو</unitPattern>
+				<unitPattern count="other">{0} بو</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="one">{0} gal Imp.</unitPattern>
+				<unitPattern count="other">{0} gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>کپ</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>بیرل</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>dsp</displayName>
@@ -9907,9 +9907,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>قطرہ</displayName>
+				<unitPattern count="one">{0} قطرہ</unitPattern>
+				<unitPattern count="other">{0} قطرہ</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl.dr.</displayName>
@@ -9917,19 +9917,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>جگر</displayName>
+				<unitPattern count="one">{0} جگر</unitPattern>
+				<unitPattern count="other">{0} جگر</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>چٹکی</displayName>
+				<unitPattern count="one">{0} چٹکی</unitPattern>
+				<unitPattern count="other">{0} چٹکی</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>ڈائریکشن</displayName>
@@ -9963,20 +9963,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} یا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}، {1}</listPatternPart>
+			<listPatternPart type="middle">{0}، {1}</listPatternPart>
+			<listPatternPart type="end">{0}، یا {1}</listPatternPart>
+			<listPatternPart type="2">{0} یا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}، {1}</listPatternPart>
+			<listPatternPart type="middle">{0}، {1}</listPatternPart>
+			<listPatternPart type="end">{0}، یا {1}</listPatternPart>
+			<listPatternPart type="2">{0} یا {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}، {1}</listPatternPart>
+			<listPatternPart type="middle">{0}، {1}</listPatternPart>
 			<listPatternPart type="end">{0}، {1}</listPatternPart>
 			<listPatternPart type="2">{0}، {1}</listPatternPart>
 		</listPattern>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -82,8 +82,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">cheroki</language>
 			<language type="chy">cheyenn</language>
 			<language type="ckb">sorani-kurd</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">sorani-kurd</language>
+			<language type="ckb" alt="variant">sorani-kurd</language>
 			<language type="clc">chilkotin</language>
 			<language type="co">korsikan</language>
 			<language type="crg">michif</language>
@@ -814,7 +814,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunis</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Turkiya</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Turkiya</territory>
 			<territory type="TT">Trinidad va Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Tayvan</territory>
@@ -1025,7 +1025,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1033,7 +1033,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1041,7 +1041,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1049,7 +1049,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1557,7 +1557,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1565,7 +1565,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1573,7 +1573,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1581,7 +1581,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1800,18 +1800,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">Zul-h.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Muharram</month>
@@ -1830,15 +1830,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">Muh.</month>
+							<month type="2">Saf.</month>
 							<month type="3">Rob. avv.</month>
 							<month type="4">Rob. ox.</month>
 							<month type="5">Jum. avv.</month>
 							<month type="6">Jum. ox.</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
+							<month type="7">Raj.</month>
+							<month type="8">Sha.</month>
+							<month type="9">Ram.</month>
 							<month type="10">Shav.</month>
 							<month type="11">Zul-q.</month>
 							<month type="12">Zul-h.</month>
@@ -1858,83 +1858,83 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">Muharram</month>
+							<month type="2">Safar</month>
 							<month type="3">Robi’ ul-avval</month>
 							<month type="4">Robi’ ul-oxir</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
+							<month type="5">Jumad ul-avval</month>
+							<month type="6">Jumad ul-oxir</month>
+							<month type="7">Rajab</month>
 							<month type="8">Sha’bon</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
+							<month type="9">Ramazon</month>
+							<month type="10">Shavvol</month>
 							<month type="11">Zul-qa’da</month>
-							<month type="12">↑↑↑</month>
+							<month type="12">Zul-hijja</month>
 						</monthWidth>
 					</monthContext>
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">hijriy</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">hijriy</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">hijriy</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, d-MMMM, y (G)</pattern>
+							<datetimeSkeleton>GyMMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d-MMMM, y (G)</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d-MMM, y (G)</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>dd.MM.y (GGGGG)</pattern>
+							<datetimeSkeleton>GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">E, d</dateFormatItem>
+						<dateFormatItem id="Gy">y (G)</dateFormatItem>
 						<dateFormatItem id="GyMd">dd.MM.y GGGGG</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM, y (G)</dateFormatItem>
+						<dateFormatItem id="GyMMMd">d-MMM, y (G)</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, d-MMM, y (G)</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">dd.MM</dateFormatItem>
+						<dateFormatItem id="MEd">E, dd.MM</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">d-MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d-MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d-MMMM</dateFormatItem>
+						<dateFormatItem id="y">y (G)</dateFormatItem>
+						<dateFormatItem id="yyyy">y (G)</dateFormatItem>
+						<dateFormatItem id="yyyyM">MM.y (GGGGG)</dateFormatItem>
+						<dateFormatItem id="yyyyMd">dd.MM.y (GGGGG)</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, dd.MM.y (GGGGG)</dateFormatItem>
 						<dateFormatItem id="yyyyMMM">MMM, y (G)</dateFormatItem>
 						<dateFormatItem id="yyyyMMMd">d-MMM, y G</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, d-MMM, y (G)</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM">MMMM, y G</dateFormatItem>
 						<dateFormatItem id="yyyyQQQ">QQQ, y (G)</dateFormatItem>
 						<dateFormatItem id="yyyyQQQQ">QQQQ, y (G)</dateFormatItem>
@@ -1959,18 +1959,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">isfan</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">farvardin</month>
@@ -2159,7 +2159,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>oy</displayName>
 				<relative type="-1">o‘tgan oy</relative>
 				<relative type="0">bu oy</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="1">keyingi oy</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} oydan keyin</relativeTimePattern>
 					<relativeTimePattern count="other">{0} oydan keyin</relativeTimePattern>
@@ -2239,9 +2239,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-short">
 				<displayName>kun</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">kecha</relative>
+				<relative type="0">bugun</relative>
+				<relative type="1">ertaga</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} kundan keyin</relativeTimePattern>
 					<relativeTimePattern count="other">{0} kundan keyin</relativeTimePattern>
@@ -2253,9 +2253,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="day-narrow">
 				<displayName>kun</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">kecha</relative>
+				<relative type="0">bugun</relative>
+				<relative type="1">ertaga</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} kundan keyin</relativeTimePattern>
 					<relativeTimePattern count="other">{0} kundan keyin</relativeTimePattern>
@@ -6256,7 +6256,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0} kub</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>gravitatsiya kuchi</displayName>
@@ -6344,9 +6344,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/kvadrat duym</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>karat</displayName>
@@ -6389,9 +6389,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} promiriada</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>litr/kilometr</displayName>
@@ -6643,8 +6643,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipografik em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piksel</displayName>
@@ -6941,9 +6941,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} duym simob ustuni</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>millibar</displayName>
@@ -7396,7 +7396,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunam</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -7436,12 +7436,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>promiriada</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mol</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7644,7 +7644,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elektronvolt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -7664,7 +7664,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-newton">
 				<displayName>nyuton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -7694,17 +7694,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>piksel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapiksel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
@@ -7844,7 +7844,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>quyosh radiusi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -7864,7 +7864,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>quyosh nuri kuchi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -7928,17 +7928,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>Yer massasi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>quyosh massasi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -7993,7 +7993,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>bar</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -8008,7 +8008,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>Pa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8018,12 +8018,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>kPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>MPa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -8073,7 +8073,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>N⋅m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -8321,28 +8321,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
@@ -8358,117 +8358,117 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>grav. kuchi</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metr/soniya²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>aylanish</displayName>
+				<unitPattern count="one">{0} marta ayl.</unitPattern>
+				<unitPattern count="other">{0} marta ayl.</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>gradus</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>yoy daqiqasi</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>yoy soniyasi</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">{0} km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>gektar</displayName>
 				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m²</displayName>
 				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">{0} m²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sm²</displayName>
+				<unitPattern count="one">{0} sm²</unitPattern>
+				<unitPattern count="other">{0} sm²</unitPattern>
+				<perUnitPattern>{0}/sm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>kv. mil</displayName>
 				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">{0} mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mil²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>akr</displayName>
 				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yard²</displayName>
+				<unitPattern count="one">{0} yard²</unitPattern>
+				<unitPattern count="other">{0} yard²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kv. fut</displayName>
 				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kvadrat duym</displayName>
+				<unitPattern count="one">{0} kv. duym</unitPattern>
+				<unitPattern count="other">{0} kv. duym</unitPattern>
+				<perUnitPattern>{0} kv. duym</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millimol/litr</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>element</displayName>
+				<unitPattern count="one">{0} element</unitPattern>
+				<unitPattern count="other">{0} ta element</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
@@ -8481,24 +8481,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>promille</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>promiriada</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>litr/km</displayName>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100 km</displayName>
@@ -8506,85 +8506,85 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil/gal</displayName>
+				<unitPattern count="one">{0} mil/gal</unitPattern>
+				<unitPattern count="other">{0} mil/gal</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil/imp. gallon</displayName>
+				<unitPattern count="one">{0} mil/imp.gal</unitPattern>
+				<unitPattern count="other">{0} mil/imp.gal</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tbit</displayName>
+				<unitPattern count="one">{0} Tbit</unitPattern>
+				<unitPattern count="other">{0} Tbit</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gbit</displayName>
+				<unitPattern count="one">{0} Gbit</unitPattern>
+				<unitPattern count="other">{0} Gbit</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mbit</displayName>
+				<unitPattern count="one">{0} Mbit</unitPattern>
+				<unitPattern count="other">{0} Mbit</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kbit</displayName>
+				<unitPattern count="one">{0} kbit</unitPattern>
+				<unitPattern count="other">{0} kbit</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bayt</displayName>
+				<unitPattern count="one">{0} bayt</unitPattern>
+				<unitPattern count="other">{0} bayt</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>asr</displayName>
+				<unitPattern count="one">{0} asr</unitPattern>
+				<unitPattern count="other">{0} asr</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dekada</displayName>
+				<unitPattern count="one">{0} dekada</unitPattern>
+				<unitPattern count="other">{0} dekada</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>yil</displayName>
 				<unitPattern count="one">{0} yil</unitPattern>
 				<unitPattern count="other">{0} yil</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/yil</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>chorak</displayName>
@@ -8596,37 +8596,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>oy</displayName>
 				<unitPattern count="one">{0} oy</unitPattern>
 				<unitPattern count="other">{0} oy</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oy</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>hafta</displayName>
 				<unitPattern count="one">{0} hafta</unitPattern>
 				<unitPattern count="other">{0} hafta</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/hafta</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>kun</displayName>
 				<unitPattern count="one">{0} kun</unitPattern>
 				<unitPattern count="other">{0} kun</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kun</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>soat</displayName>
 				<unitPattern count="one">{0} soat</unitPattern>
 				<unitPattern count="other">{0} soat</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/soat</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>daq.</displayName>
 				<unitPattern count="one">{0} daq.</unitPattern>
 				<unitPattern count="other">{0} daq.</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/daq.</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>son.</displayName>
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>mson</displayName>
@@ -8634,182 +8634,182 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mks</displayName>
+				<unitPattern count="one">{0} mks</unitPattern>
+				<unitPattern count="other">{0} mks</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nanosoniya</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amper</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>om</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kkal</displayName>
+				<unitPattern count="one">{0} kkal</unitPattern>
+				<unitPattern count="other">{0} kkal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kal</displayName>
+				<unitPattern count="one">{0} kal</unitPattern>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kal</displayName>
+				<unitPattern count="one">{0} kal</unitPattern>
+				<unitPattern count="other">{0} kal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilojoul</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joul</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kVt-soat</displayName>
+				<unitPattern count="one">{0} kVt-soat</unitPattern>
+				<unitPattern count="other">{0} kVt-soat</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>elektronvolt</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="one">{0} BTU</unitPattern>
+				<unitPattern count="other">{0} BTU</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>AQSH termi</displayName>
+				<unitPattern count="one">{0} AQSH termi</unitPattern>
+				<unitPattern count="other">{0} AQSH termi</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>funt-kuch</displayName>
+				<unitPattern count="one">{0} funt-kuch</unitPattern>
+				<unitPattern count="other">{0} funt-kuch</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nyuton</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GGs</displayName>
+				<unitPattern count="one">{0} GGs</unitPattern>
+				<unitPattern count="other">{0} GGs</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MGs</displayName>
+				<unitPattern count="one">{0} MGs</unitPattern>
+				<unitPattern count="other">{0} MGs</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kGs</displayName>
+				<unitPattern count="one">{0} kGs</unitPattern>
+				<unitPattern count="other">{0} kGs</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gs</displayName>
+				<unitPattern count="one">{0} Gs</unitPattern>
+				<unitPattern count="other">{0} Gs</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>piksel</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapiksel</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px/sm</displayName>
+				<unitPattern count="one">{0} px/sm</unitPattern>
+				<unitPattern count="other">{0} px/sm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>piksel/duym</displayName>
+				<unitPattern count="one">{0} piksel/duym</unitPattern>
+				<unitPattern count="other">{0} piksel/duym</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>nuqta/sm</displayName>
 				<unitPattern count="one">{0} nqt/sm</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} nuqta/sm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nuqta/duym</displayName>
+				<unitPattern count="one">{0} nuqta/duym</unitPattern>
+				<unitPattern count="other">{0} nuqta/duym</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>piksel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} piksel</unitPattern>
+				<unitPattern count="other">{0} piksel</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yer radiusi</displayName>
+				<unitPattern count="one">{0} yer radiusi</unitPattern>
+				<unitPattern count="other">{0} yer radiusi</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>metr</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>sm</displayName>
 				<unitPattern count="one">{0} sm</unitPattern>
 				<unitPattern count="other">{0} sm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/sm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -8817,91 +8817,91 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μmetr</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil</displayName>
 				<unitPattern count="one">{0} milya</unitPattern>
 				<unitPattern count="other">{0} milya</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yard</displayName>
 				<unitPattern count="one">{0} yard</unitPattern>
 				<unitPattern count="other">{0} yard</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>fut</displayName>
 				<unitPattern count="one">{0} fut</unitPattern>
 				<unitPattern count="other">{0} fut</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} fut</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>duym</displayName>
 				<unitPattern count="one">{0} dyuym</unitPattern>
 				<unitPattern count="other">{0} dyuym</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/dy</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pk</displayName>
+				<unitPattern count="one">{0} pk</unitPattern>
+				<unitPattern count="other">{0} pk</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>yorug‘lik yili</displayName>
 				<unitPattern count="one">{0} yo.y.</unitPattern>
 				<unitPattern count="other">{0} yo.y.</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>a.b.</displayName>
+				<unitPattern count="one">{0} a.b.</unitPattern>
+				<unitPattern count="other">{0} a.b.</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>farlong</displayName>
+				<unitPattern count="one">{0} farlong</unitPattern>
+				<unitPattern count="other">{0} farlong</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fatom</displayName>
+				<unitPattern count="one">{0} fatom</unitPattern>
+				<unitPattern count="other">{0} fatom</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>den. mili</displayName>
+				<unitPattern count="one">{0} den. mili</unitPattern>
+				<unitPattern count="other">{0} den. mili</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sk. mili</displayName>
+				<unitPattern count="one">{0} sk. mili</unitPattern>
+				<unitPattern count="other">{0} sk. mili</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nuqta</displayName>
+				<unitPattern count="one">{0} nuqta</unitPattern>
+				<unitPattern count="other">{0} nuqta</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>quyosh radiusi</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lk</displayName>
+				<unitPattern count="one">{0} lk</unitPattern>
+				<unitPattern count="other">{0} lk</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>kd</displayName>
@@ -8909,7 +8909,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0}lm</unitPattern>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
@@ -8919,163 +8919,163 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gramm</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amer. t</displayName>
+				<unitPattern count="one">{0} amer. t</unitPattern>
+				<unitPattern count="other">{0} amer. t</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tosh</displayName>
+				<unitPattern count="one">{0} tosh</unitPattern>
+				<unitPattern count="other">{0} tosh</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>funt</displayName>
 				<unitPattern count="one">{0} funt</unitPattern>
 				<unitPattern count="other">{0} funt</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/funt</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>unsiya</displayName>
 				<unitPattern count="one">{0} untsiya</unitPattern>
 				<unitPattern count="other">{0} untsiya</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/unsiya</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>troya unsiyasi</displayName>
+				<unitPattern count="one">{0} troya unsiyasi</unitPattern>
+				<unitPattern count="other">{0} troya unsiyasi</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="one">{0} kar</unitPattern>
+				<unitPattern count="other">{0} kar</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dalton</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Yer massasi</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>quyosh massasi</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gran</displayName>
+				<unitPattern count="one">{0} gran</unitPattern>
+				<unitPattern count="other">{0} gran</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GVt</displayName>
+				<unitPattern count="one">{0} GVt</unitPattern>
+				<unitPattern count="other">{0} GVt</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MVt</displayName>
+				<unitPattern count="one">{0} MVt</unitPattern>
+				<unitPattern count="other">{0} MVt</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kVt</displayName>
 				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>Vt</displayName>
 				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mVt</displayName>
+				<unitPattern count="one">{0} mVt</unitPattern>
+				<unitPattern count="other">{0} mVt</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>o.k.</displayName>
 				<unitPattern count="one">{0} hp</unitPattern>
 				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="one">{0} mmHg</unitPattern>
+				<unitPattern count="other">{0} mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>funt/dy.kv</displayName>
+				<unitPattern count="one">{0} funt/dy.kv</unitPattern>
+				<unitPattern count="other">{0} funt/dy.kv</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>gPa</displayName>
 				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/soat</displayName>
@@ -9083,24 +9083,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/soat</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil/soat</displayName>
 				<unitPattern count="one">{0} mi/h</unitPattern>
 				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>uzel</displayName>
+				<unitPattern count="one">{0} uzel</unitPattern>
+				<unitPattern count="other">{0} uzel</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9108,14 +9108,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>funt-fut</displayName>
@@ -9123,184 +9123,184 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} funt-fut</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>N⋅m</displayName>
 				<unitPattern count="one">{0}N⋅m</unitPattern>
 				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sm³</displayName>
+				<unitPattern count="one">{0} sm³</unitPattern>
+				<unitPattern count="other">{0} sm³</unitPattern>
+				<perUnitPattern>{0}/sm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>kub mil</displayName>
 				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kub yard</displayName>
+				<unitPattern count="one">{0} yard³</unitPattern>
+				<unitPattern count="other">{0} yard³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kub fut</displayName>
+				<unitPattern count="one">{0} kub fut</unitPattern>
+				<unitPattern count="other">{0} kub fut</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kub duym</displayName>
+				<unitPattern count="one">{0} kub duym</unitPattern>
+				<unitPattern count="other">{0} kub duym</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gL</displayName>
+				<unitPattern count="one">{0} gL</unitPattern>
+				<unitPattern count="other">{0} gL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litr</displayName>
 				<unitPattern count="one">{0}L</unitPattern>
 				<unitPattern count="other">{0}L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sL</displayName>
+				<unitPattern count="one">{0} sL</unitPattern>
+				<unitPattern count="other">{0} sL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m. piyola</displayName>
+				<unitPattern count="one">{0} m. piyola</unitPattern>
+				<unitPattern count="other">{0} m. piyola</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>akrofut</displayName>
+				<unitPattern count="one">{0} akrofut</unitPattern>
+				<unitPattern count="other">{0} akrofut</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bushel</displayName>
+				<unitPattern count="one">{0} bushel</unitPattern>
+				<unitPattern count="other">{0} bushel</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>imp. gal.</displayName>
+				<unitPattern count="one">{0} imp. gal.</unitPattern>
+				<unitPattern count="other">{0} imp. gal.</unitPattern>
+				<perUnitPattern>{0} imp. gal.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kvart</displayName>
+				<unitPattern count="one">{0} kvart</unitPattern>
+				<unitPattern count="other">{0} kvart</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pint</displayName>
+				<unitPattern count="one">{0} pint</unitPattern>
+				<unitPattern count="other">{0} pint</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>piyola</displayName>
+				<unitPattern count="one">{0} piyola</unitPattern>
+				<unitPattern count="other">{0} piyola</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>suyuq unsiya</displayName>
+				<unitPattern count="one">{0} suyuq unsiya</unitPattern>
+				<unitPattern count="other">{0} suyuq unsiya</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ingliz suyuq unsiyasi</displayName>
+				<unitPattern count="one">{0} ing. suyuq uns.</unitPattern>
+				<unitPattern count="other">{0} ing. suyuq uns.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>osh qoshiq</displayName>
+				<unitPattern count="one">{0} osh qoshiq</unitPattern>
+				<unitPattern count="other">{0} osh qoshiq</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>choy qoshiq</displayName>
+				<unitPattern count="one">{0} choy qoshiq</unitPattern>
+				<unitPattern count="other">{0} choy qoshiq</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>barrel</displayName>
+				<unitPattern count="one">{0} barrel</unitPattern>
+				<unitPattern count="other">{0} barrel</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>desert qoshiq</displayName>
+				<unitPattern count="one">{0} desert qoshiq</unitPattern>
+				<unitPattern count="other">{0} desert qoshiq</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp desert qoshiq</displayName>
+				<unitPattern count="one">{0} imp desert qoshiq</unitPattern>
+				<unitPattern count="other">{0} imp desert qoshiq</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tomchi</displayName>
+				<unitPattern count="one">{0} tomchi</unitPattern>
+				<unitPattern count="other">{0} tomchi</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>suyuqlik draxmasi</displayName>
+				<unitPattern count="one">{0} suyuqlik draxmasi</unitPattern>
+				<unitPattern count="other">{0} suyuqlik draxmasi</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qadah</displayName>
+				<unitPattern count="one">{0} qadah</unitPattern>
+				<unitPattern count="other">{0} qadah</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>chimdim</displayName>
+				<unitPattern count="one">{0} chimdim</unitPattern>
+				<unitPattern count="other">{0} chimdim</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>imp kvarta</displayName>
+				<unitPattern count="one">{0} imp. kvarta</unitPattern>
+				<unitPattern count="other">{0} imp. kvarta</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>yo‘nalish</displayName>
@@ -9334,16 +9334,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} yoki {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} yoki {1}</listPatternPart>
+			<listPatternPart type="2">{0} yoki {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} yoki {1}</listPatternPart>
+			<listPatternPart type="2">{0} yoki {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -121,7 +121,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">Tiếng Cherokee</language>
 			<language type="chy">Tiếng Cheyenne</language>
 			<language type="ckb">Tiếng Kurd Miền Trung</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">Tiếng Kurd Miền Trung</language>
 			<language type="ckb" alt="variant">Tiếng Kurd Sorani</language>
 			<language type="clc">Tiếng Chilcotin</language>
 			<language type="co">Tiếng Corsica</language>
@@ -1020,7 +1020,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">Nauru</territory>
 			<territory type="NU">Niue</territory>
 			<territory type="NZ">New Zealand</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">New Zealand</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -1080,7 +1080,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">Tunisia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Thổ Nhĩ Kỳ</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Thổ Nhĩ Kỳ</territory>
 			<territory type="TT">Trinidad và Tobago</territory>
 			<territory type="TV">Tuvalu</territory>
 			<territory type="TW">Đài Loan</territory>
@@ -1425,51 +1425,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd-MM-y GGGGG – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd-MM-y GGGGG – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1989,66 +1989,66 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
-						<era type="1" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">ERA0</era>
+						<era type="1" draft="contributed">ERA1</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="contributed">↑↑↑</era>
 						<era type="1" draft="contributed">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
-						<era type="1" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">ERA0</era>
+						<era type="1" draft="contributed">ERA1</era>
 					</eraNarrow>
 				</eras>
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd-MM-y GGGGG – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd-MM-y GGGGG – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2057,126 +2057,126 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
 							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH – HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm a</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm – HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm – HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm a v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm – HH:mm v</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm – HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="a" draft="contributed">h a – h a v</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH – HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M – M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">MMM d–d</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="y" draft="contributed">U – U</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M" draft="contributed">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M" draft="contributed">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">U MMM–MMM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">U MMM – U MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">U MMM d–d</greatestDifference>
+							<greatestDifference id="M" draft="contributed">U MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y" draft="contributed">U MMM d – U MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M" draft="contributed">U MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y" draft="contributed">U MMM d, E – U MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="M" draft="contributed">U MMMM–MMMM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">U MMMM – U MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2280,66 +2280,66 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
-						<era type="1" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">ERA0</era>
+						<era type="1" draft="contributed">ERA1</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="contributed">↑↑↑</era>
 						<era type="1" draft="contributed">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
-						<era type="1" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">ERA0</era>
+						<era type="1" draft="contributed">ERA1</era>
 					</eraNarrow>
 				</eras>
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd-MM-y GGGGG – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd-MM-y GGGGG – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2347,13 +2347,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="ethiopic-amete-alem">
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">ERA0</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="contributed">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">ERA0</era>
 					</eraNarrow>
 				</eras>
 			</calendar>
@@ -3208,20 +3208,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="13" draft="contributed">Elul</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="7" yeartype="leap" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
-							<month type="13" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">1</month>
+							<month type="2" draft="contributed">2</month>
+							<month type="3" draft="contributed">3</month>
+							<month type="4" draft="contributed">4</month>
+							<month type="5" draft="contributed">5</month>
+							<month type="6" draft="contributed">6</month>
+							<month type="7" draft="contributed">7</month>
+							<month type="7" yeartype="leap" draft="contributed">7</month>
+							<month type="8" draft="contributed">8</month>
+							<month type="9" draft="contributed">9</month>
+							<month type="10" draft="contributed">10</month>
+							<month type="11" draft="contributed">11</month>
+							<month type="12" draft="contributed">12</month>
+							<month type="13" draft="contributed">13</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1" draft="contributed">↑↑↑</month>
@@ -3293,63 +3293,63 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">AM</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="contributed">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">AM</era>
 					</eraNarrow>
 				</eras>
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd-MM-y GGGGG – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd-MM-y GGGGG – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3447,63 +3447,63 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">Saka</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="contributed">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">Saka</era>
 					</eraNarrow>
 				</eras>
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd-MM-y GGGGG – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd-MM-y GGGGG – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3526,18 +3526,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12" draft="contributed">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">1</month>
+							<month type="2" draft="contributed">2</month>
+							<month type="3" draft="contributed">3</month>
+							<month type="4" draft="contributed">4</month>
+							<month type="5" draft="contributed">5</month>
+							<month type="6" draft="contributed">6</month>
+							<month type="7" draft="contributed">7</month>
+							<month type="8" draft="contributed">8</month>
+							<month type="9" draft="contributed">9</month>
+							<month type="10" draft="contributed">10</month>
+							<month type="11" draft="contributed">11</month>
+							<month type="12" draft="contributed">12</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1" draft="contributed">↑↑↑</month>
@@ -3556,18 +3556,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Muh.</month>
+							<month type="2" draft="contributed">Saf.</month>
+							<month type="3" draft="contributed">Rab. I</month>
+							<month type="4" draft="contributed">Rab. II</month>
+							<month type="5" draft="contributed">Jum. I</month>
+							<month type="6" draft="contributed">Jum. II</month>
+							<month type="7" draft="contributed">Raj.</month>
+							<month type="8" draft="contributed">Sha.</month>
+							<month type="9" draft="contributed">Ram.</month>
+							<month type="10" draft="contributed">Shaw.</month>
+							<month type="11" draft="contributed">Dhuʻl-Q.</month>
+							<month type="12" draft="contributed">Dhuʻl-H.</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1" draft="contributed">↑↑↑</month>
@@ -3584,18 +3584,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12" draft="contributed">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1" draft="contributed">↑↑↑</month>
-							<month type="2" draft="contributed">↑↑↑</month>
-							<month type="3" draft="contributed">↑↑↑</month>
-							<month type="4" draft="contributed">↑↑↑</month>
-							<month type="5" draft="contributed">↑↑↑</month>
-							<month type="6" draft="contributed">↑↑↑</month>
-							<month type="7" draft="contributed">↑↑↑</month>
-							<month type="8" draft="contributed">↑↑↑</month>
-							<month type="9" draft="contributed">↑↑↑</month>
-							<month type="10" draft="contributed">↑↑↑</month>
-							<month type="11" draft="contributed">↑↑↑</month>
-							<month type="12" draft="contributed">↑↑↑</month>
+							<month type="1" draft="contributed">Muharram</month>
+							<month type="2" draft="contributed">Safar</month>
+							<month type="3" draft="contributed">Rabiʻ I</month>
+							<month type="4" draft="contributed">Rabiʻ II</month>
+							<month type="5" draft="contributed">Jumada I</month>
+							<month type="6" draft="contributed">Jumada II</month>
+							<month type="7" draft="contributed">Rajab</month>
+							<month type="8" draft="contributed">Shaʻban</month>
+							<month type="9" draft="contributed">Ramadan</month>
+							<month type="10" draft="contributed">Shawwal</month>
+							<month type="11" draft="contributed">Dhuʻl-Qiʻdah</month>
+							<month type="12" draft="contributed">Dhuʻl-Hijjah</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -3607,51 +3607,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd-MM-y GGGGG – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd-MM-y GGGGG – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -3659,243 +3659,243 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="japanese">
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
-						<era type="1" draft="contributed">↑↑↑</era>
-						<era type="2" draft="contributed">↑↑↑</era>
-						<era type="3" draft="contributed">↑↑↑</era>
-						<era type="4" draft="contributed">↑↑↑</era>
-						<era type="5" draft="contributed">↑↑↑</era>
-						<era type="6" draft="contributed">↑↑↑</era>
-						<era type="7" draft="contributed">↑↑↑</era>
-						<era type="8" draft="contributed">↑↑↑</era>
-						<era type="9" draft="contributed">↑↑↑</era>
-						<era type="10" draft="contributed">↑↑↑</era>
-						<era type="11" draft="contributed">↑↑↑</era>
-						<era type="12" draft="contributed">↑↑↑</era>
-						<era type="13" draft="contributed">↑↑↑</era>
-						<era type="14" draft="contributed">↑↑↑</era>
-						<era type="15" draft="contributed">↑↑↑</era>
-						<era type="16" draft="contributed">↑↑↑</era>
-						<era type="17" draft="contributed">↑↑↑</era>
-						<era type="18" draft="contributed">↑↑↑</era>
-						<era type="19" draft="contributed">↑↑↑</era>
-						<era type="20" draft="contributed">↑↑↑</era>
-						<era type="21" draft="contributed">↑↑↑</era>
-						<era type="22" draft="contributed">↑↑↑</era>
-						<era type="23" draft="contributed">↑↑↑</era>
-						<era type="24" draft="contributed">↑↑↑</era>
-						<era type="25" draft="contributed">↑↑↑</era>
-						<era type="26" draft="contributed">↑↑↑</era>
-						<era type="27" draft="contributed">↑↑↑</era>
-						<era type="28" draft="contributed">↑↑↑</era>
-						<era type="29" draft="contributed">↑↑↑</era>
-						<era type="30" draft="contributed">↑↑↑</era>
-						<era type="31" draft="contributed">↑↑↑</era>
-						<era type="32" draft="contributed">↑↑↑</era>
-						<era type="33" draft="contributed">↑↑↑</era>
-						<era type="34" draft="contributed">↑↑↑</era>
-						<era type="35" draft="contributed">↑↑↑</era>
-						<era type="36" draft="contributed">↑↑↑</era>
-						<era type="37" draft="contributed">↑↑↑</era>
-						<era type="38" draft="contributed">↑↑↑</era>
-						<era type="39" draft="contributed">↑↑↑</era>
-						<era type="40" draft="contributed">↑↑↑</era>
-						<era type="41" draft="contributed">↑↑↑</era>
-						<era type="42" draft="contributed">↑↑↑</era>
-						<era type="43" draft="contributed">↑↑↑</era>
-						<era type="44" draft="contributed">↑↑↑</era>
-						<era type="45" draft="contributed">↑↑↑</era>
-						<era type="46" draft="contributed">↑↑↑</era>
-						<era type="47" draft="contributed">↑↑↑</era>
-						<era type="48" draft="contributed">↑↑↑</era>
-						<era type="49" draft="contributed">↑↑↑</era>
-						<era type="50" draft="contributed">↑↑↑</era>
-						<era type="51" draft="contributed">↑↑↑</era>
-						<era type="52" draft="contributed">↑↑↑</era>
-						<era type="53" draft="contributed">↑↑↑</era>
-						<era type="54" draft="contributed">↑↑↑</era>
-						<era type="55" draft="contributed">↑↑↑</era>
-						<era type="56" draft="contributed">↑↑↑</era>
-						<era type="57" draft="contributed">↑↑↑</era>
-						<era type="58" draft="contributed">↑↑↑</era>
-						<era type="59" draft="contributed">↑↑↑</era>
-						<era type="60" draft="contributed">↑↑↑</era>
-						<era type="61" draft="contributed">↑↑↑</era>
-						<era type="62" draft="contributed">↑↑↑</era>
-						<era type="63" draft="contributed">↑↑↑</era>
-						<era type="64" draft="contributed">↑↑↑</era>
-						<era type="65" draft="contributed">↑↑↑</era>
-						<era type="66" draft="contributed">↑↑↑</era>
-						<era type="67" draft="contributed">↑↑↑</era>
-						<era type="68" draft="contributed">↑↑↑</era>
-						<era type="69" draft="contributed">↑↑↑</era>
-						<era type="70" draft="contributed">↑↑↑</era>
-						<era type="71" draft="contributed">↑↑↑</era>
-						<era type="72" draft="contributed">↑↑↑</era>
-						<era type="73" draft="contributed">↑↑↑</era>
-						<era type="74" draft="contributed">↑↑↑</era>
-						<era type="75" draft="contributed">↑↑↑</era>
-						<era type="76" draft="contributed">↑↑↑</era>
-						<era type="77" draft="contributed">↑↑↑</era>
-						<era type="78" draft="contributed">↑↑↑</era>
-						<era type="79" draft="contributed">↑↑↑</era>
-						<era type="80" draft="contributed">↑↑↑</era>
-						<era type="81" draft="contributed">↑↑↑</era>
-						<era type="82" draft="contributed">↑↑↑</era>
-						<era type="83" draft="contributed">↑↑↑</era>
-						<era type="84" draft="contributed">↑↑↑</era>
-						<era type="85" draft="contributed">↑↑↑</era>
-						<era type="86" draft="contributed">↑↑↑</era>
-						<era type="87" draft="contributed">↑↑↑</era>
-						<era type="88" draft="contributed">↑↑↑</era>
-						<era type="89" draft="contributed">↑↑↑</era>
-						<era type="90" draft="contributed">↑↑↑</era>
-						<era type="91" draft="contributed">↑↑↑</era>
-						<era type="92" draft="contributed">↑↑↑</era>
-						<era type="93" draft="contributed">↑↑↑</era>
-						<era type="94" draft="contributed">↑↑↑</era>
-						<era type="95" draft="contributed">↑↑↑</era>
-						<era type="96" draft="contributed">↑↑↑</era>
-						<era type="97" draft="contributed">↑↑↑</era>
-						<era type="98" draft="contributed">↑↑↑</era>
-						<era type="99" draft="contributed">↑↑↑</era>
-						<era type="100" draft="contributed">↑↑↑</era>
-						<era type="101" draft="contributed">↑↑↑</era>
-						<era type="102" draft="contributed">↑↑↑</era>
-						<era type="103" draft="contributed">↑↑↑</era>
-						<era type="104" draft="contributed">↑↑↑</era>
-						<era type="105" draft="contributed">↑↑↑</era>
-						<era type="106" draft="contributed">↑↑↑</era>
-						<era type="107" draft="contributed">↑↑↑</era>
-						<era type="108" draft="contributed">↑↑↑</era>
-						<era type="109" draft="contributed">↑↑↑</era>
-						<era type="110" draft="contributed">↑↑↑</era>
-						<era type="111" draft="contributed">↑↑↑</era>
-						<era type="112" draft="contributed">↑↑↑</era>
-						<era type="113" draft="contributed">↑↑↑</era>
-						<era type="114" draft="contributed">↑↑↑</era>
-						<era type="115" draft="contributed">↑↑↑</era>
-						<era type="116" draft="contributed">↑↑↑</era>
-						<era type="117" draft="contributed">↑↑↑</era>
-						<era type="118" draft="contributed">↑↑↑</era>
-						<era type="119" draft="contributed">↑↑↑</era>
-						<era type="120" draft="contributed">↑↑↑</era>
-						<era type="121" draft="contributed">↑↑↑</era>
-						<era type="122" draft="contributed">↑↑↑</era>
-						<era type="123" draft="contributed">↑↑↑</era>
-						<era type="124" draft="contributed">↑↑↑</era>
-						<era type="125" draft="contributed">↑↑↑</era>
-						<era type="126" draft="contributed">↑↑↑</era>
-						<era type="127" draft="contributed">↑↑↑</era>
-						<era type="128" draft="contributed">↑↑↑</era>
-						<era type="129" draft="contributed">↑↑↑</era>
-						<era type="130" draft="contributed">↑↑↑</era>
-						<era type="131" draft="contributed">↑↑↑</era>
-						<era type="132" draft="contributed">↑↑↑</era>
-						<era type="133" draft="contributed">↑↑↑</era>
-						<era type="134" draft="contributed">↑↑↑</era>
-						<era type="135" draft="contributed">↑↑↑</era>
-						<era type="136" draft="contributed">↑↑↑</era>
-						<era type="137" draft="contributed">↑↑↑</era>
-						<era type="138" draft="contributed">↑↑↑</era>
-						<era type="139" draft="contributed">↑↑↑</era>
-						<era type="140" draft="contributed">↑↑↑</era>
-						<era type="141" draft="contributed">↑↑↑</era>
-						<era type="142" draft="contributed">↑↑↑</era>
-						<era type="143" draft="contributed">↑↑↑</era>
-						<era type="144" draft="contributed">↑↑↑</era>
-						<era type="145" draft="contributed">↑↑↑</era>
-						<era type="146" draft="contributed">↑↑↑</era>
-						<era type="147" draft="contributed">↑↑↑</era>
-						<era type="148" draft="contributed">↑↑↑</era>
-						<era type="149" draft="contributed">↑↑↑</era>
-						<era type="150" draft="contributed">↑↑↑</era>
-						<era type="151" draft="contributed">↑↑↑</era>
-						<era type="152" draft="contributed">↑↑↑</era>
-						<era type="153" draft="contributed">↑↑↑</era>
-						<era type="154" draft="contributed">↑↑↑</era>
-						<era type="155" draft="contributed">↑↑↑</era>
-						<era type="156" draft="contributed">↑↑↑</era>
-						<era type="157" draft="contributed">↑↑↑</era>
-						<era type="158" draft="contributed">↑↑↑</era>
-						<era type="159" draft="contributed">↑↑↑</era>
-						<era type="160" draft="contributed">↑↑↑</era>
-						<era type="161" draft="contributed">↑↑↑</era>
-						<era type="162" draft="contributed">↑↑↑</era>
-						<era type="163" draft="contributed">↑↑↑</era>
-						<era type="164" draft="contributed">↑↑↑</era>
-						<era type="165" draft="contributed">↑↑↑</era>
-						<era type="166" draft="contributed">↑↑↑</era>
-						<era type="167" draft="contributed">↑↑↑</era>
-						<era type="168" draft="contributed">↑↑↑</era>
-						<era type="169" draft="contributed">↑↑↑</era>
-						<era type="170" draft="contributed">↑↑↑</era>
-						<era type="171" draft="contributed">↑↑↑</era>
-						<era type="172" draft="contributed">↑↑↑</era>
-						<era type="173" draft="contributed">↑↑↑</era>
-						<era type="174" draft="contributed">↑↑↑</era>
-						<era type="175" draft="contributed">↑↑↑</era>
-						<era type="176" draft="contributed">↑↑↑</era>
-						<era type="177" draft="contributed">↑↑↑</era>
-						<era type="178" draft="contributed">↑↑↑</era>
-						<era type="179" draft="contributed">↑↑↑</era>
-						<era type="180" draft="contributed">↑↑↑</era>
-						<era type="181" draft="contributed">↑↑↑</era>
-						<era type="182" draft="contributed">↑↑↑</era>
-						<era type="183" draft="contributed">↑↑↑</era>
-						<era type="184" draft="contributed">↑↑↑</era>
-						<era type="185" draft="contributed">↑↑↑</era>
-						<era type="186" draft="contributed">↑↑↑</era>
-						<era type="187" draft="contributed">↑↑↑</era>
-						<era type="188" draft="contributed">↑↑↑</era>
-						<era type="189" draft="contributed">↑↑↑</era>
-						<era type="190" draft="contributed">↑↑↑</era>
-						<era type="191" draft="contributed">↑↑↑</era>
-						<era type="192" draft="contributed">↑↑↑</era>
-						<era type="193" draft="contributed">↑↑↑</era>
-						<era type="194" draft="contributed">↑↑↑</era>
-						<era type="195" draft="contributed">↑↑↑</era>
-						<era type="196" draft="contributed">↑↑↑</era>
-						<era type="197" draft="contributed">↑↑↑</era>
-						<era type="198" draft="contributed">↑↑↑</era>
-						<era type="199" draft="contributed">↑↑↑</era>
-						<era type="200" draft="contributed">↑↑↑</era>
-						<era type="201" draft="contributed">↑↑↑</era>
-						<era type="202" draft="contributed">↑↑↑</era>
-						<era type="203" draft="contributed">↑↑↑</era>
-						<era type="204" draft="contributed">↑↑↑</era>
-						<era type="205" draft="contributed">↑↑↑</era>
-						<era type="206" draft="contributed">↑↑↑</era>
-						<era type="207" draft="contributed">↑↑↑</era>
-						<era type="208" draft="contributed">↑↑↑</era>
-						<era type="209" draft="contributed">↑↑↑</era>
-						<era type="210" draft="contributed">↑↑↑</era>
-						<era type="211" draft="contributed">↑↑↑</era>
-						<era type="212" draft="contributed">↑↑↑</era>
-						<era type="213" draft="contributed">↑↑↑</era>
-						<era type="214" draft="contributed">↑↑↑</era>
-						<era type="215" draft="contributed">↑↑↑</era>
-						<era type="216" draft="contributed">↑↑↑</era>
-						<era type="217" draft="contributed">↑↑↑</era>
-						<era type="218" draft="contributed">↑↑↑</era>
-						<era type="219" draft="contributed">↑↑↑</era>
-						<era type="220" draft="contributed">↑↑↑</era>
-						<era type="221" draft="contributed">↑↑↑</era>
-						<era type="222" draft="contributed">↑↑↑</era>
-						<era type="223" draft="contributed">↑↑↑</era>
-						<era type="224" draft="contributed">↑↑↑</era>
-						<era type="225" draft="contributed">↑↑↑</era>
-						<era type="226" draft="contributed">↑↑↑</era>
-						<era type="227" draft="contributed">↑↑↑</era>
-						<era type="228" draft="contributed">↑↑↑</era>
-						<era type="229" draft="contributed">↑↑↑</era>
-						<era type="230" draft="contributed">↑↑↑</era>
-						<era type="231" draft="contributed">↑↑↑</era>
-						<era type="232" draft="contributed">↑↑↑</era>
-						<era type="233" draft="contributed">↑↑↑</era>
-						<era type="234" draft="contributed">↑↑↑</era>
-						<era type="235" draft="contributed">↑↑↑</era>
-						<era type="236" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">Taika (645–650)</era>
+						<era type="1" draft="contributed">Hakuchi (650–671)</era>
+						<era type="2" draft="contributed">Hakuhō (672–686)</era>
+						<era type="3" draft="contributed">Shuchō (686–701)</era>
+						<era type="4" draft="contributed">Taihō (701–704)</era>
+						<era type="5" draft="contributed">Keiun (704–708)</era>
+						<era type="6" draft="contributed">Wadō (708–715)</era>
+						<era type="7" draft="contributed">Reiki (715–717)</era>
+						<era type="8" draft="contributed">Yōrō (717–724)</era>
+						<era type="9" draft="contributed">Jinki (724–729)</era>
+						<era type="10" draft="contributed">Tenpyō (729–749)</era>
+						<era type="11" draft="contributed">Tenpyō-kampō (749–749)</era>
+						<era type="12" draft="contributed">Tenpyō-shōhō (749–757)</era>
+						<era type="13" draft="contributed">Tenpyō-hōji (757–765)</era>
+						<era type="14" draft="contributed">Tenpyō-jingo (765–767)</era>
+						<era type="15" draft="contributed">Jingo-keiun (767–770)</era>
+						<era type="16" draft="contributed">Hōki (770–780)</era>
+						<era type="17" draft="contributed">Ten-ō (781–782)</era>
+						<era type="18" draft="contributed">Enryaku (782–806)</era>
+						<era type="19" draft="contributed">Daidō (806–810)</era>
+						<era type="20" draft="contributed">Kōnin (810–824)</era>
+						<era type="21" draft="contributed">Tenchō (824–834)</era>
+						<era type="22" draft="contributed">Jōwa (834–848)</era>
+						<era type="23" draft="contributed">Kajō (848–851)</era>
+						<era type="24" draft="contributed">Ninju (851–854)</era>
+						<era type="25" draft="contributed">Saikō (854–857)</era>
+						<era type="26" draft="contributed">Ten-an (857–859)</era>
+						<era type="27" draft="contributed">Jōgan (859–877)</era>
+						<era type="28" draft="contributed">Gangyō (877–885)</era>
+						<era type="29" draft="contributed">Ninna (885–889)</era>
+						<era type="30" draft="contributed">Kanpyō (889–898)</era>
+						<era type="31" draft="contributed">Shōtai (898–901)</era>
+						<era type="32" draft="contributed">Engi (901–923)</era>
+						<era type="33" draft="contributed">Enchō (923–931)</era>
+						<era type="34" draft="contributed">Jōhei (931–938)</era>
+						<era type="35" draft="contributed">Tengyō (938–947)</era>
+						<era type="36" draft="contributed">Tenryaku (947–957)</era>
+						<era type="37" draft="contributed">Tentoku (957–961)</era>
+						<era type="38" draft="contributed">Ōwa (961–964)</era>
+						<era type="39" draft="contributed">Kōhō (964–968)</era>
+						<era type="40" draft="contributed">Anna (968–970)</era>
+						<era type="41" draft="contributed">Tenroku (970–973)</era>
+						<era type="42" draft="contributed">Ten’en (973–976)</era>
+						<era type="43" draft="contributed">Jōgen (976–978)</era>
+						<era type="44" draft="contributed">Tengen (978–983)</era>
+						<era type="45" draft="contributed">Eikan (983–985)</era>
+						<era type="46" draft="contributed">Kanna (985–987)</era>
+						<era type="47" draft="contributed">Eien (987–989)</era>
+						<era type="48" draft="contributed">Eiso (989–990)</era>
+						<era type="49" draft="contributed">Shōryaku (990–995)</era>
+						<era type="50" draft="contributed">Chōtoku (995–999)</era>
+						<era type="51" draft="contributed">Chōhō (999–1004)</era>
+						<era type="52" draft="contributed">Kankō (1004–1012)</era>
+						<era type="53" draft="contributed">Chōwa (1012–1017)</era>
+						<era type="54" draft="contributed">Kannin (1017–1021)</era>
+						<era type="55" draft="contributed">Jian (1021–1024)</era>
+						<era type="56" draft="contributed">Manju (1024–1028)</era>
+						<era type="57" draft="contributed">Chōgen (1028–1037)</era>
+						<era type="58" draft="contributed">Chōryaku (1037–1040)</era>
+						<era type="59" draft="contributed">Chōkyū (1040–1044)</era>
+						<era type="60" draft="contributed">Kantoku (1044–1046)</era>
+						<era type="61" draft="contributed">Eishō (1046–1053)</era>
+						<era type="62" draft="contributed">Tengi (1053–1058)</era>
+						<era type="63" draft="contributed">Kōhei (1058–1065)</era>
+						<era type="64" draft="contributed">Jiryaku (1065–1069)</era>
+						<era type="65" draft="contributed">Enkyū (1069–1074)</era>
+						<era type="66" draft="contributed">Shōho (1074–1077)</era>
+						<era type="67" draft="contributed">Shōryaku (1077–1081)</era>
+						<era type="68" draft="contributed">Eihō (1081–1084)</era>
+						<era type="69" draft="contributed">Ōtoku (1084–1087)</era>
+						<era type="70" draft="contributed">Kanji (1087–1094)</era>
+						<era type="71" draft="contributed">Kahō (1094–1096)</era>
+						<era type="72" draft="contributed">Eichō (1096–1097)</era>
+						<era type="73" draft="contributed">Jōtoku (1097–1099)</era>
+						<era type="74" draft="contributed">Kōwa (1099–1104)</era>
+						<era type="75" draft="contributed">Chōji (1104–1106)</era>
+						<era type="76" draft="contributed">Kashō (1106–1108)</era>
+						<era type="77" draft="contributed">Tennin (1108–1110)</era>
+						<era type="78" draft="contributed">Ten-ei (1110–1113)</era>
+						<era type="79" draft="contributed">Eikyū (1113–1118)</era>
+						<era type="80" draft="contributed">Gen’ei (1118–1120)</era>
+						<era type="81" draft="contributed">Hōan (1120–1124)</era>
+						<era type="82" draft="contributed">Tenji (1124–1126)</era>
+						<era type="83" draft="contributed">Daiji (1126–1131)</era>
+						<era type="84" draft="contributed">Tenshō (1131–1132)</era>
+						<era type="85" draft="contributed">Chōshō (1132–1135)</era>
+						<era type="86" draft="contributed">Hōen (1135–1141)</era>
+						<era type="87" draft="contributed">Eiji (1141–1142)</era>
+						<era type="88" draft="contributed">Kōji (1142–1144)</era>
+						<era type="89" draft="contributed">Ten’yō (1144–1145)</era>
+						<era type="90" draft="contributed">Kyūan (1145–1151)</era>
+						<era type="91" draft="contributed">Ninpei (1151–1154)</era>
+						<era type="92" draft="contributed">Kyūju (1154–1156)</era>
+						<era type="93" draft="contributed">Hōgen (1156–1159)</era>
+						<era type="94" draft="contributed">Heiji (1159–1160)</era>
+						<era type="95" draft="contributed">Eiryaku (1160–1161)</era>
+						<era type="96" draft="contributed">Ōho (1161–1163)</era>
+						<era type="97" draft="contributed">Chōkan (1163–1165)</era>
+						<era type="98" draft="contributed">Eiman (1165–1166)</era>
+						<era type="99" draft="contributed">Nin’an (1166–1169)</era>
+						<era type="100" draft="contributed">Kaō (1169–1171)</era>
+						<era type="101" draft="contributed">Shōan (1171–1175)</era>
+						<era type="102" draft="contributed">Angen (1175–1177)</era>
+						<era type="103" draft="contributed">Jishō (1177–1181)</era>
+						<era type="104" draft="contributed">Yōwa (1181–1182)</era>
+						<era type="105" draft="contributed">Juei (1182–1184)</era>
+						<era type="106" draft="contributed">Genryaku (1184–1185)</era>
+						<era type="107" draft="contributed">Bunji (1185–1190)</era>
+						<era type="108" draft="contributed">Kenkyū (1190–1199)</era>
+						<era type="109" draft="contributed">Shōji (1199–1201)</era>
+						<era type="110" draft="contributed">Kennin (1201–1204)</era>
+						<era type="111" draft="contributed">Genkyū (1204–1206)</era>
+						<era type="112" draft="contributed">Ken’ei (1206–1207)</era>
+						<era type="113" draft="contributed">Jōgen (1207–1211)</era>
+						<era type="114" draft="contributed">Kenryaku (1211–1213)</era>
+						<era type="115" draft="contributed">Kenpō (1213–1219)</era>
+						<era type="116" draft="contributed">Jōkyū (1219–1222)</era>
+						<era type="117" draft="contributed">Jōō (1222–1224)</era>
+						<era type="118" draft="contributed">Gennin (1224–1225)</era>
+						<era type="119" draft="contributed">Karoku (1225–1227)</era>
+						<era type="120" draft="contributed">Antei (1227–1229)</era>
+						<era type="121" draft="contributed">Kanki (1229–1232)</era>
+						<era type="122" draft="contributed">Jōei (1232–1233)</era>
+						<era type="123" draft="contributed">Tenpuku (1233–1234)</era>
+						<era type="124" draft="contributed">Bunryaku (1234–1235)</era>
+						<era type="125" draft="contributed">Katei (1235–1238)</era>
+						<era type="126" draft="contributed">Ryakunin (1238–1239)</era>
+						<era type="127" draft="contributed">En’ō (1239–1240)</era>
+						<era type="128" draft="contributed">Ninji (1240–1243)</era>
+						<era type="129" draft="contributed">Kangen (1243–1247)</era>
+						<era type="130" draft="contributed">Hōji (1247–1249)</era>
+						<era type="131" draft="contributed">Kenchō (1249–1256)</era>
+						<era type="132" draft="contributed">Kōgen (1256–1257)</era>
+						<era type="133" draft="contributed">Shōka (1257–1259)</era>
+						<era type="134" draft="contributed">Shōgen (1259–1260)</era>
+						<era type="135" draft="contributed">Bun’ō (1260–1261)</era>
+						<era type="136" draft="contributed">Kōchō (1261–1264)</era>
+						<era type="137" draft="contributed">Bun’ei (1264–1275)</era>
+						<era type="138" draft="contributed">Kenji (1275–1278)</era>
+						<era type="139" draft="contributed">Kōan (1278–1288)</era>
+						<era type="140" draft="contributed">Shōō (1288–1293)</era>
+						<era type="141" draft="contributed">Einin (1293–1299)</era>
+						<era type="142" draft="contributed">Shōan (1299–1302)</era>
+						<era type="143" draft="contributed">Kengen (1302–1303)</era>
+						<era type="144" draft="contributed">Kagen (1303–1306)</era>
+						<era type="145" draft="contributed">Tokuji (1306–1308)</era>
+						<era type="146" draft="contributed">Enkyō (1308–1311)</era>
+						<era type="147" draft="contributed">Ōchō (1311–1312)</era>
+						<era type="148" draft="contributed">Shōwa (1312–1317)</era>
+						<era type="149" draft="contributed">Bunpō (1317–1319)</era>
+						<era type="150" draft="contributed">Genō (1319–1321)</era>
+						<era type="151" draft="contributed">Genkō (1321–1324)</era>
+						<era type="152" draft="contributed">Shōchū (1324–1326)</era>
+						<era type="153" draft="contributed">Karyaku (1326–1329)</era>
+						<era type="154" draft="contributed">Gentoku (1329–1331)</era>
+						<era type="155" draft="contributed">Genkō (1331–1334)</era>
+						<era type="156" draft="contributed">Kenmu (1334–1336)</era>
+						<era type="157" draft="contributed">Engen (1336–1340)</era>
+						<era type="158" draft="contributed">Kōkoku (1340–1346)</era>
+						<era type="159" draft="contributed">Shōhei (1346–1370)</era>
+						<era type="160" draft="contributed">Kentoku (1370–1372)</era>
+						<era type="161" draft="contributed">Bunchū (1372–1375)</era>
+						<era type="162" draft="contributed">Tenju (1375–1379)</era>
+						<era type="163" draft="contributed">Kōryaku (1379–1381)</era>
+						<era type="164" draft="contributed">Kōwa (1381–1384)</era>
+						<era type="165" draft="contributed">Genchū (1384–1392)</era>
+						<era type="166" draft="contributed">Meitoku (1384–1387)</era>
+						<era type="167" draft="contributed">Kakei (1387–1389)</era>
+						<era type="168" draft="contributed">Kōō (1389–1390)</era>
+						<era type="169" draft="contributed">Meitoku (1390–1394)</era>
+						<era type="170" draft="contributed">Ōei (1394–1428)</era>
+						<era type="171" draft="contributed">Shōchō (1428–1429)</era>
+						<era type="172" draft="contributed">Eikyō (1429–1441)</era>
+						<era type="173" draft="contributed">Kakitsu (1441–1444)</era>
+						<era type="174" draft="contributed">Bun’an (1444–1449)</era>
+						<era type="175" draft="contributed">Hōtoku (1449–1452)</era>
+						<era type="176" draft="contributed">Kyōtoku (1452–1455)</era>
+						<era type="177" draft="contributed">Kōshō (1455–1457)</era>
+						<era type="178" draft="contributed">Chōroku (1457–1460)</era>
+						<era type="179" draft="contributed">Kanshō (1460–1466)</era>
+						<era type="180" draft="contributed">Bunshō (1466–1467)</era>
+						<era type="181" draft="contributed">Ōnin (1467–1469)</era>
+						<era type="182" draft="contributed">Bunmei (1469–1487)</era>
+						<era type="183" draft="contributed">Chōkyō (1487–1489)</era>
+						<era type="184" draft="contributed">Entoku (1489–1492)</era>
+						<era type="185" draft="contributed">Meiō (1492–1501)</era>
+						<era type="186" draft="contributed">Bunki (1501–1504)</era>
+						<era type="187" draft="contributed">Eishō (1504–1521)</era>
+						<era type="188" draft="contributed">Taiei (1521–1528)</era>
+						<era type="189" draft="contributed">Kyōroku (1528–1532)</era>
+						<era type="190" draft="contributed">Tenbun (1532–1555)</era>
+						<era type="191" draft="contributed">Kōji (1555–1558)</era>
+						<era type="192" draft="contributed">Eiroku (1558–1570)</era>
+						<era type="193" draft="contributed">Genki (1570–1573)</era>
+						<era type="194" draft="contributed">Tenshō (1573–1592)</era>
+						<era type="195" draft="contributed">Bunroku (1592–1596)</era>
+						<era type="196" draft="contributed">Keichō (1596–1615)</era>
+						<era type="197" draft="contributed">Genna (1615–1624)</era>
+						<era type="198" draft="contributed">Kan’ei (1624–1644)</era>
+						<era type="199" draft="contributed">Shōho (1644–1648)</era>
+						<era type="200" draft="contributed">Keian (1648–1652)</era>
+						<era type="201" draft="contributed">Jōō (1652–1655)</era>
+						<era type="202" draft="contributed">Meireki (1655–1658)</era>
+						<era type="203" draft="contributed">Manji (1658–1661)</era>
+						<era type="204" draft="contributed">Kanbun (1661–1673)</era>
+						<era type="205" draft="contributed">Enpō (1673–1681)</era>
+						<era type="206" draft="contributed">Tenna (1681–1684)</era>
+						<era type="207" draft="contributed">Jōkyō (1684–1688)</era>
+						<era type="208" draft="contributed">Genroku (1688–1704)</era>
+						<era type="209" draft="contributed">Hōei (1704–1711)</era>
+						<era type="210" draft="contributed">Shōtoku (1711–1716)</era>
+						<era type="211" draft="contributed">Kyōhō (1716–1736)</era>
+						<era type="212" draft="contributed">Genbun (1736–1741)</era>
+						<era type="213" draft="contributed">Kanpō (1741–1744)</era>
+						<era type="214" draft="contributed">Enkyō (1744–1748)</era>
+						<era type="215" draft="contributed">Kan’en (1748–1751)</era>
+						<era type="216" draft="contributed">Hōreki (1751–1764)</era>
+						<era type="217" draft="contributed">Meiwa (1764–1772)</era>
+						<era type="218" draft="contributed">An’ei (1772–1781)</era>
+						<era type="219" draft="contributed">Tenmei (1781–1789)</era>
+						<era type="220" draft="contributed">Kansei (1789–1801)</era>
+						<era type="221" draft="contributed">Kyōwa (1801–1804)</era>
+						<era type="222" draft="contributed">Bunka (1804–1818)</era>
+						<era type="223" draft="contributed">Bunsei (1818–1830)</era>
+						<era type="224" draft="contributed">Tenpō (1830–1844)</era>
+						<era type="225" draft="contributed">Kōka (1844–1848)</era>
+						<era type="226" draft="contributed">Kaei (1848–1854)</era>
+						<era type="227" draft="contributed">Ansei (1854–1860)</era>
+						<era type="228" draft="contributed">Man’en (1860–1861)</era>
+						<era type="229" draft="contributed">Bunkyū (1861–1864)</era>
+						<era type="230" draft="contributed">Genji (1864–1865)</era>
+						<era type="231" draft="contributed">Keiō (1865–1868)</era>
+						<era type="232" draft="contributed">Meiji</era>
+						<era type="233" draft="contributed">Taishō</era>
+						<era type="234" draft="contributed">Shōwa</era>
+						<era type="235" draft="contributed">Heisei</era>
+						<era type="236" draft="contributed">Reiwa</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="contributed">↑↑↑</era>
@@ -4405,51 +4405,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd-MM-y GGGGG – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd-MM-y GGGGG – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4547,63 +4547,63 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">AP</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0" draft="contributed">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">AP</era>
 					</eraNarrow>
 				</eras>
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd-MM-y GGGGG – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd-MM-y GGGGG – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4631,51 +4631,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h B – h B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h – h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h" draft="contributed">h:mm – h:mm B</greatestDifference>
+							<greatestDifference id="m" draft="contributed">h:mm – h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">y G – y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">M/y GGGGG – M/y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">M/y – M/y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">M/y – M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">dd-MM-y GGGGG – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">dd-MM-y – dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, dd-MM-y GGGGG – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, dd-MM-y – E, dd-MM-y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">d – d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">d MMM y G – d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">d MMM – d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">d MMM y – d MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="contributed">E, d MMM y G – E, d MMM y G</greatestDifference>
+							<greatestDifference id="M" draft="contributed">E, d MMM – E, d MMM y G</greatestDifference>
+							<greatestDifference id="y" draft="contributed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -4878,9 +4878,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-narrow">
 				<displayName>Ngày</displayName>
 				<relative type="-2" draft="contributed">Hôm kia</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">hôm qua</relative>
+				<relative type="0">hôm nay</relative>
+				<relative type="1">ngày mai</relative>
 				<relative type="2" draft="contributed">Ngày kia</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">sau {0} ngày nữa</relativeTimePattern>
@@ -7687,7 +7687,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -8672,7 +8672,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="RUR">
 				<displayName draft="contributed">Đồng Rúp Nga (1991–1998)</displayName>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">RUR</symbol>
 			</currency>
 			<currency type="RWF">
 				<displayName>Franc Rwanda</displayName>
@@ -9078,7 +9078,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>mili{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
 				<unitPrefixPattern>nano{0}</unitPrefixPattern>
@@ -9153,7 +9153,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>yobi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="other">{0} vuông</compoundUnitPattern1>
@@ -9162,15 +9162,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0} khối</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>lực g</displayName>
 				<unitPattern count="other">{0} lực g</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>vòng</displayName>
@@ -9195,7 +9195,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-kilometer">
 				<displayName>kilômét vuông</displayName>
 				<unitPattern count="other">{0} kilômét vuông</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>héc-ta</displayName>
@@ -9204,17 +9204,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-meter">
 				<displayName>mét vuông</displayName>
 				<unitPattern count="other">{0} mét vuông</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>xentimét vuông</displayName>
 				<unitPattern count="other">{0} xentimét vuông</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>dặm vuông</displayName>
 				<unitPattern count="other">{0} dặm vuông</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>mẫu</displayName>
@@ -9231,31 +9231,31 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-inch">
 				<displayName>inch vuông</displayName>
 				<unitPattern count="other">{0} inch vuông</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>carat</displayName>
 				<unitPattern count="other">{0} carat</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>mục</displayName>
 				<unitPattern count="other">{0} mục</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
@@ -9266,7 +9266,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>phần vạn</displayName>
 				<unitPattern count="other">{0} phần vạn</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
@@ -9287,11 +9287,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
 				<displayName>dặm/galông Anh</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>petabyte</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
 				<displayName>terabyte</displayName>
@@ -9326,12 +9326,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kilobit</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>byte</displayName>
+				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>thế kỷ</displayName>
@@ -9454,28 +9454,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} newton</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pixel</displayName>
@@ -9512,12 +9512,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-kilometer">
 				<displayName>kilômét</displayName>
 				<unitPattern count="other">{0} kilômét</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>mét</displayName>
 				<unitPattern count="other">{0} mét</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>đềximét</displayName>
@@ -9526,7 +9526,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-centimeter">
 				<displayName>xentimét</displayName>
 				<unitPattern count="other">{0} xentimét</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>milimét</displayName>
@@ -9555,7 +9555,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-foot">
 				<displayName>feet</displayName>
 				<unitPattern count="other">{0} feet</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>inch</displayName>
@@ -9575,12 +9575,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} đơn vị thiên văn</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>hải lý</displayName>
@@ -9621,7 +9621,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="mass-kilogram">
 				<displayName>kilôgam</displayName>
 				<unitPattern count="other">{0} kilôgam</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>gam</displayName>
@@ -9641,13 +9641,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} tấn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>pao</displayName>
 				<unitPattern count="other">{0} pao</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>aoxơ</displayName>
@@ -9715,8 +9715,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inch thủy ngân</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>millibar</displayName>
@@ -9727,20 +9727,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} átmốtphe</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>héctô pascal</displayName>
 				<unitPattern count="other">{0} héctô pascal</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>kilômét/giờ</displayName>
@@ -9759,8 +9759,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hải lý/giờ</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>độ C</displayName>
@@ -9789,12 +9789,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-cubic-meter">
 				<displayName>mét khối</displayName>
 				<unitPattern count="other">{0} mét khối</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>xentimét khối</displayName>
 				<unitPattern count="other">{0} xentimét khối</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>dặm khối</displayName>
@@ -9823,7 +9823,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-liter">
 				<displayName>lít</displayName>
 				<unitPattern count="other">{0} lít</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>đềxilít</displayName>
@@ -9846,12 +9846,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} cup khối</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>gallon</displayName>
@@ -9873,7 +9873,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cup">
 				<displayName>tách</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} tách</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<displayName>aoxơ chất lỏng</displayName>
@@ -10284,8 +10284,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>↑↑↑</displayName>
@@ -10799,64 +10799,64 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
@@ -10883,777 +10883,777 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>lực g</displayName>
 				<unitPattern count="other">{0}G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>vòng</displayName>
+				<unitPattern count="other">{0} vòng</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>độ</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>phút</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>giây</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>ha</displayName>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>mẫu</displayName>
 				<unitPattern count="other">{0} mẫu</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mục</displayName>
+				<unitPattern count="other">{0} mục</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">‰</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>‱</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>l/km</displayName>
+				<unitPattern count="other">{0} l/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>l/100km</displayName>
 				<unitPattern count="other">{0} l/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName draft="contributed">PB</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName draft="contributed">B</displayName>
 				<unitPattern count="other" draft="contributed">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thế kỷ</displayName>
+				<unitPattern count="other">{0} thế kỷ</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thập kỷ</displayName>
+				<unitPattern count="other">{0} thập kỷ</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>năm</displayName>
 				<unitPattern count="other">{0} năm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/năm</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName draft="contributed">quý</displayName>
+				<unitPattern count="other" draft="contributed">{0} qúy</unitPattern>
+				<perUnitPattern>{0}/quý</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>tháng</displayName>
 				<unitPattern count="other">{0} tháng</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/tháng</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>tuần</displayName>
 				<unitPattern count="other">{0} tuần</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/tuần</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>ngày</displayName>
 				<unitPattern count="other">{0} ngày</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ngày</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>giờ</displayName>
 				<unitPattern count="other">{0} giờ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/giờ</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>phút</displayName>
 				<unitPattern count="other">{0} phút</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/phút</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>giây</displayName>
 				<unitPattern count="other">{0} giây</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/giây</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>mili giây</displayName>
 				<unitPattern count="other">{0}miligiây</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nano giây</displayName>
+				<unitPattern count="other">{0} nano giây</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>A</displayName>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Ω</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>v</displayName>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>J</displayName>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>eV</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>therm Mỹ</displayName>
+				<unitPattern count="other">{0} therm Mỹ</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>lbf</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>N</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName draft="contributed">MPMM</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>chấm</displayName>
+				<unitPattern count="other">{0} chấm</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="other">{0}km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="other">{0}m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="other">{0}cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
 				<unitPattern count="other">{0}mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>pm</displayName>
 				<unitPattern count="other">{0}pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>dặm</displayName>
 				<unitPattern count="other">{0}mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd</displayName>
 				<unitPattern count="other">{0}yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft</displayName>
 				<unitPattern count="other">{0}'</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>inch</displayName>
 				<unitPattern count="other">{0}&quot;</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>ly</displayName>
 				<unitPattern count="other">{0}ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>đ</displayName>
+				<unitPattern count="other">{0} đ</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>R☉</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>L☉</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName draft="contributed">lb</displayName>
 				<unitPattern count="other">{0}lb</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="other">{0}oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ozt</displayName>
+				<unitPattern count="other">{0} ozt</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cara</displayName>
+				<unitPattern count="other">{0} CT</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>Da</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>M⊕</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>M☉</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gren</displayName>
+				<unitPattern count="other">{0} gren</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>W</displayName>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="other">{0}&quot; Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>km/h</displayName>
 				<unitPattern count="other">{0}km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">m/s</displayName>
 				<unitPattern count="other">{0}m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/h</displayName>
 				<unitPattern count="other">{0}mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">yd³</displayName>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
 				<unitPattern count="other">{0}L</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other" draft="contributed">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="other">{0} gal</unitPattern>
 				<perUnitPattern draft="contributed">{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal Anh</displayName>
+				<unitPattern count="other">{0} gal Anh</unitPattern>
+				<perUnitPattern>{0}/gal Anh</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c</displayName>
+				<unitPattern count="other">{0} tách</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz Anh</displayName>
 				<unitPattern count="other">{0} fl ozIm</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thìa xúp</displayName>
+				<unitPattern count="other">{0} thìa xúp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
 				<displayName draft="contributed">thìa cà phê</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} thìa cà phê</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thùng</displayName>
+				<unitPattern count="other">{0} thùng</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName draft="contributed">thìa tráng miệng</displayName>
+				<unitPattern count="other">{0} thìa tm</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>thìa tráng miệng Anh</displayName>
+				<unitPattern count="other">{0} thìa tm Anh</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>giọt</displayName>
+				<unitPattern count="other">{0} giọt</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram chất lỏng</displayName>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>nhúm</displayName>
+				<unitPattern count="other" draft="contributed">{0} nhúm</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lít Anh</displayName>
+				<unitPattern count="other">{0} lít Anh</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>hướng</displayName>
@@ -11687,16 +11687,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} hoặc {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} hoặc {1}</listPatternPart>
+			<listPatternPart type="2">{0} hoặc {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} hoặc {1}</listPatternPart>
+			<listPatternPart type="2">{0} hoặc {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
 			<listPatternPart type="start">{0}, {1}</listPatternPart>
@@ -11705,16 +11705,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} và {1}</listPatternPart>
 			<listPatternPart type="2">{0} và {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
 			<listPatternPart type="start">{0} {1}</listPatternPart>
@@ -11723,8 +11723,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>

--- a/common/main/wo.xml
+++ b/common/main/wo.xml
@@ -179,7 +179,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="yi">Yidis</language>
 			<language type="yo">Yoruba</language>
 			<language type="zh">Sinuwaa</language>
-			<language type="zh" alt="menu">↑↑↑</language>
+			<language type="zh" alt="menu">Sinuwaa</language>
 			<language type="zh_Hans">Sinuwaa buñ woyofal</language>
 			<language type="zh_Hans" alt="long">Sinuwaa buñ woyofal</language>
 			<language type="zh_Hant">Sinuwaa bu cosaan</language>
@@ -525,7 +525,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} - {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} - {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -533,7 +533,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} - {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} - {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1019,7 +1019,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} - {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} - {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1027,7 +1027,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} - {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} - {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1232,10 +1232,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>jamono</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>jamono</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>jamono</displayName>
 			</field>
 			<field type="year">
 				<displayName>at</displayName>
@@ -1401,9 +1401,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>fan</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">démb</relative>
+				<relative type="0">tay</relative>
+				<relative type="1">suba</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">fileek {0} fan</relativeTimePattern>
 				</relativeTime>
@@ -1413,9 +1413,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>fan</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">démb</relative>
+				<relative type="0">tay</relative>
+				<relative type="1">suba</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">fileek {0} fan</relativeTimePattern>
 				</relativeTime>
@@ -1436,10 +1436,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>bisu ayu-bis</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>bisu ayu-bis</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>bisu ayu-bis</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>bisu ayu-bisu weer wi</displayName>
@@ -1682,13 +1682,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sub/Ngo</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>Sub/Ngo</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sub/Ngo</displayName>
 			</field>
 			<field type="hour">
 				<displayName>waxt</displayName>

--- a/common/main/xh.xml
+++ b/common/main/xh.xml
@@ -748,8 +748,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Dis</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">1</month>
+							<month type="2">2</month>
 							<month type="3">3</month>
 							<month type="4">4</month>
 							<month type="5">5</month>
@@ -812,12 +812,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="4">Epreli</month>
 							<month type="5">Meyi</month>
 							<month type="6">Juni</month>
-							<month type="7">↑↑↑</month>
+							<month type="7">Julayi</month>
 							<month type="8">Agasti</month>
-							<month type="9">↑↑↑</month>
+							<month type="9">Septemba</month>
 							<month type="10">Okthoba</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="11">Novemba</month>
+							<month type="12">Disemba</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -842,13 +842,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">Mgq</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Caw</day>
+							<day type="mon">Mvu</day>
+							<day type="tue">Lwesb</day>
+							<day type="wed">Tha</day>
+							<day type="thu">Sin</day>
+							<day type="fri">Hla</day>
+							<day type="sat">Mgq</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">Cawe</day>
@@ -880,13 +880,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">Mgq</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Caw</day>
+							<day type="mon">Mvu</day>
+							<day type="tue">Lwesb</day>
+							<day type="wed">Tha</day>
+							<day type="thu">Sin</day>
+							<day type="fri">Hla</day>
+							<day type="sat">Mgq</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">Cawe</day>
@@ -908,10 +908,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">Kota 4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
+							<quarter type="1">1</quarter>
 							<quarter type="2">2</quarter>
 							<quarter type="3">3</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="4">4</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
 							<quarter type="1">ikota yoku-1</quarter>
@@ -948,8 +948,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">AM</dayPeriod>
@@ -962,21 +962,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="0">BC</era>
+						<era type="0" alt="variant">BCE</era>
+						<era type="1">AD</era>
+						<era type="1" alt="variant">CE</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">BC</era>
@@ -1043,7 +1043,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1059,7 +1059,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1067,7 +1067,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1278,8 +1278,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>uny</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">unyaka ophel.</relative>
+				<relative type="0">kulo nyak.</relative>
 				<relative type="1">unyak oza.</relative>
 			</field>
 			<field type="quarter">
@@ -1337,7 +1337,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">ngomso</relative>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>usuku</displayName>
 				<relative type="-1">izolo</relative>
 				<relative type="0">namhlanje</relative>
 				<relative type="1">ngomso</relative>
@@ -1379,7 +1379,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>zuzwa.</displayName>
 			</field>
 			<field type="second-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>zuzwa.</displayName>
 			</field>
 			<field type="zone">
 				<displayName>ingingqi yexesha</displayName>
@@ -3618,9 +3618,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency" draft="provisional">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one">{0} {1}</unitPattern>
@@ -3776,7 +3776,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="BWP">
 				<displayName>I-Pula yaseBotswana</displayName>
 				<displayName count="one">I-pula yaseBotswana</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">I-Pula yaseBotswana</displayName>
 				<symbol draft="contributed">BWP</symbol>
 				<symbol alt="narrow" draft="contributed">P</symbol>
 			</currency>
@@ -4642,8 +4642,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="XXX">
 				<displayName>Ikharensi Engaziwayo</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">Ikharensi Engaziwayo</displayName>
+				<displayName count="other">Ikharensi Engaziwayo</displayName>
 			</currency>
 			<currency type="YER">
 				<displayName>I-Rial yaseYemen</displayName>
@@ -4673,7 +4673,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<minimalPairs>
-			<pluralMinimalPairs count="one" draft="contributed">↑↑↑</pluralMinimalPairs>
+			<pluralMinimalPairs count="one" draft="contributed">{0}?</pluralMinimalPairs>
 			<pluralMinimalPairs count="other" draft="contributed">↑↑↑</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">↑↑↑</ordinalMinimalPairs>
 		</minimalPairs>
@@ -4681,17 +4681,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>direction</displayName>
+				<coordinateUnitPattern type="east">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<unitLength type="short">
@@ -4711,17 +4711,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>direction</displayName>
+				<coordinateUnitPattern type="east">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -4748,46 +4748,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">↑↑↑</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, or {1}</listPatternPart>
+			<listPatternPart type="2">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, or {1}</listPatternPart>
+			<listPatternPart type="2">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -44,7 +44,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="awa">Èdè Awadi</language>
 			<language type="ay">Èdè Amara</language>
 			<language type="az">Èdè Azerbaijani</language>
-			<language type="az" alt="short">↑↑↑</language>
+			<language type="az" alt="short">Èdè Azerbaijani</language>
 			<language type="ba">Èdè Bashiri</language>
 			<language type="ban">Èdè Balini</language>
 			<language type="bas">Èdè Basaa</language>
@@ -78,8 +78,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">Èdè Shẹ́rókiì</language>
 			<language type="chy">Èdè Sheyeni</language>
 			<language type="ckb">Ààrin Gbùngbùn Kurdish</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">Ààrin Gbùngbùn Kurdish</language>
+			<language type="ckb" alt="variant">Ààrin Gbùngbùn Kurdish</language>
 			<language type="clc">Èdè Shikoti</language>
 			<language type="co">Èdè Corsican</language>
 			<language type="crg">Èdè Misifu</language>
@@ -600,7 +600,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CG" alt="variant">Kóńgò (Olómìnira)</territory>
 			<territory type="CH">switiṣilandi</territory>
 			<territory type="CI">Kóútè forà</territory>
-			<territory type="CI" alt="variant">↑↑↑</territory>
+			<territory type="CI" alt="variant">Kóútè forà</territory>
 			<territory type="CK">Etíokun Kùúkù</territory>
 			<territory type="CL">Ṣílè</territory>
 			<territory type="CM">Kamerúúnì</territory>
@@ -635,13 +635,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="FI">Filandi</territory>
 			<territory type="FJ">Fiji</territory>
 			<territory type="FK">Etikun Fakalandi</territory>
-			<territory type="FK" alt="variant">↑↑↑</territory>
+			<territory type="FK" alt="variant">Etikun Fakalandi</territory>
 			<territory type="FM">Makoronesia</territory>
 			<territory type="FO">Àwọn Erékùsù ti Faroe</territory>
 			<territory type="FR">Faranse</territory>
 			<territory type="GA">Gabon</territory>
 			<territory type="GB">Gẹ̀ẹ́sì</territory>
-			<territory type="GB" alt="short">↑↑↑</territory>
+			<territory type="GB" alt="short">Gẹ̀ẹ́sì</territory>
 			<territory type="GD">Genada</territory>
 			<territory type="GE">Gọgia</territory>
 			<territory type="GF">Firenṣi Guana</territory>
@@ -799,7 +799,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">Tuniṣia</territory>
 			<territory type="TO">Tonga</territory>
 			<territory type="TR">Tọọki</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">Tọọki</territory>
 			<territory type="TT">Tirinida ati Tobaga</territory>
 			<territory type="TV">Tufalu</territory>
 			<territory type="TW">Taiwani</territory>
@@ -809,7 +809,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="UM">Àwọn Erékùsù Kékèké Agbègbè US</territory>
 			<territory type="UN">Ìṣọ̀kan àgbáyé</territory>
 			<territory type="US">Amẹrikà</territory>
-			<territory type="US" alt="short">↑↑↑</territory>
+			<territory type="US" alt="short">Amẹrikà</territory>
 			<territory type="UY">Nruguayi</territory>
 			<territory type="UZ">Nṣibẹkisitani</territory>
 			<territory type="VA">Ìlú Vatican</territory>
@@ -1311,13 +1311,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">À</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Àìk</day>
+							<day type="mon">Aj</day>
+							<day type="tue">Ìsẹ́g</day>
+							<day type="wed">Ọjọ́r</day>
+							<day type="thu">Ọjọ́b</day>
+							<day type="fri">Ẹt</day>
+							<day type="sat">Àbám</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">Ọjọ́ Àìkú</day>
@@ -1331,13 +1331,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Àìk</day>
+							<day type="mon">Aj</day>
+							<day type="tue">Ìsẹ́g</day>
+							<day type="wed">Ọjọ́r</day>
+							<day type="thu">Ọjọ́b</day>
+							<day type="fri">Ẹt</day>
+							<day type="sat">Àbám</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">À</day>
@@ -1349,13 +1349,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">À</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Àìk</day>
+							<day type="mon">Aj</day>
+							<day type="tue">Ìsẹ́g</day>
+							<day type="wed">Ọjọ́r</day>
+							<day type="thu">Ọjọ́b</day>
+							<day type="fri">Ẹt</day>
+							<day type="sat">Àbám</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">Àìkú</day>
@@ -1371,10 +1371,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<quarters>
 					<quarterContext type="format">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">Ìdámẹ́rin kíní</quarter>
+							<quarter type="2">Ìdámẹ́rin Kejì</quarter>
+							<quarter type="3">Ìdámẹ́rin Kẹta</quarter>
+							<quarter type="4">Ìdámẹ́rin Kẹrin</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">kíní</quarter>
@@ -1391,10 +1391,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">Ìdámẹ́rin kíní</quarter>
+							<quarter type="2">Ìdámẹ́rin Kejì</quarter>
+							<quarter type="3">Ìdámẹ́rin Kẹta</quarter>
+							<quarter type="4">Ìdámẹ́rin Kẹrin</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">kí</quarter>
@@ -1403,10 +1403,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">Kẹr</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
+							<quarter type="1">Ìdámẹ́rin kíní</quarter>
+							<quarter type="2">Ìdámẹ́rin Kejì</quarter>
 							<quarter type="3">Ìdámẹ́rin Kẹta</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="4">Ìdámẹ́rin Kẹrin</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -1760,27 +1760,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ọdún</displayName>
 				<relative type="-1">Ọdún tó kọjá</relative>
 				<relative type="0">Ọdún yìí</relative>
 				<relative type="1">Ọdún tó ńbọ̀</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} y</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} y</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Ọdún</displayName>
+				<relative type="-1">Ọdún tó kọjá</relative>
+				<relative type="0">Ọdún yìí</relative>
+				<relative type="1">Ọdún tó ńbọ̀</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} y</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} y</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
@@ -1796,21 +1796,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ìdá mẹ́rin</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Q</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Q</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
 				<displayName>Ìdá mẹ́rin</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Q</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Q</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -1826,27 +1826,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Osù</displayName>
+				<relative type="-1">óṣù tó kọjá</relative>
+				<relative type="0">oṣù yìí</relative>
+				<relative type="1">óṣù tó ń bọ̀,</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} m</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} m</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
 				<displayName>Oṣù</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">óṣù tó kọjá</relative>
+				<relative type="0">oṣù yìí</relative>
+				<relative type="1">óṣù tó ń bọ̀,</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} m</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} m</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
@@ -1863,39 +1863,39 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relativePeriod>ọ̀sẹ̀ ti {0}</relativePeriod>
 			</field>
 			<field type="week-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Ọ̀sẹ̀</displayName>
+				<relative type="-1">ọ̀sẹ̀ tó kọjá</relative>
+				<relative type="0">ọ̀sẹ̀ yìí</relative>
+				<relative type="1">ọ́sẹ̀ tó ń bọ̀</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>ọ̀sẹ̀ ti {0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Ọ̀sẹ̀</displayName>
+				<relative type="-1">ọ̀sẹ̀ tó kọjá</relative>
+				<relative type="0">ọ̀sẹ̀ yìí</relative>
+				<relative type="1">ọ́sẹ̀ tó ń bọ̀</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} w</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} w</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>ọ̀sẹ̀ ti {0}</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName>Ọṣẹ̀ inú Oṣù</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ọṣẹ̀ inú Oṣù</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ọṣẹ̀ inú Oṣù</displayName>
 			</field>
 			<field type="day">
 				<displayName>Ọjọ́</displayName>
@@ -1912,27 +1912,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Ọjọ́</displayName>
+				<relative type="-1">Àná</relative>
+				<relative type="0">Òní</relative>
+				<relative type="1">Ọ̀la</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} d</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} d</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Ọjọ́</displayName>
+				<relative type="-1">Àná</relative>
+				<relative type="0">Òní</relative>
+				<relative type="1">Ọ̀la</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} d</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} d</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
@@ -1974,25 +1974,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sun-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Ọjọ́ Àìkú tó kọjá</relative>
+				<relative type="0">Ọjọ́ Àìkú yìí</relative>
+				<relative type="1">Ọjọ́ Àìkú tó ń bọ̀</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Sundays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Sundays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Ọjọ́ Àìkú tó kọjá</relative>
+				<relative type="0">Ọjọ́ Àìkú yìí</relative>
+				<relative type="1">Ọjọ́ Àìkú tó ń bọ̀</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">Ọjọ́ Àíkú +{0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Sundays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2007,25 +2007,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="mon-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last Monday</relative>
+				<relative type="0">this Monday</relative>
+				<relative type="1">next Monday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Mondays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Mondays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">last Monday</relative>
+				<relative type="0">this Monday</relative>
+				<relative type="1">next Monday</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Mondays</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} Mondays</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -2117,9 +2117,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Ojọ́ sẹ́yìn</relative>
+				<relative type="0">Ojọ́ èyí</relative>
+				<relative type="1">Ojọ́ tónbọ̀</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} Ojọ́</relativeTimePattern>
 				</relativeTime>
@@ -2194,13 +2194,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Àárọ̀/ọ̀sán</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>Àárọ̀/ọ̀sán</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Àárọ̀/ọ̀sán</displayName>
 			</field>
 			<field type="hour">
 				<displayName>Wákàtí</displayName>
@@ -2213,21 +2213,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="hour-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Wákàtí</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} h</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} h</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Wákàtí</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} h</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} h</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute">
@@ -2241,21 +2241,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="minute-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ìsẹ́jú</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} min</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} min</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ìsẹ́jú</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} min</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} min</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -2271,29 +2271,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="second-short">
 				<displayName>Ìsẹ́jú Ààyá</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} s</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
 				<displayName>Ìsẹ́jú Ààyá</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} s</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">-{0} s</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
 				<displayName>Agbègbè àkókò</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Agbègbè àkókò</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Agbègbè àkókò</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -4606,12 +4606,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencies>
 			<currency type="AED">
 				<displayName>Diami ti Awon Orílẹ́ède Arabu</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Diami ti Awon Orílẹ́ède Arabu</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="AFN">
 				<displayName>Afugánì Afuganísítàànì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Afugánì Afuganísítàànì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4622,7 +4622,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="AMD">
 				<displayName>Dírààmù Àmẹ́níà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dírààmù Àmẹ́níà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4645,7 +4645,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="AUD">
 				<displayName>Dọla ti Orílẹ́ède Ástràlìá</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dọla ti Orílẹ́ède Ástràlìá</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4656,7 +4656,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="AZN">
 				<displayName>Mánààtì Àsàbáíjáì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Mánààtì Àsàbáíjáì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4674,7 +4674,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BDT">
 				<displayName>Tákà Báńgíládẹ̀ẹ̀ṣì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Tákà Báńgíládẹ̀ẹ̀ṣì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4685,7 +4685,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BHD">
 				<displayName>Dina ti Orílẹ́ède Báránì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dina ti Orílẹ́ède Báránì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BIF">
@@ -4701,7 +4701,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BND">
 				<displayName>Dọ́là Bùrùnéì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dọ́là Bùrùnéì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4725,7 +4725,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="BTN">
 				<displayName>Ìngọ́tírọ̀mù Bútàànì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ìngọ́tírọ̀mù Bútàànì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BWP">
@@ -4738,7 +4738,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Rọ́bù Bẹ̀lárùùsì</displayName>
 				<displayName count="other">àwọn rọ́bù Bẹ̀lárùùsì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
-				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
+				<symbol alt="narrow" draft="contributed">BYN</symbol>
 			</currency>
 			<currency type="BZD">
 				<displayName>Dọ́là Bẹ̀lísè</displayName>
@@ -4770,12 +4770,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CNH">
 				<displayName>Yúànì Sháínà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Yúànì Sháínà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="CNY">
 				<displayName>Reminibi ti Orílẹ́ède ṣáínà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Reminibi ti Orílẹ́ède ṣáínà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4799,7 +4799,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="CUP">
 				<displayName>Pẹ́sò Kúbà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Pẹ́sò Kúbà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4860,7 +4860,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="FJD">
 				<displayName>Dọ́là Fíjì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dọ́là Fíjì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4872,13 +4872,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="GBP">
 				<displayName>Pọ́n-ùn ti Orilẹ̀-èdè Gẹ̀ẹ́sì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Pọ́n-ùn ti Orilẹ̀-èdè Gẹ̀ẹ́sì</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GEL">
 				<displayName>Lárì Jọ́jíà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Lárì Jọ́jíà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4925,7 +4925,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="HKD">
 				<displayName>Dọ́là Hong Kong</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dọ́là Hong Kong</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4954,30 +4954,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="IDR">
 				<displayName>Rúpìyá Indonésíà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rúpìyá Indonésíà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ILS">
 				<displayName>Ṣékélì Tuntun Ísírẹ̀ẹ̀lì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ṣékélì Tuntun Ísírẹ̀ẹ̀lì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="INR">
 				<displayName>Rupi ti Orílẹ́ède Indina</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rupi ti Orílẹ́ède Indina</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="IQD">
 				<displayName>Dínárì Ìráákì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dínárì Ìráákì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="IRR">
 				<displayName>Rial Iranian</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rial Iranian</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ISK">
@@ -4994,12 +4994,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="JOD">
 				<displayName>Dínárì Jọ́dàànì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dínárì Jọ́dàànì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="JPY">
 				<displayName>Yeni ti Orílẹ́ède Japani</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Yeni ti Orílẹ́ède Japani</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5010,12 +5010,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="KGS">
 				<displayName>Sómú Kirijísítàànì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Sómú Kirijísítàànì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="KHR">
 				<displayName>Ráyò Kàm̀bọ́díà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ráyò Kàm̀bọ́díà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5027,19 +5027,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="KPW">
 				<displayName>Wọ́ọ̀nù Àríwá Kòríà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Wọ́ọ̀nù Àríwá Kòríà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="KRW">
 				<displayName>Wọ́ọ̀nù Gúúsù Kòríà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Wọ́ọ̀nù Gúúsù Kòríà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">₩</symbol>
 			</currency>
 			<currency type="KWD">
 				<displayName>Dínárì Kuwaiti</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dínárì Kuwaiti</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="KYD">
@@ -5050,25 +5050,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="KZT">
 				<displayName>Tẹngé Kasakísítàànì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Tẹngé Kasakísítàànì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LAK">
 				<displayName>Kíììpù Làótì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Kíììpù Làótì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LBP">
 				<displayName>Pọ́n-ùn Lebanese</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Pọ́n-ùn Lebanese</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LKR">
 				<displayName>Rúpìì Siri Láńkà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rúpìì Siri Láńkà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5111,19 +5111,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MMK">
 				<displayName>Kíyàtì Myanmar</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Kíyàtì Myanmar</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MNT">
 				<displayName>Túgúrììkì Mòǹgólíà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Túgúrììkì Mòǹgólíà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MOP">
 				<displayName>Pàtákà Màkáò</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Pàtákà Màkáò</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MRO">
@@ -5131,7 +5131,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MRU">
 				<displayName>Ouguiya ti Orílẹ́ède Maritania</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ouguiya ti Orílẹ́ède Maritania</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MUR">
@@ -5142,7 +5142,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MVR">
 				<displayName>Rúfìyá Mọ̀lìdífà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rúfìyá Mọ̀lìdífà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MWK">
@@ -5158,7 +5158,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="MYR">
 				<displayName>Ríngìtì Màléṣíà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ríngìtì Màléṣíà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5196,19 +5196,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="NPR">
 				<displayName>Rúpìì Nẹ̵́pààlì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rúpìì Nẹ̵́pààlì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="NZD">
 				<displayName>Dọ́là New Zealand</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dọ́là New Zealand</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="OMR">
 				<displayName>Ráyò Omani</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ráyò Omani</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PAB">
@@ -5223,18 +5223,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="PGK">
 				<displayName>Kínà Papua Guinea Tuntun</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Kínà Papua Guinea Tuntun</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PHP">
 				<displayName>Písò Fílípìnì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Písò Fílípìnì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PKR">
 				<displayName>Rúpìì Pakisitánì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Rúpìì Pakisitánì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5252,7 +5252,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="QAR">
 				<displayName>Ráyò Kàtárì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ráyò Kàtárì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="RON">
@@ -5280,12 +5280,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="SAR">
 				<displayName>Riya ti Orílẹ́ède Saudi</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Riya ti Orílẹ́ède Saudi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="SBD">
 				<displayName>Dọ́là Erékùsù Sọ́lómọ́nì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dọ́là Erékùsù Sọ́lómọ́nì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5310,7 +5310,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="SGD">
 				<displayName>Dọ́là Síngápọ̀</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dọ́là Síngápọ̀</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5347,13 +5347,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="STN">
 				<displayName>Dọbíra Sao tome àti Pirisipi</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dọbíra Sao tome àti Pirisipi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="SYP">
 				<displayName>Pọ́n-ùn Sírìà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Pọ́n-ùn Sírìà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5364,18 +5364,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="THB">
 				<displayName>Báàtì Tháì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Báàtì Tháì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="TJS">
 				<displayName>Sómónì Tajikístàànì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Sómónì Tajikístàànì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="TMT">
 				<displayName>Mánààtì Tọkimẹnístàànì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Mánààtì Tọkimẹnístàànì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="TND">
@@ -5385,13 +5385,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="TOP">
 				<displayName>Pàángà Tóńgà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Pàángà Tóńgà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="TRY">
 				<displayName>Lírà Tọ́kì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Lírà Tọ́kì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 				<symbol alt="variant" draft="contributed">↑↑↑</symbol>
@@ -5404,7 +5404,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="TWD">
 				<displayName>Dọ́là Tàìwánì Tuntun</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dọ́là Tàìwánì Tuntun</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5415,7 +5415,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="UAH">
 				<displayName>Ọrifiníyà Yukiréníà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ọrifiníyà Yukiréníà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5438,7 +5438,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="UZS">
 				<displayName>Sómú Usibẹkísítàànì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Sómú Usibẹkísítàànì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="VES">
@@ -5448,18 +5448,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="VND">
 				<displayName>Dáhùn Vietnamese</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dáhùn Vietnamese</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="VUV">
 				<displayName>Fátù Vanuatu</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Fátù Vanuatu</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="WST">
 				<displayName>Tálà Sàmóà</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Tálà Sàmóà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="XAF">
@@ -5480,7 +5480,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="XPF">
 				<displayName>Fírànkì CFP</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Fírànkì CFP</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="XXX">
@@ -5489,7 +5489,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currency>
 			<currency type="YER">
 				<displayName>Ráyò Yẹ́mẹ̀nì</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ráyò Yẹ́mẹ̀nì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ZAR">
@@ -5525,64 +5525,64 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>kibi{0}</unitPrefixPattern>
@@ -5609,7 +5609,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>yóòbù {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="other">{0} sikuwe</compoundUnitPattern1>
@@ -5618,132 +5618,132 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">kubiki {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>g-force</displayName>
+				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>deg</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcmin</displayName>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcsec</displayName>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hectare</displayName>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre</displayName>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>àwọ́n ohun</displayName>
 				<unitPattern count="other">{0} àwon ohun</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ara/milíọ̀nù</displayName>
+				<unitPattern count="other">{0} ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>ìdákan nínú ẹgbẹ̀rún</displayName>
 				<unitPattern count="other">{0} ìdákan nínú ẹgbẹ̀rún</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/100km</displayName>
+				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg US</displayName>
+				<unitPattern count="other">{0} mpg US</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg Imp.</displayName>
+				<unitPattern count="other">{0} mpg Imp.</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
 				<displayName>àwọn pẹ́tábáìtì</displayName>
@@ -5838,124 +5838,124 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/ìṣ àáy</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ms</displayName>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>iseju aya kekere</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joule</displayName>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>àwọ́n wákàtí kílówáàtì ní kìlómítà ọgọ́rùn</displayName>
 				<unitPattern count="other">{0} àwọ́n wákàtí kílówáàtì ní kìlómítà ọgọ́rùn</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>dọ́ọ̀tì</displayName>
@@ -5966,69 +5966,69 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ìdinwọ̀n ayé</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>meter</displayName>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi</displayName>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd</displayName>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in</displayName>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ly</displayName>
+				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>àwọn fọ́lọ́ọ̀ngì</displayName>
@@ -6039,24 +6039,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} fátọ́ọ̀mù</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lx</displayName>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>kandẹ́là</displayName>
@@ -6067,289 +6067,289 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} lumẹ́ẹ̀nì</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gram</displayName>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>àwon okùta</displayName>
 				<unitPattern count="other">{0} àwon okùta</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>lb</displayName>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>CD</displayName>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>giréènì</displayName>
 				<unitPattern count="other">{0} gíréènì</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>watt</displayName>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/h</displayName>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°C</displayName>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>liter</displayName>
+				<unitPattern count="other">{0} l</unitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>búsẹ́ẹ̀li</displayName>
 				<unitPattern count="other">{0} búsẹ́ẹ̀li</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>US gal</displayName>
+				<unitPattern count="other">{0} gal US</unitPattern>
+				<perUnitPattern>{0}/gal US</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gal</displayName>
+				<unitPattern count="other">{0} gal Imp.</unitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cup</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US fl oz</displayName>
+				<unitPattern count="other">{0} fl oz US</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>àmì ṣíbí oúnjẹ́ kékeré</displayName>
@@ -6380,11 +6380,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ìdásímérin</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>direction</displayName>
+				<coordinateUnitPattern type="east">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<unitLength type="short">
@@ -6740,8 +6740,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>↑↑↑</displayName>
@@ -6816,12 +6816,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>dọ́ọ̀tì</displayName>
@@ -7255,64 +7255,64 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>àmì Ki {0}</unitPrefixPattern>
@@ -7339,102 +7339,102 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>àmì Yí {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>g-force</displayName>
 				<unitPattern count="other">{0}Gs</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s²</displayName>
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
+				<displayName>rev</displayName>
 				<unitPattern count="other">{0}rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>rad</displayName>
 				<unitPattern count="other">{0}rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>deg</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcmin</displayName>
+				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcsec</displayName>
+				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km²</displayName>
 				<unitPattern count="other">{0}km²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hectare</displayName>
 				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm²</displayName>
 				<unitPattern count="other">{0}cm²</unitPattern>
 				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi²</displayName>
 				<unitPattern count="other">{0}mi²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>acre</displayName>
 				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd²</displayName>
 				<unitPattern count="other">{0}yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft²</displayName>
 				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in²</displayName>
 				<unitPattern count="other">{0}in²</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>dunam</displayName>
 				<unitPattern count="other">{0}dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>kt</displayName>
 				<unitPattern count="other">{0}kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg/dL</displayName>
 				<unitPattern count="other">{0}mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mmol/L</displayName>
 				<unitPattern count="other">{0}mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
@@ -7442,32 +7442,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ohun</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>ara/milíọ̀nù</displayName>
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>%</displayName>
+				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>ìdákan nínú ẹgbẹ̀rún</displayName>
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mol</displayName>
 				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>L/km</displayName>
 				<unitPattern count="other">{0}L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/100km</displayName>
+				<unitPattern count="other">{0} L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>mpg</displayName>
@@ -7486,7 +7486,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Tb</displayName>
 				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
@@ -7522,17 +7522,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}bíìtì</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c</displayName>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ẹ̀wádùn</displayName>
+				<unitPattern count="other">ẹ̀wádún {0}</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>ọd</displayName>
 				<unitPattern count="other">{0} ọd</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ọd</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>idame</displayName>
@@ -7542,7 +7542,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-month">
 				<displayName>oṣù</displayName>
 				<unitPattern count="other">{0} oṣù</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oṣù</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>ọṣẹ́</displayName>
@@ -7552,77 +7552,77 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-day">
 				<displayName>ọjọ́</displayName>
 				<unitPattern count="other">ọj {0}</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ọj</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>wkt</displayName>
 				<unitPattern count="other">{0} wkt</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/wkt</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>ìṣ</displayName>
 				<unitPattern count="other">{0}/ìṣ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/ìṣ</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>ìṣ àáy</displayName>
 				<unitPattern count="other">{0} ìṣ àáy</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0} ìṣ àáy</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ms</displayName>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μs</displayName>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>amp</displayName>
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>mA</displayName>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>ohm</displayName>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>volt</displayName>
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>cal</displayName>
 				<unitPattern count="other">{0}cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kcal</displayName>
 				<unitPattern count="other">{0}Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kJ</displayName>
 				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>joule</displayName>
 				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh</displayName>
 				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>eV</displayName>
 				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -7630,15 +7630,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
+				<displayName>US therm</displayName>
 				<unitPattern count="other">{0}US therms</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf</displayName>
 				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>N</displayName>
 				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
@@ -7646,40 +7646,40 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} kWh ní 100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>dpcm</displayName>
@@ -7690,77 +7690,77 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dọ́ọ̀tì</displayName>
+				<unitPattern count="other">{0} dọ́ọ̀tì</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>R⊕</displayName>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="other">{0} km</unitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>meter</displayName>
+				<unitPattern count="other">{0} m</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi</displayName>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd</displayName>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in</displayName>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ly</displayName>
+				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>fọ́lọ́ọ̀ngì</displayName>
@@ -7771,20 +7771,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lọ́s</displayName>
@@ -7799,33 +7799,33 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} Lúmẹ́nì</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>L☉</displayName>
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>t</displayName>
 				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kg</displayName>
+				<unitPattern count="other">{0} kg</unitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gram</displayName>
+				<unitPattern count="other">{0} g</unitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="other">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>μg</displayName>
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>tn</displayName>
 				<unitPattern count="other">{0}tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
@@ -7833,33 +7833,33 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>lb</displayName>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="other">{0}oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz t</displayName>
 				<unitPattern count="other">{0}oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>CD</displayName>
 				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>Da</displayName>
 				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M⊕</displayName>
 				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M☉</displayName>
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
@@ -7867,27 +7867,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>GW</displayName>
 				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>MW</displayName>
 				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW</displayName>
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>watt</displayName>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
+				<displayName>mW</displayName>
 				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>hp</displayName>
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
@@ -7895,142 +7895,142 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>″ Hg</displayName>
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm</displayName>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km/h</displayName>
+				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>m/s</displayName>
 				<unitPattern count="other">{0}m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi/h</displayName>
 				<unitPattern count="other">{0}mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kn</displayName>
 				<unitPattern count="other">{0}kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>°</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°C</displayName>
+				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
+				<displayName>K</displayName>
 				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>N⋅m</displayName>
 				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>km³</displayName>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m³</displayName>
 				<unitPattern count="other">{0}m³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cm³</displayName>
 				<unitPattern count="other">{0}cm³</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mi³</displayName>
 				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yd³</displayName>
 				<unitPattern count="other">{0}yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ft³</displayName>
 				<unitPattern count="other">{0}ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>in³</displayName>
 				<unitPattern count="other">{0}in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ML</displayName>
 				<unitPattern count="other">{0}ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>hL</displayName>
 				<unitPattern count="other">{0}hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>liter</displayName>
+				<unitPattern count="other">{0} l</unitPattern>
 				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dL</displayName>
 				<unitPattern count="other">{0}dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>cL</displayName>
 				<unitPattern count="other">{0}cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mL</displayName>
 				<unitPattern count="other">{0}mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpt</displayName>
 				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
+				<displayName>mcup</displayName>
 				<unitPattern count="other">{0}mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
@@ -8052,15 +8052,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/galIm</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qt</displayName>
 				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>cup</displayName>
 				<unitPattern count="other">{0}c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
@@ -8072,27 +8072,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>tbsp</displayName>
 				<unitPattern count="other">{0}tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>tsp</displayName>
 				<unitPattern count="other">{0}tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bbl</displayName>
 				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>ṣíbí oúnjẹ́ kékeré</displayName>
 				<unitPattern count="other">{0}dsp</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>àmì oúnjẹ kékeré</displayName>
+				<unitPattern count="other">{0} àmì oúnjẹ kékeré</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>dírọ́pù</displayName>
 				<unitPattern count="other">{0}dr</unitPattern>
 			</unit>
 			<unit type="volume-dram">
@@ -8108,15 +8108,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}pn</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>àmì ìdásímérin</displayName>
 				<unitPattern count="other">{0}àmì ìdásímérin</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>direction</displayName>
+				<coordinateUnitPattern type="east">{0}E</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0}N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0}S</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">{0}W</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -8143,46 +8143,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} tàbí {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0} pẹ̀lú {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, tabi {1}</listPatternPart>
+			<listPatternPart type="2">{0} tàbí {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0} pẹ̀lú {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, tabi {1}</listPatternPart>
+			<listPatternPart type="2">{0} tàbí {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>

--- a/common/main/yrl.xml
+++ b/common/main/yrl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1738,13 +1738,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">mit</day>
+							<day type="mon">mur</day>
+							<day type="tue">mmk</day>
+							<day type="wed">mms</day>
+							<day type="thu">sup</day>
+							<day type="fri">yuk</day>
+							<day type="sat">sau</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">mituú</day>
@@ -1758,13 +1758,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</dayContext>
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">mit</day>
+							<day type="mon">mur</day>
+							<day type="tue">mmk</day>
+							<day type="wed">mms</day>
+							<day type="thu">sup</day>
+							<day type="fri">yuk</day>
+							<day type="sat">sau</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">M</day>
@@ -1776,13 +1776,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">S</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">mit</day>
+							<day type="mon">mur</day>
+							<day type="tue">mmk</day>
+							<day type="wed">mms</day>
+							<day type="thu">sup</day>
+							<day type="fri">yuk</day>
+							<day type="sat">sau</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">mituú</day>
@@ -2418,9 +2418,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-short">
 				<displayName>ara</displayName>
 				<relative type="-2" draft="contributed">amũ kuesê</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">kuesê</relative>
+				<relative type="0">wií</relative>
+				<relative type="1">wirãdé</relative>
 				<relative type="2" draft="contributed">wirãdé ariré</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ara resê</relativeTimePattern>
@@ -2434,9 +2434,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<field type="day-narrow">
 				<displayName>ara</displayName>
 				<relative type="-2" draft="contributed">amũ kuesê</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">kuesê</relative>
+				<relative type="0">wií</relative>
+				<relative type="1">wirãdé</relative>
 				<relative type="2" draft="contributed">wirãdé ariré</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ara resê</relativeTimePattern>
@@ -7058,7 +7058,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern>{0} {1} rupi</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>kirĩba g</displayName>
@@ -7147,7 +7147,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunan-ita</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunan</unitPattern>
 				<unitPattern count="other">{0} dunan-ita</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -7181,13 +7181,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mil rupi</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>pitusá-pitasukasá</displayName>
 				<unitPattern count="one">{0} pitusá-pitasukasá</unitPattern>
 				<unitPattern count="other">{0} pitusá-pitasukasá-ita</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>mol-ita</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">{0} mol-ita</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7429,8 +7429,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>tipografia em</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pikisel-ita</displayName>
@@ -7703,7 +7703,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>bar-ita</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">{0} bar-ita</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -7757,9 +7757,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kitanga-ita</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>garau Celsius-ita</displayName>
@@ -7938,27 +7938,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>kirĩba g</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>meturu-itá/seg²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rev</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>radiano</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} rad</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>garau</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
@@ -7973,46 +7973,46 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>hectare</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ha</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>meturu-itá²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>milha-itá²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>acre</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ac</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>jarda-itá²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>pí-itá²</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft²</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
@@ -8043,7 +8043,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>pisawera miliãu rupi</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
@@ -8058,12 +8058,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>pitusá-pitasukasá</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -8177,13 +8177,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-hour">
 				<displayName>hura</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>min</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} min</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -8195,47 +8195,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>mirisegũdu</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μs</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ns</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>amp</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} A</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>miriamp</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mA</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>ohm</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Ω</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>volt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} V</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kcal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cal</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
@@ -8245,22 +8245,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>kirujoule</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kJ</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>joule</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} J</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>kW-hura</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>elétron-volt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
@@ -8275,120 +8275,120 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>libra-kirĩba</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>newton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kHz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Hz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>pixel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>megapixel</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} nm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>milha</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>jarda</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-foot">
@@ -8405,7 +8405,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-parsec">
 				<displayName>parsec</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pc</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-light-year">
@@ -8433,27 +8433,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} smi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>pitusá</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>kuarasiawa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lux</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lx</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>kuarasí muturisawa</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8463,24 +8463,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>grama</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} μg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-ton">
@@ -8493,19 +8493,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-pound">
 				<displayName>libra</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lb</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>oz troy</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} oz t</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-carat">
@@ -8515,42 +8515,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>dalton</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>iwí susuẽga</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>kuarasí susuẽga</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} GW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>watt</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} W</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mW</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
@@ -8565,12 +8565,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} psi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} inHg</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
@@ -8580,7 +8580,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mbar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
@@ -8590,32 +8590,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} hPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km/h</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>meturu/seg</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m/s</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
@@ -8630,7 +8630,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
@@ -8645,49 +8645,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} K</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} km³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cm³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mi³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>jarda-itá³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} yd³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>pí-itá³</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ft³</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
@@ -8707,7 +8707,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-liter">
 				<displayName>litros</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -8755,12 +8755,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart">
 				<displayName>qts</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>pint</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pt</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cup">
@@ -8775,7 +8775,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -8790,7 +8790,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>koroti</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -8803,10 +8803,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</unitLength>
 		<unitLength type="narrow">
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName draft="contributed">kirĩba g</displayName>
@@ -8919,13 +8919,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-hour">
 				<displayName>hura</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} h</unitPattern>
+				<unitPattern count="other">{0} h</unitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>min</displayName>
+				<unitPattern count="one">{0} min</unitPattern>
+				<unitPattern count="other">{0} min</unitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>seg</displayName>
@@ -8935,29 +8935,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ms</unitPattern>
+				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km</displayName>
+				<unitPattern count="one">{0} km</unitPattern>
+				<unitPattern count="other">{0} km</unitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} m</unitPattern>
+				<unitPattern count="other">{0} m</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<displayName>cm</displayName>
+				<unitPattern count="one">{0} cm</unitPattern>
+				<unitPattern count="other">{0} cm</unitPattern>
+				<perUnitPattern draft="contributed">{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm</displayName>
+				<unitPattern count="one">{0} mm</unitPattern>
+				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName draft="contributed">mil</displayName>
@@ -9003,7 +9003,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} mn</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
+				<displayName>kg</displayName>
 				<unitPattern count="one">{0}kg</unitPattern>
 				<unitPattern count="other">{0}kg</unitPattern>
 			</unit>
@@ -9041,7 +9041,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mb</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>km/h</displayName>
 				<unitPattern count="one">{0}km/h</unitPattern>
 				<unitPattern count="other">{0}km/h</unitPattern>
 			</unit>
@@ -9075,8 +9075,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<coordinateUnit>
 				<displayName>mupikasawa</displayName>
 				<coordinateUnitPattern type="east">{0}L</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">{0} N</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">{0} S</coordinateUnitPattern>
 				<coordinateUnitPattern type="west">{0}O</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
@@ -9104,20 +9104,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} u {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} u {1}</listPatternPart>
+			<listPatternPart type="2">{0} u {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0} u {1}</listPatternPart>
+			<listPatternPart type="2">{0} u {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
@@ -9128,8 +9128,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} asuí {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} asuí {1}</listPatternPart>
 			<listPatternPart type="2">{0} asuí {1}</listPatternPart>
 		</listPattern>
@@ -9140,8 +9140,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0} {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="unit-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0} asuí {1}</listPatternPart>
 			<listPatternPart type="2">{0} asuí {1}</listPatternPart>
 		</listPattern>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -122,8 +122,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">柴羅基文</language>
 			<language type="chy">沙伊安文</language>
 			<language type="ckb">索拉尼庫爾德文</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">索拉尼庫爾德文</language>
+			<language type="ckb" alt="variant">索拉尼庫爾德文</language>
 			<language type="clc">奇爾科延文</language>
 			<language type="co">科西嘉文</language>
 			<language type="cop">科普特文</language>
@@ -1068,7 +1068,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">諾魯</territory>
 			<territory type="NU">紐埃島</territory>
 			<territory type="NZ">紐西蘭</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">紐西蘭</territory>
 			<territory type="OM">阿曼王國</territory>
 			<territory type="PA">巴拿馬</territory>
 			<territory type="PE">秘魯</territory>
@@ -1128,7 +1128,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">突尼西亞</territory>
 			<territory type="TO">東加</territory>
 			<territory type="TR">土耳其</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">土耳其</territory>
 			<territory type="TT">千里達同多巴哥</territory>
 			<territory type="TV">吐瓦魯</territory>
 			<territory type="TW">台灣</territory>
@@ -2337,7 +2337,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}{0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}{0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2361,7 +2361,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2940,7 +2940,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4039,9 +4039,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>年</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">舊年</relative>
+				<relative type="0">今年</relative>
+				<relative type="1">下年</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 年後</relativeTimePattern>
 				</relativeTime>
@@ -4051,9 +4051,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>年</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">舊年</relative>
+				<relative type="0">今年</relative>
+				<relative type="1">下年</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 年後</relativeTimePattern>
 				</relativeTime>
@@ -4111,9 +4111,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName>月</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">上個月</relative>
+				<relative type="0">今個月</relative>
+				<relative type="1">下個月</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 個月後</relativeTimePattern>
 				</relativeTime>
@@ -4123,9 +4123,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>月</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">上個月</relative>
+				<relative type="0">今個月</relative>
+				<relative type="1">下個月</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 個月後</relativeTimePattern>
 				</relativeTime>
@@ -4148,9 +4148,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>週</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">上星期</relative>
+				<relative type="0">今個星期</relative>
+				<relative type="1">下星期</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 個星期後</relativeTimePattern>
 				</relativeTime>
@@ -4161,9 +4161,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>週</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">上星期</relative>
+				<relative type="0">今個星期</relative>
+				<relative type="1">下星期</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 個星期後</relativeTimePattern>
 				</relativeTime>
@@ -4197,9 +4197,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>日</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">尋日</relative>
+				<relative type="0">今日</relative>
+				<relative type="1">聽日</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 日後</relativeTimePattern>
 				</relativeTime>
@@ -4209,9 +4209,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>日</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">尋日</relative>
+				<relative type="0">今日</relative>
+				<relative type="1">聽日</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 日後</relativeTimePattern>
 				</relativeTime>
@@ -6874,7 +6874,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign>%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -8731,7 +8731,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">立方{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G 力</displayName>
@@ -9344,8 +9344,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} 克耳文</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>尺磅</displayName>
+				<unitPattern count="other">{0} 尺磅</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>牛頓米</displayName>
@@ -10463,189 +10463,189 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">立方{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>G 力</displayName>
+				<unitPattern count="other">{0} G 力</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>米/平方秒</displayName>
 				<unitPattern count="other">每平方秒 {0} 米</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>圈</displayName>
+				<unitPattern count="other">{0} 圈</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>弧度</displayName>
+				<unitPattern count="other">{0} 弧度</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>角度</displayName>
+				<unitPattern count="other">{0} 度</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>角分</displayName>
+				<unitPattern count="other">{0} 角分</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>角秒</displayName>
+				<unitPattern count="other">{0} 角秒</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方公里</displayName>
+				<unitPattern count="other">{0} 平方公里</unitPattern>
+				<perUnitPattern>每平方公里{0}</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公頃</displayName>
+				<unitPattern count="other">{0} 公頃</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方米</displayName>
+				<unitPattern count="other">{0} 平方米</unitPattern>
+				<perUnitPattern>每平方米{0}</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方厘米</displayName>
+				<unitPattern count="other">{0} 平方厘米</unitPattern>
+				<perUnitPattern>每平方厘米{0}</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方英里</displayName>
+				<unitPattern count="other">{0} 平方英里</unitPattern>
+				<perUnitPattern>每平方英里{0}</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英畝</displayName>
+				<unitPattern count="other">{0} 英畝</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>平方碼</displayName>
+				<unitPattern count="other">{0} 平方碼</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>平方英呎</displayName>
+				<unitPattern count="other">{0} 平方英呎</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方英吋</displayName>
+				<unitPattern count="other">{0} 平方英吋</unitPattern>
+				<perUnitPattern>每平方英吋{0}</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>德南</displayName>
+				<unitPattern count="other">{0} 德南</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>克拉</displayName>
+				<unitPattern count="other">{0} 克拉</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫克/公合</displayName>
+				<unitPattern count="other">{0} 毫克/公合</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫摩爾/公升</displayName>
+				<unitPattern count="other">{0} 毫摩爾/公升</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>項</displayName>
+				<unitPattern count="other">{0} 項</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>百萬分率</displayName>
+				<unitPattern count="other">{0} 百萬分率</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>點子</displayName>
+				<unitPattern count="other">{0} 點子</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>摩爾</displayName>
+				<unitPattern count="other">{0} 摩爾</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公升/公里</displayName>
+				<unitPattern count="other">{0} 公升/公里</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>公升/100 公里</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 公升/100 公里</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英里/加侖</displayName>
+				<unitPattern count="other">{0} 英里/加侖</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英里/英制加侖</displayName>
+				<unitPattern count="other">{0} 英里/英制加侖</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
 				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>世紀</displayName>
+				<unitPattern count="other">{0} 世紀</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>十年</displayName>
+				<unitPattern count="other">{0} 個十年</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>年</displayName>
 				<unitPattern count="other">{0} 年</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每年{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>季</displayName>
@@ -10655,132 +10655,132 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-month">
 				<displayName>月</displayName>
 				<unitPattern count="other">{0} 個月</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每月{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>週</displayName>
 				<unitPattern count="other">{0} 週</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每週{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>天</displayName>
 				<unitPattern count="other">{0} 天</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每天{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>小時</displayName>
 				<unitPattern count="other">{0} 小時</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每小時{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>分鐘</displayName>
 				<unitPattern count="other">{0} 分鐘</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每分鐘{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>秒</displayName>
 				<unitPattern count="other">{0} 秒</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每秒{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>毫秒</displayName>
 				<unitPattern count="other">{0} 毫秒</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>微秒</displayName>
+				<unitPattern count="other">{0} 微秒</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>奈秒</displayName>
+				<unitPattern count="other">{0} 奈秒</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>安培</displayName>
+				<unitPattern count="other">{0} 安培</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫安培</displayName>
+				<unitPattern count="other">{0} 毫安培</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>歐姆</displayName>
+				<unitPattern count="other">{0} 歐姆</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>伏特</displayName>
+				<unitPattern count="other">{0} 伏</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千卡</displayName>
+				<unitPattern count="other">{0} 千卡</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>卡路里</displayName>
+				<unitPattern count="other">{0} 卡路里</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>大卡</displayName>
+				<unitPattern count="other">{0} 大卡</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千焦耳</displayName>
+				<unitPattern count="other">{0} 千焦</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>焦耳</displayName>
+				<unitPattern count="other">{0} 焦耳</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千瓦小時</displayName>
+				<unitPattern count="other">{0} 千瓦小時</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>電子伏特</displayName>
+				<unitPattern count="other">{0} 電子伏特</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制熱量單位</displayName>
+				<unitPattern count="other">{0} 英制熱量單位</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>美制熱量單位</displayName>
+				<unitPattern count="other">{0} 美制熱量單位</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>磅力</displayName>
+				<unitPattern count="other">{0} 磅力</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>牛頓</displayName>
+				<unitPattern count="other">{0} 牛頓</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千瓦時/每 100 公里</displayName>
+				<unitPattern count="other">{0} 千瓦時/每 100 公里</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>吉赫</displayName>
+				<unitPattern count="other">{0} 吉赫</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>兆赫</displayName>
+				<unitPattern count="other">{0} 兆赫</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千赫</displayName>
+				<unitPattern count="other">{0} 千赫</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>赫茲</displayName>
+				<unitPattern count="other">{0} 赫茲</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>像素</displayName>
+				<unitPattern count="other">{0} 像素</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
@@ -10791,438 +10791,438 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>每吋像素</displayName>
+				<unitPattern count="other">{0} 像素/吋</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>每厘米點數</displayName>
+				<unitPattern count="other">{0} 點/厘米</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>每吋點數</displayName>
+				<unitPattern count="other">{0} 點/吋</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>圓點</displayName>
+				<unitPattern count="other">{0} 個圓點</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>地球半徑</displayName>
+				<unitPattern count="other">{0} 地球半徑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>公里</displayName>
 				<unitPattern count="other">{0} 公里</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每公里{0}</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>米</displayName>
 				<unitPattern count="other">{0} 米</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每米{0}</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公寸</displayName>
+				<unitPattern count="other">{0} 公寸</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>厘米</displayName>
 				<unitPattern count="other">{0} 厘米</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每厘米{0}</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>毫米</displayName>
 				<unitPattern count="other">{0} 毫米</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>微米</displayName>
+				<unitPattern count="other">{0} 微米</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>奈米</displayName>
+				<unitPattern count="other">{0} 奈米</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>皮米</displayName>
+				<unitPattern count="other">{0} 皮米</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英里</displayName>
+				<unitPattern count="other">{0} 英里</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>碼</displayName>
+				<unitPattern count="other">{0} 碼</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>英呎</displayName>
+				<unitPattern count="other">{0} 英呎</unitPattern>
+				<perUnitPattern>每英呎{0}</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英吋</displayName>
+				<unitPattern count="other">{0} 英吋</unitPattern>
 				<perUnitPattern>每英吋 {0}</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>秒差距</displayName>
+				<unitPattern count="other">{0} 秒差距</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>光年</displayName>
+				<unitPattern count="other">{0} 光年</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>天文單位</displayName>
+				<unitPattern count="other">{0} 天文單位</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>化朗</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 化朗</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>英尋</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 英尋</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>海里</displayName>
+				<unitPattern count="other">{0} 海里</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>斯堪地那維亞英里</displayName>
+				<unitPattern count="other">{0} 斯堪地那維亞英里</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>點</displayName>
+				<unitPattern count="other">{0} 點</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>太陽半徑</displayName>
+				<unitPattern count="other">{0} 太陽半徑</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>勒克斯</displayName>
+				<unitPattern count="other">{0} 勒克斯</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>坎德拉</displayName>
+				<unitPattern count="other">{0} 坎德拉</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>流明</displayName>
+				<unitPattern count="other">{0} 流明</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>太陽光度</displayName>
+				<unitPattern count="other">{0} 太陽光度</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公噸</displayName>
+				<unitPattern count="other">{0} 公噸</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>公斤</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 公斤</unitPattern>
 				<perUnitPattern>每公斤 {0}</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>克</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 克</unitPattern>
 				<perUnitPattern>每克 {0}</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫克</displayName>
+				<unitPattern count="other">{0} 毫克</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>微克</displayName>
+				<unitPattern count="other">{0} 微克</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英噸</displayName>
+				<unitPattern count="other">{0} 英噸</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>英石</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 英石</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>磅</displayName>
+				<unitPattern count="other">{0} 磅</unitPattern>
 				<perUnitPattern>每磅 {0}</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>安士</displayName>
+				<unitPattern count="other">{0} 安士</unitPattern>
 				<perUnitPattern>每安士 {0}</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>金衡安士</displayName>
+				<unitPattern count="other">{0} 金衡安士</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>克拉</displayName>
+				<unitPattern count="other">{0} 克拉</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>道爾頓</displayName>
+				<unitPattern count="other">{0} 道爾頓</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>地球質量</displayName>
+				<unitPattern count="other">{0} 地球質量</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>太陽質量</displayName>
+				<unitPattern count="other">{0} 太陽質量</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>喱</displayName>
+				<unitPattern count="other">{0} 喱</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>吉瓦</displayName>
+				<unitPattern count="other">{0} 吉瓦</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>百萬瓦特</displayName>
+				<unitPattern count="other">{0} 百萬瓦特</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千瓦特</displayName>
+				<unitPattern count="other">{0} 千瓦特</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>瓦特</displayName>
+				<unitPattern count="other">{0} 瓦特</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫瓦特</displayName>
+				<unitPattern count="other">{0} 毫瓦特</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>匹</displayName>
+				<unitPattern count="other">{0} 匹</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫米汞柱</displayName>
+				<unitPattern count="other">{0} 毫米汞柱</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>磅力/平方英吋</displayName>
 				<unitPattern count="other">每平方吋 {0} 磅</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英吋汞柱</displayName>
+				<unitPattern count="other">{0} 英吋汞柱</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>巴</displayName>
+				<unitPattern count="other">{0} 巴</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫巴</displayName>
+				<unitPattern count="other">{0} 毫巴</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>帕斯卡</displayName>
+				<unitPattern count="other">{0} 帕斯卡</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>百帕</displayName>
+				<unitPattern count="other">{0} 百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千帕</displayName>
+				<unitPattern count="other">{0} 千帕</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>兆帕</displayName>
+				<unitPattern count="other">{0} 兆帕</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>公里/小時</displayName>
 				<unitPattern count="other">每小時 {0} 公里</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>米/秒</displayName>
 				<unitPattern count="other">每秒 {0} 米</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>英里/小時</displayName>
 				<unitPattern count="other">每小時 {0} 英里</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>節</displayName>
+				<unitPattern count="other">{0} 節</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>華氏</displayName>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>克耳文</displayName>
+				<unitPattern count="other">{0} 克耳文</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>尺磅</displayName>
+				<unitPattern count="other">{0} 尺磅</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>牛頓米</displayName>
+				<unitPattern count="other">{0} 牛頓米</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方公里</displayName>
+				<unitPattern count="other">{0} 立方公里</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>立方米</displayName>
+				<unitPattern count="other">{0} 立方米</unitPattern>
+				<perUnitPattern>每立方米{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>立方厘米</displayName>
+				<unitPattern count="other">{0} 立方厘米</unitPattern>
+				<perUnitPattern>每立方厘米{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方英里</displayName>
+				<unitPattern count="other">{0} 立方英里</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方碼</displayName>
+				<unitPattern count="other">{0} 立方碼</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方英呎</displayName>
+				<unitPattern count="other">{0} 立方英呎</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方英吋</displayName>
+				<unitPattern count="other">{0} 立方英吋</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>兆升</displayName>
+				<unitPattern count="other">{0} 兆升</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公石</displayName>
+				<unitPattern count="other">{0} 公石</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>公升</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} 公升</unitPattern>
+				<perUnitPattern>每公升{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公合</displayName>
+				<unitPattern count="other">{0} 公合</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>釐升</displayName>
+				<unitPattern count="other">{0} 釐升</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫升</displayName>
+				<unitPattern count="other">{0} 毫升</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公制品脫</displayName>
+				<unitPattern count="other">{0} 公制品脫</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公制量杯</displayName>
+				<unitPattern count="other">{0} 公制杯</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英畝英呎</displayName>
+				<unitPattern count="other">{0} 英畝英呎</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>蒲式耳</displayName>
+				<unitPattern count="other">{0} 蒲式耳</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>加侖</displayName>
+				<unitPattern count="other">{0} 加侖</unitPattern>
+				<perUnitPattern>每加侖{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>英制加侖</displayName>
+				<unitPattern count="other">{0} 英制加侖</unitPattern>
+				<perUnitPattern>每英制加侖{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>夸脫</displayName>
+				<unitPattern count="other">{0} 夸脫</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>品脫</displayName>
+				<unitPattern count="other">{0} 品脫</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>量杯</displayName>
+				<unitPattern count="other">{0} 杯</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>液盎司</displayName>
+				<unitPattern count="other">{0} 液盎司</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制液盎司</displayName>
+				<unitPattern count="other">{0} 英制液盎司</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>湯匙</displayName>
+				<unitPattern count="other">{0} 湯匙</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>茶匙</displayName>
+				<unitPattern count="other">{0} 茶匙</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>桶</displayName>
+				<unitPattern count="other">{0} 桶</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>甜品匙</displayName>
+				<unitPattern count="other">{0}甜品匙</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制甜品匙</displayName>
+				<unitPattern count="other">{0}英制甜品匙</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>滴</displayName>
+				<unitPattern count="other">{0}滴</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制液量打蘭</displayName>
+				<unitPattern count="other">{0}英制液量打蘭</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>量酒杯</displayName>
 				<unitPattern count="other">量酒器{0}杯</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>小撮</displayName>
+				<unitPattern count="other">{0} 小撮</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制夸脫</displayName>
+				<unitPattern count="other">{0} 英制夸脫</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>方向</displayName>
@@ -11256,22 +11256,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} 或 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0} 或 {1}</listPatternPart>
+			<listPatternPart type="2">{0} 或 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0} 或 {1}</listPatternPart>
+			<listPatternPart type="2">{0} 或 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}同{1}</listPatternPart>
+			<listPatternPart type="2">{0}同{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}、{1}</listPatternPart>
@@ -11595,7 +11595,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>{surname}{given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}{given}{given2}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname}{given-informal}</namePattern>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2022 Unicode, Inc.
+<!-- Copyright © 1991-2023 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -123,8 +123,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="chr">柴罗基文</language>
 			<language type="chy">沙伊安文</language>
 			<language type="ckb">索拉尼库尔德文</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">索拉尼库尔德文</language>
+			<language type="ckb" alt="variant">索拉尼库尔德文</language>
 			<language type="clc">奇尔科延文</language>
 			<language type="co">科西嘉文</language>
 			<language type="cop">科普特文</language>
@@ -1069,7 +1069,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NR">诺鲁</territory>
 			<territory type="NU">纽埃岛</territory>
 			<territory type="NZ">纽西兰</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">纽西兰</territory>
 			<territory type="OM">阿曼王国</territory>
 			<territory type="PA">巴拿马</territory>
 			<territory type="PE">秘鲁</territory>
@@ -1129,7 +1129,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TN">突尼西亚</territory>
 			<territory type="TO">东加</territory>
 			<territory type="TR">土耳其</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">土耳其</territory>
 			<territory type="TT">千里达同多巴哥</territory>
 			<territory type="TV">吐瓦鲁</territory>
 			<territory type="TW">台湾</territory>
@@ -2338,7 +2338,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2362,7 +2362,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2941,7 +2941,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4040,9 +4040,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-short">
 				<displayName>年</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">旧年</relative>
+				<relative type="0">今年</relative>
+				<relative type="1">下年</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 年后</relativeTimePattern>
 				</relativeTime>
@@ -4052,9 +4052,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="year-narrow">
 				<displayName>年</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">旧年</relative>
+				<relative type="0">今年</relative>
+				<relative type="1">下年</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 年后</relativeTimePattern>
 				</relativeTime>
@@ -4112,9 +4112,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-short">
 				<displayName>月</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">上个月</relative>
+				<relative type="0">今个月</relative>
+				<relative type="1">下个月</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 个月后</relativeTimePattern>
 				</relativeTime>
@@ -4124,9 +4124,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month-narrow">
 				<displayName>月</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">上个月</relative>
+				<relative type="0">今个月</relative>
+				<relative type="1">下个月</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 个月后</relativeTimePattern>
 				</relativeTime>
@@ -4149,9 +4149,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-short">
 				<displayName>周</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">上星期</relative>
+				<relative type="0">今个星期</relative>
+				<relative type="1">下星期</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 个星期后</relativeTimePattern>
 				</relativeTime>
@@ -4162,9 +4162,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="week-narrow">
 				<displayName>周</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">上星期</relative>
+				<relative type="0">今个星期</relative>
+				<relative type="1">下星期</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 个星期后</relativeTimePattern>
 				</relativeTime>
@@ -4198,9 +4198,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>日</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">寻日</relative>
+				<relative type="0">今日</relative>
+				<relative type="1">听日</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 日后</relativeTimePattern>
 				</relativeTime>
@@ -4210,9 +4210,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>日</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">寻日</relative>
+				<relative type="0">今日</relative>
+				<relative type="1">听日</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">{0} 日后</relativeTimePattern>
 				</relativeTime>
@@ -6872,7 +6872,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<percentSign>%</percentSign>
 			<plusSign draft="contributed">+</plusSign>
 			<minusSign draft="contributed">-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -8729,7 +8729,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">立方{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G 力</displayName>
@@ -9342,8 +9342,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} 克耳文</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>尺磅</displayName>
+				<unitPattern count="other">{0} 尺磅</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>牛顿米</displayName>
@@ -10461,189 +10461,189 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">立方{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>G 力</displayName>
+				<unitPattern count="other">{0} G 力</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>公尺/平方秒</displayName>
 				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>圈数</displayName>
+				<unitPattern count="other">{0} 圈</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>弧度</displayName>
+				<unitPattern count="other">{0} 弧度</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>角度</displayName>
+				<unitPattern count="other">{0} 度</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>角分</displayName>
+				<unitPattern count="other">{0} 角分</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>角秒</displayName>
+				<unitPattern count="other">{0} 角秒</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方公里</displayName>
+				<unitPattern count="other">{0} 平方公里</unitPattern>
+				<perUnitPattern>每平方公里{0}</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公顷</displayName>
+				<unitPattern count="other">{0} 公顷</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方公尺</displayName>
+				<unitPattern count="other">{0} 平方公尺</unitPattern>
+				<perUnitPattern>每平方米{0}</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方公分</displayName>
+				<unitPattern count="other">{0} 平方公分</unitPattern>
+				<perUnitPattern>每平方厘米{0}</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方英里</displayName>
+				<unitPattern count="other">{0} 平方英里</unitPattern>
+				<perUnitPattern>每平方英里{0}</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英亩</displayName>
+				<unitPattern count="other">{0} 英亩</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>平方码</displayName>
+				<unitPattern count="other">{0} 平方码</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>平方英尺</displayName>
+				<unitPattern count="other">{0} 平方英尺</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>平方英寸</displayName>
+				<unitPattern count="other">{0} 平方英寸</unitPattern>
+				<perUnitPattern>每平方吋{0}</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>德南</displayName>
+				<unitPattern count="other">{0} 德南</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>克拉</displayName>
+				<unitPattern count="other">{0} 克拉</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫克/公合</displayName>
+				<unitPattern count="other">{0} 毫克/公合</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫摩尔/公升</displayName>
+				<unitPattern count="other">{0} 毫摩尔/公升</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>项</displayName>
+				<unitPattern count="other">{0} 项</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>百万分率</displayName>
+				<unitPattern count="other">{0} 百万分率</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>点子</displayName>
+				<unitPattern count="other">{0} 点子</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>摩尔</displayName>
+				<unitPattern count="other">{0} 摩尔</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公升/公里</displayName>
+				<unitPattern count="other">每公里{0}公升</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>升/100公里</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">每100公里 {0} 升</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英里/加仑</displayName>
+				<unitPattern count="other">每加仑{0}英里</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英里/英制加仑</displayName>
+				<unitPattern count="other">{0} 英里/英制加仑</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>B</displayName>
 				<unitPattern count="other">{0}byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>世纪</displayName>
+				<unitPattern count="other">{0} 世纪</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>十年</displayName>
+				<unitPattern count="other">{0} 个十年</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>年</displayName>
 				<unitPattern count="other">{0} 年</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每年{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>季</displayName>
@@ -10653,132 +10653,132 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-month">
 				<displayName>月</displayName>
 				<unitPattern count="other">{0} 个月</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每月{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>周</displayName>
 				<unitPattern count="other">{0} 周</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每周{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>天</displayName>
 				<unitPattern count="other">{0} 天</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每日{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>小时</displayName>
 				<unitPattern count="other">{0} 小时</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每小时{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>分钟</displayName>
 				<unitPattern count="other">{0} 分钟</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每分钟{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>秒</displayName>
 				<unitPattern count="other">{0} 秒</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每秒{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>毫秒</displayName>
 				<unitPattern count="other">{0} 毫秒</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>微秒</displayName>
+				<unitPattern count="other">{0} 微秒</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>奈秒</displayName>
+				<unitPattern count="other">{0} 奈秒</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>安培</displayName>
+				<unitPattern count="other">{0} 安培</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫安培</displayName>
+				<unitPattern count="other">{0} 毫安培</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>欧姆</displayName>
+				<unitPattern count="other">{0} 欧姆</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>伏特</displayName>
+				<unitPattern count="other">{0} 伏</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千卡</displayName>
+				<unitPattern count="other">{0} 千卡</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>卡路里</displayName>
+				<unitPattern count="other">{0} 卡</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>大卡</displayName>
+				<unitPattern count="other">{0} 大卡</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千焦耳</displayName>
+				<unitPattern count="other">{0} 千焦</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>焦耳</displayName>
+				<unitPattern count="other">{0} 焦</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千瓦小时</displayName>
+				<unitPattern count="other">{0} 千瓦小时</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>电子伏特</displayName>
+				<unitPattern count="other">{0} 电子伏特</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制热量单位</displayName>
+				<unitPattern count="other">{0} 英制热量单位</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>美制热量单位</displayName>
+				<unitPattern count="other">{0} 美制热量单位</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>磅力</displayName>
+				<unitPattern count="other">{0} 磅力</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>牛顿</displayName>
+				<unitPattern count="other">{0} 牛顿</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千瓦时/每 100 公里</displayName>
+				<unitPattern count="other">{0} 千瓦时/每 100 公里</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>吉赫</displayName>
+				<unitPattern count="other">{0} 吉赫</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>兆赫</displayName>
+				<unitPattern count="other">{0} 兆赫</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千赫</displayName>
+				<unitPattern count="other">{0} 千赫</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>赫兹</displayName>
+				<unitPattern count="other">{0} 赫兹</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>像素</displayName>
+				<unitPattern count="other">{0} 像素</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>MP</displayName>
@@ -10789,438 +10789,438 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>每吋像素</displayName>
+				<unitPattern count="other">{0} 像素/吋</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>每厘米点数</displayName>
+				<unitPattern count="other">{0} 点/厘米</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>每吋点数</displayName>
+				<unitPattern count="other">{0} 点/吋</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>圆点</displayName>
+				<unitPattern count="other">{0} 个圆点</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>地球半径</displayName>
+				<unitPattern count="other">{0} 地球半径</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>公里</displayName>
 				<unitPattern count="other">{0} 公里</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每公里{0}</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>公尺</displayName>
 				<unitPattern count="other">{0} 公尺</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每米{0}</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公寸</displayName>
+				<unitPattern count="other">{0} 公寸</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>公分</displayName>
 				<unitPattern count="other">{0} 公分</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>每厘米{0}</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>公厘</displayName>
 				<unitPattern count="other">{0} 公厘</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>微米</displayName>
+				<unitPattern count="other">{0} 微米</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>奈米</displayName>
+				<unitPattern count="other">{0} 奈米</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>皮米</displayName>
+				<unitPattern count="other">{0} 皮米</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英里</displayName>
+				<unitPattern count="other">{0} 英里</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>码</displayName>
+				<unitPattern count="other">{0} 码</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>英尺</displayName>
+				<unitPattern count="other">{0} 呎</unitPattern>
+				<perUnitPattern>每呎{0}</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英寸</displayName>
+				<unitPattern count="other">{0} 吋</unitPattern>
 				<perUnitPattern>每英寸 {0}</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>秒差距</displayName>
+				<unitPattern count="other">{0} 秒差距</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>光年</displayName>
+				<unitPattern count="other">{0} 光年</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="other">{0} 天文单位</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>化朗</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 化朗</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>英寻</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 英寻</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>海里</displayName>
+				<unitPattern count="other">{0} 海里</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>斯堪地那维亚英里</displayName>
+				<unitPattern count="other">{0} 斯堪地那维亚英里</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>点</displayName>
+				<unitPattern count="other">{0} 点</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>太阳半径</displayName>
+				<unitPattern count="other">{0} 太阳半径</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>勒克斯</displayName>
+				<unitPattern count="other">{0} 勒克斯</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>坎德拉</displayName>
+				<unitPattern count="other">{0} 坎德拉</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>流明</displayName>
+				<unitPattern count="other">{0} 流明</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>太阳光度</displayName>
+				<unitPattern count="other">{0} 太阳光度</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公吨</displayName>
+				<unitPattern count="other">{0} 公吨</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>公斤</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 公斤</unitPattern>
 				<perUnitPattern>每公斤 {0}</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>克</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 克</unitPattern>
 				<perUnitPattern>每克 {0}</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫克</displayName>
+				<unitPattern count="other">{0} 毫克</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>微克</displayName>
+				<unitPattern count="other">{0} 微克</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英吨</displayName>
+				<unitPattern count="other">{0} 英吨</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>英石</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 英石</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>磅</displayName>
+				<unitPattern count="other">{0} 磅</unitPattern>
 				<perUnitPattern>每磅 {0}</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>盎司</displayName>
+				<unitPattern count="other">{0} 盎司</unitPattern>
 				<perUnitPattern>每安士 {0}</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>金衡盎司</displayName>
+				<unitPattern count="other">{0} 金衡盎司</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>克拉</displayName>
+				<unitPattern count="other">{0} 克拉</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>道尔顿</displayName>
+				<unitPattern count="other">{0} 道尔顿</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>地球质量</displayName>
+				<unitPattern count="other">{0} 地球质量</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>太阳质量</displayName>
+				<unitPattern count="other">{0} 太阳质量</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>喱</displayName>
+				<unitPattern count="other">{0} 喱</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>吉瓦</displayName>
+				<unitPattern count="other">{0} 吉瓦</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>百万瓦</displayName>
+				<unitPattern count="other">{0} 百万瓦</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千瓦</displayName>
+				<unitPattern count="other">{0} 千瓦</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>瓦特</displayName>
+				<unitPattern count="other">{0} 瓦</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫瓦</displayName>
+				<unitPattern count="other">{0} 毫瓦</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>匹</displayName>
+				<unitPattern count="other">{0} 匹</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫米汞柱</displayName>
+				<unitPattern count="other">{0} 毫米汞柱</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>磅力/平方英寸</displayName>
 				<unitPattern count="other">{0}psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英寸汞柱</displayName>
+				<unitPattern count="other">{0} 英寸汞柱</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>巴</displayName>
+				<unitPattern count="other">{0} 巴</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫巴</displayName>
+				<unitPattern count="other">{0} 毫巴</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>帕斯卡</displayName>
+				<unitPattern count="other">{0} 帕斯卡</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>百帕</displayName>
+				<unitPattern count="other">{0} 百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>千帕</displayName>
+				<unitPattern count="other">{0} 千帕</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>兆帕</displayName>
+				<unitPattern count="other">{0} 兆帕</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>公里/小时</displayName>
 				<unitPattern count="other">{0}公里/小时</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>公尺/秒</displayName>
 				<unitPattern count="other">{0}m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>英里/小时</displayName>
 				<unitPattern count="other">{0}英里/小时</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>节</displayName>
+				<unitPattern count="other">{0} 节</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>华氏</displayName>
+				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>尺磅</displayName>
+				<unitPattern count="other">{0} 尺磅</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>牛顿米</displayName>
+				<unitPattern count="other">{0} 牛顿米</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方公里</displayName>
+				<unitPattern count="other">{0} 立方公里</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>立方公尺</displayName>
+				<unitPattern count="other">{0} 立方公尺</unitPattern>
+				<perUnitPattern>每立方米{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>立方公分</displayName>
+				<unitPattern count="other">{0} 立方公分</unitPattern>
+				<perUnitPattern>每立方厘米{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方英里</displayName>
+				<unitPattern count="other">{0} 立方英里</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方码</displayName>
+				<unitPattern count="other">{0} 立方码</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方英尺</displayName>
+				<unitPattern count="other">{0} 立方英尺</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>立方英寸</displayName>
+				<unitPattern count="other">{0} 立方英寸</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>兆升</displayName>
+				<unitPattern count="other">{0} 兆升</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公石</displayName>
+				<unitPattern count="other">{0} 公石</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>公升</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">{0} 升</unitPattern>
+				<perUnitPattern>每升{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公合</displayName>
+				<unitPattern count="other">{0} 公合</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>厘升</displayName>
+				<unitPattern count="other">{0} 厘升</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>毫升</displayName>
+				<unitPattern count="other">{0} 毫升</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公制品脱</displayName>
+				<unitPattern count="other">{0} 公制品脱</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>公制量杯</displayName>
+				<unitPattern count="other">{0} 公制杯</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英亩英尺</displayName>
+				<unitPattern count="other">{0} 英亩英尺</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="other">{0} 蒲式耳</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>加仑</displayName>
+				<unitPattern count="other">{0} 加仑</unitPattern>
+				<perUnitPattern>每加仑{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>英制加仑</displayName>
+				<unitPattern count="other">{0} 英制加仑</unitPattern>
+				<perUnitPattern>每英制加仑{0}</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>夸脱</displayName>
+				<unitPattern count="other">{0} 夸脱</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>品脱</displayName>
+				<unitPattern count="other">{0} 品脱</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>量杯</displayName>
+				<unitPattern count="other">{0} 杯</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>液盎司</displayName>
+				<unitPattern count="other">{0} 液盎司</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制液盎司</displayName>
+				<unitPattern count="other">{0} 英制液盎司</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>汤匙</displayName>
+				<unitPattern count="other">{0} 汤匙</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>茶匙</displayName>
+				<unitPattern count="other">{0} 茶匙</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>桶</displayName>
+				<unitPattern count="other">{0} 桶</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>甜品匙</displayName>
+				<unitPattern count="other">{0}甜品匙</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制甜品匙</displayName>
+				<unitPattern count="other">{0}英制甜品匙</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>滴</displayName>
+				<unitPattern count="other">{0}滴</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制液量打兰</displayName>
+				<unitPattern count="other">{0}英制液量打兰</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
+				<displayName>量酒杯</displayName>
 				<unitPattern count="other">量酒器{0}杯</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>小撮</displayName>
+				<unitPattern count="other">{0} 小撮</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>英制夸脱</displayName>
+				<unitPattern count="other">{0} 英制夸脱</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>方向</displayName>
@@ -11254,22 +11254,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<listPatternPart type="2">{0} 或 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0} 或 {1}</listPatternPart>
+			<listPatternPart type="2">{0} 或 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0} 或 {1}</listPatternPart>
+			<listPatternPart type="2">{0} 或 {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}同{1}</listPatternPart>
+			<listPatternPart type="2">{0}同{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}、{1}</listPatternPart>
@@ -11482,7 +11482,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern draft="provisional">↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
 			<namePattern draft="provisional">{surname}{title}</namePattern>
@@ -11494,13 +11494,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern draft="provisional">↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
 			<namePattern draft="provisional">{surname}{title}</namePattern>
@@ -11509,16 +11509,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern draft="provisional">{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
 			<namePattern draft="provisional">{surname}{title}</namePattern>
@@ -11527,10 +11527,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern draft="provisional">{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern draft="provisional">↑↑↑</namePattern>
+			<namePattern draft="provisional">{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern draft="provisional">{surname}{given}{credentials} {given2}</namePattern>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -109,7 +109,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">切罗基语</language>
 			<language type="chy">夏延语</language>
 			<language type="ckb">中库尔德语</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">中库尔德语</language>
 			<language type="ckb" alt="variant">索拉尼库尔德语</language>
 			<language type="clc">奇尔科廷语</language>
 			<language type="co">科西嘉语</language>
@@ -1026,7 +1026,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">瑙鲁</territory>
 			<territory type="NU">纽埃</territory>
 			<territory type="NZ">新西兰</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">新西兰</territory>
 			<territory type="OM">阿曼</territory>
 			<territory type="PA">巴拿马</territory>
 			<territory type="PE">秘鲁</territory>
@@ -1071,7 +1071,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="SX">荷属圣马丁</territory>
 			<territory type="SY">叙利亚</territory>
 			<territory type="SZ">斯威士兰</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
+			<territory type="SZ" alt="variant">斯威士兰</territory>
 			<territory type="TA">特里斯坦-达库尼亚群岛</territory>
 			<territory type="TC">特克斯和凯科斯群岛</territory>
 			<territory type="TD">乍得</territory>
@@ -1081,12 +1081,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TJ">塔吉克斯坦</territory>
 			<territory type="TK">托克劳</territory>
 			<territory type="TL">东帝汶</territory>
-			<territory type="TL" alt="variant">↑↑↑</territory>
+			<territory type="TL" alt="variant">东帝汶</territory>
 			<territory type="TM">土库曼斯坦</territory>
 			<territory type="TN">突尼斯</territory>
 			<territory type="TO">汤加</territory>
 			<territory type="TR">土耳其</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">土耳其</territory>
 			<territory type="TT">特立尼达和多巴哥</territory>
 			<territory type="TV">图瓦卢</territory>
 			<territory type="TW">台湾</territory>
@@ -1509,27 +1509,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
 						<dateFormatItem id="d">d日</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">d日E</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">Gy年</dateFormatItem>
 						<dateFormatItem id="GyMd" draft="contributed">Gy-M-d</dateFormatItem>
@@ -1539,7 +1539,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="M">M月</dateFormatItem>
 						<dateFormatItem id="Md">M-d</dateFormatItem>
 						<dateFormatItem id="MEd">M-dE</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LL</dateFormatItem>
 						<dateFormatItem id="MMMd">M月d日</dateFormatItem>
 						<dateFormatItem id="MMMEd">M月d日E</dateFormatItem>
 						<dateFormatItem id="MMMMd">M月d日</dateFormatItem>
@@ -1556,7 +1556,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">Gy年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B" draft="contributed">Bh时至Bh时</greatestDifference>
 							<greatestDifference id="h" draft="contributed">Bh时至h时</greatestDifference>
@@ -1570,49 +1570,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="d" draft="contributed">d至d日</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年 – Gy年</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年–y年</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM – GGGGGy-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM – y-MM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM-dd – GGGGGy-MM-dd</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM-ddE – GGGGGy-MM-ddE</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMM – Gy年MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMM–MMM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMM – y年MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">Gy年MMMd日–d日</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMMd日 – Gy年MMMd日</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMMd日 – MMMd日</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMMd日 – y年MMMd日</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">Gy年MMMd日E – MMMd日E</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMMd日E – Gy年MMMd日E</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMMd日E – MMMd日E</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMMd日E – y年MMMd日E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a" draft="contributed">ah时至ah时</greatestDifference>
 							<greatestDifference id="h" draft="contributed">ah时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
 							<greatestDifference id="a" draft="contributed">ah:mm至ah:mm</greatestDifference>
@@ -1620,8 +1620,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">ah:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
 							<greatestDifference id="a" draft="contributed">v ah:mm至ah:mm</greatestDifference>
@@ -1637,7 +1637,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="h" draft="contributed">v ah时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
 							<greatestDifference id="M" draft="contributed">M–M月</greatestDifference>
@@ -1825,113 +1825,113 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="12">亥</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">子</cyclicName>
+								<cyclicName type="2" draft="contributed">丑</cyclicName>
+								<cyclicName type="3" draft="contributed">寅</cyclicName>
+								<cyclicName type="4" draft="contributed">卯</cyclicName>
+								<cyclicName type="5" draft="contributed">辰</cyclicName>
+								<cyclicName type="6" draft="contributed">巳</cyclicName>
+								<cyclicName type="7" draft="contributed">午</cyclicName>
+								<cyclicName type="8" draft="contributed">未</cyclicName>
+								<cyclicName type="9" draft="contributed">申</cyclicName>
+								<cyclicName type="10" draft="contributed">酉</cyclicName>
+								<cyclicName type="11" draft="contributed">戌</cyclicName>
+								<cyclicName type="12" draft="contributed">亥</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="wide">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">子</cyclicName>
+								<cyclicName type="2" draft="contributed">丑</cyclicName>
+								<cyclicName type="3" draft="contributed">寅</cyclicName>
+								<cyclicName type="4" draft="contributed">卯</cyclicName>
+								<cyclicName type="5" draft="contributed">辰</cyclicName>
+								<cyclicName type="6" draft="contributed">巳</cyclicName>
+								<cyclicName type="7" draft="contributed">午</cyclicName>
+								<cyclicName type="8" draft="contributed">未</cyclicName>
+								<cyclicName type="9" draft="contributed">申</cyclicName>
+								<cyclicName type="10" draft="contributed">酉</cyclicName>
+								<cyclicName type="11" draft="contributed">戌</cyclicName>
+								<cyclicName type="12" draft="contributed">亥</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
 					<cyclicNameSet type="days">
 						<cyclicNameContext type="format">
 							<cyclicNameWidth type="abbreviated">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="14" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="15" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="16" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="17" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="18" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="19" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="20" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="21" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="22" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="23" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="24" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="25" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="26" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="27" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="28" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="29" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="30" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="31" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="32" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="33" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="34" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="35" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="36" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="37" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="38" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="39" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="40" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="41" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="42" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="43" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="44" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="45" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="46" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="47" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="48" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="49" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="50" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="51" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="52" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="53" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="54" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="55" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="56" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="57" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="58" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="59" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="60" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">甲子</cyclicName>
+								<cyclicName type="2" draft="contributed">乙丑</cyclicName>
+								<cyclicName type="3" draft="contributed">丙寅</cyclicName>
+								<cyclicName type="4" draft="contributed">丁卯</cyclicName>
+								<cyclicName type="5" draft="contributed">戊辰</cyclicName>
+								<cyclicName type="6" draft="contributed">己巳</cyclicName>
+								<cyclicName type="7" draft="contributed">庚午</cyclicName>
+								<cyclicName type="8" draft="contributed">辛未</cyclicName>
+								<cyclicName type="9" draft="contributed">壬申</cyclicName>
+								<cyclicName type="10" draft="contributed">癸酉</cyclicName>
+								<cyclicName type="11" draft="contributed">甲戌</cyclicName>
+								<cyclicName type="12" draft="contributed">乙亥</cyclicName>
+								<cyclicName type="13" draft="contributed">丙子</cyclicName>
+								<cyclicName type="14" draft="contributed">丁丑</cyclicName>
+								<cyclicName type="15" draft="contributed">戊寅</cyclicName>
+								<cyclicName type="16" draft="contributed">己卯</cyclicName>
+								<cyclicName type="17" draft="contributed">庚辰</cyclicName>
+								<cyclicName type="18" draft="contributed">辛巳</cyclicName>
+								<cyclicName type="19" draft="contributed">壬午</cyclicName>
+								<cyclicName type="20" draft="contributed">癸未</cyclicName>
+								<cyclicName type="21" draft="contributed">甲申</cyclicName>
+								<cyclicName type="22" draft="contributed">乙酉</cyclicName>
+								<cyclicName type="23" draft="contributed">丙戌</cyclicName>
+								<cyclicName type="24" draft="contributed">丁亥</cyclicName>
+								<cyclicName type="25" draft="contributed">戊子</cyclicName>
+								<cyclicName type="26" draft="contributed">己丑</cyclicName>
+								<cyclicName type="27" draft="contributed">庚寅</cyclicName>
+								<cyclicName type="28" draft="contributed">辛卯</cyclicName>
+								<cyclicName type="29" draft="contributed">壬辰</cyclicName>
+								<cyclicName type="30" draft="contributed">癸巳</cyclicName>
+								<cyclicName type="31" draft="contributed">甲午</cyclicName>
+								<cyclicName type="32" draft="contributed">乙未</cyclicName>
+								<cyclicName type="33" draft="contributed">丙申</cyclicName>
+								<cyclicName type="34" draft="contributed">丁酉</cyclicName>
+								<cyclicName type="35" draft="contributed">戊戌</cyclicName>
+								<cyclicName type="36" draft="contributed">己亥</cyclicName>
+								<cyclicName type="37" draft="contributed">庚子</cyclicName>
+								<cyclicName type="38" draft="contributed">辛丑</cyclicName>
+								<cyclicName type="39" draft="contributed">壬寅</cyclicName>
+								<cyclicName type="40" draft="contributed">癸卯</cyclicName>
+								<cyclicName type="41" draft="contributed">甲辰</cyclicName>
+								<cyclicName type="42" draft="contributed">乙巳</cyclicName>
+								<cyclicName type="43" draft="contributed">丙午</cyclicName>
+								<cyclicName type="44" draft="contributed">丁未</cyclicName>
+								<cyclicName type="45" draft="contributed">戊申</cyclicName>
+								<cyclicName type="46" draft="contributed">己酉</cyclicName>
+								<cyclicName type="47" draft="contributed">庚戌</cyclicName>
+								<cyclicName type="48" draft="contributed">辛亥</cyclicName>
+								<cyclicName type="49" draft="contributed">壬子</cyclicName>
+								<cyclicName type="50" draft="contributed">癸丑</cyclicName>
+								<cyclicName type="51" draft="contributed">甲寅</cyclicName>
+								<cyclicName type="52" draft="contributed">乙卯</cyclicName>
+								<cyclicName type="53" draft="contributed">丙辰</cyclicName>
+								<cyclicName type="54" draft="contributed">丁巳</cyclicName>
+								<cyclicName type="55" draft="contributed">戊午</cyclicName>
+								<cyclicName type="56" draft="contributed">己未</cyclicName>
+								<cyclicName type="57" draft="contributed">庚申</cyclicName>
+								<cyclicName type="58" draft="contributed">辛酉</cyclicName>
+								<cyclicName type="59" draft="contributed">壬戌</cyclicName>
+								<cyclicName type="60" draft="contributed">癸亥</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="2" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="3" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="4" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="5" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="6" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="7" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="8" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="9" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="10" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="11" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="12" draft="contributed">↑↑↑</cyclicName>
-								<cyclicName type="13" draft="contributed">↑↑↑</cyclicName>
+								<cyclicName type="1" draft="contributed">甲子</cyclicName>
+								<cyclicName type="2" draft="contributed">乙丑</cyclicName>
+								<cyclicName type="3" draft="contributed">丙寅</cyclicName>
+								<cyclicName type="4" draft="contributed">丁卯</cyclicName>
+								<cyclicName type="5" draft="contributed">戊辰</cyclicName>
+								<cyclicName type="6" draft="contributed">己巳</cyclicName>
+								<cyclicName type="7" draft="contributed">庚午</cyclicName>
+								<cyclicName type="8" draft="contributed">辛未</cyclicName>
+								<cyclicName type="9" draft="contributed">壬申</cyclicName>
+								<cyclicName type="10" draft="contributed">癸酉</cyclicName>
+								<cyclicName type="11" draft="contributed">甲戌</cyclicName>
+								<cyclicName type="12" draft="contributed">乙亥</cyclicName>
+								<cyclicName type="13" draft="contributed">丙子</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -2374,51 +2374,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">Bh时至Bh时</greatestDifference>
+							<greatestDifference id="h" draft="contributed">Bh时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">Bh:mm至Bh:mm</greatestDifference>
+							<greatestDifference id="h" draft="contributed">Bh:mm至h:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">Bh:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年 – Gy年</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年–y年</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM – GGGGGy-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM – y-MM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM-dd – GGGGGy-MM-dd</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM-ddE – GGGGGy-MM-ddE</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMM – Gy年MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMM–MMM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMM – y年MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">Gy年MMMd日–d日</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMMd日 – Gy年MMMd日</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMMd日 – MMMd日</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMMd日 – y年MMMd日</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">Gy年MMMd日E – MMMd日E</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMMd日E – Gy年MMMd日E</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMMd日E – MMMd日E</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMMd日E – y年MMMd日E</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2665,33 +2665,33 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">Bh至Bh时</greatestDifference>
+							<greatestDifference id="h" draft="contributed">Bh至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">Bh:mm至Bh:mm</greatestDifference>
+							<greatestDifference id="h" draft="contributed">Bh:mm至h:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">Bh:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -2856,7 +2856,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2864,7 +2864,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2872,7 +2872,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2880,7 +2880,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -3358,21 +3358,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<eras>
 					<eraNames>
 						<era type="0">公元前</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">公元前</era>
 						<era type="1">公元</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">公元</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">公元前</era>
-						<era type="0" alt="variant">↑↑↑</era>
+						<era type="0" alt="variant">公元前</era>
 						<era type="1">公元</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1" alt="variant">公元</era>
 					</eraAbbr>
 					<eraNarrow>
 						<era type="0">公元前</era>
-						<era type="0" alt="variant" draft="contributed">↑↑↑</era>
+						<era type="0" alt="variant" draft="contributed">公元前</era>
 						<era type="1">公元</era>
-						<era type="1" alt="variant" draft="contributed">↑↑↑</era>
+						<era type="1" alt="variant" draft="contributed">公元</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -3433,7 +3433,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -3441,7 +3441,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -3449,7 +3449,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -3457,7 +3457,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4220,7 +4220,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</months>
 				<eras>
 					<eraNames>
-						<era type="0" draft="contributed">↑↑↑</era>
+						<era type="0" draft="contributed">伊斯兰历</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">伊斯兰历</era>
@@ -4946,7 +4946,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -4954,7 +4954,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -4962,7 +4962,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4970,16 +4970,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
 						<dateFormatItem id="d">d日</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed">d日E</dateFormatItem>
 						<dateFormatItem id="Gy">Gy年</dateFormatItem>
 						<dateFormatItem id="GyMd">Gy-MM-dd</dateFormatItem>
-						<dateFormatItem id="GyMEEEEd" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMEEEEd" draft="contributed">Gy年M月d日EEEE</dateFormatItem>
 						<dateFormatItem id="GyMMM">Gy年M月</dateFormatItem>
 						<dateFormatItem id="GyMMMd">Gy年M月d日</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">Gy年M月d日E</dateFormatItem>
@@ -5011,51 +5011,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</availableFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">Bh时至Bh时</greatestDifference>
+							<greatestDifference id="h" draft="contributed">Bh时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">Bh:mm至Bh:mm</greatestDifference>
+							<greatestDifference id="h" draft="contributed">Bh:mm至h:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">Bh:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年 – Gy年</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年–y年</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM – GGGGGy-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM – y-MM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM-dd – GGGGGy-MM-dd</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM-ddE – GGGGGy-MM-ddE</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMM – Gy年MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMM–MMM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMM – y年MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">Gy年MMMd日–d日</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMMd日 – Gy年MMMd日</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMMd日 – MMMd日</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMMd日 – y年MMMd日</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">Gy年MMMd日E – MMMd日E</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMMd日E – Gy年MMMd日E</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMMd日E – MMMd日E</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMMd日E – y年MMMd日E</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5165,44 +5165,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<intervalFormats>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">Bh时至Bh时</greatestDifference>
+							<greatestDifference id="h" draft="contributed">Bh时至h时</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="h" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="B" draft="contributed">Bh:mm至Bh:mm</greatestDifference>
+							<greatestDifference id="h" draft="contributed">Bh:mm至h:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">Bh:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年 – Gy年</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年–y年</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM – GGGGGy-MM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM – y-MM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM-dd – GGGGGy-MM-dd</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
+							<greatestDifference id="G" draft="contributed">GGGGGy-MM-ddE – GGGGGy-MM-ddE</greatestDifference>
+							<greatestDifference id="M" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
+							<greatestDifference id="y" draft="contributed">GGGGGy-MM-ddE – y-MM-ddE</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="y" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMM – Gy年MMM</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMM–MMM</greatestDifference>
+							<greatestDifference id="y" draft="contributed">Gy年MMM – y年MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="G" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="M" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="d" draft="contributed">Gy年MMMd日–d日</greatestDifference>
+							<greatestDifference id="G" draft="contributed">Gy年MMMd日 – Gy年MMMd日</greatestDifference>
+							<greatestDifference id="M" draft="contributed">Gy年MMMd日 – MMMd日</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -5255,7 +5255,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="Ed">d日E</dateFormatItem>
 						<dateFormatItem id="Gy">Gy年</dateFormatItem>
 						<dateFormatItem id="GyMd">Gy/M/d</dateFormatItem>
-						<dateFormatItem id="GyMEEEEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMEEEEd">Gy年M月d日EEEE</dateFormatItem>
 						<dateFormatItem id="GyMMM">Gy年M月</dateFormatItem>
 						<dateFormatItem id="GyMMMd">Gy年M月d日</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">Gy年M月d日E</dateFormatItem>
@@ -8271,17 +8271,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<symbols numberSystem="hanidec">
 			<decimal>.</decimal>
 			<group>,</group>
-			<list draft="contributed">↑↑↑</list>
+			<list draft="contributed">;</list>
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
 			<infinity>∞</infinity>
 			<nan>NaN</nan>
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
@@ -8891,7 +8891,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="AFA">
 				<displayName>阿富汗尼 (1927–2002)</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">阿富汗尼 (1927–2002)</displayName>
 				<symbol>AFA</symbol>
 			</currency>
 			<currency type="AFN">
@@ -9150,7 +9150,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="BUK">
 				<displayName>缅元</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">缅元</displayName>
 				<symbol>BUK</symbol>
 			</currency>
 			<currency type="BWP">
@@ -9623,12 +9623,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="KRH">
 				<displayName>韩元 (1953–1962)</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">韩元 (1953–1962)</displayName>
 				<symbol>KRH</symbol>
 			</currency>
 			<currency type="KRO">
 				<displayName>韩元 (1945–1953)</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">韩元 (1945–1953)</displayName>
 				<symbol>KRO</symbol>
 			</currency>
 			<currency type="KRW">
@@ -10187,7 +10187,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="TPE">
 				<displayName>帝汶埃斯库多</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">帝汶埃斯库多</displayName>
 				<symbol>TPE</symbol>
 			</currency>
 			<currency type="TRL">
@@ -10311,7 +10311,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="VNN">
 				<displayName>越南盾 (1978–1985)</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">越南盾 (1978–1985)</displayName>
 				<symbol>VNN</symbol>
 			</currency>
 			<currency type="VUV">
@@ -10331,32 +10331,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="XAG">
 				<displayName>银</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">银</displayName>
 				<symbol>XAG</symbol>
 			</currency>
 			<currency type="XAU">
 				<displayName>黄金</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">黄金</displayName>
 				<symbol>XAU</symbol>
 			</currency>
 			<currency type="XBA">
 				<displayName>欧洲复合单位</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">欧洲复合单位</displayName>
 				<symbol>XBA</symbol>
 			</currency>
 			<currency type="XBB">
 				<displayName>欧洲货币联盟</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">欧洲货币联盟</displayName>
 				<symbol>XBB</symbol>
 			</currency>
 			<currency type="XBC">
 				<displayName>欧洲计算单位 (XBC)</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">欧洲计算单位 (XBC)</displayName>
 				<symbol>XBC</symbol>
 			</currency>
 			<currency type="XBD">
 				<displayName>欧洲计算单位 (XBD)</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">欧洲计算单位 (XBD)</displayName>
 				<symbol>XBD</symbol>
 			</currency>
 			<currency type="XCD">
@@ -10367,7 +10367,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="XDR">
 				<displayName>特别提款权</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">特别提款权</displayName>
 				<symbol>XDR</symbol>
 			</currency>
 			<currency type="XEU">
@@ -10377,12 +10377,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="XFO">
 				<displayName>法国金法郎</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">法国金法郎</displayName>
 				<symbol>XFO</symbol>
 			</currency>
 			<currency type="XFU">
 				<displayName>法国法郎 (UIC)</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">法国法郎 (UIC)</displayName>
 				<symbol>XFU</symbol>
 			</currency>
 			<currency type="XOF">
@@ -10392,7 +10392,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="XPD">
 				<displayName>钯</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">钯</displayName>
 				<symbol>XPD</symbol>
 			</currency>
 			<currency type="XPF">
@@ -10402,12 +10402,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="XPT">
 				<displayName>铂</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">铂</displayName>
 				<symbol>XPT</symbol>
 			</currency>
 			<currency type="XRE">
 				<displayName>RINET 基金</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">RINET 基金</displayName>
 				<symbol>XRE</symbol>
 			</currency>
 			<currency type="XSU">
@@ -10417,7 +10417,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="XTS">
 				<displayName>测试货币代码</displayName>
-				<displayName count="other" draft="contributed">↑↑↑</displayName>
+				<displayName count="other" draft="contributed">测试货币代码</displayName>
 				<symbol>XTS</symbol>
 			</currency>
 			<currency type="XUA">
@@ -10750,28 +10750,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>尧{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
 				<unitPrefixPattern>Gib{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>每{1}{0}</compoundUnitPattern>
@@ -10816,7 +10816,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-kilometer">
 				<displayName>平方公里</displayName>
 				<unitPattern count="other">{0}平方公里</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/平方公里</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>公顷</displayName>
@@ -10825,17 +10825,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-meter">
 				<displayName>平方米</displayName>
 				<unitPattern count="other">{0}平方米</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/平方米</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>平方厘米</displayName>
 				<unitPattern count="other">{0}平方厘米</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/平方厘米</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>平方英里</displayName>
 				<unitPattern count="other">{0}平方英里</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/平方英里</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>英亩</displayName>
@@ -10852,7 +10852,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-inch">
 				<displayName>平方英寸</displayName>
 				<unitPattern count="other">{0}平方英寸</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/平方英寸</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>杜纳亩</displayName>
@@ -10887,8 +10887,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>摩尔</displayName>
@@ -10965,7 +10965,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-year">
 				<displayName>年</displayName>
 				<unitPattern count="other">{0}年</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/年</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>季度</displayName>
@@ -10975,27 +10975,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-month">
 				<displayName>个月</displayName>
 				<unitPattern count="other">{0}个月</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/月</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>周</displayName>
 				<unitPattern count="other">{0}周</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/周</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>天</displayName>
 				<unitPattern count="other">{0}天</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/天</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>小时</displayName>
 				<unitPattern count="other">{0}小时</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/小时</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>分钟</displayName>
 				<unitPattern count="other">{0}分钟</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/分钟</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>秒钟</displayName>
@@ -11133,12 +11133,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-kilometer">
 				<displayName>公里</displayName>
 				<unitPattern count="other">{0}公里</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/公里</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>米</displayName>
 				<unitPattern count="other">{0}米</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/米</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>分米</displayName>
@@ -11147,7 +11147,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-centimeter">
 				<displayName>厘米</displayName>
 				<unitPattern count="other">{0}厘米</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/厘米</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>毫米</displayName>
@@ -11176,12 +11176,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-foot">
 				<displayName>英尺</displayName>
 				<unitPattern count="other">{0}英尺</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/英尺</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>英寸</displayName>
 				<unitPattern count="other">{0}英寸</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/英寸</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>秒差距</displayName>
@@ -11247,7 +11247,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="mass-gram">
 				<displayName>克</displayName>
 				<unitPattern count="other">{0}克</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>毫克</displayName>
@@ -11410,12 +11410,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-cubic-meter">
 				<displayName>立方米</displayName>
 				<unitPattern count="other">{0}立方米</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/立方米</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>立方厘米</displayName>
 				<unitPattern count="other">{0}立方厘米</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/立方厘米</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>立方英里</displayName>
@@ -11444,7 +11444,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-liter">
 				<displayName>升</displayName>
 				<unitPattern count="other">{0}升</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/升</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>分升</displayName>
@@ -11477,12 +11477,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-gallon">
 				<displayName>加仑</displayName>
 				<unitPattern count="other">{0}加仑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/加仑</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>英制加仑</displayName>
 				<unitPattern count="other">{0}英制加仑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/英制加仑</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>夸脱</displayName>
@@ -11989,8 +11989,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
@@ -12427,96 +12427,96 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>d{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>c{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>m{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>μ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>n{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>p{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>f{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>a{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>da{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>h{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>k{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>M{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>G{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>T{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>P{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>E{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Z{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
 				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1>↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
@@ -12530,23 +12530,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}米/秒²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>转</displayName>
+				<unitPattern count="other">{0}转</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>弧度</displayName>
+				<unitPattern count="other">{0}弧度</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>度</displayName>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>弧分</displayName>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>弧秒</displayName>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
@@ -12595,43 +12595,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>kt</displayName>
+				<unitPattern count="other" draft="contributed">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="other" draft="contributed">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="other" draft="contributed">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>项</displayName>
+				<unitPattern count="other">{0}项</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>%</displayName>
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="other" draft="contributed">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>L/km</displayName>
 				<unitPattern count="other">{0}L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
@@ -12639,56 +12639,56 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mpg US</displayName>
 				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">mpg Imp.</displayName>
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>b</displayName>
+				<unitPattern count="other">{0} b</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>个世纪</displayName>
@@ -12705,7 +12705,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-quarter">
 				<displayName draft="contributed">季</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0}季</unitPattern>
 				<perUnitPattern draft="contributed">{0}/季</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
@@ -12751,19 +12751,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>A</displayName>
 				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>mA</displayName>
 				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ω</displayName>
 				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>V</displayName>
 				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
@@ -12803,51 +12803,51 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}美制克卡</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf</displayName>
 				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>牛</displayName>
+				<unitPattern count="other">{0}牛</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>GHz</displayName>
 				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>MHz</displayName>
 				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>kHz</displayName>
 				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
+				<displayName>Hz</displayName>
 				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>MP</displayName>
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -12856,14 +12856,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>dpi</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>dot</displayName>
 				<unitPattern count="other">{0}dot</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -12948,7 +12948,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>pt</displayName>
 				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
@@ -12956,45 +12956,45 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lx</displayName>
 				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
+				<displayName>cd</displayName>
 				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="other">{0}lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>L☉</displayName>
 				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
+				<displayName>t</displayName>
 				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="other">{0}kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="other">{0}g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
+				<displayName>mg</displayName>
 				<unitPattern count="other">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
+				<displayName>μg</displayName>
 				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">tn</displayName>
 				<unitPattern count="other">{0}tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
@@ -13002,37 +13002,37 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">lb</displayName>
 				<unitPattern count="other">{0}#</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz</displayName>
 				<unitPattern count="other">{0}oz</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>oz t</displayName>
 				<unitPattern count="other">{0}oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>CD</displayName>
 				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
+				<displayName>Da</displayName>
 				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M⊕</displayName>
 				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>M☉</displayName>
 				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>gr</displayName>
 				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -13048,7 +13048,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">瓦特</displayName>
 				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
@@ -13060,43 +13060,43 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>mmHg</displayName>
 				<unitPattern count="other">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>psi</displayName>
 				<unitPattern count="other">{0}psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
+				<displayName>inHg</displayName>
 				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>bar</displayName>
 				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
+				<displayName>mbar</displayName>
 				<unitPattern count="other">{0}mb</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>atm</displayName>
 				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pa</displayName>
 				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>hPa</displayName>
 				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>kPa</displayName>
 				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
+				<displayName>MPa</displayName>
 				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -13112,32 +13112,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
+				<displayName>kn</displayName>
 				<unitPattern count="other">{0}kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
 				<unitPattern count="other">{0}°C</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>lbf⋅ft</displayName>
 				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>牛米</displayName>
+				<unitPattern count="other">{0}牛米</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>km³</displayName>
@@ -13237,7 +13237,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">英制液盎司</displayName>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -13249,11 +13249,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">桶</displayName>
 				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">甜点匙</displayName>
 				<unitPattern count="other">{0}dsp</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
@@ -13261,19 +13261,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">滴</displayName>
 				<unitPattern count="other">{0}dr</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">液量打兰</displayName>
 				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">量杯</displayName>
 				<unitPattern count="other">{0}jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">撮</displayName>
 				<unitPattern count="other">{0}pn</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
@@ -13312,20 +13312,20 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0}或{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}或{1}</listPatternPart>
+			<listPatternPart type="2">{0}或{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}或{1}</listPatternPart>
+			<listPatternPart type="2">{0}或{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
 			<listPatternPart type="end">{0}、{1}</listPatternPart>
 			<listPatternPart type="2">{0}、{1}</listPatternPart>
 		</listPattern>
@@ -13612,7 +13612,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}{title}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
 			<namePattern>{surname} {given-informal}</namePattern>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -126,7 +126,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">柴羅基文</language>
 			<language type="chy">沙伊安文</language>
 			<language type="ckb">中庫德文</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
+			<language type="ckb" alt="menu">中庫德文</language>
 			<language type="ckb" alt="variant">庫德文（索拉尼）</language>
 			<language type="clc">齊爾柯廷語</language>
 			<language type="co">科西嘉文</language>
@@ -674,9 +674,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="zh">中文</language>
 			<language type="zh" alt="menu">中文</language>
 			<language type="zh_Hans">簡體中文</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">簡體中文</language>
 			<language type="zh_Hant">繁體中文</language>
-			<language type="zh_Hant" alt="long">↑↑↑</language>
+			<language type="zh_Hant" alt="long">繁體中文</language>
 			<language type="zu">祖魯文</language>
 			<language type="zun">祖尼文</language>
 			<language type="zxx">無語言內容</language>
@@ -1086,7 +1086,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="NR">諾魯</territory>
 			<territory type="NU">紐埃島</territory>
 			<territory type="NZ">紐西蘭</territory>
-			<territory type="NZ" alt="variant" draft="contributed">↑↑↑</territory>
+			<territory type="NZ" alt="variant" draft="contributed">紐西蘭</territory>
 			<territory type="OM">阿曼</territory>
 			<territory type="PA">巴拿馬</territory>
 			<territory type="PE">秘魯</territory>
@@ -1146,7 +1146,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="TN">突尼西亞</territory>
 			<territory type="TO">東加</territory>
 			<territory type="TR">土耳其</territory>
-			<territory type="TR" alt="variant">↑↑↑</territory>
+			<territory type="TR" alt="variant">土耳其</territory>
 			<territory type="TT">千里達及托巴哥</territory>
 			<territory type="TV">吐瓦魯</territory>
 			<territory type="TW">台灣</territory>
@@ -1573,7 +1573,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">Gy年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d日至d日</greatestDifference>
 						</intervalFormatItem>
@@ -2920,7 +2920,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ" draft="contributed">G y年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d日至d日</greatestDifference>
 						</intervalFormatItem>
@@ -3914,27 +3914,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern draft="contributed">↑↑↑</pattern>
+							<pattern draft="contributed">{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
 						<dateFormatItem id="d" draft="contributed">d日</dateFormatItem>
-						<dateFormatItem id="E" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="E" draft="contributed">ccc</dateFormatItem>
 						<dateFormatItem id="Ed" draft="contributed">d日E</dateFormatItem>
 						<dateFormatItem id="Gy" draft="contributed">rU年</dateFormatItem>
 						<dateFormatItem id="GyMMM" draft="contributed">rU年MMM</dateFormatItem>
@@ -3943,7 +3943,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="M" draft="contributed">MMM</dateFormatItem>
 						<dateFormatItem id="Md" draft="contributed">M/d</dateFormatItem>
 						<dateFormatItem id="MEd" draft="contributed">M/dE</dateFormatItem>
-						<dateFormatItem id="MMM" draft="contributed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMM" draft="contributed">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd" draft="contributed">MMMd日</dateFormatItem>
 						<dateFormatItem id="MMMEd" draft="contributed">MMMd日E</dateFormatItem>
 						<dateFormatItem id="MMMMd" draft="contributed">MMMMd日</dateFormatItem>
@@ -3974,7 +3974,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="h" draft="contributed">Bh時至h時</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH至HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
 							<greatestDifference id="B" draft="contributed">Bh:mm至Bh:mm</greatestDifference>
@@ -3982,8 +3982,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m" draft="contributed">Bh:mm至h:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H" draft="contributed">↑↑↑</greatestDifference>
-							<greatestDifference id="m" draft="contributed">↑↑↑</greatestDifference>
+							<greatestDifference id="H" draft="contributed">HH:mm至HH:mm</greatestDifference>
+							<greatestDifference id="m" draft="contributed">HH:mm至HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
 							<greatestDifference id="B" draft="contributed">Bh:mm至Bh:mm [v]</greatestDifference>
@@ -4250,7 +4250,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ" draft="contributed">G y年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d日至d日</greatestDifference>
 						</intervalFormatItem>
@@ -4395,7 +4395,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1}{0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}{0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -4403,7 +4403,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -4411,7 +4411,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4419,7 +4419,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -4785,10 +4785,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<quarters>
 					<quarterContext type="format">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">第1季</quarter>
+							<quarter type="2">第2季</quarter>
+							<quarter type="3">第3季</quarter>
+							<quarter type="4">第4季</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">1</quarter>
@@ -4805,8 +4805,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
+							<quarter type="1">第1季</quarter>
+							<quarter type="2">第2季</quarter>
 							<quarter type="3">第3季</quarter>
 							<quarter type="4">第4季</quarter>
 						</quarterWidth>
@@ -4974,7 +4974,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -4982,7 +4982,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -4990,7 +4990,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -4998,7 +4998,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -5396,7 +5396,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ" draft="contributed">G y年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d日至d日</greatestDifference>
 						</intervalFormatItem>
@@ -5672,7 +5672,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ" draft="contributed">G y年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d日至d日</greatestDifference>
 						</intervalFormatItem>
@@ -5948,7 +5948,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">Gy年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d日至d日</greatestDifference>
 						</intervalFormatItem>
@@ -6842,7 +6842,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">Gy年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d日至d日</greatestDifference>
 						</intervalFormatItem>
@@ -7118,7 +7118,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ" draft="contributed">G y年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d日至d日</greatestDifference>
 						</intervalFormatItem>
@@ -7314,7 +7314,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">Gy年QQQQ</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d日至d日</greatestDifference>
 						</intervalFormatItem>
@@ -10493,7 +10493,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<percentSign>%</percentSign>
 			<plusSign>+</plusSign>
 			<minusSign>-</minusSign>
-			<approximatelySign>↑↑↑</approximatelySign>
+			<approximatelySign>~</approximatelySign>
 			<exponential>E</exponential>
 			<superscriptingExponent>×</superscriptingExponent>
 			<perMille>‰</perMille>
@@ -11863,7 +11863,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -14241,7 +14241,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">立方{0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G 力</displayName>
@@ -14345,8 +14345,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>莫耳</displayName>
@@ -14534,7 +14534,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName draft="contributed">每百公里千瓦小時</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>吉赫</displayName>
@@ -14553,8 +14553,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} 赫茲</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>像素</displayName>
@@ -14565,24 +14565,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} 百萬像素</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>dpcm</displayName>
 				<unitPattern count="other">{0} dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>地球半徑</displayName>
@@ -14755,7 +14755,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-grain">
 				<displayName>格林</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 格林</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>吉瓦</displayName>
@@ -14984,7 +14984,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-drop">
 				<displayName>滴</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} 滴</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>打蘭</displayName>
@@ -15447,8 +15447,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
@@ -15938,42 +15938,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>{0} 佑米</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1>{0}²</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}²</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
 				<compoundUnitPattern1>{0}³</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName draft="contributed">G 力</displayName>
@@ -16006,7 +16006,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-kilometer">
 				<displayName draft="contributed">平方公里</displayName>
 				<unitPattern count="other" draft="contributed">{0}km²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/平方公里</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName draft="contributed">公頃</displayName>
@@ -16015,17 +16015,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-meter">
 				<displayName draft="contributed">平方公尺</displayName>
 				<unitPattern count="other" draft="contributed">{0}m²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/平方公尺</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName draft="contributed">平方公分</displayName>
 				<unitPattern count="other" draft="contributed">{0}cm²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/平分公分</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName draft="contributed">平方英里</displayName>
 				<unitPattern count="other">{0}平方英里</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/平方英里</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName draft="contributed">英畝</displayName>
@@ -16042,10 +16042,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-inch">
 				<displayName draft="contributed">平方英寸</displayName>
 				<unitPattern count="other" draft="contributed">{0}in²</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/平方英寸</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">杜納畝</displayName>
 				<unitPattern count="other" draft="contributed">{0}杜納畝</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -16061,8 +16061,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">個項目</displayName>
+				<unitPattern count="other" draft="contributed">{0} 個項目</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName draft="contributed">百萬分率</displayName>
@@ -16073,15 +16073,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">千分比</displayName>
+				<unitPattern count="other" draft="contributed">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">‱</displayName>
+				<unitPattern count="other" draft="contributed">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">莫耳</displayName>
 				<unitPattern count="other" draft="contributed">{0}莫耳</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -16101,7 +16101,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">PB</displayName>
 				<unitPattern count="other" draft="contributed">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
@@ -16149,8 +16149,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0} 世紀</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName draft="contributed">↑↑↑</displayName>
-				<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
+				<displayName draft="contributed">10 年</displayName>
+				<unitPattern count="other" draft="contributed">{0}0 年</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>年</displayName>
@@ -16245,27 +16245,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">電子伏特</displayName>
 				<unitPattern count="other" draft="contributed">{0}電子伏特</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">英熱單位</displayName>
 				<unitPattern count="other" draft="contributed">{0}英熱單位</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">美制撒姆</displayName>
 				<unitPattern count="other" draft="contributed">{0}美制撒姆</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">lbf</displayName>
 				<unitPattern count="other" draft="contributed">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">N</displayName>
 				<unitPattern count="other" draft="contributed">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">kWh/100km</displayName>
 				<unitPattern count="other" draft="contributed">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -16285,23 +16285,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>em</displayName>
 				<unitPattern count="other">{0}em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>px</displayName>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>MP</displayName>
 				<unitPattern count="other">{0}MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppcm</displayName>
 				<unitPattern count="other">{0}ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>ppi</displayName>
 				<unitPattern count="other">{0}ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
@@ -16313,11 +16313,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">px</displayName>
 				<unitPattern count="other">{0}px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>R⊕</displayName>
 				<unitPattern count="other" draft="contributed">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -16406,7 +16406,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}點</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">R☉</displayName>
 				<unitPattern count="other" draft="contributed">{0}R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -16414,15 +16414,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">燭光</displayName>
 				<unitPattern count="other" draft="contributed">{0}燭光</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">流明</displayName>
 				<unitPattern count="other" draft="contributed">{0}流明</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">L☉</displayName>
 				<unitPattern count="other" draft="contributed">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -16432,12 +16432,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="mass-kilogram">
 				<displayName>公斤</displayName>
 				<unitPattern count="other">{0} 公斤</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/公斤</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>克</displayName>
 				<unitPattern count="other">{0}克</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/克</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName draft="contributed">毫克</displayName>
@@ -16463,7 +16463,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="mass-ounce">
 				<displayName draft="contributed">盎司</displayName>
 				<unitPattern count="other">{0}盎司</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/盎司</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName draft="contributed">金衡盎司</displayName>
@@ -16474,19 +16474,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">達爾頓</displayName>
 				<unitPattern count="other" draft="contributed">{0}達爾頓</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">地球質量</displayName>
 				<unitPattern count="other" draft="contributed">{0}地球質量</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">太陽質量</displayName>
 				<unitPattern count="other" draft="contributed">{0}太陽質量</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">格林</displayName>
 				<unitPattern count="other" draft="contributed">{0}格林</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -16526,7 +16526,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}英吋汞柱</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">巴</displayName>
 				<unitPattern count="other" draft="contributed">{0}巴</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -16534,11 +16534,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}毫巴</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">atm</displayName>
 				<unitPattern count="other" draft="contributed">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">帕</displayName>
 				<unitPattern count="other" draft="contributed">{0}帕</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -16546,11 +16546,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}百帕</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">千帕</displayName>
 				<unitPattern count="other" draft="contributed">{0}千帕</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">兆帕</displayName>
 				<unitPattern count="other" draft="contributed">{0}兆帕</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -16586,26 +16586,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}°K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">磅英尺</displayName>
 				<unitPattern count="other" draft="contributed">{0}磅英尺</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">牛頓米</displayName>
 				<unitPattern count="other" draft="contributed">{0}牛頓米</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">立方公里</displayName>
 				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName draft="contributed">立方公尺</displayName>
 				<unitPattern count="other" draft="contributed">{0}m³</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/立方公尺</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName draft="contributed">立方公分</displayName>
 				<unitPattern count="other" draft="contributed">{0}cm³</unitPattern>
-				<perUnitPattern draft="contributed">↑↑↑</perUnitPattern>
+				<perUnitPattern draft="contributed">{0}/立方公分</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName draft="contributed">立方英里</displayName>
@@ -16691,7 +16691,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}fl-oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">英液盎司</displayName>
 				<unitPattern count="other" draft="contributed">{0}英液盎司</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -16703,35 +16703,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">桶</displayName>
 				<unitPattern count="other" draft="contributed">{0}桶</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">甜品匙</displayName>
 				<unitPattern count="other" draft="contributed">{0}甜品匙</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">英制甜品匙</displayName>
 				<unitPattern count="other" draft="contributed">{0}dsp-Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">滴</displayName>
 				<unitPattern count="other" draft="contributed">{0}滴</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">打蘭</displayName>
 				<unitPattern count="other" draft="contributed">{0}打蘭</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">量酒杯</displayName>
 				<unitPattern count="other" draft="contributed">{0}量酒杯</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">小撮</displayName>
 				<unitPattern count="other" draft="contributed">{0}小撮</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName draft="contributed">↑↑↑</displayName>
+				<displayName draft="contributed">英制夸脫</displayName>
 				<unitPattern count="other" draft="contributed">{0}英制夸脫</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -16766,22 +16766,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">{0}或{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}或{1}</listPatternPart>
+			<listPatternPart type="2">{0}或{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}或{1}</listPatternPart>
+			<listPatternPart type="2">{0}或{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}、{1}</listPatternPart>
+			<listPatternPart type="middle">{0}、{1}</listPatternPart>
+			<listPatternPart type="end">{0}和{1}</listPatternPart>
+			<listPatternPart type="2">{0}和{1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-short">
 			<listPatternPart type="start">{0}、{1}</listPatternPart>
@@ -16995,7 +16995,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
 			<namePattern>{surname} {title}</namePattern>
@@ -17007,13 +17007,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
 			<namePattern>{surname} {title}</namePattern>
@@ -17022,16 +17022,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
 			<namePattern>{surname} {title}</namePattern>
@@ -17040,10 +17040,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>{surname}{given}{given2}{generation}{credentials}</namePattern>
@@ -17061,7 +17061,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
 			<namePattern>{surname}{given}{given2-initial}{generation}{credentials}</namePattern>
@@ -17079,7 +17079,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
 			<namePattern>{surname}{given}{given2}</namePattern>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -83,8 +83,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="chr">isi-Cherokee</language>
 			<language type="chy">isi-Cheyenne</language>
 			<language type="ckb">isi-Central Kurdish</language>
-			<language type="ckb" alt="menu">↑↑↑</language>
-			<language type="ckb" alt="variant">↑↑↑</language>
+			<language type="ckb" alt="menu">isi-Central Kurdish</language>
+			<language type="ckb" alt="variant">isi-Central Kurdish</language>
 			<language type="clc">isi-Chilcotin</language>
 			<language type="co">isi-Corsican</language>
 			<language type="crg">isi-Michif</language>
@@ -475,7 +475,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="zh">isi-Chinese</language>
 			<language type="zh" alt="menu">isi-Chinese, Mandarin</language>
 			<language type="zh_Hans">isi-Chinese (esenziwe-lula)</language>
-			<language type="zh_Hans" alt="long">↑↑↑</language>
+			<language type="zh_Hans" alt="long">isi-Chinese (esenziwe-lula)</language>
 			<language type="zh_Hant">isi-Chinese (Sasendulo)</language>
 			<language type="zh_Hant" alt="long">isi-Chinese (sasendulo)</language>
 			<language type="zu">isiZulu</language>
@@ -921,7 +921,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<territory type="SX">i-Sint Maarten</territory>
 			<territory type="SY">i-Syria</territory>
 			<territory type="SZ">i-Swaziland</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
+			<territory type="SZ" alt="variant">i-Swaziland</territory>
 			<territory type="TA">i-Tristan da Cunha</territory>
 			<territory type="TC">i-Turks ne-Caicos Islands</territory>
 			<territory type="TD">i-Chad</territory>
@@ -1312,237 +1312,237 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<calendar type="buddhist">
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">BE</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
+						<era type="0">BE</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE dd MMMM y G</pattern>
+							<datetimeSkeleton>GyMMMMEEEEdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MMMM y G</pattern>
+							<datetimeSkeleton>GyMMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MMM y G</pattern>
+							<datetimeSkeleton>GyMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>GGGGG y-MM-dd</pattern>
+							<datetimeSkeleton>GGGGGyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
-						<dateFormatItem id="d">↑↑↑</dateFormatItem>
-						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="d">d</dateFormatItem>
+						<dateFormatItem id="E">ccc</dateFormatItem>
+						<dateFormatItem id="Ed">d E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="M">L</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
+						<dateFormatItem id="MMM">LLL</dateFormatItem>
+						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="y">y G</dateFormatItem>
+						<dateFormatItem id="yM">yM</dateFormatItem>
+						<dateFormatItem id="yMd">M/d/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMd">MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, M/d/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h B – h B</greatestDifference>
+							<greatestDifference id="h">h–h B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
-							<greatestDifference id="B">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="B">h:mm B – h:mm B</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm B</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="d">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">d–d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y – G y</greatestDifference>
+							<greatestDifference id="y">G y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM – GGGGG y-MM</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM – y-MM</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd – GGGGG y-MM-dd</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="G">GGGGG y-MM-dd, E – GGGGG y-MM-dd, E</greatestDifference>
+							<greatestDifference id="M">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">GGGGG y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">G y MMM – G y MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM–MMM</greatestDifference>
+							<greatestDifference id="y">G y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d–d</greatestDifference>
+							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH:mm–HH:mm v</greatestDifference>
+							<greatestDifference id="m">HH:mm–HH:mm v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
-							<greatestDifference id="H">↑↑↑</greatestDifference>
+							<greatestDifference id="H">HH–HH v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="M">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M–M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d – M/d</greatestDifference>
+							<greatestDifference id="M">M/d – M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d – E, M/d</greatestDifference>
+							<greatestDifference id="M">E, M/d – E, M/d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM–MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y–y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">M/y – M/y</greatestDifference>
+							<greatestDifference id="y">M/y – M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
+							<greatestDifference id="y">MMMM y – MMMM y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1566,8 +1566,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 								<cyclicName type="12">↑↑↑</cyclicName>
 							</cyclicNameWidth>
 							<cyclicNameWidth type="narrow">
-								<cyclicName type="1">↑↑↑</cyclicName>
-								<cyclicName type="2">↑↑↑</cyclicName>
+								<cyclicName type="1">zi</cyclicName>
+								<cyclicName type="2">chou</cyclicName>
 							</cyclicNameWidth>
 						</cyclicNameContext>
 					</cyclicNameSet>
@@ -1606,7 +1606,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1614,7 +1614,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1622,7 +1622,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1630,7 +1630,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1877,10 +1877,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
+							<month type="1">Jan</month>
+							<month type="2">Feb</month>
+							<month type="3">Mas</month>
+							<month type="4">Eph</month>
 							<month type="5">Mey</month>
 							<month type="6">Jun</month>
 							<month type="7">Jul</month>
@@ -1905,18 +1905,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<month type="12">D</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Januwari</month>
+							<month type="2">Februwari</month>
+							<month type="3">Mashi</month>
+							<month type="4">Ephreli</month>
+							<month type="5">Meyi</month>
+							<month type="6">Juni</month>
+							<month type="7">Julayi</month>
+							<month type="8">Agasti</month>
+							<month type="9">Septhemba</month>
+							<month type="10">Okthoba</month>
+							<month type="11">Novemba</month>
+							<month type="12">Disemba</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1932,22 +1932,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">Mgq</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">S</day>
+							<day type="mon">M</day>
+							<day type="tue">B</day>
+							<day type="wed">T</day>
+							<day type="thu">S</day>
+							<day type="fri">H</day>
+							<day type="sat">M</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Son</day>
+							<day type="mon">Mso</day>
+							<day type="tue">Bil</day>
+							<day type="wed">Tha</day>
+							<day type="thu">Sin</day>
+							<day type="fri">Hla</day>
+							<day type="sat">Mgq</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">ISonto</day>
@@ -1962,12 +1962,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<dayContext type="stand-alone">
 						<dayWidth type="abbreviated">
 							<day type="sun">Son</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="mon">Mso</day>
+							<day type="tue">Bil</day>
+							<day type="wed">Tha</day>
+							<day type="thu">Sin</day>
+							<day type="fri">Hla</day>
+							<day type="sat">Mgq</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">↑↑↑</day>
@@ -1979,22 +1979,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">M</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Son</day>
+							<day type="mon">Mso</day>
+							<day type="tue">Bil</day>
+							<day type="wed">Tha</day>
+							<day type="thu">Sin</day>
+							<day type="fri">Hla</day>
+							<day type="sat">Mgq</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
+							<day type="sun">ISonto</day>
+							<day type="mon">UMsombuluko</day>
+							<day type="tue">ULwesibili</day>
 							<day type="wed">ULwesithathu</day>
 							<day type="thu">ULwesine</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="fri">ULwesihlanu</day>
+							<day type="sat">UMgqibelo</day>
 						</dayWidth>
 					</dayContext>
 				</days>
@@ -2054,58 +2054,58 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="am">a</dayPeriod>
 							<dayPeriod type="pm">p</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
-							<dayPeriod type="morning2">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
-						</dayPeriodWidth>
-						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
-							<dayPeriod type="morning2">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
-						</dayPeriodWidth>
-					</dayPeriodContext>
-					<dayPeriodContext type="stand-alone">
-						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
-							<dayPeriod type="morning2">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
-						</dayPeriodWidth>
-						<dayPeriodWidth type="narrow">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
-							<dayPeriod type="morning2">↑↑↑</dayPeriod>
+							<dayPeriod type="morning1">entathakusa</dayPeriod>
+							<dayPeriod type="morning2">ekuseni</dayPeriod>
 							<dayPeriod type="afternoon1">emini</dayPeriod>
 							<dayPeriod type="evening1">ntambama</dayPeriod>
 							<dayPeriod type="night1">ebusuku</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
-							<dayPeriod type="morning2">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
+							<dayPeriod type="morning1">entathakusa</dayPeriod>
+							<dayPeriod type="morning2">ekuseni</dayPeriod>
+							<dayPeriod type="afternoon1">emini</dayPeriod>
+							<dayPeriod type="evening1">ntambama</dayPeriod>
+							<dayPeriod type="night1">ebusuku</dayPeriod>
+						</dayPeriodWidth>
+					</dayPeriodContext>
+					<dayPeriodContext type="stand-alone">
+						<dayPeriodWidth type="abbreviated">
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
+							<dayPeriod type="morning1">entathakusa</dayPeriod>
+							<dayPeriod type="morning2">ekuseni</dayPeriod>
+							<dayPeriod type="afternoon1">emini</dayPeriod>
+							<dayPeriod type="evening1">ntambama</dayPeriod>
+							<dayPeriod type="night1">ebusuku</dayPeriod>
+						</dayPeriodWidth>
+						<dayPeriodWidth type="narrow">
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
+							<dayPeriod type="morning1">entathakusa</dayPeriod>
+							<dayPeriod type="morning2">ekuseni</dayPeriod>
+							<dayPeriod type="afternoon1">emini</dayPeriod>
+							<dayPeriod type="evening1">ntambama</dayPeriod>
+							<dayPeriod type="night1">ebusuku</dayPeriod>
+						</dayPeriodWidth>
+						<dayPeriodWidth type="wide">
+							<dayPeriod type="am">AM</dayPeriod>
+							<dayPeriod type="pm">PM</dayPeriod>
+							<dayPeriod type="morning1">entathakusa</dayPeriod>
+							<dayPeriod type="morning2">ekuseni</dayPeriod>
+							<dayPeriod type="afternoon1">emini</dayPeriod>
+							<dayPeriod type="evening1">ntambama</dayPeriod>
+							<dayPeriod type="night1">ebusuku</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="0">BC</era>
+						<era type="0" alt="variant">BCE</era>
+						<era type="1">AD</era>
+						<era type="1" alt="variant">CE</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">BC</era>
@@ -2114,10 +2114,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<era type="1" alt="variant">CE</era>
 					</eraAbbr>
 					<eraNarrow>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="0">BC</era>
+						<era type="0" alt="variant">BCE</era>
+						<era type="1">AD</era>
+						<era type="1" alt="variant">CE</era>
 					</eraNarrow>
 				</eras>
 				<dateFormats>
@@ -2178,7 +2178,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -2186,7 +2186,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -2194,7 +2194,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -2202,7 +2202,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -2409,10 +2409,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Isikhathi</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Isikhathi</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Isikhathi</displayName>
 			</field>
 			<field type="year">
 				<displayName>Unyaka</displayName>
@@ -2429,10 +2429,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="year-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Unyaka</displayName>
+				<relative type="-1">onyakeni odlule</relative>
+				<relative type="0">kulo nyaka</relative>
+				<relative type="1">unyaka ozayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">onyakeni ongu-{0} ozayo</relativeTimePattern>
 					<relativeTimePattern count="other">eminyakeni engu-{0} ezayo</relativeTimePattern>
@@ -2443,10 +2443,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Unyaka</displayName>
+				<relative type="-1">onyakeni odlule</relative>
+				<relative type="0">kulo nyaka</relative>
+				<relative type="1">unyaka ozayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">onyakeni ongu-{0} ozayo</relativeTimePattern>
 					<relativeTimePattern count="other">eminyakeni engu-{0} ezayo</relativeTimePattern>
@@ -2471,10 +2471,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Ikota</displayName>
+				<relative type="-1">ikota edlule</relative>
+				<relative type="0">le kota</relative>
+				<relative type="1">ikota ezayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">kwikota engu-{0} ezayo</relativeTimePattern>
 					<relativeTimePattern count="other">kumakota angu-{0} ezayo</relativeTimePattern>
@@ -2485,10 +2485,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Ikota</displayName>
+				<relative type="-1">ikota edlule</relative>
+				<relative type="0">le kota</relative>
+				<relative type="1">ikota ezayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">kumakota angu-{0}</relativeTimePattern>
 					<relativeTimePattern count="other">kumakota angu-{0}</relativeTimePattern>
@@ -2513,10 +2513,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="month-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Inyanga</displayName>
+				<relative type="-1">inyanga edlule</relative>
+				<relative type="0">le nyanga</relative>
+				<relative type="1">inyanga ezayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ezinyangeni ezingu-{0} ezizayo</relativeTimePattern>
 					<relativeTimePattern count="other">ezinyangeni ezingu-{0} ezizayo</relativeTimePattern>
@@ -2527,10 +2527,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Inyanga</displayName>
+				<relative type="-1">inyanga edlule</relative>
+				<relative type="0">le nyanga</relative>
+				<relative type="1">inyanga ezayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">enyangeni engu-{0} ezayo</relativeTimePattern>
 					<relativeTimePattern count="other">enyangeni engu-{0} ezayo</relativeTimePattern>
@@ -2556,10 +2556,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relativePeriod>evikini le-{0}</relativePeriod>
 			</field>
 			<field type="week-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Iviki</displayName>
+				<relative type="-1">iviki eledlule</relative>
+				<relative type="0">leli viki</relative>
+				<relative type="1">iviki elizayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">evikini elingu-{0} elizayo</relativeTimePattern>
 					<relativeTimePattern count="other">emavikini angu-{0} ezayo</relativeTimePattern>
@@ -2571,28 +2571,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relativePeriod>evikini le-{0}</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>Iviki</displayName>
+				<relative type="-1">iviki eledlule</relative>
+				<relative type="0">leli viki</relative>
+				<relative type="1">iviki elizayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">emavikini angu-{0} ezayo</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">emavikini angu-{0} ezayo</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">amaviki angu-{0} edlule</relativeTimePattern>
+					<relativeTimePattern count="other">amaviki angu-{0} edlule</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>evikini le-{0}</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
 				<displayName>Iviki leNyanga</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Iviki leNyanga</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Iviki leNyanga</displayName>
 			</field>
 			<field type="day">
 				<displayName>Usuku</displayName>
@@ -2611,15 +2611,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="day-short">
-				<displayName>↑↑↑</displayName>
-				<relative type="-2">↑↑↑</relative>
+				<displayName>Usuku</displayName>
+				<relative type="-2">usuku olwandulela olwayizolo</relative>
 				<relative type="-1">izolo</relative>
 				<relative type="0">namhlanje</relative>
 				<relative type="1">kusasa</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="2">usuku olulandela olwakusasa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">osukwini olungu-{0} oluzayo</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ezinsukwini ezingu-{0} ezizayo</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} usuku olwedlule</relativeTimePattern>
@@ -2627,18 +2627,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="day-narrow">
-				<displayName>↑↑↑</displayName>
-				<relative type="-2">↑↑↑</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
-				<relative type="2">↑↑↑</relative>
+				<displayName>Usuku</displayName>
+				<relative type="-2">usuku olwandulela olwayizolo</relative>
+				<relative type="-1">izolo</relative>
+				<relative type="0">namhlanje</relative>
+				<relative type="1">kusasa</relative>
+				<relative type="2">usuku olulandela olwakusasa</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">osukwini olungu-{0} oluzayo</relativeTimePattern>
+					<relativeTimePattern count="other">ezinsukwini ezingu-{0} ezizayo</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} usuku olwedlule</relativeTimePattern>
 					<relativeTimePattern count="other">{0} izinsuku ezedlule</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -2649,7 +2649,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>usuku lonyaka</displayName>
 			</field>
 			<field type="dayOfYear-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>usuku lonyaka</displayName>
 			</field>
 			<field type="weekday">
 				<displayName>Usuku evikini</displayName>
@@ -2658,13 +2658,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Usuku evikini</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Usuku evikini</displayName>
 			</field>
 			<field type="weekdayOfMonth">
 				<displayName>usuku lwenyanga</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>usuku lwenyanga</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
 				<displayName>usuku lwenyanga</displayName>
@@ -2688,24 +2688,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<relative type="1">iSonto elizayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">kumaSonto angu-{0}</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">kumaSonto angu-{0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">{0} amaSonto edlule</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} amaSonto edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">iSonto eledlule</relative>
+				<relative type="0">kuleli Sonto</relative>
+				<relative type="1">iSonto elizayo</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">kumaSonto angu-{0}</relativeTimePattern>
+					<relativeTimePattern count="other">kumaSonto angu-{0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} amaSonto edlule</relativeTimePattern>
+					<relativeTimePattern count="other">{0} amaSonto edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon">
@@ -2722,29 +2722,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="mon-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">uMsombuluko odlule</relative>
+				<relative type="0">kulo Msombuluko</relative>
+				<relative type="1">uMsombuluko ozayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ngeMisombuluko e-{0}</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ngeMisombuluko e-{0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">ngeMsombuluko e-{0} edlule</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ngeMsombuluko e-{0} edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">uMsombuluko odlule</relative>
+				<relative type="0">kulo Msombuluko</relative>
+				<relative type="1">uMsombuluko ozayo</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ngeMisombuluko e-{0}</relativeTimePattern>
+					<relativeTimePattern count="other">ngeMisombuluko e-{0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ngeMsombuluko e-{0} edlule</relativeTimePattern>
+					<relativeTimePattern count="other">ngeMsombuluko e-{0} edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
@@ -2761,9 +2761,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="tue-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">uLwesibili oludlule</relative>
+				<relative type="0">kulo Lwesibili</relative>
+				<relative type="1">uLwesibili oluzayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">{0} ngoLwezibili</relativeTimePattern>
 					<relativeTimePattern count="other">{0} ngoLwezibili</relativeTimePattern>
@@ -2840,28 +2840,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="thu-short">
 				<relative type="-1">uLwesine olwedlule</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="0">kulo Lwesine</relative>
+				<relative type="1">uLwesine oluzayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ngoLwezine abangu-{0}</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ngoLwezine abangu-{0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">ngoLwezine abangu-{0} abedlule</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ngoLwezine abangu-{0} abedlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">uLwesine olwedlule</relative>
+				<relative type="0">kulo Lwesine</relative>
+				<relative type="1">uLwesine oluzayo</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ngoLwezine abangu-{0}</relativeTimePattern>
+					<relativeTimePattern count="other">ngoLwezine abangu-{0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ngoLwezine abangu-{0} abedlule</relativeTimePattern>
+					<relativeTimePattern count="other">ngoLwezine abangu-{0} abedlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri">
@@ -2917,16 +2917,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="sat-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">uMgqibelo odlule</relative>
+				<relative type="0">kulo Mgqibelo</relative>
+				<relative type="1">uMgqibelo ozayo</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">ngeMgqibelo engu-{0}</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ngeMgqibelo engu-{0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">ngeMgqibelo engu-{0} edlule</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ngeMgqibelo engu-{0} edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-narrow">
@@ -2943,13 +2943,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>AM/PM</displayName>
 			</field>
 			<field type="dayperiod">
 				<displayName>AM/PM</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>AM/PM</displayName>
 			</field>
 			<field type="hour">
 				<displayName>Ihora</displayName>
@@ -2965,25 +2965,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="hour-short">
 				<displayName>Ihora</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">leli hora</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ehoreni elingu-{0} elizayo</relativeTimePattern>
+					<relativeTimePattern count="other">emahoreni angu-{0} ezayo</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ihora eledlule</relativeTimePattern>
+					<relativeTimePattern count="other">emahoreni angu-{0} edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
 				<displayName>Ihora</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">leli hora</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">ehoreni elingu-{0} elizayo</relativeTimePattern>
+					<relativeTimePattern count="other">emahoreni angu-{0} ezayo</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} ihora eledlule</relativeTimePattern>
 					<relativeTimePattern count="other">{0} amahora edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
@@ -3001,26 +3001,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="minute-short">
 				<displayName>Iminithi</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">leli minithi</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">kuminithi elingu-{0} elizayo</relativeTimePattern>
+					<relativeTimePattern count="other">kumaminithi angu-{0} ezayo</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} iminithi eledlule</relativeTimePattern>
+					<relativeTimePattern count="other">{0} amaminithi edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-narrow">
 				<displayName>Iminithi</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">leli minithi</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">kuminithi elingu-{0} elizayo</relativeTimePattern>
+					<relativeTimePattern count="other">kumaminithi angu-{0} ezayo</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} iminithi eledlule</relativeTimePattern>
+					<relativeTimePattern count="other">{0} amaminithi edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second">
@@ -3037,36 +3037,36 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</field>
 			<field type="second-short">
 				<displayName>Isekhondi</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">manje</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">kusekhondi elingu-{0} elizayo</relativeTimePattern>
+					<relativeTimePattern count="other">kumasekhondi angu-{0} ezayo</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} isekhondi eledlule</relativeTimePattern>
+					<relativeTimePattern count="other">{0} amasekhondi edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-narrow">
 				<displayName>Isekhondi</displayName>
-				<relative type="0">↑↑↑</relative>
+				<relative type="0">manje</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">kusekhondi elingu-{0} elizayo</relativeTimePattern>
+					<relativeTimePattern count="other">kumasekhondi angu-{0} ezayo</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} isekhondi eledlule</relativeTimePattern>
+					<relativeTimePattern count="other">{0} amasekhondi edlule</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="zone">
 				<displayName>Isikhathi sendawo</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>↑↑↑</displayName>
+				<displayName>Isikhathi sendawo</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Isikhathi sendawo</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -5309,32 +5309,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="olck">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<list>↑↑↑</list>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<exponential>↑↑↑</exponential>
-			<superscriptingExponent>↑↑↑</superscriptingExponent>
-			<perMille>↑↑↑</perMille>
-			<nan>↑↑↑</nan>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<list>;</list>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<exponential>E</exponential>
+			<superscriptingExponent>×</superscriptingExponent>
+			<perMille>‰</perMille>
+			<nan>NaN</nan>
 		</symbols>
 		<symbols numberSystem="sora">
-			<timeSeparator draft="contributed">↑↑↑</timeSeparator>
+			<timeSeparator draft="contributed">:</timeSeparator>
 		</symbols>
 		<symbols numberSystem="talu">
-			<decimal draft="contributed">↑↑↑</decimal>
-			<group draft="contributed">↑↑↑</group>
-			<percentSign>↑↑↑</percentSign>
-			<plusSign draft="contributed">↑↑↑</plusSign>
-			<minusSign draft="contributed">↑↑↑</minusSign>
-			<perMille>↑↑↑</perMille>
+			<decimal draft="contributed">.</decimal>
+			<group draft="contributed">,</group>
+			<percentSign>%</percentSign>
+			<plusSign draft="contributed">+</plusSign>
+			<minusSign draft="contributed">-</minusSign>
+			<perMille>‰</perMille>
 		</symbols>
 		<decimalFormats numberSystem="java">
 			<decimalFormatLength>
 				<decimalFormat>
-					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern draft="contributed">#,##0.###</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
@@ -5404,7 +5404,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scientificFormats numberSystem="java">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
@@ -5418,14 +5418,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scientificFormats numberSystem="tibt">
 			<scientificFormatLength>
 				<scientificFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#E0</pattern>
 				</scientificFormat>
 			</scientificFormatLength>
 		</scientificFormats>
 		<percentFormats numberSystem="java">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
@@ -5439,17 +5439,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<percentFormats numberSystem="tibt">
 			<percentFormatLength>
 				<percentFormat>
-					<pattern>↑↑↑</pattern>
+					<pattern>#,##0%</pattern>
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5523,7 +5523,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -6086,8 +6086,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currency>
 			<currency type="LSL">
 				<displayName>i-Lesotho Loti</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="one">i-Lesotho Loti</displayName>
+				<displayName count="other">i-Lesotho Loti</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LTL">
@@ -6609,8 +6609,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pattern type="range">{0}–{1}</pattern>
 		</miscPatterns>
 		<miscPatterns numberSystem="vaii">
-			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
+			<pattern type="approximately">~{0}</pattern>
+			<pattern type="atLeast">{0}+</pattern>
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one">{0} usuku</pluralMinimalPairs>
@@ -6681,28 +6681,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>yotta{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0} nge-{1}</compoundUnitPattern>
@@ -6718,7 +6718,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">cubic {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>g-force</displayName>
@@ -6806,9 +6806,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunams</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>ama-karats</displayName>
@@ -6826,9 +6826,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ppm</displayName>
@@ -6846,14 +6846,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>L/km</displayName>
@@ -6936,8 +6936,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="one">{0} dec</unitPattern>
 				<unitPattern count="other">{0} decades</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -6947,10 +6947,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/y</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>qtr</displayName>
+				<unitPattern count="one">{0} q</unitPattern>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>izinyanga</displayName>
@@ -7054,34 +7054,34 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh/100km</displayName>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
+				<unitPattern count="other">{0} kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>GHz</displayName>
@@ -7104,49 +7104,49 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">{0} megapixels</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
@@ -7229,14 +7229,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>nmi</displayName>
@@ -7254,9 +7254,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lux</displayName>
@@ -7264,19 +7264,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} i-lux</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">{0} candela</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="one">{0} i-lumen</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>t</displayName>
@@ -7311,9 +7311,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>lb</displayName>
@@ -7338,24 +7338,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>GW</displayName>
@@ -7403,9 +7403,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>mbar</displayName>
@@ -7418,9 +7418,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>hPa</displayName>
@@ -7428,14 +7428,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -7478,14 +7478,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>km³</displayName>
@@ -7571,9 +7571,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>gal</displayName>
@@ -7608,9 +7608,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fl oz</displayName>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
+				<unitPattern count="other">{0} fl oz Imp.</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>tbsp</displayName>
@@ -7623,44 +7623,44 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstspn</displayName>
 				<unitPattern count="one">{0} sipuni dessert</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstspn Imp</displayName>
 				<unitPattern count="one">{0} Imp. isipuni dessert</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} dstspn Imp</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>drop</displayName>
+				<unitPattern count="one">{0} drop</unitPattern>
+				<unitPattern count="other">{0} drop</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram fluid</displayName>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="one">{0} pinch</unitPattern>
+				<unitPattern count="other">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>indlela</displayName>
@@ -7858,7 +7858,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-dunam">
 				<displayName>dunams</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dunam</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
@@ -7878,7 +7878,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} item</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
@@ -7898,12 +7898,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}‱</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} mol</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
@@ -7988,7 +7988,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-decade">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dec</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-year">
@@ -7999,7 +7999,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} q</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
@@ -8106,32 +8106,32 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} eV</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Btu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} US therm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kWh/100km</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
@@ -8156,47 +8156,47 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} em</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} px</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MP</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppcm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} ppi</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
@@ -8281,12 +8281,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fur</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fth</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
@@ -8306,7 +8306,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} R☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lux">
@@ -8316,17 +8316,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} cd</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lm</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} L☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
@@ -8363,7 +8363,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} st</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -8390,22 +8390,22 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Da</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M⊕</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} M☉</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} grain</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -8455,7 +8455,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bar</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
@@ -8470,7 +8470,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} Pa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
@@ -8480,12 +8480,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} kPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} MPa</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
@@ -8530,12 +8530,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
@@ -8623,7 +8623,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bu</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
@@ -8660,7 +8660,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} fl oz Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
@@ -8675,42 +8675,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} bbl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dstspn Imp</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} drop</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} jigger</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} pinch</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<coordinateUnit>
@@ -8783,28 +8783,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPrefixPattern>Y{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ki{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Mi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Gi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Pi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Ei{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Zi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>Yi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>{0}/{1}</compoundUnitPattern>
@@ -8820,121 +8820,121 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">{0}³</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>g-force</displayName>
 				<unitPattern count="one">{0} G</unitPattern>
 				<unitPattern count="other">{0} G</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">{0} m/s²</unitPattern>
+				<unitPattern count="other">{0} m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rev</displayName>
+				<unitPattern count="one">{0} rev</unitPattern>
+				<unitPattern count="other">{0} rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>radians</displayName>
+				<unitPattern count="one">{0} rad</unitPattern>
+				<unitPattern count="other">{0} rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>°</displayName>
 				<unitPattern count="one">{0}°</unitPattern>
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcmins</displayName>
 				<unitPattern count="one">{0}′</unitPattern>
 				<unitPattern count="other">{0}′</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcsecs</displayName>
 				<unitPattern count="one">{0}″</unitPattern>
 				<unitPattern count="other">{0}″</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>km²</displayName>
+				<unitPattern count="one">{0} km²</unitPattern>
+				<unitPattern count="other">{0} km²</unitPattern>
+				<perUnitPattern>{0}/km²</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hectare</displayName>
+				<unitPattern count="one">{0} ha</unitPattern>
+				<unitPattern count="other">{0} ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m²</displayName>
+				<unitPattern count="one">{0} m²</unitPattern>
+				<unitPattern count="other">{0} m²</unitPattern>
+				<perUnitPattern>{0}/m²</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm²</displayName>
+				<unitPattern count="one">{0} cm²</unitPattern>
+				<unitPattern count="other">{0} cm²</unitPattern>
+				<perUnitPattern>{0}/cm²</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mi²</displayName>
+				<unitPattern count="one">{0} mi²</unitPattern>
+				<unitPattern count="other">{0} mi²</unitPattern>
+				<perUnitPattern>{0}/mi²</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre</displayName>
+				<unitPattern count="one">{0} ac</unitPattern>
+				<unitPattern count="other">{0} ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">{0} yd²</unitPattern>
+				<unitPattern count="other">{0} yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft²</displayName>
+				<unitPattern count="one">{0} ft²</unitPattern>
+				<unitPattern count="other">{0} ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in²</displayName>
+				<unitPattern count="one">{0} in²</unitPattern>
+				<unitPattern count="other">{0} in²</unitPattern>
+				<perUnitPattern>{0}/in²</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunams</displayName>
+				<unitPattern count="one">{0} dunam</unitPattern>
+				<unitPattern count="other">{0} dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karats</displayName>
+				<unitPattern count="one">{0} kt</unitPattern>
+				<unitPattern count="other">{0} kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg/dL</displayName>
+				<unitPattern count="one">{0} mg/dL</unitPattern>
+				<unitPattern count="other">{0} mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">{0} mmol/L</unitPattern>
+				<unitPattern count="other">{0} mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>item</displayName>
+				<unitPattern count="one">{0} item</unitPattern>
+				<unitPattern count="other">{0} item</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>izingxenye/izigidi</displayName>
+				<unitPattern count="one">{0} ppm</unitPattern>
 				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
@@ -8943,24 +8943,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}%</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‰</displayName>
+				<unitPattern count="one">{0}‰</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>‱</displayName>
+				<unitPattern count="one">{0}‱</unitPattern>
+				<unitPattern count="other">{0}‱</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">{0} mol</unitPattern>
+				<unitPattern count="other">{0} mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="one">{0} L/km</unitPattern>
+				<unitPattern count="other">{0} L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>L/100km</displayName>
@@ -8968,127 +8968,127 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}L/100km</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>miles/gal</displayName>
+				<unitPattern count="one">{0} mpg</unitPattern>
+				<unitPattern count="other">{0} mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>mpg Imp.</displayName>
 				<unitPattern count="one">{0}m/gUK</unitPattern>
 				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">{0} PB</unitPattern>
+				<unitPattern count="other">{0} PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">{0} TB</unitPattern>
+				<unitPattern count="other">{0} TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tbit</displayName>
+				<unitPattern count="one">{0} Tb</unitPattern>
+				<unitPattern count="other">{0} Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">{0} GB</unitPattern>
+				<unitPattern count="other">{0} GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gbit</displayName>
+				<unitPattern count="one">{0} Gb</unitPattern>
+				<unitPattern count="other">{0} Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">{0} MB</unitPattern>
+				<unitPattern count="other">{0} MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mbit</displayName>
+				<unitPattern count="one">{0} Mb</unitPattern>
+				<unitPattern count="other">{0} Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">{0} kB</unitPattern>
+				<unitPattern count="other">{0} kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kbit</displayName>
+				<unitPattern count="one">{0} kb</unitPattern>
+				<unitPattern count="other">{0} kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>byte</displayName>
+				<unitPattern count="one">{0} byte</unitPattern>
+				<unitPattern count="other">{0} byte</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="one">{0} bit</unitPattern>
+				<unitPattern count="other">{0} bit</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>c</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dec</displayName>
+				<unitPattern count="one">{0} dec</unitPattern>
+				<unitPattern count="other">{0} dec</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>y</displayName>
 				<unitPattern count="one">{0} y</unitPattern>
 				<unitPattern count="other">{0} y</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/y</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>qtr</displayName>
+				<unitPattern count="one">{0} q</unitPattern>
+				<unitPattern count="other">{0} q</unitPattern>
+				<perUnitPattern>{0}/q</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>izinyanga</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>amaviki</displayName>
 				<unitPattern count="one">{0} w</unitPattern>
 				<unitPattern count="other">{0} w</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/w</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>izinsuku</displayName>
 				<unitPattern count="one">{0}</unitPattern>
 				<unitPattern count="other">{0} suku</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>amahora</displayName>
 				<unitPattern count="one">{0} hora</unitPattern>
 				<unitPattern count="other">{0} hora</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/h</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>amaminithi</displayName>
 				<unitPattern count="one">{0} umzuzu</unitPattern>
 				<unitPattern count="other">{0} umzuzu</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/min</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
 				<displayName>isekhondi</displayName>
 				<unitPattern count="one">{0} s</unitPattern>
 				<unitPattern count="other">{0} s</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
 				<displayName>ms</displayName>
@@ -9096,182 +9096,182 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} ms</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μsecs</displayName>
+				<unitPattern count="one">{0} μs</unitPattern>
+				<unitPattern count="other">{0} μs</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ns</displayName>
+				<unitPattern count="one">{0} ns</unitPattern>
+				<unitPattern count="other">{0} ns</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amp</displayName>
+				<unitPattern count="one">{0} A</unitPattern>
+				<unitPattern count="other">{0} A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">{0} mA</unitPattern>
+				<unitPattern count="other">{0} mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohm</displayName>
+				<unitPattern count="one">{0} Ω</unitPattern>
+				<unitPattern count="other">{0} Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="one">{0} V</unitPattern>
+				<unitPattern count="other">{0} V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kcal</displayName>
+				<unitPattern count="one">{0} kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cal</displayName>
+				<unitPattern count="one">{0} cal</unitPattern>
+				<unitPattern count="other">{0} cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Cal</displayName>
+				<unitPattern count="one">{0} Cal</unitPattern>
+				<unitPattern count="other">{0} Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kJ</displayName>
+				<unitPattern count="one">{0} kJ</unitPattern>
+				<unitPattern count="other">{0} kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joules</displayName>
+				<unitPattern count="one">{0} J</unitPattern>
+				<unitPattern count="other">{0} J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">{0} kWh</unitPattern>
+				<unitPattern count="other">{0} kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">{0} eV</unitPattern>
+				<unitPattern count="other">{0} eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Btu</displayName>
+				<unitPattern count="one">{0} Btu</unitPattern>
+				<unitPattern count="other">{0} Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>US therm</displayName>
+				<unitPattern count="one">{0} US therm</unitPattern>
+				<unitPattern count="other">{0} US therm</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">{0} lbf</unitPattern>
+				<unitPattern count="other">{0} lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">{0} N</unitPattern>
+				<unitPattern count="other">{0} N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>kWh/100km</displayName>
 				<unitPattern count="one">{0}kWh/100km</unitPattern>
 				<unitPattern count="other">{0}kWh/100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GHz</displayName>
+				<unitPattern count="one">{0} GHz</unitPattern>
+				<unitPattern count="other">{0} GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MHz</displayName>
+				<unitPattern count="one">{0} MHz</unitPattern>
+				<unitPattern count="other">{0} MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kHz</displayName>
+				<unitPattern count="one">{0} kHz</unitPattern>
+				<unitPattern count="other">{0} kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Hz</displayName>
+				<unitPattern count="one">{0} Hz</unitPattern>
+				<unitPattern count="other">{0} Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>em</displayName>
+				<unitPattern count="one">{0} em</unitPattern>
+				<unitPattern count="other">{0} em</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MP</displayName>
+				<unitPattern count="one">{0} MP</unitPattern>
+				<unitPattern count="other">{0} MP</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppcm</displayName>
+				<unitPattern count="one">{0} ppcm</unitPattern>
+				<unitPattern count="other">{0} ppcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppi</displayName>
+				<unitPattern count="one">{0} ppi</unitPattern>
+				<unitPattern count="other">{0} ppi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>px</displayName>
+				<unitPattern count="one">{0} px</unitPattern>
+				<unitPattern count="other">{0} px</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="one">{0} R⊕</unitPattern>
+				<unitPattern count="other">{0} R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>km</displayName>
 				<unitPattern count="one">{0} km</unitPattern>
 				<unitPattern count="other">{0} km</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/km</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>m</displayName>
 				<unitPattern count="one">{0} m</unitPattern>
 				<unitPattern count="other">{0} m</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dm</displayName>
+				<unitPattern count="one">{0} dm</unitPattern>
+				<unitPattern count="other">{0} dm</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>cm</displayName>
 				<unitPattern count="one">{0} cm</unitPattern>
 				<unitPattern count="other">{0} cm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/cm</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>mm</displayName>
@@ -9279,265 +9279,265 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} mm</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μm</displayName>
+				<unitPattern count="one">{0} μm</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nm</displayName>
+				<unitPattern count="one">{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pm</displayName>
+				<unitPattern count="one">{0} pm</unitPattern>
+				<unitPattern count="other">{0} pm</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi</displayName>
+				<unitPattern count="one">{0} mi</unitPattern>
+				<unitPattern count="other">{0} mi</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd</displayName>
+				<unitPattern count="one">{0} yd</unitPattern>
+				<unitPattern count="other">{0} yd</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ft</displayName>
+				<unitPattern count="one">{0} ft</unitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0}/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>in</displayName>
+				<unitPattern count="one">{0} in</unitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0}/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pc</displayName>
+				<unitPattern count="one">{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ly</displayName>
+				<unitPattern count="one">{0} ly</unitPattern>
+				<unitPattern count="other">{0} ly</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>au</displayName>
+				<unitPattern count="one">{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fur</displayName>
+				<unitPattern count="one">{0} fur</unitPattern>
+				<unitPattern count="other">{0} fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fm</displayName>
+				<unitPattern count="one">{0} fth</unitPattern>
+				<unitPattern count="other">{0} fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nmi</displayName>
+				<unitPattern count="one">{0} nmi</unitPattern>
+				<unitPattern count="other">{0} nmi</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>smi</displayName>
+				<unitPattern count="one">{0} smi</unitPattern>
+				<unitPattern count="other">{0} smi</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">{0} R☉</unitPattern>
+				<unitPattern count="other">{0} R☉</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lux</displayName>
+				<unitPattern count="one">{0} lx</unitPattern>
+				<unitPattern count="other">{0} lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="one">{0} cd</unitPattern>
+				<unitPattern count="other">{0} cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lm</displayName>
+				<unitPattern count="one">{0} lm</unitPattern>
+				<unitPattern count="other">{0} lm</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">{0} L☉</unitPattern>
+				<unitPattern count="other">{0} L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>t</displayName>
+				<unitPattern count="one">{0} t</unitPattern>
+				<unitPattern count="other">{0} t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>kg</displayName>
 				<unitPattern count="one">{0} kg</unitPattern>
 				<unitPattern count="other">{0} kg</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/kg</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>g</displayName>
 				<unitPattern count="one">{0} g</unitPattern>
 				<unitPattern count="other">{0} g</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/g</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mg</displayName>
+				<unitPattern count="one">{0} mg</unitPattern>
+				<unitPattern count="other">{0} mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>μg</displayName>
+				<unitPattern count="one">{0} μg</unitPattern>
+				<unitPattern count="other">{0} μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tn</displayName>
+				<unitPattern count="one">{0} tn</unitPattern>
+				<unitPattern count="other">{0} tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>st</displayName>
+				<unitPattern count="one">{0} st</unitPattern>
+				<unitPattern count="other">{0} st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>lb</displayName>
+				<unitPattern count="one">{0} lb</unitPattern>
+				<unitPattern count="other">{0} lb</unitPattern>
+				<perUnitPattern>{0}/lb</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oz</displayName>
+				<unitPattern count="one">{0} oz</unitPattern>
+				<unitPattern count="other">{0} oz</unitPattern>
+				<perUnitPattern>{0}/oz</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">{0} oz t</unitPattern>
+				<unitPattern count="other">{0} oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>CD</displayName>
+				<unitPattern count="one">{0} CD</unitPattern>
+				<unitPattern count="other">{0} CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">{0} Da</unitPattern>
+				<unitPattern count="other">{0} Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">{0} M⊕</unitPattern>
+				<unitPattern count="other">{0} M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">{0} M☉</unitPattern>
+				<unitPattern count="other">{0} M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>grain</displayName>
+				<unitPattern count="one">{0} grain</unitPattern>
+				<unitPattern count="other">{0} grain</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GW</displayName>
+				<unitPattern count="one">{0} GW</unitPattern>
+				<unitPattern count="other">{0} GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MW</displayName>
+				<unitPattern count="one">{0} MW</unitPattern>
+				<unitPattern count="other">{0} MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kW</displayName>
+				<unitPattern count="one">{0} kW</unitPattern>
+				<unitPattern count="other">{0} kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>watt</displayName>
+				<unitPattern count="one">{0} W</unitPattern>
+				<unitPattern count="other">{0} W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mW</displayName>
+				<unitPattern count="one">{0} mW</unitPattern>
+				<unitPattern count="other">{0} mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hp</displayName>
+				<unitPattern count="one">{0} hp</unitPattern>
+				<unitPattern count="other">{0} hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mm Hg</displayName>
+				<unitPattern count="one">{0} mm Hg</unitPattern>
+				<unitPattern count="other">{0} mm Hg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>psi</displayName>
+				<unitPattern count="one">{0} psi</unitPattern>
+				<unitPattern count="other">{0} psi</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>inHg</displayName>
+				<unitPattern count="one">{0} inHg</unitPattern>
+				<unitPattern count="other">{0} inHg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bar</displayName>
+				<unitPattern count="one">{0} bar</unitPattern>
+				<unitPattern count="other">{0} bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mbar</displayName>
+				<unitPattern count="one">{0} mbar</unitPattern>
+				<unitPattern count="other">{0} mbar</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>atm</displayName>
+				<unitPattern count="one">{0} atm</unitPattern>
+				<unitPattern count="other">{0} atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Pa</displayName>
+				<unitPattern count="one">{0} Pa</unitPattern>
+				<unitPattern count="other">{0} Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hPa</displayName>
+				<unitPattern count="one">{0} hPa</unitPattern>
+				<unitPattern count="other">{0} hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kPa</displayName>
+				<unitPattern count="one">{0} kPa</unitPattern>
+				<unitPattern count="other">{0} kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MPa</displayName>
+				<unitPattern count="one">{0} MPa</unitPattern>
+				<unitPattern count="other">{0} MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>km/h</displayName>
@@ -9545,24 +9545,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} km/h</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s</displayName>
+				<unitPattern count="one">{0} m/s</unitPattern>
+				<unitPattern count="other">{0} m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi/h</displayName>
+				<unitPattern count="one">{0} mi/h</unitPattern>
+				<unitPattern count="other">{0} mi/h</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kn</displayName>
+				<unitPattern count="one">{0} kn</unitPattern>
+				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°</displayName>
+				<unitPattern count="one">{0}°</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
 				<displayName>°C</displayName>
@@ -9570,172 +9570,172 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>°F</displayName>
 				<unitPattern count="one">{0}°F</unitPattern>
 				<unitPattern count="other">{0}°F</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>K</displayName>
+				<unitPattern count="one">{0} K</unitPattern>
+				<unitPattern count="other">{0} K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf⋅ft</displayName>
+				<unitPattern count="one">{0} lbf⋅ft</unitPattern>
+				<unitPattern count="other">{0} lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N⋅m</displayName>
+				<unitPattern count="one">{0} N⋅m</unitPattern>
+				<unitPattern count="other">{0} N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>km³</displayName>
+				<unitPattern count="one">{0} km³</unitPattern>
+				<unitPattern count="other">{0} km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>m³</displayName>
+				<unitPattern count="one">{0} m³</unitPattern>
+				<unitPattern count="other">{0} m³</unitPattern>
+				<perUnitPattern>{0}/m³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>cm³</displayName>
+				<unitPattern count="one">{0} cm³</unitPattern>
+				<unitPattern count="other">{0} cm³</unitPattern>
+				<perUnitPattern>{0}/cm³</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mi³</displayName>
+				<unitPattern count="one">{0} mi³</unitPattern>
+				<unitPattern count="other">{0} mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd³</displayName>
+				<unitPattern count="one">{0} yd³</unitPattern>
+				<unitPattern count="other">{0} yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ft³</displayName>
+				<unitPattern count="one">{0} ft³</unitPattern>
+				<unitPattern count="other">{0} ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>in³</displayName>
+				<unitPattern count="one">{0} in³</unitPattern>
+				<unitPattern count="other">{0} in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ML</displayName>
+				<unitPattern count="one">{0} ML</unitPattern>
+				<unitPattern count="other">{0} ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hL</displayName>
+				<unitPattern count="one">{0} hL</unitPattern>
+				<unitPattern count="other">{0} hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>l</displayName>
 				<unitPattern count="one">{0} l</unitPattern>
 				<unitPattern count="other">{0} l</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/l</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dL</displayName>
+				<unitPattern count="one">{0} dL</unitPattern>
+				<unitPattern count="other">{0} dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cL</displayName>
+				<unitPattern count="one">{0} cL</unitPattern>
+				<unitPattern count="other">{0} cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mL</displayName>
+				<unitPattern count="one">{0} mL</unitPattern>
+				<unitPattern count="other">{0} mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpt</displayName>
+				<unitPattern count="one">{0} mpt</unitPattern>
+				<unitPattern count="other">{0} mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mcup</displayName>
+				<unitPattern count="one">{0} mc</unitPattern>
+				<unitPattern count="other">{0} mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ac ft</displayName>
+				<unitPattern count="one">{0} ac ft</unitPattern>
+				<unitPattern count="other">{0} ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bu</displayName>
+				<unitPattern count="one">{0} bu</unitPattern>
+				<unitPattern count="other">{0} bu</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="one">{0} gal</unitPattern>
+				<unitPattern count="other">{0} gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. gal</displayName>
 				<unitPattern count="one">{0}galIm</unitPattern>
 				<unitPattern count="other">{0}galIm</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/gal Imp.</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">{0} qt</unitPattern>
+				<unitPattern count="other">{0} qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">{0} pt</unitPattern>
+				<unitPattern count="other">{0} pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cup</displayName>
+				<unitPattern count="one">{0} c</unitPattern>
+				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="one">{0} fl oz</unitPattern>
+				<unitPattern count="other">{0} fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>Imp. fl oz</displayName>
 				<unitPattern count="one">{0}fl oz Im</unitPattern>
 				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tbsp</displayName>
+				<unitPattern count="one">{0} tbsp</unitPattern>
+				<unitPattern count="other">{0} tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tsp</displayName>
+				<unitPattern count="one">{0} tsp</unitPattern>
+				<unitPattern count="other">{0} tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bbl</displayName>
+				<unitPattern count="one">{0} bbl</unitPattern>
+				<unitPattern count="other">{0} bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dstspn</displayName>
+				<unitPattern count="one">{0} dstspn</unitPattern>
+				<unitPattern count="other">{0} dstspn</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>dstspn Imp</displayName>
 				<unitPattern count="one">{0}dsp-Imp</unitPattern>
 				<unitPattern count="other">{0}dsp-Imp</unitPattern>
 			</unit>
@@ -9746,23 +9746,23 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl.dr.</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0} dram fl</unitPattern>
+				<unitPattern count="other">{0} dram fl</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jigger</displayName>
+				<unitPattern count="one">{0} jigger</unitPattern>
+				<unitPattern count="other">{0} jigger</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pinch</displayName>
+				<unitPattern count="one">{0} pinch</unitPattern>
+				<unitPattern count="other">{0} pinch</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt Imp</displayName>
+				<unitPattern count="one">{0} qt Imp.</unitPattern>
+				<unitPattern count="other">{0} qt Imp.</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>indlela</displayName>
@@ -9796,19 +9796,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<listPatternPart type="2">↑↑↑</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, or {1}</listPatternPart>
+			<listPatternPart type="2">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-short">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
-			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
+			<listPatternPart type="middle">{0}, {1}</listPatternPart>
+			<listPatternPart type="end">{0}, or {1}</listPatternPart>
+			<listPatternPart type="2">{0} or {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="standard-narrow">
-			<listPatternPart type="start">↑↑↑</listPatternPart>
+			<listPatternPart type="start">{0}, {1}</listPatternPart>
 			<listPatternPart type="middle">{0}, {1}</listPatternPart>
 			<listPatternPart type="end">{0}, {1}</listPatternPart>
 			<listPatternPart type="2">{0}, {1}</listPatternPart>
@@ -10025,127 +10025,127 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {given} {given2} {surname} {surname2} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-monogram-allCaps}{given2-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2} {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-monogram-allCaps}{given2-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {surname2}, {title} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
 			<nameField type="given">Sinbad</nameField>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -2436,7 +2436,7 @@ public class CLDRModify {
             boolean skip;
             @Override
             public void handleStart() {
-                skip = "ROOT".equals(LocaleIDParser.getParent(cldrFileToFilter.getLocaleID()));
+                skip = !XMLSource.ROOT_ID.equals(LocaleIDParser.getParent(getLocaleID()));
             }
             @Override
             public void handlePath(String xpath) {
@@ -2448,7 +2448,9 @@ public class CLDRModify {
                     Output<String> pathWhereFound = new Output<>();
                     Output<String> localeWhereFound = new Output<>();
                     String baileyValue = getResolved().getBaileyValue(xpath, pathWhereFound, localeWhereFound);
-                    if (baileyValue != null && !xpath.equals(pathWhereFound.value)) {
+                    if (baileyValue != null
+                        && !xpath.equals(pathWhereFound.value)
+                        && !"constructed".equals(pathWhereFound.value)) {
                         String fullPath = cldrFileToFilter.getFullXPath(xpath);
                         replace(fullPath, fullPath, baileyValue, "fix lateral");
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -2436,6 +2436,7 @@ public class CLDRModify {
             boolean skip;
             @Override
             public void handleStart() {
+                // skip if the locale id's parent isn't root. That is, it must be at level-1 locale.
                 skip = !XMLSource.ROOT_ID.equals(LocaleIDParser.getParent(getLocaleID()));
             }
             @Override


### PR DESCRIPTION
CLDR-16239

I would suggest looking at the CLDRModify changes first, then spot-checking some of the generated files. Note that "constructed" is the path returned for fallback constructed language items, like en_US.

Some files have many changes, so you might prefer to use the magic . option in the Files view to use the other diff mechanisms.

The key issues are:
1. nothing but inheritance markers (↑↑↑) should be affected (code inspection should be sufficient for this)
2. only markers that inherit laterally should be affected (also code inspection), but with sanity check.
3. constructed values (only languages with types having _) are not affected
4. ↑↑↑ may be left in where they inherit from root, with no lateral.
5. L2+ locales (eg fr_CA) won't be affected. This is a bit of a short-cut; it depends on the parent locale's being complete. I think that is enough for this release, but we might revisit.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
6. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
7. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
